### PR TITLE
feat: package content tests 

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -283,6 +283,10 @@ pub async fn run_build(
         )
         .await
         .into_diagnostic()?;
+
+        test::run_package_content_tests(output.recipe.test().package_content())
+            .await
+            .into_diagnostic()?;
     }
 
     if !tool_configuration.no_clean {

--- a/src/recipe/parser.rs
+++ b/src/recipe/parser.rs
@@ -31,7 +31,7 @@ pub use self::{
     package::{OutputPackage, Package},
     requirements::{Compiler, Dependency, PinSubpackage, Requirements},
     source::{Checksum, GitSource, GitUrl, PathSource, Source, UrlSource},
-    test::Test,
+    test::{PackageContent, Test},
 };
 
 use super::custom_yaml::Node;

--- a/src/recipe/parser/test.rs
+++ b/src/recipe/parser/test.rs
@@ -1,13 +1,9 @@
-use std::backtrace;
-
 use serde::{Deserialize, Serialize};
 
 use crate::{
     _partialerror,
     recipe::{
-        custom_yaml::{
-            HasSpan, RenderedMappingNode, RenderedNode, RenderedScalarNode, TryConvertNode,
-        },
+        custom_yaml::{HasSpan, RenderedMappingNode, RenderedNode, TryConvertNode},
         error::{ErrorKind, PartialParsingError},
     },
 };
@@ -25,11 +21,12 @@ pub struct Test {
     source_files: Vec<String>,
     /// Extra files to be copied to the test environment from the build dir (can be globs)
     files: Vec<String>,
-    /// TODO: use a better name: All new test section
+    /// <!-- TODO: use a better name: --> All new test section
     package_contents: PackageContent,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+/// PackageContent
 pub struct PackageContent {
     /// file paths, direct and/or globs
     files: Vec<String>,
@@ -116,6 +113,11 @@ impl TryConvertNode<PackageContent> for RenderedMappingNode {
 }
 
 impl Test {
+    /// Get package content.
+    pub fn package_content(&self) -> &PackageContent {
+        &self.package_contents
+    }
+
     /// Get the imports.
     pub fn imports(&self) -> &[String] {
         self.imports.as_slice()


### PR DESCRIPTION
TODO:
- [x] Parsing
- [x] Basic implementation for tests
- [ ] site_packages scanning (not sure for which python installation)
- [ ] add e2e tests
- [ ] perhaps? provide cli flags to just run the package contents test or to skip it?

fix https://github.com/prefix-dev/rattler-build/issues/307