### PR TITLE
Add support for local source file url scheme

### DIFF
--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -33,6 +33,9 @@ pub enum SourceError {
     #[error("Download could not be validated with checksum!")]
     ValidationFailed,
 
+    #[error("File not found!")]
+    FileNotFound,
+
     #[error("Failed to apply patch: {0}")]
     PatchFailed(String),
 


### PR DESCRIPTION
Allow to specify a local file as source:

```yaml
source:
  - url: file:///build/rich/rich-{{ version }}.tar.gz
    sha256: fb9d6c0a0f643c99eed3875b5377a184132ba9be4d61516a55273d3554d75a39
```

Fix #176

I never wrote any rust before, so this might require some change :-)