### PR TITLE
feat: add completions generation for shells

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,6 +562,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bffe91f06a11b4b9420f62103854e90867812cd5d01557f853c5ee8e791b12ae"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2519,6 +2528,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap-verbosity-flag",
+ "clap_complete",
  "comfy-table",
  "console",
  "content_inspector",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ indexmap = "2.1.0"
 dunce = "1.0.4"
 fs-err = "2.11.0"
 which = "5.0.0"
+clap_complete = "4.4.4"
 
 [dev-dependencies]
 insta = { version = "1.34.0", features = ["yaml"] }

--- a/docs/cli_usage.md
+++ b/docs/cli_usage.md
@@ -1,0 +1,29 @@
+# CLI Usage
+
+## Shell Completions
+
+We support shell completions through clap-complete.
+You can generate them for your shell using the `--generate` command.
+
+Eg,
+```sh
+rattler-build --generate=zsh > ${ZSH_COMPLETIONS_PATH:~/.zsh/completions}/_rattler-build
+compinit
+```
+
+Ensure that whereever you install the is pointed to by your FPATH (for zsh or equivalent in other shells).
+Now you can use TAB or your configured completion key. :3
+
+```sh
+$ rattler-build <TAB>
+build    -- Build a package
+help     -- Print this message or the help of the given subcommand(s)
+rebuild  -- Rebuild a package
+test     -- Test a package
+```
+
+Example for Fish Shell just generate the `completions.fish` and add to `~/.config/fish/completions`.
+```sh
+rattler-build --generate=fish > ${ZSH_COMPLETIONS_PATH:~/.config/fish/completions}/rattler-build.fish
+```
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,13 +78,14 @@ nav:
 
   - Package specification: package_spec.md
   - Compilers and cross compilation: compilers.md
-  - Automatic recipe linting: automatic_linting.md
   - Testing packages: testing.md
   - Reproducible builds: rebuild.md
 
   - Internals: internals.md
   - Recipe file: recipe_file.md
 
+  - CLI Usage: cli_usage.md
+  - Automatic recipe linting: automatic_linting.md
 
 plugins:
   - search

--- a/rust-tests/src/lib.rs
+++ b/rust-tests/src/lib.rs
@@ -186,12 +186,7 @@ mod tests {
             // no heap allocations happen here, ideally!
             .with_args(Vec::<&str>::new())
             .map(|out| out.stdout)
-            .map(|s| {
-                #[cfg(target_family = "unix")]
-                return s.starts_with(b"Usage: rattler-build [OPTIONS]");
-                #[cfg(target_family = "windows")]
-                return s.starts_with(b"Usage: rattler-build.exe [OPTIONS]");
-            })
+            .map(|s| s.starts_with(b"Usage: rattler-build [OPTIONS]"))
             .unwrap();
         assert!(help_test);
     }

--- a/rust-tests/src/lib.rs
+++ b/rust-tests/src/lib.rs
@@ -185,7 +185,7 @@ mod tests {
         let help_test = rattler()
             // no heap allocations happen here, ideally!
             .with_args(Vec::<&str>::new())
-            .map(|out| out.stderr)
+            .map(|out| out.stdout)
             .map(|s| {
                 #[cfg(target_family = "unix")]
                 return s.starts_with(b"Usage: rattler-build [OPTIONS]");


### PR DESCRIPTION
uses clap-complete should support most shells, for support for any other shell an issue would need to be filed to clap

Fixes #366