### PR TITLE
feat: build .conda package right away

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -220,6 +220,7 @@ pub async fn run_build(
         &difference,
         &directories.host_prefix,
         &directories.output_dir,
+        output.build_configuration.package_format,
     )?;
 
     if !output.build_configuration.no_clean {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,4 +1,5 @@
 //! All the metadata that makes up a recipe file
+use rattler_conda_types::package::ArchiveType;
 use rattler_conda_types::package::EntryPoint;
 use rattler_conda_types::NoArchType;
 use rattler_conda_types::PackageName;
@@ -440,6 +441,8 @@ pub struct BuildConfiguration {
     pub timestamp: chrono::DateTime<chrono::Utc>,
     /// All subpackages coming from this output or other outputs from the same recipe
     pub subpackages: BTreeMap<PackageName, PackageIdentifier>,
+    /// Package format (.tar.bz2 or .conda)
+    pub package_format: ArchiveType,
 }
 
 impl BuildConfiguration {


### PR DESCRIPTION
Add a new command line option to build a `.conda` package straight away instead of a `.tar.bz2`.

Fix #170 