### PR TITLE
copy_dir with gitignore options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,6 +364,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1066,6 +1076,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "globset"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1391ab1f92ffcc08911957149833e682aa3fe252b9f45f966d2ef972274c97df"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "goblin"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1283,6 +1306,23 @@ checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbe7873dab538a9a44ad79ede1faf5f30d49f9a5c883ddbab48bce81b64b7492"
+dependencies = [
+ "globset",
+ "lazy_static",
+ "log",
+ "memchr",
+ "regex",
+ "same-file",
+ "thread_local",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -2243,6 +2283,7 @@ dependencies = [
  "git2",
  "goblin",
  "hex",
+ "ignore",
  "indicatif",
  "insta",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ chrono = "0.4.26"
 sha1 = "0.10.5"
 git2 = { version = "0.17.2", features = ["vendored-openssl"] }
 fs_extra = "1.3.0"
+ignore = "0.4.20"
 
 [dev-dependencies]
 insta = {version = "1.31.0", features = ["yaml"] }

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -4,8 +4,8 @@ use std::{
     process::Command,
 };
 
-use fs_extra::dir::{copy, create_all, remove, CopyOptions};
-use fs_extra::error::ErrorKind::PermissionDenied;
+use fs_extra::dir::{create_all, CopyOptions};
+use ignore::WalkBuilder;
 
 use crate::metadata::Source;
 
@@ -38,6 +38,9 @@ pub enum SourceError {
 
     #[error("Failed to run git command: {0}")]
     GitError(#[from] git2::Error),
+
+    #[error("Could not walk dir")]
+    IgnoreError(#[from] ignore::Error),
 }
 
 /// Fetches all sources in a list of sources and applies specified patches
@@ -63,7 +66,7 @@ pub async fn fetch_sources(
                 } else {
                     work_dir.to_path_buf()
                 };
-                copy_dir(&result, &dest_dir)?;
+                copy_dir(&result, &dest_dir, &[], &[], false)?;
 
                 if let Some(patches) = &src.patches {
                     patch::apply_patches(patches, work_dir, recipe_dir)?;
@@ -93,7 +96,7 @@ pub async fn fetch_sources(
                 } else {
                     work_dir.to_path_buf()
                 };
-                copy_dir(&src_path, &dest_dir)?;
+                copy_dir(&src_path, &dest_dir, &[], &[], true)?;
 
                 if let Some(patches) = &src.patches {
                     patch::apply_patches(patches, work_dir, recipe_dir)?;
@@ -121,7 +124,18 @@ fn extract(
     output
 }
 
-fn copy_dir(from: &PathBuf, to: &PathBuf) -> Result<(), SourceError> {
+/// The copy_dir function accepts additionally a list of globs to ignore or include in the copy process.
+/// It uses the `ignore` crate to read the `.gitignore` file in the source directory and uses the globs
+/// to filter the files and directories to copy.
+///
+/// The copy process also ignores hidden files and directories by default.
+fn copy_dir(
+    from: &PathBuf,
+    to: &PathBuf,
+    include_globs: &[&str],
+    exclude_globs: &[&str],
+    use_gitignore: bool,
+) -> Result<(), SourceError> {
     // Create the to path because we're going to copy the contents only
     create_all(to, true).unwrap();
 
@@ -130,30 +144,116 @@ fn copy_dir(from: &PathBuf, to: &PathBuf) -> Result<(), SourceError> {
     options.overwrite = true;
     options.content_only = true;
 
-    match copy(from, to, &options) {
-        Ok(_) => tracing::info!(
-            "Copied {} to {}",
-            from.to_string_lossy(),
-            to.to_string_lossy()
-        ),
-        // Use matches as the ErrorKind does not support `==`
-        Err(e) if matches!(e.kind, PermissionDenied) => {
-            tracing::debug!("Permission error in cache, this often happens when the previous run was exited in a faulty way. Removing the cache and retrying the copy.");
-            if let Err(remove_error) = remove(to) {
-                tracing::error!("Failed to remove cache directory: {}", remove_error);
-                return Err(SourceError::FileSystemError(e));
-            } else if let Err(retry_error) = copy(from, to, &options) {
-                tracing::error!("Failed to retry the copy operation: {}", retry_error);
-                return Err(SourceError::FileSystemError(e));
-            } else {
-                tracing::debug!(
-                    "Successfully retried copying {} to {}",
-                    from.to_string_lossy(),
-                    to.to_string_lossy()
-                );
+    let walker = WalkBuilder::new(from)
+        // disregard global gitignore
+        .git_global(false)
+        .git_ignore(use_gitignore)
+        .hidden(true)
+        .build();
+
+    let include_globber = if !include_globs.is_empty() {
+        let mut builder = ignore::gitignore::GitignoreBuilder::new(from);
+        for glob in include_globs {
+            builder.add_line(None, glob)?;
+        }
+        Some(builder.build()?)
+    } else {
+        None
+    };
+
+    let exclude_globber = if !exclude_globs.is_empty() {
+        let mut builder = ignore::gitignore::GitignoreBuilder::new(from);
+        for glob in exclude_globs {
+            builder.add_line(None, glob)?;
+        }
+        Some(builder.build()?)
+    } else {
+        None
+    };
+
+    for entry in walker {
+        let entry = entry?;
+        let path = entry.path();
+        let stripped_path = path.strip_prefix(from)?;
+        let dest_path = to.join(stripped_path);
+        if let Some(include_globber) = &include_globber {
+            match include_globber.matched(path, path.is_dir()) {
+                ignore::Match::None | ignore::Match::Whitelist(_) => {
+                    continue;
+                }
+                ignore::Match::Ignore(_) => {}
             }
         }
-        Err(e) => return Err(SourceError::FileSystemError(e)),
+
+        if let Some(exclude_globber) = &exclude_globber {
+            match exclude_globber.matched(path, path.is_dir()) {
+                ignore::Match::None | ignore::Match::Whitelist(_) => {}
+                ignore::Match::Ignore(_) => {
+                    continue;
+                }
+            }
+        }
+
+        if path.is_dir() {
+            create_all(&dest_path, true).unwrap();
+        } else {
+            let file_options = fs_extra::file::CopyOptions {
+                overwrite: options.overwrite,
+                skip_exist: options.skip_exist,
+                buffer_size: options.buffer_size,
+            };
+            match fs_extra::file::copy(&path, &dest_path, &file_options) {
+                Ok(_) => tracing::debug!(
+                    "Copied {} to {}",
+                    path.to_string_lossy(),
+                    dest_path.to_string_lossy()
+                ),
+                Err(e) => return Err(SourceError::FileSystemError(e)),
+            }
+        }
     }
+
     Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use std::{fs, path::PathBuf};
+
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_copy_dir() {
+        let tmp_dir = tempdir::TempDir::new("test").unwrap().into_path();
+        let dir = tmp_dir.as_path().join("test_copy_dir");
+
+        fs_extra::dir::create_all(&dir, true).unwrap();
+        fs::write(dir.join("test.txt"), "test").unwrap();
+        fs::create_dir(dir.join("test_dir")).unwrap();
+        fs::write(dir.join("test_dir").join("test.md"), "test").unwrap();
+        fs::create_dir(dir.join("test_dir").join("test_dir2")).unwrap();
+
+        let dest_dir = tmp_dir.as_path().join("test_copy_dir_dest");
+        super::copy_dir(&dir, &dest_dir, &[], &[], false).unwrap();
+
+        for entry in walkdir::WalkDir::new(dest_dir) {
+            println!("{}", entry.unwrap().path().display());
+        }
+
+        let dest_dir_2 = tmp_dir.as_path().join("test_copy_dir_dest_2");
+        // ignore all txt files
+        super::copy_dir(&dir, &dest_dir_2, &["*.txt"], &[], false).unwrap();
+        println!("---------------------");
+        for entry in walkdir::WalkDir::new(dest_dir_2) {
+            println!("{}", entry.unwrap().path().display());
+        }
+
+        let dest_dir_2 = tmp_dir.as_path().join("test_copy_dir_dest_2");
+        // ignore all txt files
+        super::copy_dir(&dir, &dest_dir_2, &[], &["*.txt"], false).unwrap();
+        println!("---------------------");
+        for entry in walkdir::WalkDir::new(dest_dir_2) {
+            println!("{}", entry.unwrap().path().display());
+        }
+    }
 }


### PR DESCRIPTION
This will adhere to the gitignore file found in the directory to copy and also allows include / exclude globs to be specified for further filtering.