### PR TITLE
refactor: move run_exports to requiremens

### DIFF
--- a/examples/mamba/recipe.yaml
+++ b/examples/mamba/recipe.yaml
@@ -25,12 +25,6 @@ outputs:
       script:
         - ${{ "build_mamba.sh" if unix }}
         - ${{ "build_mamba.bat" if win }}
-      run_exports:
-        - ${{ pin_subpackage('libmamba', max_pin='x.x') }}
-      ignore_run_exports:
-        - spdlog
-        - python
-        # - ${{ "python" if win }}
     requirements:
       build:
         - ${{ compiler('cxx') }}
@@ -54,6 +48,13 @@ outputs:
         - zstd
       run:
         - libsolv >=0.7.23
+      run_exports:
+        - ${{ pin_subpackage('libmamba', max_pin='x.x') }}
+      ignore_run_exports:
+        by_name:
+          - spdlog
+          - python
+        # - ${{ "python" if win }}
     test:
       commands:
         - if: unix
@@ -81,10 +82,6 @@ outputs:
         - ${{ "build_mamba.sh" if unix }}
         - ${{ "build_mamba.bat" if win }}
       string: py_sup${{ python | version_to_buildstring }}h${{ hash }}_${{ build_number }}
-      run_exports:
-        - ${{ pin_subpackage('libmambapy', max_pin='x.x') }}
-      ignore_run_exports:
-        - spdlog
     requirements:
       build:
         - ${{ compiler('cxx') }}
@@ -112,7 +109,11 @@ outputs:
       run:
         - python
         - ${{ pin_subpackage('libmamba', exact=True) }}
-
+      run_exports:
+        - ${{ pin_subpackage('libmambapy', max_pin='x.x') }}
+      ignore_run_exports:
+        by_name:
+          - spdlog
     test:
       imports:
         - libmambapy

--- a/src/recipe/custom_yaml.rs
+++ b/src/recipe/custom_yaml.rs
@@ -3,7 +3,7 @@
 
 use std::{collections::BTreeMap, fmt, hash::Hash, ops, path::PathBuf};
 
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 use marked_yaml::{types::MarkedScalarNode, Span};
 use url::Url;
 
@@ -1083,6 +1083,16 @@ where
 {
     fn try_convert(&self, name: &str) -> Result<Option<T>, PartialParsingError> {
         self.try_convert(name).map(|v| Some(v))
+    }
+}
+
+impl<T: Hash + Eq> TryConvertNode<IndexSet<T>> for RenderedNode
+where
+    RenderedNode: TryConvertNode<T>,
+    RenderedScalarNode: TryConvertNode<T>,
+{
+    fn try_convert(&self, name: &str) -> Result<IndexSet<T>, PartialParsingError> {
+        TryConvertNode::<Vec<T>>::try_convert(self, name).map(|v| v.into_iter().collect())
     }
 }
 

--- a/src/recipe/parser.rs
+++ b/src/recipe/parser.rs
@@ -27,10 +27,12 @@ mod test;
 
 pub use self::{
     about::About,
-    build::{Build, RunExports},
+    build::Build,
     output::find_outputs_from_src,
     package::{OutputPackage, Package},
-    requirements::{Compiler, Dependency, PinSubpackage, Requirements},
+    requirements::{
+        Compiler, Dependency, IgnoreRunExports, PinSubpackage, Requirements, RunExports,
+    },
     script::{Script, ScriptContent},
     source::{Checksum, GitSource, GitUrl, PathSource, Source, UrlSource},
     test::{PackageContent, Test},

--- a/src/recipe/parser/snapshots/rattler_build__recipe__parser__requirements__test__compiler_serde-2.snap
+++ b/src/recipe/parser/snapshots/rattler_build__recipe__parser__requirements__test__compiler_serde-2.snap
@@ -4,7 +4,4 @@ expression: deserialized
 ---
 build:
   - __COMPILER gcc
-host: []
-run: []
-run_constrained: []
 

--- a/src/recipe/parser/snapshots/rattler_build__recipe__parser__requirements__test__compiler_serde.snap
+++ b/src/recipe/parser/snapshots/rattler_build__recipe__parser__requirements__test__compiler_serde.snap
@@ -4,7 +4,4 @@ expression: requirements
 ---
 build:
   - __COMPILER gcc
-host: []
-run: []
-run_constrained: []
 

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__it_works.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__it_works.snap
@@ -85,15 +85,6 @@ Recipe {
                 ],
             ),
         },
-        ignore_run_exports: [],
-        ignore_run_exports_from: [],
-        run_exports: RunExports {
-            noarch: [],
-            strong: [],
-            strong_constrains: [],
-            weak: [],
-            weak_constrains: [],
-        },
         noarch: NoArchType(
             None,
         ),

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__it_works.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__it_works.snap
@@ -259,6 +259,17 @@ Recipe {
                 },
             ),
         ],
+        run_exports: RunExports {
+            noarch: [],
+            strong: [],
+            strong_constrains: [],
+            weak: [],
+            weak_constrains: [],
+        },
+        ignore_run_exports: IgnoreRunExports {
+            by_name: {},
+            from_package: {},
+        },
     },
     test: Test {
         imports: [],

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__jinja_sequence.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__jinja_sequence.snap
@@ -12,21 +12,9 @@ build:
   skip: false
   script:
     - test succeeded
-  ignore_run_exports: []
-  ignore_run_exports_from: []
-  run_exports:
-    noarch: []
-    strong: []
-    strong_constrains: []
-    weak: []
-    weak_constrains: []
   noarch: false
   entry_points: []
-requirements:
-  build: []
-  host: []
-  run: []
-  run_constrained: []
+requirements: {}
 test:
   imports: []
   commands: []

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__recipe_windows.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__recipe_windows.snap
@@ -85,15 +85,6 @@ Recipe {
                 ],
             ),
         },
-        ignore_run_exports: [],
-        ignore_run_exports_from: [],
-        run_exports: RunExports {
-            noarch: [],
-            strong: [],
-            strong_constrains: [],
-            weak: [],
-            weak_constrains: [],
-        },
         noarch: NoArchType(
             None,
         ),
@@ -249,6 +240,17 @@ Recipe {
                 },
             ),
         ],
+        run_exports: RunExports {
+            noarch: [],
+            strong: [],
+            strong_constrains: [],
+            weak: [],
+            weak_constrains: [],
+        },
+        ignore_run_exports: IgnoreRunExports {
+            by_name: {},
+            from_package: {},
+        },
     },
     test: Test {
         imports: [],

--- a/src/render/resolved_dependencies.rs
+++ b/src/render/resolved_dependencies.rs
@@ -478,12 +478,13 @@ pub async fn resolve_dependencies(
                 .iter()
                 .any(|m| Some(&rec.package_record.name) == m.name.as_ref());
 
-            let ignore_run_exports_from = output.recipe.build().ignore_run_exports_from();
-            if !ignore_run_exports_from.is_empty() {
-                res && !ignore_run_exports_from.contains(&rec.package_record.name)
-            } else {
-                res
-            }
+            let ignore_run_exports_from = output
+                .recipe
+                .requirements()
+                .ignore_run_exports()
+                .from_package();
+
+            res && !ignore_run_exports_from.contains(&rec.package_record.name)
         })
         .map_err(ResolveError::CouldNotCollectRunExports)?;
 
@@ -588,7 +589,7 @@ pub async fn resolve_dependencies(
             .collect::<Vec<_>>())
     };
 
-    let run_exports = output.recipe.build().run_exports();
+    let run_exports = output.recipe.requirements().run_exports();
 
     let run_exports = if !run_exports.is_empty() {
         Some(RunExportsJson {

--- a/src/render/snapshots/rattler_build__render__recipe__tests__render.snap
+++ b/src/render/snapshots/rattler_build__render__recipe__tests__render.snap
@@ -17,10 +17,6 @@ source:
 build:
   number: 0
   string: h12341234_0
-  script: ~
-  ignore_run_exports: ~
-  ignore_run_exports_from: ~
-  run_exports: ~
   noarch: false
   entry_points: []
 requirements:

--- a/src/snapshots/rattler_build__metadata__test__read_full_recipe-2.snap
+++ b/src/snapshots/rattler_build__metadata__test__read_full_recipe-2.snap
@@ -17,14 +17,6 @@ recipe:
     string: h60d57d3_0
     skip: false
     script: []
-    ignore_run_exports: []
-    ignore_run_exports_from: []
-    run_exports:
-      noarch: []
-      strong: []
-      strong_constrains: []
-      weak: []
-      weak_constrains: []
     noarch: false
     entry_points: []
   requirements:
@@ -34,9 +26,6 @@ recipe:
       - perl
       - pkg-config
       - libtool
-    host: []
-    run: []
-    run_constrained: []
   test:
     imports: []
     commands: []

--- a/src/snapshots/rattler_build__metadata__test__read_full_recipe.snap
+++ b/src/snapshots/rattler_build__metadata__test__read_full_recipe.snap
@@ -18,18 +18,9 @@ recipe:
     skip: false
     script:
       - python -m pip install . -vv --no-deps --no-build-isolation
-    ignore_run_exports: []
-    ignore_run_exports_from: []
-    run_exports:
-      noarch: []
-      strong: []
-      strong_constrains: []
-      weak: []
-      weak_constrains: []
     noarch: python
     entry_points: []
   requirements:
-    build: []
     host:
       - pip
       - poetry-core >=1.0.0
@@ -39,7 +30,6 @@ recipe:
       - "pygments >=2.13.0,<3.0.0"
       - python ==3.10
       - "typing_extensions >=4.0.0,<5.0.0"
-    run_constrained: []
   test:
     imports:
       - rich

--- a/src/snapshots/rattler_build__selectors__tests__flatten_selectors@selectors_flatten_2.yaml.snap
+++ b/src/snapshots/rattler_build__selectors__tests__flatten_selectors@selectors_flatten_2.yaml.snap
@@ -12,12 +12,6 @@ source:
     sha256: 63fd8a1dbec811e63d4f9b5e27757af45d08a219d0900c7c7a19e0b177a576b8
 build:
   number: 0
-  ignore_run_exports:
-    - libcurl
-    - libarchive
-    - libgcc-ng
-    - libstdcxx-ng
-    - spdlog
 requirements:
   build:
     - "{{ compiler(\"c\") }}"
@@ -42,6 +36,13 @@ requirements:
     - openssl-static
     - reproc-cpp-static
     - reproc-static
+  ignore_run_exports:
+    by_name:
+    - libcurl
+    - libarchive
+    - libgcc-ng
+    - libstdcxx-ng
+    - spdlog
 test:
   commands:
     - test -f $PREFIX/bin/micromamba

--- a/src/variant_config.rs
+++ b/src/variant_config.rs
@@ -599,7 +599,7 @@ impl VariantConfig {
                     .run
                     .iter()
                     .chain(requirements.run_constrained.iter())
-                    .chain(parsed_recipe.build().run_exports().all())
+                    .chain(requirements.run_exports().all())
                     .try_for_each(|dep| -> Result<(), VariantError> {
                         if let Dependency::PinSubpackage(pin_sub) = dep {
                             let pin = pin_sub.pin_value();

--- a/test-data/recipes/run_exports/recipe.yaml
+++ b/test-data/recipes/run_exports/recipe.yaml
@@ -2,6 +2,6 @@ package:
   name: run_exports_test
   version: "1.0.0"
 
-build:
+requirements:
   run_exports:
     - ${{ pin_subpackage("run_exports_test", exact=True) }}

--- a/test-data/rendered_recipes/curl_recipe.yaml
+++ b/test-data/rendered_recipes/curl_recipe.yaml
@@ -13,14 +13,6 @@ recipe:
     string: h60d57d3_0
     skip: false
     script: []
-    ignore_run_exports: []
-    ignore_run_exports_from: []
-    run_exports:
-      noarch: []
-      strong: []
-      strong_constrains: []
-      weak: []
-      weak_constrains: []
     noarch: false
     entry_points: []
   requirements:

--- a/test-data/rendered_recipes/rich_recipe.yaml
+++ b/test-data/rendered_recipes/rich_recipe.yaml
@@ -14,14 +14,6 @@ recipe:
     skip: false
     script:
     - python -m pip install . -vv --no-deps --no-build-isolation
-    ignore_run_exports: []
-    ignore_run_exports_from: []
-    run_exports:
-      noarch: []
-      strong: []
-      strong_constrains: []
-      weak: []
-      weak_constrains: []
     noarch: python
     entry_points: []
   requirements:


### PR DESCRIPTION
Move `run_exports` and `ignore_run_exports` from `build` to `requirements`.