### PR TITLE
make sure that single-line build script is correctly treated as build…

### DIFF
--- a/src/recipe/parser/script.rs
+++ b/src/recipe/parser/script.rs
@@ -206,12 +206,16 @@ impl TryConvertNode<Script> for RenderedScalarNode {
 
 impl TryConvertNode<Script> for RenderedSequenceNode {
     fn try_convert(&self, name: &str) -> Result<Script, Vec<PartialParsingError>> {
-        Ok(ScriptContent::Commands(
-            self.iter()
-                .map(|node| node.try_convert(name))
-                .collect::<Result<_, _>>()?,
-        )
-        .into())
+        let strings = self
+            .iter()
+            .map(|node| node.try_convert(name))
+            .collect::<Result<Vec<String>, _>>()?;
+
+        if strings.len() == 1 {
+            Ok(ScriptContent::CommandOrPath(strings[0].clone()).into())
+        } else {
+            Ok(ScriptContent::Commands(strings).into())
+        }
     }
 }
 

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__jinja_sequence.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__jinja_sequence.snap
@@ -7,7 +7,6 @@ package:
   version: 0.1.0
 build:
   number: 0
-  script:
-    - test succeeded
+  script: test succeeded
 requirements: {}
 

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__recipe_windows.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__recipe_windows.snap
@@ -79,10 +79,8 @@ Recipe {
             interpreter: None,
             env: {},
             secrets: [],
-            content: Commands(
-                [
-                    "cmake -G \"NMake Makefiles\" -D BUILD_TESTS=OFF -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% %SRC_DIR%\nnmake\nnmake install",
-                ],
+            content: CommandOrPath(
+                "cmake -G \"NMake Makefiles\" -D BUILD_TESTS=OFF -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% %SRC_DIR%\nnmake\nnmake install",
             ),
         },
         noarch: NoArchType(

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__unix_recipe.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__unix_recipe.snap
@@ -79,10 +79,8 @@ Recipe {
             interpreter: None,
             env: {},
             secrets: [],
-            content: Commands(
-                [
-                    "cmake ${CMAKE_ARGS} -DBUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX=$PREFIX $SRC_DIR -DCMAKE_INSTALL_LIBDIR=lib\nmake install",
-                ],
+            content: CommandOrPath(
+                "cmake ${CMAKE_ARGS} -DBUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX=$PREFIX $SRC_DIR -DCMAKE_INSTALL_LIBDIR=lib\nmake install",
             ),
         },
         noarch: NoArchType(


### PR DESCRIPTION
This is useful for `if / then / else` blocks that select one or the other script.