### PR TITLE
Make copy_dir() return copied pathes

### DIFF
--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -1,6 +1,6 @@
 use std::{
     fs,
-    path::{Path, StripPrefixError},
+    path::{Path, PathBuf, StripPrefixError},
     process::Command,
 };
 


### PR DESCRIPTION
This patch makes the `copy_dir()` function return the pathes it copied (targets, not sources).

This is needed so the fn is more useful when using it to rewrite copy functionality later.