### PR TITLE
Fix: Do not use PathBuf in arguments

### DIFF
--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -136,8 +136,8 @@ fn extract(
 ///
 /// The copy process also ignores hidden files and directories by default.
 fn copy_dir(
-    from: &PathBuf,
-    to: &PathBuf,
+    from: &Path,
+    to: &Path,
     include_globs: &[&str],
     exclude_globs: &[&str],
     use_gitignore: bool,


### PR DESCRIPTION
We can use `&Path` here, as `PathBuf` dereferences to that.