### PR TITLE
docs: added LicenseRef option

### DIFF
--- a/docs/recipe_file.md
+++ b/docs/recipe_file.md
@@ -891,6 +891,7 @@ about:
 ```
 
 1.  Only the SPDX specifiers are allowed, more info here: [SPDX](https://spdx.org/licenses/)
+    If you want another license type `LicenseRef-<YOUR-LICENSE>` can be used, e.g. `license: LicenseRef-Proprietary`
 
 ### License file
 


### PR DESCRIPTION
Add docs to show what to do when a proprietary license wants to be used.