### PR TITLE
Fix jinja string interp instructions

### DIFF
--- a/docs/recipe_file.md
+++ b/docs/recipe_file.md
@@ -30,8 +30,8 @@ The reason for a new spec are:
 - no full Jinja2 support: no conditional or `{% set ...` support, only string
   interpolation. Variables can be set in the toplevel "context" which is valid
   YAML
-- Jinja string interpolation needs to be quoted at the beginning of a string,
-  e.g. `- "{{ version }}"` in order for it to be valid YAML
+- Jinja string interpolation needs to be preceded by a dollar sign at the beginning of a string,
+  e.g. `- ${{ version }}` in order for it to be valid YAML
 - Selectors use a YAML dictionary style (vs. comments in conda-build). Instead of `- somepkg  #[osx]` 
   we use
    ```yaml


### PR DESCRIPTION
Explains using the new jinja string interp syntax for `recipe.yaml` as described in https://github.com/conda-incubator/ceps/pull/54 