### PR TITLE
feat: no-build-id aka static build dirs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -298,6 +298,7 @@ async fn run_build_from_args(args: BuildOpts, multi_progress: MultiProgress) -> 
                 .clone()
                 .unwrap_or(vec!["conda-forge".to_string()]);
 
+            let timestamp = chrono::Utc::now();
             let output = rattler_build::metadata::Output {
                 recipe,
                 build_configuration: BuildConfiguration {
@@ -315,10 +316,11 @@ async fn run_build_from_args(args: BuildOpts, multi_progress: MultiProgress) -> 
                         &recipe_path,
                         &args.output_dir,
                         args.no_build_id,
+                        &timestamp,
                     )
                     .into_diagnostic()?,
                     channels,
-                    timestamp: chrono::Utc::now(),
+                    timestamp,
                     subpackages,
                     package_format: match args.package_format {
                         PackageFormat::TarBz2 => ArchiveType::TarBz2,

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,6 +95,10 @@ struct BuildOpts {
     #[clap(long, env = "CONDA_BLD_PATH", default_value = "./output")]
     output_dir: PathBuf,
 
+    /// Don't use build id(timestamp) when creating build directory name. Defaults to `false`.
+    #[arg(long)]
+    no_build_id: bool,
+
     /// The package format to use for the build.
     /// Defaults to `.tar.bz2`.
     #[arg(long, default_value = "tar-bz2")]
@@ -310,6 +314,7 @@ async fn run_build_from_args(args: BuildOpts, multi_progress: MultiProgress) -> 
                         name.as_normalized(),
                         &recipe_path,
                         &args.output_dir,
+                        args.no_build_id,
                     )
                     .into_diagnostic()?,
                     channels,

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -70,11 +70,15 @@ pub struct Directories {
     pub output_dir: PathBuf,
 }
 
-fn setup_build_dir(name: &str) -> Result<PathBuf, std::io::Error> {
+fn setup_build_dir(name: &str, build_id: bool) -> Result<PathBuf, std::io::Error> {
     let now = SystemTime::now();
     let since_the_epoch = now.duration_since(UNIX_EPOCH).expect("Time went backwards");
 
-    let dirname = format!("rattler-build_{}_{:?}", name, since_the_epoch.as_millis());
+    let dirname = if build_id {
+        format!("rattler-build_{}", name)
+    } else {
+        format!("rattler-build_{}_{:?}", name, since_the_epoch.as_millis())
+    };
     let path = env::temp_dir().join(dirname);
     fs::create_dir_all(path.join("work"))?;
     Ok(path)
@@ -85,8 +89,9 @@ impl Directories {
         name: &str,
         recipe_path: &Path,
         output_dir: &Path,
+        build_id: bool,
     ) -> Result<Directories, std::io::Error> {
-        let build_dir = setup_build_dir(name).expect("Could not create build directory");
+        let build_dir = setup_build_dir(name, build_id).expect("Could not create build directory");
         let recipe_dir = recipe_path.parent().unwrap().to_path_buf();
 
         if !output_dir.exists() {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -286,21 +286,18 @@ mod tests {
 
     #[test]
     fn setup_build_dir_test() {
-        let temp_dir = std::env::temp_dir();
-        let temp_dir = temp_dir.to_str().unwrap();
-
         // without build_id (aka timestamp)
         let p1 = setup_build_dir("name", true, &Utc::now()).unwrap();
-        let ps1 = p1.to_str().unwrap();
-        assert!(ps1.eq(&format!("{temp_dir}rattler-build_name")));
-        _ = ps1;
+        let f1 = p1.file_name().unwrap();
+        assert!(f1.eq("rattler-build_name"));
         _ = std::fs::remove_dir_all(p1);
 
         // with build_id (aka timestamp)
-        let p2 = setup_build_dir("name", false, &Utc::now()).unwrap();
-        let ps2 = p2.to_str().unwrap();
-        assert!(ps2.starts_with(&format!("{temp_dir}rattler-build_name_")));
-        _ = ps2;
+        let timestamp = &Utc::now();
+        let p2 = setup_build_dir("name", false, &timestamp).unwrap();
+        let f2 = p2.file_name().unwrap().to_string_lossy();
+        let epoch = timestamp.timestamp();
+        assert!(f2.eq(&format!("rattler-build_name_{}", epoch.to_string())));
         _ = std::fs::remove_dir_all(p2);
     }
 }


### PR DESCRIPTION
Adds build option akin to conda with `--no-build-id`. 

Tasks:
- [x] Add cli flag.
- [x] Add tests?

Notes:
- Discuss, if we should provide an ENV variable as well to setup the flag?
- Figure out, how to add tests for the newly added option.

Fixes #248