### PR TITLE
refactor: serde Dependency instead of string magic

### DIFF
--- a/src/recipe/parser/snapshots/rattler_build__recipe__parser__requirements__test__compiler_serde-2.snap
+++ b/src/recipe/parser/snapshots/rattler_build__recipe__parser__requirements__test__compiler_serde-2.snap
@@ -3,5 +3,5 @@ source: src/recipe/parser/requirements.rs
 expression: deserialized
 ---
 build:
-  - __COMPILER gcc
+  - compiler: gcc
 

--- a/src/recipe/parser/snapshots/rattler_build__recipe__parser__requirements__test__compiler_serde.snap
+++ b/src/recipe/parser/snapshots/rattler_build__recipe__parser__requirements__test__compiler_serde.snap
@@ -3,5 +3,5 @@ source: src/recipe/parser/requirements.rs
 expression: requirements
 ---
 build:
-  - __COMPILER gcc
+  - compiler: gcc
 

--- a/src/snapshots/rattler_build__metadata__test__read_full_recipe-2.snap
+++ b/src/snapshots/rattler_build__metadata__test__read_full_recipe-2.snap
@@ -20,7 +20,7 @@ recipe:
     noarch: false
   requirements:
     build:
-      - __COMPILER c
+      - compiler: c
       - make
       - perl
       - pkg-config

--- a/test-data/rendered_recipes/curl_recipe.yaml
+++ b/test-data/rendered_recipes/curl_recipe.yaml
@@ -16,7 +16,7 @@ recipe:
     noarch: false
   requirements:
     build:
-    - __COMPILER c
+    - compiler: c
     - make
     - perl
     - pkg-config


### PR DESCRIPTION
Instead of serializing dependencies as magic strings (e.g. `__COMPILER c`) in the rendered recipe we render them using enum types instead. 

Turns:

```yaml
- __COMPILER c
- make
- perl
```

into 

```yaml
- compiler: c
- make
- perl
```