### PR TITLE
Don't use cross for x86_64-unknown-linux-gnu

### DIFF
--- a/.github/workflows/rust-compile.yml
+++ b/.github/workflows/rust-compile.yml
@@ -88,7 +88,7 @@ jobs:
           - { target: aarch64-apple-darwin        , os: macos-11 }
           # - { target: x86_64-pc-windows-gnu       , os: windows-2019 }
           - { target: x86_64-pc-windows-msvc      , os: windows-2019 }
-          - { target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04, use-cross: true }
+          - { target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04 }
           # - { target: x86_64-unknown-linux-musl   , os: ubuntu-20.04, use-cross: true }
     env:
       BUILD_CMD: cargo


### PR DESCRIPTION
It seems that when cross is activated, a very old (1.0) openssl version is linked which isn't available on modern systems.