### PR TITLE
fix: avoid cross-device link errors while moving files

### DIFF
--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -287,6 +287,7 @@ fn rename(src: &Path, dest: &Path) -> IoResult<()> {
     } else {
         File::create(dest)?;
     }
+    // check if the files are on the same filesystem
     if fs::metadata(src)?.dev() != fs::metadata(dest)?.dev() {
         if src.is_dir() {
             copy_dir(src, dest).and(fs::remove_dir_all(src))?;


### PR DESCRIPTION
## Background

#447 changed the archive extraction logic to:

1. Extract files into a temporary directory. (`/tmp`)
2. Move all files to the target directory.

However, step 2 uses [`fs::rename`](https://doc.rust-lang.org/std/fs/fn.rename.html) which poses a potential issue on Linux systems:

> This will not work if the new name is on a different mount point.

We can demonstrate this with the following snippet:

```rs
#!/usr/bin/env rust-script

//! ```cargo
//! [dependencies]
//! anyhow = "1.0.79"
//! dirs = "5.0.1"
//! tempfile = "3.9.0"
//! ```

use anyhow::Result;
use std::fs::{self, File};

fn main() -> Result<()> {
    let tmp_dir = tempfile::tempdir()?;

    let file_path = tmp_dir.path().join("test.txt");
    File::create(&file_path)?;

    let new_path = dirs::home_dir().unwrap().join("new.txt");
    fs::rename(file_path, new_path)?;
    Ok(())
}
```

```sh
$ chmod +x script.rs && ./script.rs

thread 'main' panicked at src/main.rs:7:41:
called `Result::unwrap()` on an `Err` value: Os { code: 18, kind: CrossesDevices, message: "In
valid cross-device link" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This is because `/tmp` is a different mount point than `~/`.

## The issue

Due to the reason above, `rattler-build build` is not able to move the extracted files for me:

```sh
$ rattler-build build -r recipe.yaml --output-dir ../rattler-output/

No target platform specified, using current platform
Found variants:

git-cliff-1.4.0-hb0f4dca_0
╭─────────────────┬──────────╮
│ Variant         ┆ Version  │
╞═════════════════╪══════════╡
│ target_platform ┆ linux-64 │
╰─────────────────┴──────────╯

Fetching source from URL: https://github.com/orhun/git-cliff/archive/refs/tags/v0.4.0.tar.gz
Validated SHA256 values of the downloaded file!
Found valid source cache file.
Error:   × IO Error: failed to rename file from /tmp/.tmpjOYIft/git-cliff-0.4.0/.dockerignore to /home/
  │ orhun/gh/conda-forge-staged-recipes/recipes/rattler-output/bld/rattler-build_git-cliff_1704219413/
  │ work/.dockerignore
  ├─▶ failed to rename file from /tmp/.tmpjOYIft/git-cliff-0.4.0/.dockerignore to /home/orhun/gh/
  │   conda-forge-staged-recipes/recipes/rattler-output/bld/rattler-build_git-cliff_1704219413/
  │   work/.dockerignore
  ╰─▶ Invalid cross-device link (os error 18)
```

This PR simply fixes that issue by copying + deleting files instead of moving for Linux systems.

## Error type

Rust throws `std::io::ErrorKind::CrossesDevices` for this case. However, we can directly check this type because it is gated behind [`#![feature(io_error_more)]`](https://github.com/rust-lang/rust/issues/86442) feature. What we can do is enable this feature for the crate but this means that we will need the nightly compiler for builds. I don't think this is feasible.

Another thing that we can do is to check [`libc::EXDEV`](https://www.gnu.org/software/libc/manual/html_node/Error-Codes.html) error type:

> “Invalid cross-device link.” An attempt to make an improper link across file systems was detected. This happens not only when you use link (see Hard Links) but also when you rename a file with rename (see Renaming Files).

This means adding the `libc` dependency... so let's not do that.

For additional context, see the ["renaming directories"](https://www.kernel.org/doc/Documentation/filesystems/overlayfs.txt) section of the Kernel documentation.

> 1. return EXDEV error: this error is returned by rename(2) when trying to
>    move a file or directory across filesystem boundaries. Hence
>    applications are usually prepared to hande this error (mv(1) for example
>    recursively copies the directory tree). This is the default behavior.

Long story short, I find it most applicable to have a simple string check until `io_error_more` feature is stabilized:

```rs
// TODO: replace it with `std::io::ErrorKind::CrossesDevices`
// when <https://github.com/rust-lang/rust/issues/86442> is stabilized.
if format!("{:?}", e.kind()) == *"CrossesDevices" {
```

## Additional context

The implementation is heavily inspired by `rustup`: https://github.com/rust-lang/rustup/blob/3b0ae079d91144ea9cf99a5fc6d493701a160823/src/utils/utils.rs#L566

Here is a related discussion: https://github.com/rust-lang/rustup/issues/1239

:bear:
