### PR TITLE
always add python version as `$PY_VER`

### DIFF
--- a/src/env_vars.rs
+++ b/src/env_vars.rs
@@ -36,7 +36,7 @@ fn get_sitepackages_dir(prefix: &Path, platform: &Platform, py_ver: &str) -> Pat
 pub fn python_vars(output: &Output) -> HashMap<String, String> {
     let mut result = HashMap::<String, String>::new();
 
-    if output.target_platform().is_windows() {
+    if output.host_platform().is_windows() {
         let python = output.prefix().join("python.exe");
         result.insert("PYTHON".to_string(), python.to_string_lossy().to_string());
     } else {
@@ -63,9 +63,9 @@ pub fn python_vars(output: &Output) -> HashMap<String, String> {
     if let Some(py_ver) = python_version {
         let py_ver = py_ver.split('.').collect::<Vec<_>>();
         let py_ver_str = format!("{}.{}", py_ver[0], py_ver[1]);
-        let stdlib_dir = get_stdlib_dir(output.prefix(), output.target_platform(), &py_ver_str);
+        let stdlib_dir = get_stdlib_dir(output.prefix(), output.host_platform(), &py_ver_str);
         let site_packages_dir =
-            get_sitepackages_dir(output.prefix(), output.target_platform(), &py_ver_str);
+            get_sitepackages_dir(output.prefix(), output.host_platform(), &py_ver_str);
         result.insert(
             "PY3K".to_string(),
             if py_ver[0] == "3" {
@@ -109,7 +109,7 @@ pub fn r_vars(output: &Output) -> HashMap<String, String> {
     if let Some(r_ver) = output.variant().get("r-base") {
         result.insert("R_VER".to_string(), r_ver.clone());
 
-        let r_bin = if output.target_platform().is_windows() {
+        let r_bin = if output.host_platform().is_windows() {
             output.prefix().join("Scripts/R.exe")
         } else {
             output.prefix().join("bin/R")
@@ -218,12 +218,7 @@ pub fn vars(output: &Output, build_state: &str) -> HashMap<String, String> {
     insert!(vars, "CONDA_BUILD", "1");
     insert!(vars, "PYTHONNOUSERSITE", "1");
 
-    if let Some((_, host_arch)) = output
-        .build_configuration
-        .host_platform
-        .to_string()
-        .rsplit_once('-')
-    {
+    if let Some((_, host_arch)) = output.host_platform().to_string().rsplit_once('-') {
         insert!(vars, "ARCH", host_arch);
     }
 

--- a/src/env_vars.rs
+++ b/src/env_vars.rs
@@ -47,15 +47,9 @@ pub fn python_vars(output: &Output) -> HashMap<String, String> {
     // find python in the host dependencies
     let mut python_version = output.variant().get("python").map(|s| s.to_string());
     if python_version.is_none() {
-        if let Some(finalized_deps) = &output.finalized_dependencies {
-            if let Some(host) = &finalized_deps.host {
-                let python_record = host
-                    .resolved
-                    .iter()
-                    .find(|record| record.package_record.name.as_normalized() == "python");
-                if let Some(python_record) = python_record {
-                    python_version = Some(python_record.package_record.version.to_string());
-                }
+        if let Some((record, requested)) = output.find_resolved_package("python") {
+            if requested {
+                python_version = Some(record.package_record.version.to_string());
             }
         }
     }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -386,6 +386,11 @@ impl Output {
         &self.build_configuration.target_platform
     }
 
+    /// Shorthand to retrieve the target platform for this output
+    pub fn host_platform(&self) -> &Platform {
+        &self.build_configuration.host_platform
+    }
+
     /// Print a nice summary of the build
     pub fn log_build_summary(&self) -> Result<(), std::io::Error> {
         let summary = self.build_summary.lock().unwrap();

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -366,6 +366,26 @@ impl Output {
         summary.build_end = Some(chrono::Utc::now());
     }
 
+    /// Shorthand to retrieve the variant configuration for this output
+    pub fn variant(&self) -> &BTreeMap<String, String> {
+        &self.build_configuration.variant
+    }
+
+    /// Shorthand to retrieve the host prefix for this output
+    pub fn prefix(&self) -> &Path {
+        &self.build_configuration.directories.host_prefix
+    }
+
+    /// Shorthand to retrieve the build prefix for this output
+    pub fn build_prefix(&self) -> &Path {
+        &self.build_configuration.directories.build_prefix
+    }
+
+    /// Shorthand to retrieve the target platform for this output
+    pub fn target_platform(&self) -> &Platform {
+        &self.build_configuration.target_platform
+    }
+
     /// Print a nice summary of the build
     pub fn log_build_summary(&self) -> Result<(), std::io::Error> {
         let summary = self.build_summary.lock().unwrap();

--- a/src/post_process/python.rs
+++ b/src/post_process/python.rs
@@ -303,7 +303,6 @@ pub(crate) fn create_entry_points(
         return Ok(Vec::new());
     }
 
-    let target_platform = &output.build_configuration.target_platform;
     let mut new_files = Vec::new();
 
     let (python_record, _) = output.find_resolved_package("python").ok_or_else(|| {
@@ -316,22 +315,18 @@ pub(crate) fn create_entry_points(
 
     for ep in &output.recipe.build().python().entry_points {
         let script = python_entry_point_template(
-            &output
-                .build_configuration
-                .directories
-                .host_prefix
-                .to_string_lossy(),
+            &output.prefix().to_string_lossy(),
             ep,
-            &PythonInfo::from_version(&python_version, output.build_configuration.target_platform)
-                .map_err(|e| {
-                    PackagingError::CannotCreateEntryPoint(format!(
-                        "Could not create python info: {}",
-                        e
-                    ))
-                })?,
+            // using target_platform is OK because this should never be noarch
+            &PythonInfo::from_version(&python_version, *output.target_platform()).map_err(|e| {
+                PackagingError::CannotCreateEntryPoint(format!(
+                    "Could not create python info: {}",
+                    e
+                ))
+            })?,
         );
 
-        if target_platform.is_windows() {
+        if output.target_platform().is_windows() {
             fs::create_dir_all(tmp_dir_path.join("Scripts"))?;
 
             let script_path = tmp_dir_path.join(format!("Scripts/{}-script.py", ep.command));
@@ -341,7 +336,7 @@ pub(crate) fn create_entry_points(
             // write exe launcher as well
             let exe_path = tmp_dir_path.join(format!("Scripts/{}.exe", ep.command));
             let mut exe = fs::File::create(&exe_path)?;
-            exe.write_all(get_windows_launcher(target_platform))?;
+            exe.write_all(get_windows_launcher(output.target_platform()))?;
 
             new_files.extend(vec![script_path, exe_path]);
         } else {
@@ -357,12 +352,12 @@ pub(crate) fn create_entry_points(
                 std::os::unix::fs::PermissionsExt::from_mode(0o775),
             )?;
 
-            if output.build_configuration.target_platform.is_osx()
+            if output.target_platform().is_osx()
                 && output.recipe.build().python().use_python_app_entrypoint
             {
                 fix_shebang(
                     &script_path,
-                    &output.build_configuration.directories.host_prefix,
+                    output.prefix(),
                     output.recipe.build().python().use_python_app_entrypoint,
                 )?;
             }

--- a/test-data/recipes/flask/recipe.yaml
+++ b/test-data/recipes/flask/recipe.yaml
@@ -15,7 +15,15 @@ source:
 
 build:
   number: 0
-  script: python -m pip install . -vv --no-deps --no-build-isolation
+  script:
+    - python -m pip install . -vv --no-deps --no-build-isolation
+    # make sure that PY_VER is set even for noarch packages
+    - if: unix
+      then:
+      - test ! -z "$PY_VER"
+      else:
+      - if not defined PY_VER exit 1
+
   python:
     entry_points:
       - flask = flask.cli:main


### PR DESCRIPTION
This searches for the Python version in the resolved dependencies and adds it.

Should we do the same for `numpy` and `R`?

Fixes #557 