### PR TITLE
Improve rendering of DependencyInfo

### DIFF
--- a/src/render/resolved_dependencies.rs
+++ b/src/render/resolved_dependencies.rs
@@ -632,8 +632,12 @@ mod tests {
             DependencyInfo::Compiler {
                 spec: MatchSpec::from_str("foo").unwrap(),
             },
-            DependencyInfo::PinSubpackage { spec: MatchSpec::from_str("baz").unwrap() },
-            DependencyInfo::PinCompatible { spec: MatchSpec::from_str("bat").unwrap() },
+            DependencyInfo::PinSubpackage {
+                spec: MatchSpec::from_str("baz").unwrap(),
+            },
+            DependencyInfo::PinCompatible {
+                spec: MatchSpec::from_str("bat").unwrap(),
+            },
         ];
         let yaml_str = serde_yaml::to_string(&dep_info).unwrap();
         insta::assert_snapshot!(yaml_str);

--- a/src/render/resolved_dependencies.rs
+++ b/src/render/resolved_dependencies.rs
@@ -612,3 +612,23 @@ pub async fn resolve_dependencies(
         run: run_specs,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    // test rendering of DependencyInfo
+    use super::*;
+
+    #[test]
+    fn test_dependency_info_render() {
+        let dep_info = vec![DependencyInfo::Variant {
+            spec: MatchSpec::from_str("foo").unwrap(),
+            variant: "bar".to_string(),
+        },
+        DependencyInfo::Compiler {
+            spec: MatchSpec::from_str("foo").unwrap(),
+        },
+        ];
+        let yaml_str = serde_yaml::to_string(&dep_info).unwrap();
+        insta::assert_snapshot!(yaml_str);
+    }
+}

--- a/src/render/snapshots/rattler_build__render__resolved_dependencies__tests__dependency_info_render.snap
+++ b/src/render/snapshots/rattler_build__render__resolved_dependencies__tests__dependency_info_render.snap
@@ -1,0 +1,16 @@
+---
+source: src/render/resolved_dependencies.rs
+expression: yaml_str
+---
+- source: raw
+  spec: xyz
+- source: variant
+  spec: foo
+  variant: bar
+- source: compiler
+  spec: foo
+- source: pin_subpackage
+  spec: baz
+- source: pin_compatible
+  spec: bat
+

--- a/src/snapshots/rattler_build__metadata__test__read_full_recipe-2.snap
+++ b/src/snapshots/rattler_build__metadata__test__read_full_recipe-2.snap
@@ -86,16 +86,16 @@ build_configuration:
 finalized_dependencies:
   build:
     specs:
-      - Compiler:
-          spec: clang_osx-arm64
-      - Raw:
-          spec: make
-      - Raw:
-          spec: perl
-      - Raw:
-          spec: pkg-config
-      - Raw:
-          spec: libtool
+      - source: compiler
+        spec: clang_osx-arm64
+      - source: raw
+        spec: make
+      - source: raw
+        spec: perl
+      - source: raw
+        spec: pkg-config
+      - source: raw
+        spec: libtool
     resolved:
       - build: he57ea6c_1
         build_number: 1

--- a/src/snapshots/rattler_build__metadata__test__read_full_recipe.snap
+++ b/src/snapshots/rattler_build__metadata__test__read_full_recipe.snap
@@ -93,12 +93,12 @@ finalized_dependencies:
   build: ~
   host:
     specs:
-      - Raw:
-          spec: pip
-      - Raw:
-          spec: poetry-core >=1.0.0
-      - Raw:
-          spec: python ==3.10
+      - source: raw
+        spec: pip
+      - source: raw
+        spec: poetry-core >=1.0.0
+      - source: raw
+        spec: python ==3.10
     resolved:
       - build: h43b31ca_3_cpython
         build_number: 3
@@ -392,18 +392,18 @@ finalized_dependencies:
           - python
   run:
     depends:
-      - Raw:
-          spec: markdown-it-py >=2.2.0
-      - Raw:
-          spec: "pygments >=2.13.0,<3.0.0"
-      - Raw:
-          spec: python ==3.10
-      - Raw:
-          spec: "typing_extensions >=4.0.0,<5.0.0"
-      - RunExports:
-          spec: python
-          from: host
-          source_package: python
+      - source: raw
+        spec: markdown-it-py >=2.2.0
+      - source: raw
+        spec: "pygments >=2.13.0,<3.0.0"
+      - source: raw
+        spec: python ==3.10
+      - source: raw
+        spec: "typing_extensions >=4.0.0,<5.0.0"
+      - source: run_export
+        spec: python
+        from: host
+        source_package: python
     constrains: []
     run_exports: ~
 

--- a/src/snapshots/rattler_build__metadata__test__resolved_dependencies_rendering.snap
+++ b/src/snapshots/rattler_build__metadata__test__resolved_dependencies_rendering.snap
@@ -3,8 +3,8 @@ source: src/metadata.rs
 expression: resolved_dependencies
 ---
 specs:
-  - Raw:
-      spec: python 3.12.* h12332
+  - source: raw
+    spec: python 3.12.* h12332
 resolved:
   - arch: x86_64
     build: h123

--- a/test-data/rendered_recipes/curl_recipe.yaml
+++ b/test-data/rendered_recipes/curl_recipe.yaml
@@ -84,15 +84,15 @@ build_configuration:
 finalized_dependencies:
   build:
     specs:
-    - !Compiler
+    - source: compiler
       spec: clang_osx-arm64
-    - !Raw
+    - source: raw
       spec: make
-    - !Raw
+    - source: raw
       spec: perl
-    - !Raw
+    - source: raw
       spec: pkg-config
-    - !Raw
+    - source: raw
       spec: libtool
     resolved:
     - build: he57ea6c_1

--- a/test-data/rendered_recipes/dependencies.yaml
+++ b/test-data/rendered_recipes/dependencies.yaml
@@ -1,9 +1,9 @@
 specs:
-  - !Raw
+  - source: raw
     spec: pip
-  - !Raw
+  - source: raw
     spec: poetry-core >=1.0.0
-  - !Raw
+  - source: raw
     spec: python ==3.10
 resolved:
   - build: h43b31ca_3_cpython

--- a/test-data/rendered_recipes/rich_recipe.yaml
+++ b/test-data/rendered_recipes/rich_recipe.yaml
@@ -94,11 +94,11 @@ finalized_dependencies:
   build: null
   host:
     specs:
-    - !Raw
+    - source: raw
       spec: pip
-    - !Raw
+    - source: raw
       spec: poetry-core >=1.0.0
-    - !Raw
+    - source: raw
       spec: python ==3.10
     resolved:
     - build: h43b31ca_3_cpython
@@ -393,15 +393,15 @@ finalized_dependencies:
         - python
   run:
     depends:
-    - !Raw
+    - source: raw
       spec: markdown-it-py >=2.2.0
-    - !Raw
+    - source: raw
       spec: pygments >=2.13.0,<3.0.0
-    - !Raw
+    - source: raw
       spec: python ==3.10
-    - !Raw
+    - source: raw
       spec: typing_extensions >=4.0.0,<5.0.0
-    - !RunExports
+    - source: run_export
       spec: python
       from: host
       source_package: python


### PR DESCRIPTION
I want to get rid of the YAML tagging. 
Currently this renders as `!Raw`, `!Compiler`, etc.