### PR TITLE
feat(recipe): Expand `TryConvertNode` implementations to include `Option`

### DIFF
--- a/src/recipe/custom_yaml.rs
+++ b/src/recipe/custom_yaml.rs
@@ -1071,6 +1071,27 @@ impl TryConvertNode<Url> for RenderedScalarNode {
     }
 }
 
+impl<T> TryConvertNode<Option<T>> for RenderedNode
+where
+    RenderedNode: TryConvertNode<T>,
+{
+    fn try_convert(&self, name: &str) -> Result<Option<T>, PartialParsingError> {
+        match self {
+            RenderedNode::Null(_) => Ok(None),
+            _ => Ok(Some(self.try_convert(name)?)),
+        }
+    }
+}
+
+impl<T> TryConvertNode<Option<T>> for RenderedScalarNode
+where
+    RenderedScalarNode: TryConvertNode<T>,
+{
+    fn try_convert(&self, name: &str) -> Result<Option<T>, PartialParsingError> {
+        self.try_convert(name).map(|v| Some(v))
+    }
+}
+
 impl<T> TryConvertNode<Vec<T>> for RenderedNode
 where
     RenderedNode: TryConvertNode<T>,

--- a/src/recipe/custom_yaml.rs
+++ b/src/recipe/custom_yaml.rs
@@ -1097,6 +1097,14 @@ where
     RenderedNode: TryConvertNode<T>,
     RenderedScalarNode: TryConvertNode<T>,
 {
+    /// # Caveats
+    /// Converting the node into a vector may result in a empty vector if the node is null.
+    ///
+    /// If that is not the desired behavior, and you want to handle the case of a null node
+    /// differently, specify the result to be `Option<Vec<_>>` instead.
+    ///
+    /// Alternatively, you can also specify the result to be `Vec<Option<_>>` to handle the
+    /// case of a null node in other ways.
     fn try_convert(&self, name: &str) -> Result<Vec<T>, PartialParsingError> {
         match self {
             RenderedNode::Scalar(s) => {

--- a/src/recipe/custom_yaml/rendered.rs
+++ b/src/recipe/custom_yaml/rendered.rs
@@ -648,7 +648,14 @@ impl Render<RenderedMappingNode> for MappingNode {
 
 impl Render<RenderedNode> for SequenceNode {
     fn render(&self, jinja: &Jinja, name: &str) -> Result<RenderedNode, PartialParsingError> {
-        let rendered = self.render(jinja, name)?;
+        let rendered: RenderedSequenceNode = self.render(jinja, name)?;
+
+        if rendered.is_empty() {
+            return Ok(RenderedNode::Null(RenderedScalarNode::new(
+                *self.span(),
+                String::new(),
+            )));
+        }
 
         Ok(RenderedNode::Sequence(rendered))
     }

--- a/src/recipe/parser/about.rs
+++ b/src/recipe/parser/about.rs
@@ -99,23 +99,23 @@ impl TryConvertNode<About> for RenderedMappingNode {
         for (key, value) in self.iter() {
             let key_str = key.as_str();
             match key_str {
-                "homepage" => about.homepage = Some(value.try_convert(key_str)?),
+                "homepage" => about.homepage = value.try_convert(key_str)?,
                 "repository" => {
-                    about.repository = Some(value.try_convert(key_str)?)
+                    about.repository = value.try_convert(key_str)?
                 }
                 "documentation" => {
-                    about.documentation = Some(value.try_convert(key_str)?)
+                    about.documentation = value.try_convert(key_str)?
                 }
-                "license" => about.license = Some(value.try_convert(key_str)?),
+                "license" => about.license = value.try_convert(key_str)?,
                 "license_family" => {
-                    about.license_family = Some(value.try_convert(key_str)?)
+                    about.license_family = value.try_convert(key_str)?
                 }
                 "license_file" => about.license_files = value.try_convert(key_str)?,
-                "license_url" => about.license_url = Some(value.try_convert(key_str)?),
-                "summary" => about.summary = Some(value.try_convert(key_str)?),
-                "description" => about.description = Some(value.try_convert(key_str)?),
+                "license_url" => about.license_url = value.try_convert(key_str)?,
+                "summary" => about.summary = value.try_convert(key_str)?,
+                "description" => about.description = value.try_convert(key_str)?,
                 "prelink_message" => {
-                    about.prelink_message = Some(value.try_convert(key_str)?)
+                    about.prelink_message = value.try_convert(key_str)?
                 }
                 invalid_key => {
                     return Err(_partialerror!(

--- a/src/recipe/parser/build.rs
+++ b/src/recipe/parser/build.rs
@@ -126,7 +126,7 @@ impl TryConvertNode<Build> for RenderedMappingNode {
                     build.number = value.try_convert(key_str)?;
                 }
                 "string" => {
-                    build.string = Some(value.try_convert(key_str)?);
+                    build.string = value.try_convert(key_str)?;
                 }
                 "skip" => {
                     let conds: Vec<bool> = value.try_convert(key_str)?;

--- a/src/recipe/parser/package.rs
+++ b/src/recipe/parser/package.rs
@@ -50,10 +50,10 @@ impl TryConvertNode<Package> for RenderedMappingNode {
             let key_str = key.as_str();
             match key_str {
                 "name" => {
-                    name_val = Some(value.try_convert(key_str)?);
+                    name_val = value.try_convert(key_str)?;
                 }
                 "version" => {
-                    version = Some(value.try_convert(key_str)?);
+                    version = value.try_convert(key_str)?;
                 }
                 invalid => {
                     return Err(_partialerror!(

--- a/src/recipe/parser/source.rs
+++ b/src/recipe/parser/source.rs
@@ -284,7 +284,7 @@ impl TryConvertNode<UrlSource> for RenderedMappingNode {
         for (key, value) in self.iter() {
             let key_str = key.as_str();
             match key_str {
-                "url" => url = Some(value.try_convert(key_str)?),
+                "url" => url = value.try_convert(key_str)?,
                 "sha256" => {
                     let sha256_str: RenderedScalarNode = value.try_convert(key_str)?;
                     let sha256_out = rattler_digest::parse_digest_from_hex::<Sha256>(sha256_str.as_str()).ok_or_else(|| _partialerror!(*sha256_str.span(), ErrorKind::InvalidMd5))?;
@@ -295,9 +295,9 @@ impl TryConvertNode<UrlSource> for RenderedMappingNode {
                     let md5_out = rattler_digest::parse_digest_from_hex::<Md5>(md5_str.as_str()).ok_or_else(|| _partialerror!(*md5_str.span(), ErrorKind::InvalidMd5))?;
                     checksums.push(Checksum::Md5(md5_out));
                 }
-                "file_name" => file_name = Some(value.try_convert(key_str)?),
+                "file_name" => file_name = value.try_convert(key_str)?,
                 "patches" => patches = value.try_convert(key_str)?,
-                "folder" => folder = Some(value.try_convert(key_str)?),
+                "folder" => folder = value.try_convert(key_str)?,
                 invalid_key => {
                     return Err(_partialerror!(
                         *key.span(),
@@ -379,9 +379,9 @@ impl TryConvertNode<PathSource> for RenderedMappingNode {
 
         for (key, value) in self.iter() {
             match key.as_str() {
-                "path" => path = Some(value.try_convert("path")?),
+                "path" => path = value.try_convert("path")?,
                 "patches" => patches = value.try_convert("patches")?,
-                "folder" => folder = Some(value.try_convert("folder")?),
+                "folder" => folder = value.try_convert("folder")?,
                 invalid_key => {
                     return Err(_partialerror!(
                         *key.span(),

--- a/src/variant_config.rs
+++ b/src/variant_config.rs
@@ -347,8 +347,8 @@ impl TryConvertNode<VariantConfig> for RenderedMappingNode {
                     config.zip_keys = Some(zip_keys);
                 }
                 _ => {
-                    let variants: Vec<_> = value.try_convert(key_str)?;
-                    if !variants.is_empty() {
+                    let variants: Option<Vec<_>> = value.try_convert(key_str)?;
+                    if let Some(variants) = variants {
                         config.variants.insert(key_str.to_string(), variants);
                     }
                 }

--- a/src/variant_config.rs
+++ b/src/variant_config.rs
@@ -44,10 +44,10 @@ impl TryConvertNode<Pin> for RenderedMappingNode {
             let key_str = key.as_str();
             match key_str {
                 "max_pin" => {
-                    pin.max_pin = Some(value.try_convert(key_str)?);
+                    pin.max_pin = value.try_convert(key_str)?;
                 }
                 "min_pin" => {
-                    pin.min_pin = Some(value.try_convert(key_str)?);
+                    pin.min_pin = value.try_convert(key_str)?;
                 }
                 _ => {
                     return Err(_partialerror!(
@@ -339,12 +339,10 @@ impl TryConvertNode<VariantConfig> for RenderedMappingNode {
             let key_str = key.as_str();
             match key_str {
                 "pin_run_as_build" => {
-                    let pin_run_as_build = value.try_convert(key_str)?;
-                    config.pin_run_as_build = Some(pin_run_as_build);
+                    config.pin_run_as_build = value.try_convert(key_str)?;
                 }
                 "zip_keys" => {
-                    let zip_keys = value.try_convert(key_str)?;
-                    config.zip_keys = Some(zip_keys);
+                    config.zip_keys = value.try_convert(key_str)?;
                 }
                 _ => {
                     let variants: Option<Vec<_>> = value.try_convert(key_str)?;


### PR DESCRIPTION
This also allowed me to find a bug where in a particular case rendering YAML sequences should render as a null node but was resulting in an empty `Vec`.