### PR TITLE
Replace unmaintained actions-rs/* actions in CI workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,9 +38,9 @@ jobs:
           mdbook-version: 'latest'
 
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
+          toolchain: 1.68.0
 
       - name: Setup Pages
         uses: actions/configure-pages@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,12 +60,10 @@ jobs:
           echo "PROJECT_HOMEPAGE=$(sed -n 's/^homepage = "\(.*\)"/\1/p' Cargo.toml)" >> $GITHUB_ENV
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          target: ${{ matrix.job.target }}
-          override: true
-          profile: minimal # minimal component installation (ie, no documentation)
+          targets: ${{ matrix.job.target }}
 
       - name: Install cross
         if: matrix.job.use-cross

--- a/.github/workflows/rust-compile.yml
+++ b/.github/workflows/rust-compile.yml
@@ -24,12 +24,10 @@ jobs:
         with:
           submodules: recursive
       - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
+          toolchain: 1.68.0
+      - run: cargo check
 
   # check-rustdoc-links:
   #   name: Check intra-doc links
@@ -38,9 +36,9 @@ jobs:
   #     - uses: actions/checkout@v3
   #       with:
   #         submodules: recursive
-  #     - uses: actions-rs/toolchain@v1
+  #     - uses: dtolnay/rust-toolchain@master
   #       with:
-  #         profile: minimal
+  #         toolchain: 1.68.0
   #     - run: |
   #         for package in $(cargo metadata --no-deps --format-version=1 | jq -r '.packages[] | .name'); do
   #           cargo rustdoc -p "$package" --all-features -- -D warnings -W unreachable-pub
@@ -61,13 +59,10 @@ jobs:
           # The tests require data that is stored in LFS
           lfs: true
       - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features -- --nocapture
+          toolchain: 1.68.0
+      - run: cargo test --all-features -- --nocapture
 
   fmt:
     name: Rustfmt
@@ -76,15 +71,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
+          toolchain: 1.68.0
       - uses: Swatinem/rust-cache@v2
       - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: cargo fmt --all -- --check
 
   clippy:
     runs-on: ubuntu-latest
@@ -92,10 +84,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           components: clippy
+          toolchain: 1.68.0
       - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/clippy-check@v1
         with:


### PR DESCRIPTION
Basically all of the `actions-rs/*` actions are unmaintained. See <https://github.com/actions-rs/toolchain/issues/216> for more information. Due to their age they generate several warnings in CI runs, for example in https://github.com/prefix-dev/rattler-build/actions/runs/4725432487:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions-rs/toolchain@v1, actions-rs/cargo@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

To get rid of some of those warnings the occurrences of `actions-rs/toolchain` are replaced by [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain), and the occurrences of `actions-rs/cargo` are replaced by direct invocations of `cargo`.