### PR TITLE
fix: labels and help messages for partial errors for clarity

### DIFF
--- a/src/recipe/custom_yaml.rs
+++ b/src/recipe/custom_yaml.rs
@@ -1103,7 +1103,13 @@ impl TryConvertNode<Url> for RenderedNode {
 impl TryConvertNode<Url> for RenderedScalarNode {
     fn try_convert(&self, _name: &str) -> Result<Url, Vec<PartialParsingError>> {
         Url::parse(self.as_str())
-            .map_err(|err| _partialerror!(*self.span(), ErrorKind::from(err)))
+            .map_err(|err| {
+                _partialerror!(
+                    *self.span(),
+                    ErrorKind::from(err),
+                    label = "failed to parse the URL"
+                )
+            })
             .map_err(|e| vec![e])
     }
 }

--- a/src/recipe/parser.rs
+++ b/src/recipe/parser.rs
@@ -150,6 +150,7 @@ impl Recipe {
             vec![_partialerror!(
                 *root_node.span(),
                 ErrorKind::ExpectedMapping,
+                label = "expects a map as the yaml root"
             )]
         })?;
 
@@ -170,7 +171,7 @@ impl Recipe {
                         vec![_partialerror!(
                             *v.span(),
                             ErrorKind::ExpectedScalar,
-                            help = "`context` values must always be scalars"
+                            help = "`context` field values must always be scalars"
                         )]
                     })?;
                     let rendered: Option<ScalarNode> =
@@ -221,6 +222,7 @@ impl Recipe {
                         return Err(vec![_partialerror!(
                             *key.span(),
                             ErrorKind::InvalidField(invalid_key.to_string().into()),
+                            label = "only valid keys are `package`, `recipe`, `source`, `build`, `requirements`, `tests`, `about`, `context` and `extra`"
                         )])
                     }
                 }

--- a/src/recipe/parser/about.rs
+++ b/src/recipe/parser/about.rs
@@ -66,7 +66,13 @@ impl About {
 impl TryConvertNode<About> for RenderedNode {
     fn try_convert(&self, name: &str) -> Result<About, Vec<PartialParsingError>> {
         self.as_mapping()
-            .ok_or_else(|| vec![_partialerror!(*self.span(), ErrorKind::ExpectedMapping,)])
+            .ok_or_else(|| {
+                vec![_partialerror!(
+                    *self.span(),
+                    ErrorKind::ExpectedMapping,
+                    label = "about section requires package information fields"
+                )]
+            })
             .and_then(|m| m.try_convert(name))
     }
 }
@@ -127,7 +133,13 @@ impl FromStr for License {
 impl TryConvertNode<License> for RenderedNode {
     fn try_convert(&self, name: &str) -> Result<License, Vec<PartialParsingError>> {
         self.as_scalar()
-            .ok_or_else(|| vec![_partialerror!(*self.span(), ErrorKind::ExpectedScalar,)])
+            .ok_or_else(|| {
+                vec![_partialerror!(
+                    *self.span(),
+                    ErrorKind::ExpectedScalar,
+                    label = "license requires a valid SPDX string"
+                )]
+            })
             .and_then(|m| m.try_convert(name))
     }
 }
@@ -135,8 +147,13 @@ impl TryConvertNode<License> for RenderedNode {
 impl TryConvertNode<License> for RenderedScalarNode {
     fn try_convert(&self, name: &str) -> Result<License, Vec<PartialParsingError>> {
         let original: String = self.try_convert(name)?;
-        let expr = Expression::parse(original.as_str())
-            .map_err(|err| vec![_partialerror!(*self.span(), ErrorKind::from(err),)])?;
+        let expr = Expression::parse(original.as_str()).map_err(|err| {
+            vec![_partialerror!(
+                *self.span(),
+                ErrorKind::from(err),
+                label = "invalid SPDX license expression"
+            )]
+        })?;
 
         Ok(License { original, expr })
     }

--- a/src/recipe/parser/build.rs
+++ b/src/recipe/parser/build.rs
@@ -35,7 +35,13 @@ pub struct VariantKeyUsage {
 impl TryConvertNode<VariantKeyUsage> for RenderedNode {
     fn try_convert(&self, name: &str) -> Result<VariantKeyUsage, Vec<PartialParsingError>> {
         self.as_mapping()
-            .ok_or_else(|| vec![_partialerror!(*self.span(), ErrorKind::ExpectedMapping)])
+            .ok_or_else(|| {
+                vec![_partialerror!(
+                    *self.span(),
+                    ErrorKind::ExpectedMapping,
+                    label = format!("expects mapping for {name}")
+                )]
+            })
             .and_then(|m| m.try_convert(name))
     }
 }
@@ -174,7 +180,13 @@ impl Build {
 impl TryConvertNode<Build> for RenderedNode {
     fn try_convert(&self, name: &str) -> Result<Build, Vec<PartialParsingError>> {
         self.as_mapping()
-            .ok_or_else(|| vec![_partialerror!(*self.span(), ErrorKind::ExpectedMapping)])
+            .ok_or_else(|| {
+                vec![_partialerror!(
+                    *self.span(),
+                    ErrorKind::ExpectedMapping,
+                    label = format!("expects mapping for {name}")
+                )]
+            })
             .and_then(|m| m.try_convert(name))
     }
 }
@@ -288,7 +300,13 @@ impl TryConvertNode<LinkingCheckBehavior> for RenderedNode {
     fn try_convert(&self, name: &str) -> Result<LinkingCheckBehavior, Vec<PartialParsingError>> {
         self.as_scalar()
             .cloned()
-            .ok_or_else(|| vec![_partialerror!(*self.span(), ErrorKind::ExpectedScalar)])
+            .ok_or_else(|| {
+                vec![_partialerror!(
+                    *self.span(),
+                    ErrorKind::ExpectedScalar,
+                    label = format!("expects string scalar for {name}")
+                )]
+            })
             .and_then(|m| m.try_convert(name))
     }
 }
@@ -301,7 +319,7 @@ impl TryConvertNode<LinkingCheckBehavior> for RenderedScalarNode {
             _ => Err(vec![_partialerror!(
                 *self.span(),
                 ErrorKind::ExpectedScalar,
-                help = format!("valid options for {name} are `ignore` or `error`")
+                help = format!("valid options for {name} are \"ignore\" or \"error\"")
             )]),
         }
     }
@@ -364,7 +382,13 @@ impl Python {
 impl TryConvertNode<Python> for RenderedNode {
     fn try_convert(&self, name: &str) -> Result<Python, Vec<PartialParsingError>> {
         self.as_mapping()
-            .ok_or_else(|| vec![_partialerror!(*self.span(), ErrorKind::ExpectedMapping)])
+            .ok_or_else(|| {
+                vec![_partialerror!(
+                    *self.span(),
+                    ErrorKind::ExpectedMapping,
+                    label = format!("expects mapping for {name}")
+                )]
+            })
             .and_then(|m| m.try_convert(name))
     }
 }
@@ -459,7 +483,13 @@ impl TryConvertNode<NoArchType> for RenderedScalarNode {
 impl TryConvertNode<EntryPoint> for RenderedNode {
     fn try_convert(&self, name: &str) -> Result<EntryPoint, Vec<PartialParsingError>> {
         self.as_scalar()
-            .ok_or_else(|| vec![_partialerror!(*self.span(), ErrorKind::ExpectedScalar)])
+            .ok_or_else(|| {
+                vec![_partialerror!(
+                    *self.span(),
+                    ErrorKind::ExpectedScalar,
+                    label = format!("expected string scalar for {name}")
+                )]
+            })
             .and_then(|s| s.try_convert(name))
     }
 }
@@ -470,6 +500,7 @@ impl TryConvertNode<EntryPoint> for RenderedScalarNode {
             vec![_partialerror!(
                 *self.span(),
                 ErrorKind::EntryPointParsing(err),
+                label = "failed to parse entrypoint, provide either `python` or `generic`"
             )]
         })
     }

--- a/src/recipe/parser/helper.rs
+++ b/src/recipe/parser/helper.rs
@@ -11,6 +11,7 @@ macro_rules! validate_keys {
                 return Err(vec![_partialerror!(
                     *key.span(),
                     ErrorKind::DuplicateKey(key_str.to_string()),
+                    label = format!("{key_str} is a duplicate")
                 )]);
             }
 

--- a/src/recipe/parser/requirements.rs
+++ b/src/recipe/parser/requirements.rs
@@ -228,7 +228,7 @@ impl TryConvertNode<Vec<Dependency>> for RenderedNode {
             RenderedNode::Mapping(_) => Err(vec![_partialerror!(
                 *self.span(),
                 ErrorKind::Other,
-                label = "expected scalar or sequence"
+                label = format!("expected scalar or sequence for {name}")
             )]),
             RenderedNode::Null(_) => Ok(vec![]),
         }
@@ -511,7 +511,13 @@ impl IgnoreRunExports {
 impl TryConvertNode<IgnoreRunExports> for RenderedNode {
     fn try_convert(&self, name: &str) -> Result<IgnoreRunExports, Vec<PartialParsingError>> {
         self.as_mapping()
-            .ok_or_else(|| vec![_partialerror!(*self.span(), ErrorKind::ExpectedMapping)])
+            .ok_or_else(|| {
+                vec![_partialerror!(
+                    *self.span(),
+                    ErrorKind::ExpectedMapping,
+                    label = format!("expects mapping for {name}")
+                )]
+            })
             .and_then(|m| m.try_convert(name))
     }
 }

--- a/src/recipe/parser/script.rs
+++ b/src/recipe/parser/script.rs
@@ -271,7 +271,7 @@ impl TryConvertNode<Script> for RenderedMappingNode {
                 return Err(vec![_partialerror!(
                     *last_node.span(),
                     ErrorKind::InvalidField(last_node_name.into()),
-                    help = format!("cannot specify both `content` and `file`")
+                    help = "cannot specify both `content` and `file`"
                 )]);
             }
             (Some(file), None) => file.try_convert("file").map(ScriptContent::Path)?,

--- a/src/variant_config.rs
+++ b/src/variant_config.rs
@@ -51,7 +51,13 @@ pub struct Pin {
 impl TryConvertNode<Pin> for RenderedNode {
     fn try_convert(&self, name: &str) -> Result<Pin, Vec<PartialParsingError>> {
         self.as_mapping()
-            .ok_or_else(|| _partialerror!(*self.span(), ErrorKind::ExpectedMapping,))
+            .ok_or_else(|| {
+                _partialerror!(
+                    *self.span(),
+                    ErrorKind::ExpectedMapping,
+                    label = format!("expects mapping for {name}")
+                )
+            })
             .map_err(|e| vec![e])
             .and_then(|map| map.try_convert(name))
     }
@@ -731,7 +737,13 @@ impl VariantConfig {
 impl TryConvertNode<VariantConfig> for RenderedNode {
     fn try_convert(&self, name: &str) -> Result<VariantConfig, Vec<PartialParsingError>> {
         self.as_mapping()
-            .ok_or_else(|| vec![_partialerror!(*self.span(), ErrorKind::ExpectedMapping)])
+            .ok_or_else(|| {
+                vec![_partialerror!(
+                    *self.span(),
+                    ErrorKind::ExpectedMapping,
+                    label = format!("expects mapping for `{name}`")
+                )]
+            })
             .and_then(|map| map.try_convert(name))
     }
 }


### PR DESCRIPTION
Some of the partial errors could use labels, this pr adds some of them in cases where I thought they would improve clarity especially in edge cases where spans and error messages aren't clear enough.

fixes https://github.com/prefix-dev/rattler-build/issues/399