### PR TITLE
fix: ignore pyo and egg-info files for noarch

### DIFF
--- a/src/packaging.rs
+++ b/src/packaging.rs
@@ -454,7 +454,8 @@ fn write_to_dest(
     }
 
     if noarch_type.is_python() {
-        if ext == "pyc" {
+        // skip .pyc or .pyo or .egg-info files
+        if ["pyc", "egg-info", "pyo"].iter().any(|s| ext.eq(*s)) {
             return Ok(None); // skip .pyc files
         }
 


### PR DESCRIPTION
Closes #136 

Note the ".exe" ignore part is already taken care of at, https://github.com/prefix-dev/rattler-build/blob/1eb0fd4416819c1e82f39e24c196da5bc0ade6b3/src/packaging.rs#L905-L910