### PR TITLE
Add version assertion for release

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -80,6 +80,15 @@ jobs:
         run: |
           echo "project-version=$(yq '.package.version' Cargo.toml)" >> $GITHUB_OUTPUT
 
+      - name: Assert version in release
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        run: |
+          if [[ "v${{ steps.metadata.outputs.project-version }}" != "${{ github.ref_name }}" ]]; then
+            echo ::error file=Cargo.toml::"Version mismatch: Cargo.toml: v${{ steps.metadata.outputs.project-version }} != ${{ github.ref_name }}"
+            exit 1
+          fi
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2514,7 +2514,7 @@ dependencies = [
 
 [[package]]
 name = "rattler-build"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 
 [package]
 name = "rattler-build"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 homepage = "https://github.com/prefix-dev/rattler-build"
 edition = "2021"

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,5 @@
 [project]
 name = "rattler-build"
-version = "0.3.1"
 description = "Conda package builder, using the rattler rust backend"
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 channels = ["conda-forge"]


### PR DESCRIPTION
In the 0.6.1 release, you forgot to update the version. This makes sure that this won't happen again.