### PR TITLE
skip over any Null values in mappings

### DIFF
--- a/src/recipe/custom_yaml.rs
+++ b/src/recipe/custom_yaml.rs
@@ -1196,10 +1196,6 @@ where
         let mut map = BTreeMap::new();
         for (key, value) in self.iter() {
             let key = key.try_convert(name)?;
-            // skip over null values
-            if matches!(value, RenderedNode::Null(_)) {
-                continue;
-            }
             let value = value.try_convert(name)?;
             map.insert(key, value);
         }

--- a/src/recipe/custom_yaml/rendered.rs
+++ b/src/recipe/custom_yaml/rendered.rs
@@ -87,6 +87,10 @@ impl RenderedNode {
         matches!(self, Self::Sequence(_))
     }
 
+    pub fn is_null(&self) -> bool {
+        matches!(self, Self::Null(_))
+    }
+
     /// Retrieve the scalar from this node if there is one
     pub fn as_scalar(&self) -> Option<&RenderedScalarNode> {
         match self {
@@ -655,8 +659,10 @@ impl Render<RenderedMappingNode> for MappingNode {
 
         for (key, value) in self.iter() {
             let key = RenderedScalarNode::new(*key.span(), key.as_str().to_owned());
-            let value = value.render(jinja, &format!("{name}.{}", key.as_str()))?;
-
+            let value: RenderedNode = value.render(jinja, &format!("{name}.{}", key.as_str()))?;
+            if value.is_null() {
+                continue;
+            }
             rendered.insert(key, value);
         }
 

--- a/test-data/recipes/variant_config/recipe.yaml
+++ b/test-data/recipes/variant_config/recipe.yaml
@@ -3,6 +3,7 @@ package:
   version: "0.1.0"
 
 build:
+  number: ${{ 10 if false }}
   noarch: generic
   script:
     env:


### PR DESCRIPTION
This is an extension to the fix for the `env` mapping and skips over any `Null` values in `RenderedMapppings`. 

That means, keys are ignored if the value is `Null`. I do think that's the desired behavior and means we can write stuff like 

```yaml
build:
  number: ${{ 10 if false }}
```

without error.