### PR TITLE
feat: add cdt function

### DIFF
--- a/src/recipe/jinja.rs
+++ b/src/recipe/jinja.rs
@@ -97,13 +97,13 @@ fn set_jinja(config: &SelectorConfig) -> minijinja::Environment<'static> {
             let version = Version::from_str(version).map_err(|e| {
                 minijinja::Error::new(
                     minijinja::ErrorKind::CannotDeserialize,
-                    format!("Failed to deserialize `version`: {}", e.to_string()),
+                    format!("Failed to deserialize `version`: {}", e),
                 )
             })?;
             let version_spec = VersionSpec::from_str(spec).map_err(|e| {
                 minijinja::Error::new(
                     minijinja::ErrorKind::SyntaxError,
-                    format!("Bad syntax for `spec`: {}", e.to_string()),
+                    format!("Bad syntax for `spec`: {}", e),
                 )
             })?;
             Ok(version_spec.matches(&version))

--- a/src/recipe/jinja.rs
+++ b/src/recipe/jinja.rs
@@ -18,7 +18,7 @@ pub struct Jinja<'a> {
 impl<'a> Jinja<'a> {
     /// Create a new Jinja instance with the given selector configuration.
     pub fn new(config: SelectorConfig) -> Self {
-        let env = set_jinja();
+        let env = set_jinja(&config);
         let context = config.into_context();
         Self { env, context }
     }
@@ -66,7 +66,7 @@ impl<'a> Jinja<'a> {
 impl Default for Jinja<'_> {
     fn default() -> Self {
         Self {
-            env: set_jinja(),
+            env: set_jinja(&SelectorConfig::default()),
             context: BTreeMap::new(),
         }
     }
@@ -78,7 +78,7 @@ impl<'a> Extend<(String, Value)> for Jinja<'a> {
     }
 }
 
-fn set_jinja() -> minijinja::Environment<'static> {
+fn set_jinja(config: &SelectorConfig) -> minijinja::Environment<'static> {
     use rattler_conda_types::version_spec::VersionSpec;
     let mut env = minijinja::Environment::new();
     env.set_syntax(minijinja::Syntax {
@@ -94,13 +94,70 @@ fn set_jinja() -> minijinja::Environment<'static> {
     env.add_function("cmp", |a: &Value, spec: &str| {
         if let Some(version) = a.as_str() {
             // check if version matches spec
-            let version = Version::from_str(version).unwrap();
-            let version_spec = VersionSpec::from_str(spec).unwrap();
+            let version = Version::from_str(version).map_err(|e| {
+                minijinja::Error::new(
+                    minijinja::ErrorKind::CannotDeserialize,
+                    format!("Failed to deserialize `version`: {}", e.to_string()),
+                )
+            })?;
+            let version_spec = VersionSpec::from_str(spec).map_err(|e| {
+                minijinja::Error::new(
+                    minijinja::ErrorKind::SyntaxError,
+                    format!("Bad syntax for `spec`: {}", e.to_string()),
+                )
+            })?;
             Ok(version_spec.matches(&version))
         } else {
             // if a is undefined, we are currently searching for all variants and thus return true
             Ok(true)
         }
+    });
+
+    let SelectorConfig {
+        target_platform,
+        build_platform,
+        variant,
+        ..
+    } = config.clone();
+    env.add_function("cdt", move |package_name: String| {
+        use rattler_conda_types::Arch;
+
+        let arch = build_platform
+            .arch()
+            .or_else(|| target_platform.arch())
+            .ok_or_else(|| {
+                minijinja::Error::new(
+                    minijinja::ErrorKind::UndefinedError,
+                    "No target or build architecture provided.",
+                )
+            })?;
+
+        let arch_str = format!("{arch}");
+        let cdt_arch = match arch {
+            Arch::X86_64 => "x86_64",
+            Arch::Ppc64le => "ppc64le",
+            Arch::Ppc64 => "ppc64",
+            Arch::Aarch64 => "aarch64",
+            Arch::S390X => "s390x",
+            Arch::X86 => "i686",
+            _ => arch_str.as_str(),
+        };
+
+        let cdt_name = variant.get("cdt_name").map_or(
+            match arch {
+                Arch::S390X | Arch::Aarch64 | Arch::Ppc64le | Arch::Ppc64 => "cos7",
+                _ => "cos6",
+            },
+            String::as_str,
+        );
+
+        let res = package_name.split_once(' ').map_or_else(
+            || format!("{package_name}-{cdt_name}-{cdt_arch}"),
+            |(name, ver_build)| format!("{name}-{cdt_name}-{cdt_arch} {ver_build}"),
+        );
+        tracing::info!("cdt: {res}");
+
+        Ok(res)
     });
 
     env.add_function("compiler", |lang: String| {
@@ -205,6 +262,93 @@ mod tests {
         let jinja = Jinja::new(options);
 
         assert!(jinja.eval("${{ true if win }}").expect("test 1").is_true());
+    }
+
+    #[test]
+    fn eval_cdt_x86_64() {
+        let variant = BTreeMap::new();
+        let options = SelectorConfig {
+            target_platform: Platform::Linux64,
+            build_platform: Platform::Linux64,
+            variant,
+            hash: None,
+        };
+        let jinja = Jinja::new(options);
+
+        assert_eq!(
+            jinja
+                .eval("cdt('package_name v0.1.2')")
+                .expect("test 1")
+                .to_string()
+                .as_str(),
+            "package_name-cos6-x86_64 v0.1.2"
+        );
+        assert_eq!(
+            jinja
+                .eval("cdt('package_name')")
+                .expect("test 1")
+                .to_string()
+                .as_str(),
+            "package_name-cos6-x86_64"
+        );
+    }
+
+    #[test]
+    fn eval_cdt_aarch64() {
+        let variant = BTreeMap::new();
+        let options = SelectorConfig {
+            target_platform: Platform::LinuxAarch64,
+            build_platform: Platform::LinuxAarch64,
+            variant,
+            hash: None,
+        };
+        let jinja = Jinja::new(options);
+
+        assert_eq!(
+            jinja
+                .eval("cdt('package_name v0.1.2')")
+                .expect("test 1")
+                .to_string()
+                .as_str(),
+            "package_name-cos7-aarch64 v0.1.2"
+        );
+        assert_eq!(
+            jinja
+                .eval("cdt('package_name')")
+                .expect("test 1")
+                .to_string()
+                .as_str(),
+            "package_name-cos7-aarch64"
+        );
+    }
+
+    #[test]
+    fn eval_cdt_arm6() {
+        let variant = BTreeMap::new();
+        let options = SelectorConfig {
+            target_platform: Platform::LinuxArmV6l,
+            build_platform: Platform::LinuxArmV6l,
+            variant,
+            hash: None,
+        };
+        let jinja = Jinja::new(options);
+
+        assert_eq!(
+            jinja
+                .eval("cdt('package_name v0.1.2')")
+                .expect("test 1")
+                .to_string()
+                .as_str(),
+            "package_name-cos6-armv6l v0.1.2"
+        );
+        assert_eq!(
+            jinja
+                .eval("cdt('package_name')")
+                .expect("test 1")
+                .to_string()
+                .as_str(),
+            "package_name-cos6-armv6l"
+        );
     }
 
     #[test]

--- a/src/used_variables.rs
+++ b/src/used_variables.rs
@@ -68,6 +68,9 @@ fn extract_variable_from_expression(expr: &Expr, variables: &mut HashSet<String>
                     if let Expr::Const(constant) = &call.args[0] {
                         variables.insert(format!("{}", &constant.value));
                     }
+                } else if function == "cdt" {
+                    variables.insert("cdt_name".into());
+                    variables.insert("cdt_arch".into());
                 }
             }
         }


### PR DESCRIPTION
TODO:
- [x] Add cdt function, as per, https://github.com/conda/conda-build/blob/e2916a2a5c590382323de97da6ac2fe6c516ff89/conda_build/jinja_context.py#L540
- [x] Add basic tests
- [ ] ~~Add end to end tests?~~

Notes:
- Discuss the approach to providing config into the set_jinja function. (currently we can't avoid clone, there are ways around it but would need some rearchitecturing)
- Made changes to a couple places where the unwrap was quite unbearable for my OCD(unwrapping while parsing doesn't seem nice).
- Figure out how to add end to end tests.

Fixes #91