### PR TITLE
add jinja syntax specification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2301,6 +2301,7 @@ version = "1.0.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24167c016c67b2be1772b99b682127566bad55ad12086ca5f9b313f7990d66d0"
 dependencies = [
+ "aho-corasick",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ serde_with = "3.0.0"
 url = "2.4.0"
 tracing = "0.1.37"
 clap = { version = "4.3.3", features = ["derive", "env", "cargo"] }
-minijinja = { version = "1.0.0-alpha.2", features = ["unstable_machinery"] }
+minijinja = { version = "1.0.0-alpha.2", features = ["unstable_machinery", "custom_syntax"] }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 num_cpus = "1.15.0"
 goblin = "0.7.1"

--- a/examples/rich/recipe.yaml
+++ b/examples/rich/recipe.yaml
@@ -3,11 +3,13 @@ context:
   name: "rich"
 
 package:
-  name: "rich"
-  version: "{{ version }}"
+  name: ${{ name }}
+  version: ${{ version }}
+
+
 
 source:
-  - url: https://pypi.io/packages/source/{{ name[0] }}/rich/rich-{{ version }}.tar.gz
+  - url: https://pypi.io/packages/source/${{ name[0] }}/${{ name }}/${{ name }}-${{ version }}.tar.gz
     sha256: dc84400a9d842b3a9c5ff74addd8eb798d155f36c1c91303888e0a66850d2a15
 
 build:

--- a/examples/rich/recipe.yaml
+++ b/examples/rich/recipe.yaml
@@ -6,14 +6,13 @@ package:
   name: ${{ name }}
   version: ${{ version }}
 
-
-
 source:
   - url: https://pypi.io/packages/source/${{ name[0] }}/${{ name }}/${{ name }}-${{ version }}.tar.gz
     sha256: dc84400a9d842b3a9c5ff74addd8eb798d155f36c1c91303888e0a66850d2a15
 
 build:
   # Thanks to `noarch: python` this package works on all platforms
+  number: ${{ 0 if name == 'rich' else 100 }}
   noarch: python
   script:
     - python -m pip install . -vv --no-deps --no-build-isolation

--- a/src/render/jinja.rs
+++ b/src/render/jinja.rs
@@ -1,0 +1,93 @@
+use std::str::FromStr;
+
+use minijinja::{value::Value, Environment, Syntax};
+use rattler_conda_types::{Version, VersionSpec};
+
+mod functions {
+    use std::str::FromStr;
+
+    use minijinja::Error;
+
+    use crate::render::pin::{Pin, PinExpression};
+
+    pub fn compiler(lang: String) -> Result<String, Error> {
+        // we translate the compiler into a YAML string
+        Ok(format!("__COMPILER {}", lang.to_lowercase()))
+    }
+
+    pub fn pin_subpackage(
+        name: String,
+        kwargs: Option<minijinja::value::Value>,
+    ) -> Result<String, Error> {
+        // we translate the compiler into a YAML string
+        let mut pin_subpackage = Pin {
+            name,
+            max_pin: None,
+            min_pin: None,
+            exact: false,
+        };
+
+        let pin_expr_from_value = |pin_expr: &minijinja::value::Value| {
+            PinExpression::from_str(&pin_expr.to_string()).map_err(|e| {
+                Error::new(
+                    minijinja::ErrorKind::SyntaxError,
+                    format!("Invalid pin expression: {}", e),
+                )
+            })
+        };
+
+        if let Some(kwargs) = kwargs {
+            let max_pin = kwargs.get_attr("max_pin")?;
+            if max_pin != minijinja::value::Value::UNDEFINED {
+                let pin_expr = pin_expr_from_value(&max_pin)?;
+                pin_subpackage.max_pin = Some(pin_expr);
+            }
+            let min = kwargs.get_attr("min_pin")?;
+            if min != minijinja::value::Value::UNDEFINED {
+                let pin_expr = pin_expr_from_value(&min)?;
+                pin_subpackage.min_pin = Some(pin_expr);
+            }
+            let exact = kwargs.get_attr("exact")?;
+            if exact != minijinja::value::Value::UNDEFINED {
+                pin_subpackage.exact = exact.is_true();
+            }
+        }
+
+        Ok(format!(
+            "__PIN_SUBPACKAGE {}",
+            pin_subpackage.internal_repr()
+        ))
+    }
+}
+
+/// Get a jinja environment with the correct syntax and functions
+pub fn jinja_environment() -> Environment<'static> {
+    let mut env = Environment::new();
+
+    env.set_syntax(Syntax {
+        block_start: "{%".into(),
+        block_end: "%}".into(),
+        variable_start: "${{".into(),
+        variable_end: "}}".into(),
+        comment_start: "#{{".into(),
+        comment_end: "}}#".into(),
+    })
+    .unwrap();
+
+    env.add_function("cmp", |a: &Value, spec: &str| {
+        if let Some(version) = a.as_str() {
+            // check if version matches spec
+            let version = Version::from_str(version).unwrap();
+            let version_spec = VersionSpec::from_str(spec).unwrap();
+            Ok(version_spec.matches(&version))
+        } else {
+            // if a is undefined, we are currently searching for all variants and thus return true
+            Ok(true)
+        }
+    });
+
+    env.add_function("compiler", functions::compiler);
+    env.add_function("pin_subpackage", functions::pin_subpackage);
+
+    env
+}

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1,4 +1,5 @@
 pub mod dependency_list;
+pub mod jinja;
 pub mod pin;
 pub mod recipe;
 pub mod resolved_dependencies;

--- a/src/render/recipe.rs
+++ b/src/render/recipe.rs
@@ -17,7 +17,7 @@ fn render_recipe_recursively(
     for (_, v) in recipe.iter_mut() {
         match v {
             YamlValue::String(var) => {
-                *v = YamlValue::String(jinja_env.render_str(var, context).unwrap());
+                *v = serde_yaml::from_str(&jinja_env.render_str(var, context).unwrap()).unwrap();
             }
             YamlValue::Sequence(var) => {
                 render_recipe_recursively_seq(var, jinja_env, context);
@@ -32,19 +32,19 @@ fn render_recipe_recursively(
 
 fn render_recipe_recursively_seq(
     recipe: &mut serde_yaml::Sequence,
-    environment: &Environment,
+    jinja_env: &Environment,
     context: &BTreeMap<String, Value>,
 ) {
     for v in recipe {
         match v {
             YamlValue::String(var) => {
-                *v = YamlValue::String(environment.render_str(var, context).unwrap());
+                *v = serde_yaml::from_str(&jinja_env.render_str(var, context).unwrap()).unwrap();
             }
             YamlValue::Sequence(var) => {
-                render_recipe_recursively_seq(var, environment, context);
+                render_recipe_recursively_seq(var, jinja_env, context);
             }
             YamlValue::Mapping(var) => {
-                render_recipe_recursively(var, environment, context);
+                render_recipe_recursively(var, jinja_env, context);
             }
             _ => {}
         }

--- a/src/selectors.rs
+++ b/src/selectors.rs
@@ -1,10 +1,8 @@
-use std::{
-    collections::{BTreeMap, HashMap},
-};
+use std::collections::{BTreeMap, HashMap};
 
 use crate::render::jinja::jinja_environment;
-use minijinja::{value::Value};
-use rattler_conda_types::{Platform};
+use minijinja::value::Value;
+use rattler_conda_types::Platform;
 use serde_yaml::Value as YamlValue;
 
 #[derive(Clone, Debug)]

--- a/src/used_variables.rs
+++ b/src/used_variables.rs
@@ -155,8 +155,8 @@ mod test {
         - sel(llvm_variant > 10): llvm >= 10
         - sel(linux): linux-gcc
         - sel(osx): osx-clang
-        - "{{ compiler('c') }}"
-        - "{{ pin_subpackage('abcdef') }}"
+        - "${{ compiler('c') }}"
+        - "${{ pin_subpackage('abcdef') }}"
         "#;
 
         let used_vars = used_vars_from_expressions(recipe);


### PR DESCRIPTION
This changes the syntax for variables from `{{ ... }}` to `${{ ... }}` which is better to integrate with YAML (no quotes needed).