### PR TITLE
feat: experimental indent when logging to terminal

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -22,6 +22,7 @@ env:
   RUST_BACKTRACE: 1
   RUSTFLAGS: "-D warnings"
   CARGO_TERM_COLOR: always
+  RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: "true"
 
 jobs:
   run_tests:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2996,6 +2996,7 @@ dependencies = [
  "spdx",
  "tar",
  "tempfile",
+ "terminal_size",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -4524,6 +4525,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4533,12 +4544,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ tracing-subscriber = { version = "0.3.18", features = [
     "env-filter",
     "fmt",
     "ansi",
+    "json"
 ] }
 marked-yaml = { version = "0.3.0" }
 miette = { version = "7.0.0", features = ["fancy"] }
@@ -106,6 +107,7 @@ os_pipe = "1.1.5"
 reqwest-middleware = "0.2.4"
 rattler_installs_packages = { version = "0.8.0", default-features = false }
 async-once-cell = "0.5.3"
+terminal_size = "0.3.0"
 
 [dev-dependencies]
 insta = { version = "1.34.0", features = ["yaml"] }

--- a/docs/cli_usage.md
+++ b/docs/cli_usage.md
@@ -39,3 +39,20 @@ rattler-build build --package-format tarbz2 -r recipe/recipe.yaml
 # maximum compression with 10 threads
 rattler-build build --package-format conda:max --compression-threads 10 -r recipe/recipe.yaml
 ```
+
+## Logs
+
+Rattler-build knows 3 different log-styles: `fancy`, `plain` and `json`.
+You can configure them with the `--log-style=<style>` flag.
+
+```sh
+# default
+rattler-build build --log-style fancy -r recipe/recipe.yaml
+```
+
+### Github integration
+
+Rattler-build also has a github integration. With this integration, warnings are automatically
+emitted in the github actions log and a summary is generated that is posted to the Github Actions summary page.
+
+To make use of the integration we recommend to use our Github action: [`rattler-build-action`](https://github.com/prefix-dev/rattler-build-action). To manually enable it, you can set the environment variable `RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION=true`.

--- a/pixi.toml
+++ b/pixi.toml
@@ -8,7 +8,7 @@ platforms = ["linux-64", "win-64", "osx-64", "osx-arm64"]
 [tasks]
 build = "cargo build --release"
 install = "cargo install --path . --locked"
-end_to_end_test = "pytest test/end-to-end -v"
+end_to_end_test = "pytest test/end-to-end -v -s"
 test = "cargo test"
 lint = "pre-commit run --all"
 build-docs = "mkdocs build --strict"

--- a/rust-tests/src/lib.rs
+++ b/rust-tests/src/lib.rs
@@ -36,6 +36,7 @@ mod tests {
             let rs = recipe.as_ref().display().to_string();
             let od = output_dir.as_ref().display().to_string();
             let mut iter = vec![
+                "--log-style=plain",
                 "build",
                 "--recipe",
                 rs.as_str(),
@@ -571,7 +572,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_os = "linux"))]
+    #[cfg(target_os = "linux")]
     fn test_overlinking_check() {
         let tmp = tmp("test_overlink_check");
         let rattler_build = rattler().build(
@@ -586,7 +587,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_os = "linux"))]
+    #[cfg(target_os = "linux")]
     fn test_overdepending_check() {
         let tmp = tmp("test_overdepending_check");
         let rattler_build = rattler().build(
@@ -601,7 +602,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_os = "linux"))]
+    #[cfg(target_os = "linux")]
     fn test_allow_missing_dso() {
         let tmp = tmp("test_allow_missing_dso");
         let rattler_build = rattler().build(

--- a/src/build.rs
+++ b/src/build.rs
@@ -7,88 +7,52 @@ use rattler_index::index;
 
 use crate::metadata::Output;
 use crate::package_test::TestConfiguration;
-use crate::packaging::{package_conda, Files};
 use crate::recipe::parser::TestType;
-use crate::render::resolved_dependencies::{install_environments, resolve_dependencies};
-use crate::source::fetch_sources;
 use crate::{package_test, tool_configuration};
 
 /// Run the build for the given output. This will fetch the sources, resolve the dependencies,
 /// and execute the build script. Returns the path to the resulting package.
 pub async fn run_build(
-    output: &Output,
+    output: Output,
     tool_configuration: tool_configuration::Configuration,
-) -> miette::Result<PathBuf> {
-    let directories = &output.build_configuration.directories;
+) -> miette::Result<(Output, PathBuf)> {
+    if output.build_string().is_none() {
+        miette::bail!("Build string is not set for {:?}", output.name());
+    }
+    let span = tracing::info_span!("Running build for", recipe = output.identifier().unwrap());
+    let _enter = span.enter();
+    output.record_build_start();
+
+    let directories = output.build_configuration.directories.clone();
 
     index(
         &directories.output_dir,
-        Some(&output.build_configuration.target_platform),
+        Some(&output.build_configuration.target_platform.clone()),
     )
     .into_diagnostic()?;
 
-    // Add the local channel to the list of channels
-    let mut channels = vec![directories.output_dir.to_string_lossy().to_string()];
-    channels.extend(output.build_configuration.channels.clone());
-
-    let output = if let Some(finalized_sources) = &output.finalized_sources {
-        fetch_sources(
-            finalized_sources,
-            directories,
-            &output.system_tools,
-            &tool_configuration,
-        )
+    let output = output
+        .fetch_sources(&tool_configuration)
         .await
         .into_diagnostic()?;
 
-        output.clone()
-    } else {
-        let rendered_sources = fetch_sources(
-            output.recipe.sources(),
-            directories,
-            &output.system_tools,
-            &tool_configuration,
-        )
+    let output = output
+        .resolve_dependencies(&tool_configuration)
         .await
         .into_diagnostic()?;
-
-        Output {
-            finalized_sources: Some(rendered_sources),
-            ..output.clone()
-        }
-    };
-
-    let output = if output.finalized_dependencies.is_some() {
-        tracing::info!("Using finalized dependencies");
-
-        // The output already has the finalized dependencies, so we can just use it as-is
-        install_environments(&output, tool_configuration.clone())
-            .await
-            .into_diagnostic()?;
-        output.clone()
-    } else {
-        let finalized_dependencies =
-            resolve_dependencies(&output, &channels, tool_configuration.clone())
-                .await
-                .into_diagnostic()?;
-
-        // The output with the resolved dependencies
-        Output {
-            finalized_dependencies: Some(finalized_dependencies),
-            ..output.clone()
-        }
-    };
 
     output.run_build_script().await.into_diagnostic()?;
 
-    let files_after = Files::from_prefix(
-        &directories.host_prefix,
-        output.recipe.build().always_include_files(),
-    )
-    .into_diagnostic()?;
+    // Package all the new files
+    let (result, paths_json) = output
+        .create_package(&tool_configuration)
+        .await
+        .into_diagnostic()?;
 
-    let (result, paths_json) =
-        package_conda(&output, &tool_configuration, &files_after).into_diagnostic()?;
+    output.record_artifact(&result, &paths_json);
+
+    let span = tracing::info_span!("Running package tests");
+    let enter = span.enter();
 
     // We run all the package content tests
     for test in output.recipe.tests() {
@@ -104,29 +68,16 @@ pub async fn run_build(
         fs::remove_dir_all(&directories.build_dir).into_diagnostic()?;
     }
 
-    index(
-        &directories.output_dir,
-        Some(&output.build_configuration.target_platform),
-    )
-    .into_diagnostic()?;
-
-    let test_dir = directories.work_dir.join("test");
-    fs::create_dir_all(&test_dir).into_diagnostic()?;
-
-    tracing::info!("{}", output);
-
     if tool_configuration.no_test {
         tracing::info!("Skipping tests");
     } else {
-        tracing::info!("Running tests");
-
         package_test::run_test(
             &result,
             &TestConfiguration {
-                test_prefix: test_dir.clone(),
+                test_prefix: directories.work_dir.join("test"),
                 target_platform: Some(output.build_configuration.host_platform),
                 keep_test_prefix: tool_configuration.no_clean,
-                channels,
+                channels: output.reindex_channels().into_diagnostic()?,
                 tool_configuration: tool_configuration.clone(),
             },
         )
@@ -134,9 +85,11 @@ pub async fn run_build(
         .into_diagnostic()?;
     }
 
+    drop(enter);
+
     if !tool_configuration.no_clean {
         fs::remove_dir_all(&directories.build_dir).into_diagnostic()?;
     }
 
-    Ok(result)
+    Ok((output, result))
 }

--- a/src/console_utils.rs
+++ b/src/console_utils.rs
@@ -1,43 +1,30 @@
-use indicatif::MultiProgress;
-use std::io;
-use tracing_core::{Event, Subscriber};
+//! This module contains utilities for logging and progress bar handling.
+use clap_verbosity_flag::{InfoLevel, Verbosity};
+use console::style;
+use indicatif::{HumanBytes, HumanDuration, MultiProgress, ProgressState, ProgressStyle};
+use std::{
+    collections::HashMap,
+    io,
+    str::FromStr,
+    sync::{Arc, Mutex},
+    time::Instant,
+};
+use tracing::{field, Level};
+use tracing_core::{span::Id, Event, Field, Subscriber};
 use tracing_subscriber::{
+    filter::{Directive, ParseError},
     fmt::{
+        self,
         format::{self, Format},
         FmtContext, FormatEvent, FormatFields, MakeWriter,
     },
+    layer::{Context, SubscriberExt},
     registry::LookupSpan,
+    util::SubscriberInitExt,
+    EnvFilter, Layer,
 };
 
-#[derive(Clone)]
-pub struct IndicatifWriter {
-    progress_bars: MultiProgress,
-}
-
-impl IndicatifWriter {
-    pub(crate) fn new(pb: MultiProgress) -> Self {
-        Self { progress_bars: pb }
-    }
-}
-
-impl io::Write for IndicatifWriter {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.progress_bars.suspend(|| io::stderr().write(buf))
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        self.progress_bars.suspend(|| io::stderr().flush())
-    }
-}
-
-impl<'a> MakeWriter<'a> for IndicatifWriter {
-    type Writer = IndicatifWriter;
-
-    fn make_writer(&'a self) -> Self::Writer {
-        self.clone()
-    }
-}
-
+/// A custom formatter for tracing events.
 pub struct TracingFormatter;
 
 impl<S, N> FormatEvent<S, N> for TracingFormatter
@@ -62,4 +49,475 @@ where
             default_format.format_event(ctx, writer, event)
         }
     }
+}
+
+#[derive(Debug, Default)]
+struct SharedState {
+    indentation_level: usize,
+    timestamps: HashMap<Id, Instant>,
+    formatted_spans: HashMap<Id, String>,
+    warnings: Vec<String>,
+}
+
+struct CustomVisitor<'a> {
+    writer: &'a mut dyn io::Write,
+    result: io::Result<()>,
+}
+
+impl<'a> CustomVisitor<'a> {
+    fn new(writer: &'a mut dyn io::Write) -> Self {
+        Self {
+            writer,
+            result: Ok(()),
+        }
+    }
+}
+
+impl<'a> field::Visit for CustomVisitor<'a> {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if self.result.is_err() {
+            return;
+        }
+
+        self.record_debug(field, &format_args!("{}", value))
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        if self.result.is_err() {
+            return;
+        }
+
+        self.result = match field.name() {
+            "message" => write!(self.writer, "{:?}", value),
+            "recipe" => write!(self.writer, " recipe: {:?}", value),
+            _ => Ok(()),
+        };
+    }
+}
+
+fn chunk_string_without_ansi(input: &str, max_chunk_length: usize) -> Vec<String> {
+    let mut chunks: Vec<String> = vec![];
+    let mut current_chunk = String::new();
+    let mut current_length = 0;
+    let mut chars = input.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        if c == '\x1B' {
+            // Beginning of an ANSI escape sequence
+            current_chunk.push(c);
+            while let Some(&next_char) = chars.peek() {
+                // Add to current chunk
+                current_chunk.push(chars.next().unwrap());
+                if next_char.is_ascii_alphabetic() {
+                    // End of ANSI escape sequence
+                    break;
+                }
+            }
+        } else {
+            // Regular character
+            current_length += 1;
+            current_chunk.push(c);
+            if current_length == max_chunk_length {
+                // Current chunk is full
+                chunks.push(current_chunk);
+                current_chunk = String::new();
+                current_length = 0;
+            }
+        }
+    }
+
+    // Add the last chunk if it's not empty
+    if !current_chunk.is_empty() {
+        chunks.push(current_chunk);
+    }
+
+    chunks
+}
+
+fn indent_levels(indent: usize) -> String {
+    let mut s = String::new();
+    for _ in 0..indent {
+        s.push_str(" │");
+    }
+    format!("{}", style(s).cyan())
+}
+
+impl<S> Layer<S> for LoggingOutputHandler
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_new_span(
+        &self,
+        attrs: &tracing_core::span::Attributes<'_>,
+        id: &tracing_core::span::Id,
+        ctx: Context<'_, S>,
+    ) {
+        let mut state = self.state.lock().unwrap();
+        state.timestamps.insert(id.clone(), Instant::now());
+        let span = ctx.span(id);
+
+        if let Some(span) = span {
+            let mut s = Vec::new();
+            let mut w = io::Cursor::new(&mut s);
+            attrs.record(&mut CustomVisitor::new(&mut w));
+            let s = String::from_utf8_lossy(w.get_ref());
+
+            if !s.is_empty() {
+                state
+                    .formatted_spans
+                    .insert(id.clone(), format!("{}{}", span.name(), s));
+            } else {
+                state
+                    .formatted_spans
+                    .insert(id.clone(), span.name().to_string());
+            }
+        }
+    }
+
+    fn on_enter(&self, id: &Id, _ctx: Context<'_, S>) {
+        let mut state = self.state.lock().unwrap();
+        let ind = indent_levels(state.indentation_level);
+        if let Some(txt) = state.formatted_spans.get(id) {
+            eprintln!("{ind}\n{ind} {} {}", style("╭─").cyan(), txt);
+        }
+
+        state.indentation_level += 1;
+    }
+
+    fn on_exit(&self, id: &Id, _ctx: Context<'_, S>) {
+        let mut state = self.state.lock().unwrap();
+
+        let prev_ind = indent_levels(state.indentation_level);
+
+        if state.indentation_level > 0 {
+            state.indentation_level -= 1;
+        }
+
+        let ind = indent_levels(state.indentation_level);
+
+        let elapsed_time = state
+            .timestamps
+            .remove(id)
+            .map(|t| t.elapsed())
+            .unwrap_or_default();
+
+        let human_duration = HumanDuration(elapsed_time);
+
+        eprintln!(
+            "{prev_ind}\n{ind} {} (took {})",
+            style("╰───────────────────").cyan(),
+            human_duration
+        );
+    }
+
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let mut state = self.state.lock().unwrap();
+        let indent_str = indent_levels(state.indentation_level);
+
+        let mut s = Vec::new();
+        event.record(&mut CustomVisitor::new(&mut s));
+        let s = String::from_utf8_lossy(&s);
+
+        let (prefix, prefix_len) =
+            if event.metadata().level() <= &tracing_core::metadata::Level::WARN {
+                state.warnings.push(s.to_string());
+                if event.metadata().level() == &tracing_core::metadata::Level::ERROR {
+                    (style("× error ").red().bold(), 7)
+                } else {
+                    (style("⚠ warning ").yellow().bold(), 9)
+                }
+            } else {
+                (style(""), 0)
+            };
+
+        let width: usize = terminal_size::terminal_size()
+            .map(|(w, _)| w.0)
+            .unwrap_or(160) as usize;
+
+        let max_width = width - (state.indentation_level * 2) - 1 - prefix_len;
+
+        self.progress_bars.suspend(|| {
+            for line in s.lines() {
+                // split line into max_width chunks
+                if line.len() <= max_width {
+                    eprintln!("{} {}{}", indent_str, prefix, line);
+                } else {
+                    chunk_string_without_ansi(line, max_width)
+                        .iter()
+                        .for_each(|chunk| {
+                            eprintln!("{} {}{}", indent_str, prefix, chunk);
+                        });
+                }
+            }
+        });
+    }
+}
+
+/// A custom output handler for fancy logging.
+#[derive(Debug)]
+pub struct LoggingOutputHandler {
+    state: Arc<Mutex<SharedState>>,
+    progress_bars: MultiProgress,
+    writer: io::Stderr,
+}
+
+impl Clone for LoggingOutputHandler {
+    fn clone(&self) -> Self {
+        Self {
+            state: self.state.clone(),
+            progress_bars: self.progress_bars.clone(),
+            writer: io::stderr(),
+        }
+    }
+}
+
+impl Default for LoggingOutputHandler {
+    /// Creates a new output handler.
+    fn default() -> Self {
+        Self {
+            state: Arc::new(Mutex::new(SharedState::default())),
+            progress_bars: MultiProgress::new(),
+            writer: io::stderr(),
+        }
+    }
+}
+
+impl LoggingOutputHandler {
+    /// Create a new logging handler with the given multi-progress.
+    pub fn from_multi_progress(multi_progress: MultiProgress) -> LoggingOutputHandler {
+        Self {
+            state: Arc::new(Mutex::new(SharedState::default())),
+            progress_bars: multi_progress,
+            writer: io::stderr(),
+        }
+    }
+
+    fn with_indent_levels(&self, template: &str) -> String {
+        let state = self.state.lock().unwrap();
+        let indent_str = indent_levels(state.indentation_level);
+        format!("{} {}", indent_str, template)
+    }
+
+    /// Returns the style to use for a progressbar that is currently in progress.
+    pub fn default_bytes_style(&self) -> indicatif::ProgressStyle {
+        let template_str = self.with_indent_levels(
+            "{spinner:.green} {prefix:20!} [{elapsed_precise}] [{bar:40!.bright.yellow/dim.white}] {bytes:>8} @ {smoothed_bytes_per_sec:8}"
+        );
+
+        indicatif::ProgressStyle::default_bar()
+            .template(&template_str)
+            .unwrap()
+            .progress_chars("━━╾─")
+            .with_key(
+                "smoothed_bytes_per_sec",
+                |s: &ProgressState, w: &mut dyn std::fmt::Write| match (
+                    s.pos(),
+                    s.elapsed().as_millis(),
+                ) {
+                    (pos, elapsed_ms) if elapsed_ms > 0 => {
+                        // TODO: log with tracing?
+                        _ = write!(
+                            w,
+                            "{}/s",
+                            HumanBytes((pos as f64 * 1000_f64 / elapsed_ms as f64) as u64)
+                        );
+                    }
+                    _ => {
+                        _ = write!(w, "-");
+                    }
+                },
+            )
+    }
+
+    /// Returns the style to use for a progressbar that is currently in progress.
+    pub fn default_progress_style(&self) -> indicatif::ProgressStyle {
+        let template_str = self.with_indent_levels(
+            "{spinner:.green} {prefix:20!} [{elapsed_precise}] [{bar:40!.bright.yellow/dim.white}] {pos:>7}/{len:7}"
+        );
+        indicatif::ProgressStyle::default_bar()
+            .template(&template_str)
+            .unwrap()
+            .progress_chars("━━╾─")
+    }
+
+    /// Returns the style to use for a progressbar that is in Deserializing state.
+    pub fn deserializing_progress_style(&self) -> indicatif::ProgressStyle {
+        let template_str =
+            self.with_indent_levels("{spinner:.green} {prefix:20!} [{elapsed_precise}] {wide_msg}");
+        indicatif::ProgressStyle::default_bar()
+            .template(&template_str)
+            .unwrap()
+            .progress_chars("━━╾─")
+    }
+
+    /// Returns the style to use for a progressbar that is finished.
+    pub fn finished_progress_style(&self) -> indicatif::ProgressStyle {
+        let template_str = self.with_indent_levels(&format!(
+            "{} {{spinner:.green}} {{prefix:20!}} [{{elapsed_precise}}] {{msg:.bold.green}}",
+            console::style(console::Emoji("✔", " ")).green()
+        ));
+
+        indicatif::ProgressStyle::default_bar()
+            .template(&template_str)
+            .unwrap()
+            .progress_chars("━━╾─")
+    }
+
+    /// Returns the style to use for a progressbar that is in error state.
+    pub fn errored_progress_style(&self) -> indicatif::ProgressStyle {
+        let template_str = self.with_indent_levels(&format!(
+            "{} {{prefix:20!}} [{{elapsed_precise}}] {{msg:.bold.red}}",
+            console::style(console::Emoji("×", " ")).red()
+        ));
+
+        indicatif::ProgressStyle::default_bar()
+            .template(&template_str)
+            .unwrap()
+            .progress_chars("━━╾─")
+    }
+
+    /// Returns the style to use for a progressbar that is indeterminate and simply shows a spinner.
+    pub fn long_running_progress_style(&self) -> indicatif::ProgressStyle {
+        let template_str = self.with_indent_levels("{spinner:.green} {msg}");
+        ProgressStyle::with_template(&template_str).unwrap()
+    }
+
+    /// Adds a progress bar to the handler.
+    pub fn add_progress_bar(&self, progress_bar: indicatif::ProgressBar) -> indicatif::ProgressBar {
+        self.progress_bars.add(progress_bar)
+    }
+
+    /// Set progress bars to hidden
+    pub fn set_progress_bars_hidden(&self, hidden: bool) {
+        self.progress_bars.set_draw_target(if hidden {
+            indicatif::ProgressDrawTarget::hidden()
+        } else {
+            indicatif::ProgressDrawTarget::stderr()
+        });
+    }
+}
+
+impl io::Write for LoggingOutputHandler {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.progress_bars.suspend(|| self.writer.write(buf))
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.progress_bars.suspend(|| self.writer.flush())
+    }
+}
+
+impl<'a> MakeWriter<'a> for LoggingOutputHandler {
+    type Writer = LoggingOutputHandler;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+///////////////////////
+// LOGGING CLI utils //
+///////////////////////
+
+/// The style to use for logging output.
+#[derive(clap::ValueEnum, Clone, Eq, PartialEq, Debug, Copy)]
+pub enum LogStyle {
+    /// Use fancy logging output.
+    Fancy,
+    /// Use JSON logging output.
+    Json,
+    /// Use plain logging output.
+    Plain,
+}
+
+/// Constructs a default [`EnvFilter`] that is used when the user did not specify a custom RUST_LOG.
+pub fn get_default_env_filter(
+    verbose: clap_verbosity_flag::LevelFilter,
+) -> Result<EnvFilter, ParseError> {
+    let mut result = EnvFilter::new(format!("rattler_build={verbose}"));
+
+    if verbose >= clap_verbosity_flag::LevelFilter::Trace {
+        result = result.add_directive(Directive::from_str("resolvo=info")?);
+        result = result.add_directive(Directive::from_str("rattler=info")?);
+        result = result.add_directive(Directive::from_str(
+            "rattler_networking::authentication_storage=info",
+        )?);
+    } else {
+        result = result.add_directive(Directive::from_str("resolvo=warn")?);
+        result = result.add_directive(Directive::from_str("rattler=warn")?);
+        result = result.add_directive(Directive::from_str("rattler_repodata_gateway::fetch=off")?);
+        result = result.add_directive(Directive::from_str(
+            "rattler_networking::authentication_storage=off",
+        )?);
+    }
+
+    Ok(result)
+}
+
+struct GitHubActionsLayer(bool);
+
+impl<S: Subscriber> Layer<S> for GitHubActionsLayer {
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+        if !self.0 {
+            return;
+        }
+        let metadata = event.metadata();
+        match *metadata.level() {
+            Level::WARN => println!("::warning ::{}", format_args!("{:?}", event)),
+            Level::ERROR => println!("::error ::{}", format_args!("{:?}", event)),
+            _ => {} // Ignore other levels
+        }
+    }
+}
+
+/// Initializes logging with the given style and verbosity.
+pub fn init_logging(
+    log_style: &LogStyle,
+    verbosity: &Verbosity<InfoLevel>,
+) -> Result<LoggingOutputHandler, ParseError> {
+    let log_handler = LoggingOutputHandler::default();
+
+    // Setup tracing subscriber
+    let registry =
+        tracing_subscriber::registry().with(get_default_env_filter(verbosity.log_level_filter())?);
+
+    let log_style = if verbosity.log_level_filter() >= clap_verbosity_flag::LevelFilter::Debug {
+        LogStyle::Plain
+    } else {
+        *log_style
+    };
+
+    let registry = registry.with(GitHubActionsLayer(github_integration_enabled()));
+
+    match log_style {
+        LogStyle::Fancy => {
+            registry.with(log_handler.clone()).init();
+        }
+        LogStyle::Plain => {
+            registry
+                .with(
+                    fmt::layer()
+                        .with_writer(log_handler.clone())
+                        .event_format(TracingFormatter),
+                )
+                .init();
+        }
+        LogStyle::Json => {
+            log_handler.set_progress_bars_hidden(true);
+            registry
+                .with(
+                    tracing_subscriber::fmt::layer()
+                        .json()
+                        .with_writer(io::stderr),
+                )
+                .init();
+        }
+    }
+
+    Ok(log_handler)
+}
+
+/// check if we are on Github CI nad if the user has enabled the integration
+pub fn github_integration_enabled() -> bool {
+    std::env::var("GITHUB_ACTIONS").is_ok()
+        && std::env::var("RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION") == Ok("true".to_string())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 //! The library pieces of rattler-build
 
 pub mod build;
+pub mod console_utils;
 pub mod metadata;
 pub mod package_test;
 pub mod packaging;

--- a/src/macos/link.rs
+++ b/src/macos/link.rs
@@ -306,7 +306,7 @@ impl fmt::Display for DylibChanges {
                     .starts_with("host_env_placehold_placehold")
             });
             if let Some(idx) = placeholder_index {
-                let mut pb = PathBuf::from("$PLACEHOLDER_PREFIX");
+                let mut pb = PathBuf::from("$PREFIX");
                 pb.extend(path.components().skip(idx + 1));
                 pb
             } else {
@@ -319,7 +319,7 @@ impl fmt::Display for DylibChanges {
                 (Some(old), Some(new)) => {
                     writeln!(
                         f,
-                        " - change rpath from {:?} to {:?}",
+                        " - changing absolute rpath from {:?} to {:?}",
                         strip_placeholder_prefix(old),
                         new
                     )?;

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -466,7 +466,7 @@ impl Output {
 
             writeln!(
                 summary_file,
-                "<details><summary>Resolved dependencies</summary>\n\n{}\n</details>",
+                "<details><summary>Resolved dependencies</summary>\n\n{}\n</details>\n",
                 self.format_as_markdown()
             )?;
         }

--- a/src/package_test/content_test.rs
+++ b/src/package_test/content_test.rs
@@ -12,12 +12,12 @@ fn build_glob(glob: String) -> Result<Glob, globset::Error> {
 
 fn display_success(matches: &Vec<&PathBuf>, glob: &str, section: &str) {
     tracing::info!(
-        "{} {section}: {} matched:",
+        "{} {section}: \"{}\" matched:",
         console::style(console::Emoji("✔", "")).green(),
         glob
     );
     for m in matches[0..std::cmp::min(5, matches.len())].iter() {
-        tracing::info!("-  {}", m.display());
+        tracing::info!("  - {}", m.display());
     }
     if matches.len() > 5 {
         tracing::info!("... and {} more", matches.len() - 5);
@@ -214,6 +214,9 @@ impl PackageContentsTest {
 
     /// Run the package content test
     pub fn run_test(&self, paths: &PathsJson, target_platform: &Platform) -> Result<(), TestError> {
+        let span = tracing::info_span!("Package content test");
+        let _enter = span.enter();
+
         let paths = paths
             .paths
             .iter()

--- a/src/package_test/run_test.rs
+++ b/src/package_test/run_test.rs
@@ -206,6 +206,9 @@ pub struct TestConfiguration {
 pub async fn run_test(package_file: &Path, config: &TestConfiguration) -> Result<(), TestError> {
     let tmp_repo = tempfile::tempdir()?;
 
+    // create the test prefix
+    fs::create_dir_all(&config.test_prefix)?;
+
     let target_platform = if let Some(tp) = config.target_platform {
         tp
     } else {

--- a/src/script.rs
+++ b/src/script.rs
@@ -354,6 +354,9 @@ impl Script {
 
 impl Output {
     pub async fn run_build_script(&self) -> Result<(), std::io::Error> {
+        let span = tracing::info_span!("Running build script");
+        let _enter = span.enter();
+
         let host_prefix = self.build_configuration.directories.host_prefix.clone();
         let target_platform = self.build_configuration.target_platform;
         let mut env_vars = env_vars::vars(self, "BUILD");

--- a/src/source/git_source.rs
+++ b/src/source/git_source.rs
@@ -16,7 +16,7 @@ use super::SourceError;
 
 /// Fetch the given repository using the host `git` executable.
 pub fn fetch_repo(repo_path: &Path, url: &Url, rev: &str) -> Result<(), SourceError> {
-    println!("Fetching repository from {} at {}", url, rev);
+    tracing::info!("Fetching repository from {} at {}", url, rev);
     let mut command = git_command("fetch");
     let output = command
         .args([url.to_string().as_str(), rev])

--- a/src/source/url_source.rs
+++ b/src/source/url_source.rs
@@ -7,7 +7,6 @@ use std::{
 
 use crate::{
     recipe::parser::{Checksum, UrlSource},
-    render::solver::default_bytes_style,
     tool_configuration,
 };
 use rattler_digest::{compute_file_digest, Md5};
@@ -139,12 +138,10 @@ pub(crate) async fn url_src(
         }
     };
 
-    let progress_bar = tool_configuration.multi_progress_indicator.add(
+    let progress_bar = tool_configuration.fancy_log_handler.add_progress_bar(
         indicatif::ProgressBar::new(download_size)
             .with_prefix("Downloading")
-            .with_style(default_bytes_style().map_err(|_| {
-                SourceError::UnknownError("Failed to get progress bar style".to_string())
-            })?),
+            .with_style(tool_configuration.fancy_log_handler.default_bytes_style()),
     );
     progress_bar.set_message(
         source

--- a/src/tool_configuration.rs
+++ b/src/tool_configuration.rs
@@ -3,14 +3,14 @@
 
 use std::{path::PathBuf, sync::Arc};
 
+use crate::console_utils::LoggingOutputHandler;
 use rattler_networking::{authentication_storage, AuthenticationMiddleware, AuthenticationStorage};
 use reqwest_middleware::ClientWithMiddleware;
-
 /// Global configuration for the build
 #[derive(Clone, Debug)]
 pub struct Configuration {
     /// If set to a value, a progress bar will be shown
-    pub multi_progress_indicator: indicatif::MultiProgress,
+    pub fancy_log_handler: LoggingOutputHandler,
 
     /// The authenticated reqwest download client to use
     pub client: ClientWithMiddleware,
@@ -57,16 +57,17 @@ pub fn reqwest_client_from_auth_storage(auth_file: Option<PathBuf>) -> ClientWit
 
 impl Default for Configuration {
     fn default() -> Self {
-        let auth_storage = AuthenticationStorage::default();
         Self {
-            multi_progress_indicator: indicatif::MultiProgress::new(),
+            fancy_log_handler: LoggingOutputHandler::default(),
             client: reqwest_middleware::ClientBuilder::new(
                 reqwest::Client::builder()
                     .no_gzip()
                     .build()
                     .expect("failed to create client"),
             )
-            .with_arc(Arc::new(AuthenticationMiddleware::new(auth_storage)))
+            .with_arc(Arc::new(AuthenticationMiddleware::new(
+                AuthenticationStorage::default(),
+            )))
             .build(),
             no_clean: false,
             no_test: false,


### PR DESCRIPTION
TODO:

- [x] refactor `run_in_env` so that we can use it both in tests and build execution
- [x] Add more `span!` (e.g. when running the tests)
- [x] make interpreter selectable while we are at it :)
- [x] Test `rebuild` and `test` subcommands
- [x] Add "summary" function after the build(s) is done

Still needs fixing:

- [x] Summary is nice, but needs some more tweaks:
  - Add a Github subscriber that prints warning as `::warning::{message}` and error as `::error::{message}`
  - Make the summary have proper tables

