### PR TITLE
fix: handling both forward and backward slash

### DIFF
--- a/src/packaging.rs
+++ b/src/packaging.rs
@@ -112,16 +112,15 @@ fn contains_prefix_text(file_path: &Path, prefix: &Path) -> Result<bool, Packagi
     buf_reader.read_to_string(&mut content)?;
 
     // Check if the content contains the prefix
-    let prefix = prefix.to_string_lossy().to_string();
     #[allow(unused_mut)]
-    let mut contains_prefix = content.contains(&prefix);
+    let mut contains_prefix = content.contains(&prefix.to_string_lossy().to_string());
     #[cfg(target_os = "windows")]
     {
         // absolute and unc paths will break but it,
         // will break either way as C:/ can't be converted
         // to something meaningful in unix either way
-        let prefix_str = to_forward_slash_lossy(prefix).to_string();
-        contains_prefix += content.contains(prefix_str);
+        contains_prefix =
+            contains_prefix || content.contains(&to_forward_slash_lossy(prefix).to_string());
     }
 
     Ok(contains_prefix)

--- a/src/packaging.rs
+++ b/src/packaging.rs
@@ -113,9 +113,55 @@ fn contains_prefix_text(file_path: &Path, prefix: &Path) -> Result<bool, Packagi
 
     // Check if the content contains the prefix
     let prefix = prefix.to_string_lossy().to_string();
-    let contains_prefix = content.contains(&prefix);
+    #[allow(unused_mut)]
+    let mut contains_prefix = content.contains(&prefix);
+    #[cfg(target_os = "windows")]
+    {
+        // absolute and unc paths will break but it,
+        // will break either way as C:/ can't be converted
+        // to something meaningful in unix either way
+        let prefix_str = to_forward_slash_lossy(prefix).to_string();
+        contains_prefix += content.contains(prefix_str);
+    }
 
     Ok(contains_prefix)
+}
+
+#[allow(dead_code)]
+fn to_forward_slash_lossy(path: &Path) -> std::borrow::Cow<'_, str> {
+    #[cfg(target_os = "windows")]
+    {
+        use std::path::Component;
+        let mut buf = String::new();
+        for c in path.components() {
+            match c {
+                Component::RootDir => { /* root on windows can be skipped */ }
+                Component::CurDir => buf.push('.'),
+                Component::ParentDir => buf.push_str(".."),
+                Component::Prefix(prefix) => {
+                    buf.push_str(&prefix.as_os_str().to_string_lossy());
+                    continue;
+                }
+                Component::Normal(s) => buf.push_str(&s.to_string_lossy()),
+            }
+            // use `/` instead of `\`
+            buf.push('/');
+        }
+
+        fn ends_with_main_sep(p: &Path) -> bool {
+            use std::os::windows::ffi::OsStrExt as _;
+            p.as_os_str().encode_wide().last() == Some(std::path::MAIN_SEPARATOR as u16)
+        }
+        if buf != "/" && !ends_with_main_sep(path) && buf.ends_with('/') {
+            buf.pop();
+        }
+
+        Cow::Owned(buf)
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        path.to_string_lossy()
+    }
 }
 
 fn create_prefix_placeholder(


### PR DESCRIPTION
TODO:
- [x] the conversion code
- [x] ~utf-16 dance~

Note: no utf-16 handling as technically all files can be utf-16 or utf-32 even on linux, and further based on platform we would have to handle le and be(endianness) spec as well. Hence it's better to handle these as binary or a different format all together.

fixes #369