### PR TITLE
Install rattler-build from homebrew-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Releases](https://github.com/prefix-dev/rattler-build/releases/).
 Alternatively, you can install `rattler-build` via Homebrew:
 
 ```
-brew install pavelzw/pavelzw/rattler-build
+brew install rattler-build
 ```
 
 #### Dependencies

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ micromamba install rattler-build -c conda-forge
 Alternatively, you can install `rattler-build` via Homebrew:
 
 ```bash
-brew install pavelzw/pavelzw/rattler-build
+brew install rattler-build
 ```
 
 #### Dependencies


### PR DESCRIPTION
Depends on https://github.com/Homebrew/homebrew-core/pull/159416