### PR TITLE
docs: Add github action to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ On Windows, to obtain these dependencies from conda-forge, one can install
 We have extensive documentation for `rattler-build`. You can find the [book
 here](https://prefix-dev.github.io/rattler-build).
 
+### GitHub Action
+
+There is a GitHub Action for rattler-build.
+It can be used to install `rattler-build` in CI/CD workflows and run a build command.
+Please check out the [GitHub Action documentation](https://github.com/prefix-dev/rattler-build-action) for more information.
+
 ### Usage
 
 `rattler-build` comes with two commands: `build` and `test`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,6 +58,12 @@ self-contained.
 On Windows, to obtain these dependencies from conda-forge, one can install
 `m2-patch`, `m2-bzip2`, `m2-gzip`, `m2-tar`.
 
+#### GitHub Action
+
+There is a GitHub Action for rattler-build.
+It can be used to install `rattler-build` in CI/CD workflows and run a build command.
+Please check out the [GitHub Action documentation](https://github.com/prefix-dev/rattler-build-action) for more information.
+
 ### Usage
 
 `rattler-build` comes with three commands: `build`, `test` and `rebuild`.


### PR DESCRIPTION
I'm wondering whether we should symlink `index.md` and `README.md`...