### PR TITLE
Fix: Use dtolnay/rust-toolchain to install rustfmt component

### DIFF
--- a/.github/workflows/rust-compile.yml
+++ b/.github/workflows/rust-compile.yml
@@ -75,9 +75,9 @@ jobs:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@master
         with:
+          components: rustfmt
           toolchain: 1.70.0
       - uses: Swatinem/rust-cache@v2
-      - run: rustup component add rustfmt
       - run: cargo fmt --all -- --check
 
   clippy:


### PR DESCRIPTION
Change the GH action to use `dtolnay/rust-toolchain` (which is used anyways) to install the `rustfmt` component, hopefully showing off a few seconds of the overall duration of the job.