### PR TITLE
fix: align recipes with format repo and update readme

### DIFF
--- a/examples/cargo-edit/recipe.yaml
+++ b/examples/cargo-edit/recipe.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+
 context:
   version: "0.11.9"
 
@@ -24,7 +26,7 @@ test:
     - cargo-upgrade --help
 
 about:
-  home: https://github.com/killercup/cargo-edit
+  homepage: https://github.com/killercup/cargo-edit
   license: MIT
   description: "A utility for managing cargo dependencies from the command line."
   summary: "A utility for managing cargo dependencies from the command line."

--- a/examples/curl/recipe.yaml
+++ b/examples/curl/recipe.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+
 context:
   version: "8.0.1"
 
@@ -26,20 +28,18 @@ requirements:
         - pkg-config
         - libtool
   host:
-    # - openssl
     - if: linux
       then:
         - openssl
 
 about:
-  home: http://curl.haxx.se/
+  homepage: http://curl.haxx.se/
   license: MIT/X derivate (http://curl.haxx.se/docs/copyright.html)
-  license_family: MIT
   license_file: COPYING
   summary: tool and library for transferring data with URL syntax
   description: |
     Curl is an open source command line tool and library for transferring data
     with URL syntax. It is used in command lines or scripts to transfer data.
-  doc_url: https://curl.haxx.se/docs/
-  dev_url: https://github.com/curl/curl
+  documentation: https://curl.haxx.se/docs/
+  repository: https://github.com/curl/curl
   # doc_source_url: https://github.com/curl/curl/tree/master/docs

--- a/examples/rich/recipe.yaml
+++ b/examples/rich/recipe.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+
 context:
   version: "13.4.2"
 
@@ -36,9 +38,8 @@ test:
     - pip
 
 about:
-  home: https://github.com/Textualize/rich
+  homepage: https://github.com/Textualize/rich
   license: MIT
-  license_family: MIT
   license_file: LICENSE
   summary: Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal
   description: |
@@ -47,5 +48,5 @@ about:
     The Rich API makes it easy to add color and style to terminal output. Rich
     can also render pretty tables, progress bars, markdown, syntax highlighted
     source code, tracebacks, and more — out of the box.
-  doc_url: https://rich.readthedocs.io
-  dev_url: https://github.com/Textualize/rich
+  documentation: https://rich.readthedocs.io
+  repository: https://github.com/Textualize/rich

--- a/examples/ros-humble-turtlebot4-msgs/recipe.yaml
+++ b/examples/ros-humble-turtlebot4-msgs/recipe.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+
 package:
   name: ros-humble-turtlebot4-msgs
   version: 1.0.3
@@ -14,7 +16,7 @@ build:
       else: build_ament_cmake.sh
   number: 3
 about:
-  home: https://www.ros.org/
+  homepage: https://www.ros.org/
   license: BSD-3-Clause
   summary: |
     Robot Operating System

--- a/examples/xtensor/recipe.yaml
+++ b/examples/xtensor/recipe.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+
 context:
   name: xtensor
   version: 0.24.6
@@ -42,27 +44,26 @@ requirements:
 
 test:
   commands:
-  - if: unix or emscripten
-    then:
-      - test -d ${PREFIX}/include/xtensor
-      - test -f ${PREFIX}/include/xtensor/xarray.hpp
-      - test -f ${PREFIX}/share/cmake/xtensor/xtensorConfig.cmake
-      - test -f ${PREFIX}/share/cmake/xtensor/xtensorConfigVersion.cmake
-  - if: win
-    then:
-      - if not exist %LIBRARY_PREFIX%\include\xtensor\xarray.hpp (exit 1)
-      - if not exist %LIBRARY_PREFIX%\share\cmake\xtensor\xtensorConfig.cmake (exit 1)
-      - if not exist %LIBRARY_PREFIX%\share\cmake\xtensor\xtensorConfigVersion.cmake (exit 1)
+    - if: unix or emscripten
+      then:
+        - test -d ${PREFIX}/include/xtensor
+        - test -f ${PREFIX}/include/xtensor/xarray.hpp
+        - test -f ${PREFIX}/share/cmake/xtensor/xtensorConfig.cmake
+        - test -f ${PREFIX}/share/cmake/xtensor/xtensorConfigVersion.cmake
+    - if: win
+      then:
+        - if not exist %LIBRARY_PREFIX%\include\xtensor\xarray.hpp (exit 1)
+        - if not exist %LIBRARY_PREFIX%\share\cmake\xtensor\xtensorConfig.cmake (exit 1)
+        - if not exist %LIBRARY_PREFIX%\share\cmake\xtensor\xtensorConfigVersion.cmake (exit 1)
 
 about:
-  home: https://github.com/xtensor-stack/xtensor
+  homepage: https://github.com/xtensor-stack/xtensor
   license: BSD-3-Clause
-  license_family: BSD
   license_file: LICENSE
   summary: The C++ tensor algebra library
   description: Multi dimensional arrays with broadcasting and lazy computing
-  doc_url: https://xtensor.readthedocs.io
-  dev_url: https://github.com/xtensor-stack/xtensor
+  documentation: https://xtensor.readthedocs.io
+  repository: https://github.com/xtensor-stack/xtensor
 
 extra:
   recipe-maintainers:

--- a/src/recipe/snapshots/rattler_build__recipe__stage1__tests__parse.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__stage1__tests__parse.snap
@@ -1,5 +1,6 @@
 ---
 source: src/recipe/stage1.rs
+assertion_line: 446
 expression: raw_recipe
 ---
 RawRecipe {
@@ -304,11 +305,7 @@ RawRecipe {
                     value: "BSD-3-Clause",
                 },
             ),
-            license_family: Some(
-                ScalarNode {
-                    value: "BSD",
-                },
-            ),
+            license_family: None,
             license_file: Some(
                 Scalar(
                     ScalarNode {

--- a/src/recipe/stage2/about.rs
+++ b/src/recipe/stage2/about.rs
@@ -25,6 +25,7 @@ pub struct About {
     repository: Option<Url>,
     documentation: Option<Url>,
     license: Option<License>,
+    license_family: Option<String>,
     license_files: Vec<String>,
     license_url: Option<Url>,
     summary: Option<String>,

--- a/src/recipe/stage2/about.rs
+++ b/src/recipe/stage2/about.rs
@@ -25,7 +25,6 @@ pub struct About {
     repository: Option<Url>,
     documentation: Option<Url>,
     license: Option<License>,
-    license_family: Option<String>,
     license_files: Vec<String>,
     license_url: Option<Url>,
     summary: Option<String>,


### PR DESCRIPTION
Updates the README to use the content from the recipes in the example folder.

Also adds a validation reference to the top of every recipe to ensure it follows the schema setup in: https://github.com/prefix-dev/recipe-format

We are aware that the `test` section is not compatible with the recipe-format yaml.