### PR TITLE
refactor: move scipt_env into script

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -3,12 +3,14 @@
 use std::collections::HashSet;
 use std::ffi::OsString;
 
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, ErrorKind, Write};
 
 use fs_err as fs;
 use fs_err::File;
+use std::borrow::Cow;
+use std::path::Path;
+use std::path::PathBuf;
 use std::process::{Command, Stdio};
-use std::{io::Read, path::PathBuf};
 
 use itertools::Itertools;
 use miette::IntoDiagnostic;
@@ -17,6 +19,7 @@ use rattler_shell::shell;
 use crate::env_vars::write_env_script;
 use crate::metadata::{Directories, Output};
 use crate::packaging::{package_conda, record_files};
+use crate::recipe::parser::ScriptContent;
 use crate::render::resolved_dependencies::{install_environments, resolve_dependencies};
 use crate::source::fetch_sources;
 use crate::test::TestConfiguration;
@@ -29,43 +32,69 @@ pub fn get_conda_build_script(
 ) -> Result<PathBuf, std::io::Error> {
     let recipe = &output.recipe;
 
-    let default_script = if output.build_configuration.target_platform.is_windows() {
-        ["build.bat".to_owned()]
+    let script = recipe.build().script();
+    let default_extension = if output.build_configuration.target_platform.is_windows() {
+        "bat"
     } else {
-        ["build.sh".to_owned()]
+        "sh"
     };
-
-    let script = if recipe.build().scripts().is_empty() {
-        &default_script
-    } else {
-        recipe.build().scripts()
-    };
-
-    let script = script.iter().join("\n");
-
-    let script = if script.ends_with(".sh") || script.ends_with(".bat") {
-        let recipe_file = directories.recipe_dir.join(script);
-        tracing::info!("Reading recipe file: {:?}", recipe_file);
-
-        if !recipe_file.exists() {
-            if recipe.build().scripts().is_empty() {
-                tracing::info!("Empty build script");
-                String::new()
+    let script_content = match script.contents() {
+        // The scripts path was not specified or explicitly specified. Use the default
+        // `build.{bat,sh}` if not specified. If the file cannot be found we error out.
+        ScriptContent::Default | ScriptContent::Path(_) => {
+            let path = match script.contents() {
+                ScriptContent::Path(path) => path.as_path(),
+                _ => Path::new("build"),
+            };
+            let path_with_ext = if path.extension() == None {
+                Cow::Owned(path.with_extension(default_extension))
             } else {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::NotFound,
-                    format!("Recipe file {:?} does not exist", recipe_file),
-                ));
+                Cow::Borrowed(path)
+            };
+            let recipe_file = directories.recipe_dir.join(path_with_ext);
+            match std::fs::read_to_string(&recipe_file) {
+                Err(err) if err.kind() == ErrorKind::NotFound => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::NotFound,
+                        format!("recipe file {:?} does not exist", recipe_file.display()),
+                    ));
+                }
+                Err(e) => {
+                    return Err(e);
+                }
+                Ok(content) => content,
             }
-        } else {
-            let mut orig_build_file = File::open(recipe_file)?;
-            let mut orig_build_file_text = String::new();
-            orig_build_file.read_to_string(&mut orig_build_file_text)?;
-            orig_build_file_text
         }
-    } else {
-        script
+        // The scripts content was specified but it is still ambiguous whether it is a path or the
+        // contents of the string. Try to read the file as a script but fall back to using the string
+        // as the contents itself if the file is missing.
+        ScriptContent::CommandOrPath(path) => {
+            let content =
+                if !path.contains('\n') && (path.ends_with(".bat") || path.ends_with(".sh")) {
+                    let recipe_file = directories.recipe_dir.join(Path::new(path));
+                    match std::fs::read_to_string(recipe_file) {
+                        Err(err) if err.kind() == ErrorKind::NotFound => None,
+                        Err(e) => {
+                            return Err(e);
+                        }
+                        Ok(content) => Some(content),
+                    }
+                } else {
+                    None
+                };
+            match content {
+                Some(content) => content,
+                None => path.to_owned(),
+            }
+        }
+        ScriptContent::Commands(commands) => commands.iter().join("\n"),
+        ScriptContent::Command(command) => command.to_owned(),
     };
+
+    if script.interpreter().is_some() {
+        // We don't support an interpreter yet
+        tracing::error!("build.script.interpreter is not supported yet");
+    }
 
     if cfg!(unix) {
         let build_env_script_path = directories.work_dir.join("build_env.sh");
@@ -80,7 +109,7 @@ pub fn get_conda_build_script(
                 format!("Failed to write build env script: {}", e),
             )
         })?;
-        let full_script = format!("{}\n{}", preambel, script);
+        let full_script = format!("{}\n{}", preambel, script_content);
         let build_script_path = directories.work_dir.join("conda_build.sh");
 
         let mut build_script_file = File::create(&build_script_path)?;
@@ -101,7 +130,7 @@ pub fn get_conda_build_script(
             )
         })?;
 
-        let full_script = format!("{}\n{}", preambel, script);
+        let full_script = format!("{}\n{}", preambel, script_content);
         let build_script_path = directories.work_dir.join("conda_build.bat");
 
         let mut build_script_file = File::create(&build_script_path)?;

--- a/src/env_vars.rs
+++ b/src/env_vars.rs
@@ -356,23 +356,11 @@ pub fn write_env_script<T: Shell + Clone>(
         shell_type.set_env_var(&mut s, &k, &v)?;
     }
 
-    for env_key in output.recipe.build().script_env().passthrough() {
-        let var = std::env::var(env_key);
-        if let Ok(var) = var {
-            shell_type.set_env_var(&mut s, env_key, var.as_str())?;
-        } else {
-            tracing::warn!(
-                "Could not find passthrough environment variable: {}",
-                env_key
-            );
-        }
-    }
-
-    for (k, v) in output.recipe.build().script_env().env() {
+    for (k, v) in output.recipe.build().script().env() {
         shell_type.set_env_var(&mut s, k, v)?;
     }
 
-    if !output.recipe.build().script_env().secrets().is_empty() {
+    if !output.recipe.build().script().secrets().is_empty() {
         tracing::error!("Secrets are not supported yet");
     }
 

--- a/src/recipe/parser.rs
+++ b/src/recipe/parser.rs
@@ -21,15 +21,17 @@ mod build;
 mod output;
 mod package;
 mod requirements;
+mod script;
 mod source;
 mod test;
 
 pub use self::{
     about::About,
-    build::{Build, RunExports, ScriptEnv},
+    build::{Build, RunExports},
     output::find_outputs_from_src,
     package::{OutputPackage, Package},
     requirements::{Compiler, Dependency, PinSubpackage, Requirements},
+    script::{Script, ScriptContent},
     source::{Checksum, GitSource, GitUrl, PathSource, Source, UrlSource},
     test::{PackageContent, Test},
 };
@@ -133,7 +135,7 @@ impl Recipe {
                         ErrorKind::InvalidField("recipe".to_string().into()),
                         help =
                             "The recipe field is only allowed in conjunction with multiple outputs"
-                    ))
+                    ));
                 }
                 "source" => source = value.try_convert(key_str)?,
                 "build" => build = value.try_convert(key_str)?,
@@ -146,7 +148,7 @@ impl Recipe {
                     return Err(_partialerror!(
                         *key.span(),
                         ErrorKind::InvalidField(invalid_key.to_string().into()),
-                    ))
+                    ));
                 }
             }
         }

--- a/src/recipe/parser/build.rs
+++ b/src/recipe/parser/build.rs
@@ -1,9 +1,10 @@
 use std::str::FromStr;
 
-use rattler_conda_types::{NoArchKind, NoArchType, package::EntryPoint, PackageName};
+use rattler_conda_types::{package::EntryPoint, NoArchKind, NoArchType, PackageName};
 use serde::{Deserialize, Serialize};
 
 use super::Dependency;
+use crate::recipe::parser::script::Script;
 use crate::{
     _partialerror,
     recipe::{
@@ -14,7 +15,6 @@ use crate::{
         error::{ErrorKind, PartialParsingError},
     },
 };
-use crate::recipe::parser::script::Script;
 
 /// The build options contain information about how to build the package and some additional
 /// metadata about the package.

--- a/src/recipe/parser/build.rs
+++ b/src/recipe/parser/build.rs
@@ -1,8 +1,9 @@
-use std::{collections::BTreeMap, str::FromStr};
+use std::str::FromStr;
 
-use rattler_conda_types::{package::EntryPoint, NoArchKind, NoArchType, PackageName};
+use rattler_conda_types::{NoArchKind, NoArchType, package::EntryPoint, PackageName};
 use serde::{Deserialize, Serialize};
 
+use super::Dependency;
 use crate::{
     _partialerror,
     recipe::{
@@ -13,8 +14,7 @@ use crate::{
         error::{ErrorKind, PartialParsingError},
     },
 };
-
-use super::Dependency;
+use crate::recipe::parser::script::Script;
 
 /// The build options contain information about how to build the package and some additional
 /// metadata about the package.
@@ -29,9 +29,7 @@ pub struct Build {
     pub(super) skip: bool,
     /// The build script can be either a list of commands or a path to a script. By
     /// default, the build script is set to `build.sh` or `build.bat` on Unix and Windows respectively.
-    pub(super) script: Vec<String>,
-    /// Environment variables to pass through or set in the script
-    pub(super) script_env: ScriptEnv,
+    pub(super) script: Script,
     /// A recipe can choose to ignore certain run exports of its dependencies
     pub(super) ignore_run_exports: Vec<PackageName>,
     /// A recipe can choose to ignore all run exports of coming from some packages
@@ -63,13 +61,8 @@ impl Build {
     }
 
     /// Get the build script.
-    pub fn scripts(&self) -> &[String] {
-        self.script.as_slice()
-    }
-
-    /// Get the build script environment.
-    pub const fn script_env(&self) -> &ScriptEnv {
-        &self.script_env
+    pub fn script(&self) -> &Script {
+        &self.script
     }
 
     /// Get run exports.
@@ -134,7 +127,6 @@ impl TryConvertNode<Build> for RenderedMappingNode {
                     build.skip = conds.iter().any(|&v| v);
                 }
                 "script" => build.script = value.try_convert(key_str)?,
-                "script_env" => build.script_env = value.try_convert(key_str)?,
                 "ignore_run_exports" => {
                     build.ignore_run_exports = value.try_convert(key_str)?;
                 }
@@ -162,108 +154,12 @@ impl TryConvertNode<Build> for RenderedMappingNode {
                     return Err(_partialerror!(
                         *key.span(),
                         ErrorKind::InvalidField(invalid.to_string().into()),
-                    ))
+                    ));
                 }
             }
         }
 
         Ok(build)
-    }
-}
-
-/// Extra environment variables to set during the build script execution
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
-pub struct ScriptEnv {
-    /// Environments variables to leak into the build environment from the host system.
-    /// During build time these variables are recorded and stored in the package output.
-    /// Use `secrets` for environment variables that should not be recorded.
-    pub(super) passthrough: Vec<String>,
-    /// Environment variables to set in the build environment.
-    pub(super) env: BTreeMap<String, String>,
-    /// Environment variables to leak into the build environment from the host system that
-    /// contain sensitve information. Use with care because this might make recipes no
-    /// longer reproducible on other machines.
-    pub(super) secrets: Vec<String>,
-}
-
-impl ScriptEnv {
-    /// Check if the script environment is empty is all its fields.
-    pub fn is_empty(&self) -> bool {
-        self.passthrough.is_empty() && self.env.is_empty() && self.secrets.is_empty()
-    }
-
-    /// Get the passthrough environment variables.
-    ///
-    /// Those are the environments variables to leak into the build environment from the host system.
-    ///
-    /// During build time these variables are recorded and stored in the package output.
-    /// Use `secrets` for environment variables that should not be recorded.
-    pub fn passthrough(&self) -> &[String] {
-        self.passthrough.as_slice()
-    }
-
-    /// Get the environment variables to set in the build environment.
-    pub fn env(&self) -> &BTreeMap<String, String> {
-        &self.env
-    }
-
-    /// Get the secrets environment variables.
-    ///
-    /// Environment variables to leak into the build environment from the host system that
-    /// contain sensitve information.
-    ///
-    /// # Warning
-    /// Use with care because this might make recipes no longer reproducible on other machines.
-    pub fn secrets(&self) -> &[String] {
-        self.secrets.as_slice()
-    }
-}
-
-impl TryConvertNode<ScriptEnv> for RenderedNode {
-    fn try_convert(&self, name: &str) -> Result<ScriptEnv, PartialParsingError> {
-        self.as_mapping()
-            .ok_or_else(|| _partialerror!(*self.span(), ErrorKind::ExpectedMapping))
-            .and_then(|m| m.try_convert(name))
-    }
-}
-
-impl TryConvertNode<ScriptEnv> for RenderedMappingNode {
-    fn try_convert(&self, name: &str) -> Result<ScriptEnv, PartialParsingError> {
-        let invalid = self
-            .keys()
-            .find(|k| matches!(k.as_str(), "env" | "passthrough" | "secrets"));
-
-        if let Some(invalid) = invalid {
-            return Err(_partialerror!(
-                *invalid.span(),
-                ErrorKind::InvalidField(invalid.to_string().into()),
-                help = format!("valid keys for {name} are `env`, `passthrough` or `secrets`")
-            ));
-        }
-
-        let env = self
-            .get("env")
-            .map(|node| node.try_convert("env"))
-            .transpose()?
-            .unwrap_or_default();
-
-        let passthrough = self
-            .get("passthrough")
-            .map(|node| node.try_convert("passthrough"))
-            .transpose()?
-            .unwrap_or_default();
-
-        let secrets = self
-            .get("secrets")
-            .map(|node| node.try_convert("secrets"))
-            .transpose()?
-            .unwrap_or_default();
-
-        Ok(ScriptEnv {
-            passthrough,
-            env,
-            secrets,
-        })
     }
 }
 
@@ -394,7 +290,7 @@ impl TryConvertNode<RunExports> for RenderedMappingNode {
                         *key.span(),
                         ErrorKind::InvalidField(invalid.to_owned().into()),
                         help = format!("fields for {name} should be one of: `weak`, `strong`, `noarch`, `strong_constrains`, or `weak_constrains`")
-                    ))
+                    ));
                 }
             }
         }
@@ -422,7 +318,7 @@ impl TryConvertNode<NoArchType> for RenderedScalarNode {
                     *self.span(),
                     ErrorKind::InvalidField(invalid.to_owned().into()),
                     help = format!("expected `python` or `generic` for {name}"),
-                ))
+                ));
             }
         };
         Ok(noarch)

--- a/src/recipe/parser/script.rs
+++ b/src/recipe/parser/script.rs
@@ -7,11 +7,7 @@ use crate::{
     recipe::error::{ErrorKind, PartialParsingError},
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::{
-    path::PathBuf,
-    collections::BTreeMap,
-    borrow::Cow
-};
+use std::{borrow::Cow, collections::BTreeMap, path::PathBuf};
 
 /// Defines the script to run to build the package.
 #[derive(Debug, Default, Clone)]
@@ -70,13 +66,11 @@ impl Serialize for Script {
                 env: &self.env,
                 secrets: &self.secrets,
                 content: match &self.content {
-                    ScriptContent::Command(content) => {
-                        Some(RawScriptContent::Command { content: &content })
-                    }
+                    ScriptContent::Command(content) => Some(RawScriptContent::Command { content }),
                     ScriptContent::Commands(content) => {
-                        Some(RawScriptContent::Commands { content: &content })
+                        Some(RawScriptContent::Commands { content })
                     }
-                    ScriptContent::Path(file) => Some(RawScriptContent::Path { file: &file }),
+                    ScriptContent::Path(file) => Some(RawScriptContent::Path { file }),
                     ScriptContent::Default => None,
                     ScriptContent::CommandOrPath(_) => unreachable!(),
                 },
@@ -267,14 +261,10 @@ impl TryConvertNode<Script> for RenderedMappingNode {
                     help = format!("cannot specify both `content` and `file`")
                 ));
             }
-            (Some(file), None) => file
-                .try_convert("file")
-                .map(|path| ScriptContent::Path(path))?,
+            (Some(file), None) => file.try_convert("file").map(ScriptContent::Path)?,
             (None, Some(content)) => match content {
                 RenderedNode::Scalar(node) => ScriptContent::Command(node.as_str().to_owned()),
-                node @ _ => node
-                    .try_convert("content")
-                    .map(|commands| ScriptContent::Commands(commands))?,
+                node => node.try_convert("content").map(ScriptContent::Commands)?,
             },
             (None, None) => ScriptContent::Default,
         };

--- a/src/recipe/parser/script.rs
+++ b/src/recipe/parser/script.rs
@@ -1,0 +1,316 @@
+use crate::{
+    _partialerror,
+    recipe::custom_yaml::{
+        HasSpan, RenderedMappingNode, RenderedNode, RenderedScalarNode, RenderedSequenceNode,
+        TryConvertNode,
+    },
+    recipe::error::{ErrorKind, PartialParsingError},
+};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::{
+    path::PathBuf,
+    collections::BTreeMap,
+    borrow::Cow
+};
+
+/// Defines the script to run to build the package.
+#[derive(Debug, Default, Clone)]
+pub struct Script {
+    /// The interpreter to use for the script.
+    pub(super) interpreter: Option<String>,
+    /// Environment variables to set in the build environment.
+    pub(super) env: BTreeMap<String, String>,
+    /// Environment variables to leak into the build environment from the host system that
+    /// contain sensitve information. Use with care because this might make recipes no
+    /// longer reproducible on other machines.
+    pub(super) secrets: Vec<String>,
+    /// The contents of the script, either a path or a list of commands.
+    pub(super) content: ScriptContent,
+}
+
+impl Serialize for Script {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        #[derive(Serialize)]
+        #[serde(untagged)]
+        enum RawScriptContent<'a> {
+            Command { content: &'a String },
+            Commands { content: &'a Vec<String> },
+            Path { file: &'a PathBuf },
+        }
+
+        #[derive(Serialize)]
+        #[serde(untagged)]
+        enum RawScript<'a> {
+            CommandOrPath(&'a String),
+            Commands(&'a Vec<String>),
+            Object {
+                #[serde(skip_serializing_if = "Option::is_none")]
+                interpreter: Option<&'a String>,
+                #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+                env: &'a BTreeMap<String, String>,
+                #[serde(skip_serializing_if = "Vec::is_empty")]
+                secrets: &'a Vec<String>,
+                #[serde(skip_serializing_if = "Option::is_none", flatten)]
+                content: Option<RawScriptContent<'a>>,
+            },
+        }
+
+        let raw_script = match &self.content {
+            ScriptContent::CommandOrPath(content) => RawScript::CommandOrPath(content),
+            ScriptContent::Commands(content)
+                if self.interpreter.is_none() && self.env.is_empty() && self.secrets.is_empty() =>
+            {
+                RawScript::Commands(content)
+            }
+            _ => RawScript::Object {
+                interpreter: self.interpreter.as_ref(),
+                env: &self.env,
+                secrets: &self.secrets,
+                content: match &self.content {
+                    ScriptContent::Command(content) => {
+                        Some(RawScriptContent::Command { content: &content })
+                    }
+                    ScriptContent::Commands(content) => {
+                        Some(RawScriptContent::Commands { content: &content })
+                    }
+                    ScriptContent::Path(file) => Some(RawScriptContent::Path { file: &file }),
+                    ScriptContent::Default => None,
+                    ScriptContent::CommandOrPath(_) => unreachable!(),
+                },
+            },
+        };
+
+        raw_script.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for Script {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum RawScriptContent {
+            Command { content: String },
+            Commands { content: Vec<String> },
+            Path { file: PathBuf },
+        }
+
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum RawScript {
+            CommandOrPath(String),
+            Commands(Vec<String>),
+            Object {
+                #[serde(default)]
+                interpreter: Option<String>,
+                #[serde(default)]
+                env: BTreeMap<String, String>,
+                #[serde(default)]
+                secrets: Vec<String>,
+                content: Option<RawScriptContent>,
+            },
+        }
+
+        let raw_script = RawScript::deserialize(deserializer)?;
+        Ok(match raw_script {
+            RawScript::CommandOrPath(str) => ScriptContent::CommandOrPath(str).into(),
+            RawScript::Commands(commands) => ScriptContent::Commands(commands).into(),
+            RawScript::Object {
+                interpreter,
+                env,
+                secrets,
+                content,
+            } => Self {
+                interpreter,
+                env,
+                secrets,
+                content: match content {
+                    Some(RawScriptContent::Command { content }) => ScriptContent::Command(content),
+                    Some(RawScriptContent::Commands { content }) => {
+                        ScriptContent::Commands(content)
+                    }
+                    Some(RawScriptContent::Path { file }) => ScriptContent::Path(file),
+                    None => ScriptContent::Default,
+                },
+            },
+        })
+    }
+}
+
+impl Script {
+    /// Returns the interpreter to use to execute the script
+    pub fn interpreter(&self) -> Option<&str> {
+        self.interpreter.as_deref()
+    }
+
+    /// Returns the script contents
+    pub fn contents(&self) -> &ScriptContent {
+        &self.content
+    }
+
+    /// Get the environment variables to set in the build environment.
+    pub fn env(&self) -> &BTreeMap<String, String> {
+        &self.env
+    }
+
+    /// Get the secrets environment variables.
+    ///
+    /// Environment variables to leak into the build environment from the host system that
+    /// contain sensitve information.
+    ///
+    /// # Warning
+    /// Use with care because this might make recipes no longer reproducible on other machines.
+    pub fn secrets(&self) -> &[String] {
+        self.secrets.as_slice()
+    }
+}
+
+impl From<ScriptContent> for Script {
+    fn from(value: ScriptContent) -> Self {
+        Self {
+            interpreter: None,
+            env: Default::default(),
+            secrets: Default::default(),
+            content: value,
+        }
+    }
+}
+
+impl TryConvertNode<Script> for RenderedNode {
+    fn try_convert(&self, name: &str) -> Result<Script, PartialParsingError> {
+        match self {
+            RenderedNode::Scalar(s) => s.try_convert(name),
+            RenderedNode::Sequence(seq) => seq.try_convert(name),
+            RenderedNode::Mapping(map) => map.try_convert(name),
+            RenderedNode::Null(_) => Err(_partialerror!(
+                *self.span(),
+                ErrorKind::MissingField(Cow::Owned(name.to_owned()))
+            )),
+        }
+    }
+}
+
+impl TryConvertNode<Script> for RenderedScalarNode {
+    fn try_convert(&self, _name: &str) -> Result<Script, PartialParsingError> {
+        Ok(ScriptContent::CommandOrPath(self.as_str().to_owned()).into())
+    }
+}
+
+impl TryConvertNode<Script> for RenderedSequenceNode {
+    fn try_convert(&self, name: &str) -> Result<Script, PartialParsingError> {
+        Ok(ScriptContent::Commands(
+            self.iter()
+                .map(|node| node.try_convert(name))
+                .collect::<Result<_, _>>()?,
+        )
+        .into())
+    }
+}
+
+impl TryConvertNode<Script> for RenderedMappingNode {
+    fn try_convert(&self, name: &str) -> Result<Script, PartialParsingError> {
+        let invalid = self.keys().find(|k| {
+            matches!(
+                k.as_str(),
+                "env" | "secrets" | "interpreter" | "content" | "file"
+            )
+        });
+
+        if let Some(invalid) = invalid {
+            return Err(_partialerror!(
+                *invalid.span(),
+                ErrorKind::InvalidField(invalid.to_string().into()),
+                help = format!("valid keys for {name} are `env`, `secrets`, `interpreter`, `content` or `file`")
+            ));
+        }
+
+        let env = self
+            .get("env")
+            .map(|node| node.try_convert("env"))
+            .transpose()?
+            .unwrap_or_default();
+
+        let secrets = self
+            .get("secrets")
+            .map(|node| node.try_convert("secrets"))
+            .transpose()?
+            .unwrap_or_default();
+
+        let interpreter = self
+            .get("interpreter")
+            .map(|node| node.try_convert("interpreter"))
+            .transpose()?
+            .unwrap_or_default();
+
+        let file = self.get("file");
+
+        let content = self.get("content");
+
+        let content = match (file, content) {
+            (Some(file), Some(content)) => {
+                let (last_node, last_node_name) =
+                    if file.span().start().map(|s| s.line()).unwrap_or_default()
+                        < content.span().start().map(|s| s.line()).unwrap_or_default()
+                    {
+                        (content, "content")
+                    } else {
+                        (file, "file")
+                    };
+                return Err(_partialerror!(
+                    *last_node.span(),
+                    ErrorKind::InvalidField(last_node_name.into()),
+                    help = format!("cannot specify both `content` and `file`")
+                ));
+            }
+            (Some(file), None) => file
+                .try_convert("file")
+                .map(|path| ScriptContent::Path(path))?,
+            (None, Some(content)) => match content {
+                RenderedNode::Scalar(node) => ScriptContent::Command(node.as_str().to_owned()),
+                node @ _ => node
+                    .try_convert("content")
+                    .map(|commands| ScriptContent::Commands(commands))?,
+            },
+            (None, None) => ScriptContent::Default,
+        };
+
+        Ok(Script {
+            env,
+            secrets,
+            interpreter,
+            content,
+        })
+    }
+}
+
+/// Describes the contents of the script as defined in [`Script`].
+#[derive(Debug, Clone, Default)]
+pub enum ScriptContent {
+    /// Uses the default build script.
+    #[default]
+    Default,
+
+    /// Either the script contents or the path to the script.
+    CommandOrPath(String),
+
+    /// A path to the script.
+    Path(PathBuf),
+
+    /// The script is given as inline code.
+    Commands(Vec<String>),
+
+    /// The script is given as a string
+    Command(String),
+}
+
+impl ScriptContent {
+    /// Check if the script content is the default.
+    pub const fn is_default(&self) -> bool {
+        matches!(self, Self::Default)
+    }
+}

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__it_works.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__it_works.snap
@@ -75,9 +75,16 @@ Recipe {
         number: 0,
         string: None,
         skip: false,
-        script: [
-            "cmake ${CMAKE_ARGS} -DBUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX=$PREFIX $SRC_DIR -DCMAKE_INSTALL_LIBDIR=lib\nmake install",
-        ],
+        script: Script {
+            interpreter: None,
+            env: {},
+            secrets: [],
+            content: Commands(
+                [
+                    "cmake ${CMAKE_ARGS} -DBUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX=$PREFIX $SRC_DIR -DCMAKE_INSTALL_LIBDIR=lib\nmake install",
+                ],
+            ),
+        },
         ignore_run_exports: [],
         ignore_run_exports_from: [],
         run_exports: RunExports {

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__it_works.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__it_works.snap
@@ -78,11 +78,6 @@ Recipe {
         script: [
             "cmake ${CMAKE_ARGS} -DBUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX=$PREFIX $SRC_DIR -DCMAKE_INSTALL_LIBDIR=lib\nmake install",
         ],
-        script_env: ScriptEnv {
-            passthrough: [],
-            env: {},
-            secrets: [],
-        },
         ignore_run_exports: [],
         ignore_run_exports_from: [],
         run_exports: RunExports {

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__jinja_sequence.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__jinja_sequence.snap
@@ -12,10 +12,6 @@ build:
   skip: false
   script:
     - test succeeded
-  script_env:
-    passthrough: []
-    env: {}
-    secrets: []
   ignore_run_exports: []
   ignore_run_exports_from: []
   run_exports:

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__recipe_windows.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__recipe_windows.snap
@@ -75,13 +75,15 @@ Recipe {
         number: 0,
         string: None,
         skip: false,
-        script: [
-            "cmake -G \"NMake Makefiles\" -D BUILD_TESTS=OFF -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% %SRC_DIR%\nnmake\nnmake install",
-        ],
-        script_env: ScriptEnv {
-            passthrough: [],
+        script: Script {
+            interpreter: None,
             env: {},
             secrets: [],
+            content: Commands(
+                [
+                    "cmake -G \"NMake Makefiles\" -D BUILD_TESTS=OFF -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% %SRC_DIR%\nnmake\nnmake install",
+                ],
+            ),
         },
         ignore_run_exports: [],
         ignore_run_exports_from: [],

--- a/src/snapshots/rattler_build__metadata__test__read_full_recipe-2.snap
+++ b/src/snapshots/rattler_build__metadata__test__read_full_recipe-2.snap
@@ -17,10 +17,6 @@ recipe:
     string: h60d57d3_0
     skip: false
     script: []
-    script_env:
-      passthrough: []
-      env: {}
-      secrets: []
     ignore_run_exports: []
     ignore_run_exports_from: []
     run_exports:

--- a/src/snapshots/rattler_build__metadata__test__read_full_recipe.snap
+++ b/src/snapshots/rattler_build__metadata__test__read_full_recipe.snap
@@ -18,10 +18,6 @@ recipe:
     skip: false
     script:
       - python -m pip install . -vv --no-deps --no-build-isolation
-    script_env:
-      passthrough: []
-      env: {}
-      secrets: []
     ignore_run_exports: []
     ignore_run_exports_from: []
     run_exports:

--- a/test-data/rendered_recipes/curl_recipe.yaml
+++ b/test-data/rendered_recipes/curl_recipe.yaml
@@ -13,10 +13,6 @@ recipe:
     string: h60d57d3_0
     skip: false
     script: []
-    script_env:
-      passthrough: []
-      env: {}
-      secrets: []
     ignore_run_exports: []
     ignore_run_exports_from: []
     run_exports:

--- a/test-data/rendered_recipes/rich_recipe.yaml
+++ b/test-data/rendered_recipes/rich_recipe.yaml
@@ -14,10 +14,6 @@ recipe:
     skip: false
     script:
     - python -m pip install . -vv --no-deps --no-build-isolation
-    script_env:
-      passthrough: []
-      env: {}
-      secrets: []
     ignore_run_exports: []
     ignore_run_exports_from: []
     run_exports:


### PR DESCRIPTION
To better align with the latest changes to the CEP this PR moves the contents of `script_env` into `script`.