### PR TITLE
fix: use env for shell detection

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -62,7 +62,7 @@ enum SubCommands {
 #[derive(Parser)]
 struct ShellCompletion {
     #[arg(short, long)]
-    shell: clap_complete::Shell,
+    shell: Option<clap_complete::Shell>,
 }
 
 #[derive(Parser)]
@@ -285,6 +285,9 @@ async fn main() -> miette::Result<()> {
                     &mut std::io::stdout(),
                 );
             }
+            let shell = shell
+                .or(clap_complete::Shell::from_env())
+                .unwrap_or(clap_complete::Shell::Bash);
             print_completions(shell, &mut cmd);
             Ok(())
         }


### PR DESCRIPTION
Should now be consistent with pixi, for the cli part.

note:
Also the issue regarding broken formatting in completions is due to a bug in the completions generated we will have to manually replace parts of the completion like pixi does. cc: @pavelzw 