### PR TITLE
WIP Multi outputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1403,9 +1403,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.33.0"
+version = "1.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aa511b2e298cd49b1856746f6bb73e17036bcd66b25f5e92cdcdbec9bd75686"
+checksum = "5d64600be34b2fcfc267740a243fa7744441bb4947a619ac4e5bb6507f35fbfc"
 dependencies = [
  "console",
  "lazy_static",
@@ -3397,9 +3397,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.32.0"
+version = "1.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
+checksum = "4f38200e3ef7995e5ef13baec2f432a6da0aa9ac495b2c0e8f3b7eec2c92d653"
 dependencies = [
  "backtrace",
  "bytes 1.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ sha2 = "0.10.8"
 hex = "0.4.3"
 serde_json = "1.0.107"
 reqwest = "0.11.22"
-tokio = {version = "1.32.0", features = ["rt", "macros", "rt-multi-thread"] }
+tokio = {version = "1.33.0", features = ["rt", "macros", "rt-multi-thread"] }
 itertools = "0.11.0"
 content_inspector = "0.2.4"
 serde_with = "3.3.0"
@@ -61,7 +61,7 @@ clap-verbosity-flag = "2.0.1"
 tracing-core = "0.1.31"
 
 [dev-dependencies]
-insta = {version = "1.33.0", features = ["yaml"] }
+insta = {version = "1.34.0", features = ["yaml"] }
 rstest = "0.18.2"
 
 [profile.dev.package."*"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -243,6 +243,8 @@ async fn run_build_from_args(args: BuildOpts, multi_progress: MultiProgress) -> 
         .find_variants(&recipe_text, &selector_config)
         .expect("Could not compute variants");
 
+    // find all outputs
+
     tracing::info!("Found variants:");
     for variant in &variants {
         let mut table = comfy_table::Table::new();
@@ -344,7 +346,7 @@ async fn run_build_from_args(args: BuildOpts, multi_progress: MultiProgress) -> 
             finalized_dependencies: None,
         };
 
-        run_build(&output, tool_config.clone()).await?;
+        // run_build(&output, tool_config.clone()).await?;
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -243,6 +243,9 @@ async fn run_build_from_args(args: BuildOpts, multi_progress: MultiProgress) -> 
         .find_variants_and_outputs(&recipe_text, &selector_config)
         .expect("Could not compute variants");
 
+    // order outputs topologically
+    // let outputs_variants = order_outputs(outputs_variants);
+
     println!("{:#?}", outputs_variants);
     // find all outputs
     for (orig_recipe_yaml, variants) in outputs_variants {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -218,20 +218,6 @@ pub struct Test {
     pub files: Option<Vec<String>>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
-pub struct Recipe {
-    pub context: BTreeMap<String, serde_yaml::Value>,
-    pub name: String,
-    pub version: String,
-    pub source: Vec<Source>,
-    #[serde(default)]
-    pub build: BuildOptions,
-    #[serde(default)]
-    pub requirements: Requirements,
-    #[serde(default)]
-    pub about: About,
-}
-
 pub struct Metadata {
     pub name: String,
     pub version: String,
@@ -465,6 +451,21 @@ pub struct PackageIdentifier {
     pub build_string: String,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct RecipeOutput {
+    package: Package,
+    #[serde(default)]
+    source: Vec<Source>,
+    #[serde(default)]
+    build: BuildOptions,
+    #[serde(default)]
+    requirements: Requirements,
+    #[serde(default)]
+    about: About,
+    #[serde(default)]
+    test: Option<Test>,
+}
+
 #[serde_as]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RenderedRecipe {
@@ -485,6 +486,9 @@ pub struct RenderedRecipe {
     pub about: About,
     /// The test section of the recipe
     pub test: Option<Test>,
+    /// The outputs section of the recipe
+    #[serde(default)]
+    pub outputs: Vec<RecipeOutput>
 }
 
 impl fmt::Display for GitUrl {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -488,7 +488,7 @@ pub struct RenderedRecipe {
     pub test: Option<Test>,
     /// The outputs section of the recipe
     #[serde(default)]
-    pub outputs: Vec<RecipeOutput>
+    pub outputs: Vec<RecipeOutput>,
 }
 
 impl fmt::Display for GitUrl {


### PR DESCRIPTION
This is the start of implementing support for multiple outputs (and also similar to implement support for multiple _recipes_).

Some points for discussion:

- evaluate and order the build tree, which is dependent on finding the edges of the tree. The edges can be strongly or loosely connected by a `pin_subpackage` expression. If the `pin_subpackage` pins "exact" we might have to build more variants. I am going to create a diagram for this.
- The PR takes the recipe with multiple outputs and splits it into multiple recipes. It follows some merging rules:
  - if the output does not define a version, use the version of the toplevel recipe
  - Should we make the top-level "name" optional? conda-forge uses it for the feedstock name I think
  - We merge the keys of the `about` section, as well as `extra` and `build`, although for `build` the main relevant fields are `number`, `string` and maybe `script`.
