### PR TITLE
Add reference to installation via homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ works as a standalone binary.
 You can grab a prerelease version of `rattler-build` from the [Github
 Releases](https://github.com/prefix-dev/rattler-build/releases/).
 
+Alternatively, you can install `rattler-build` via Homebrew:
+
+```
+brew install pavelzw/pavelzw/rattler-build
+```
+
 #### Dependencies
 
 Currently `rattler-build` needs some dependencies on the host system which are


### PR DESCRIPTION
I added a homebrew formula for rattler-build to my private tap. Will merge into homebrew-core once this repo hits 100 stars.
https://github.com/pavelzw/homebrew-pavelzw/pull/125

Formula at https://github.com/pavelzw/homebrew-pavelzw/blob/main/Formula/rattler-build.rb

Since this formula doesn't provide pre-built bottles, the installation via homebrew takes ~1.5min