### PR TITLE
fix: extraction bars proper length and add checksum verification to path source

### DIFF
--- a/src/recipe/parser.rs
+++ b/src/recipe/parser.rs
@@ -40,7 +40,7 @@ pub use self::{
         Compiler, Dependency, IgnoreRunExports, PinSubpackage, Requirements, RunExports,
     },
     script::{Script, ScriptContent},
-    source::{Checksum, GitRev, GitSource, GitUrl, PathSource, Source, UrlSource},
+    source::{GitRev, GitSource, GitUrl, PathSource, Source, UrlSource},
     test::{
         CommandsTest, CommandsTestFiles, CommandsTestRequirements, DownstreamTest,
         PackageContentsTest, PythonTest, TestType,

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__complete_recipe.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__complete_recipe.snap
@@ -14,6 +14,8 @@ source:
   - file.patch
   target_directory: test-package
 - path: ./some-file.tar.gz
+  sha256: 1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
+  md5: 1234567890abcdef1234567890abcdef
   patches:
   - file.patch
   target_directory: test-package

--- a/src/render/solver.rs
+++ b/src/render/solver.rs
@@ -140,7 +140,7 @@ pub async fn create_environment(
                 .await
             }
         })
-        .buffer_unordered(channel_and_platform_len)
+        .buffered(channel_and_platform_len)
         .collect::<Vec<_>>()
         .await
         // Collect into another iterator where we extract the first erroneous result

--- a/src/source/checksum.rs
+++ b/src/source/checksum.rs
@@ -1,0 +1,86 @@
+//! Module to handle checksums and validate checksums of downloaded files.
+
+use std::path::Path;
+
+use rattler_digest::{compute_file_digest, serde::SerializableHash, Md5, Md5Hash, Sha256Hash};
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+
+use crate::recipe::parser::{PathSource, UrlSource};
+
+/// Checksum information.
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub enum Checksum {
+    /// A SHA256 checksum
+    Sha256(#[serde_as(as = "SerializableHash::<rattler_digest::Sha256>")] Sha256Hash),
+    /// A MD5 checksum
+    Md5(#[serde_as(as = "SerializableHash::<rattler_digest::Md5>")] Md5Hash),
+}
+
+impl Checksum {
+    /// Create a checksum from a URL source.
+    pub fn from_url_source(source: &UrlSource) -> Option<Self> {
+        if let Some(sha256) = source.sha256() {
+            Some(Checksum::Sha256(*sha256))
+        } else {
+            source.md5().map(|md5| Checksum::Md5(*md5))
+        }
+    }
+
+    /// Create a checksum from a path source.
+    pub fn from_path_source(source: &PathSource) -> Option<Self> {
+        if let Some(sha256) = source.sha256 {
+            Some(Checksum::Sha256(sha256))
+        } else {
+            source.md5.map(Checksum::Md5)
+        }
+    }
+
+    /// Get the checksum as a hex string.
+    pub fn to_hex(&self) -> String {
+        match self {
+            Checksum::Sha256(sha256) => hex::encode(sha256),
+            Checksum::Md5(md5) => hex::encode(md5),
+        }
+    }
+
+    /// Validate the checksum of a file.
+    pub fn validate(&self, path: &Path) -> bool {
+        match self {
+            Checksum::Sha256(value) => {
+                let digest =
+                    compute_file_digest::<sha2::Sha256>(path).expect("Could not compute SHA256");
+                let computed_sha = hex::encode(digest);
+                let checksum_sha = hex::encode(value);
+                if !computed_sha.eq(&checksum_sha) {
+                    tracing::error!(
+                        "SHA256 values of downloaded file not matching!\nDownloaded = {}, should be {}",
+                        computed_sha,
+                        checksum_sha
+                    );
+                    false
+                } else {
+                    tracing::info!("Validated SHA256 values of the downloaded file!");
+                    true
+                }
+            }
+            Checksum::Md5(value) => {
+                let digest = compute_file_digest::<Md5>(path).expect("Could not compute SHA256");
+                let computed_md5 = hex::encode(digest);
+                let checksum_md5 = hex::encode(value);
+                if !computed_md5.eq(&checksum_md5) {
+                    tracing::error!(
+                        "MD5 values of downloaded file not matching!\nDownloaded = {}, should be {}",
+                        computed_md5,
+                        checksum_md5
+                    );
+                    false
+                } else {
+                    tracing::info!("Validated MD5 values of the downloaded file!");
+                    true
+                }
+            }
+        }
+    }
+}

--- a/src/source/extract.rs
+++ b/src/source/extract.rs
@@ -1,0 +1,209 @@
+//! Helpers to extract archives
+use std::{ffi::OsStr, io::BufRead, path::Path};
+
+use crate::console_utils::LoggingOutputHandler;
+
+use fs_err as fs;
+use fs_err::File;
+
+use super::SourceError;
+/// Handle Compression formats internally
+enum TarCompression<'a> {
+    PlainTar(Box<dyn BufRead + 'a>),
+    Gzip(flate2::read::GzDecoder<Box<dyn BufRead + 'a>>),
+    Bzip2(bzip2::read::BzDecoder<Box<dyn BufRead + 'a>>),
+    Xz2(xz2::read::XzDecoder<Box<dyn BufRead + 'a>>),
+    Zstd(zstd::stream::read::Decoder<'a, std::io::BufReader<Box<dyn BufRead + 'a>>>),
+    Compress,
+    Lzip,
+    Lzop,
+}
+
+fn ext_to_compression<'a>(ext: Option<&OsStr>, file: Box<dyn BufRead + 'a>) -> TarCompression<'a> {
+    match ext
+        .and_then(OsStr::to_str)
+        .and_then(|s| s.rsplit_once('.'))
+        .map(|(_, s)| s)
+    {
+        Some("gz" | "tgz" | "taz") => TarCompression::Gzip(flate2::read::GzDecoder::new(file)),
+        Some("bz2" | "tbz" | "tbz2" | "tz2") => {
+            TarCompression::Bzip2(bzip2::read::BzDecoder::new(file))
+        }
+        Some("lzma" | "tlz" | "xz" | "txz") => TarCompression::Xz2(xz2::read::XzDecoder::new(file)),
+        Some("zst" | "tzst") => {
+            TarCompression::Zstd(zstd::stream::read::Decoder::new(file).unwrap())
+        }
+        Some("Z" | "taZ") => TarCompression::Compress,
+        Some("lz") => TarCompression::Lzip,
+        Some("lzo") => TarCompression::Lzop,
+        Some(_) | None => TarCompression::PlainTar(file),
+    }
+}
+
+impl<'a> std::io::Read for TarCompression<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        match self {
+            TarCompression::PlainTar(reader) => reader.read(buf),
+            TarCompression::Gzip(reader) => reader.read(buf),
+            TarCompression::Bzip2(reader) => reader.read(buf),
+            TarCompression::Xz2(reader) => reader.read(buf),
+            TarCompression::Zstd(reader) => reader.read(buf),
+            TarCompression::Compress | TarCompression::Lzip | TarCompression::Lzop => {
+                todo!("unsupported for now")
+            }
+        }
+    }
+}
+/// Moves the directory content from src to dest after stripping root dir, if present.
+fn move_extracted_dir(src: &Path, dest: &Path) -> Result<(), SourceError> {
+    let mut entries = fs::read_dir(src)?;
+    let src_dir = match entries.next().transpose()? {
+        // ensure if only single directory in entries(root dir)
+        Some(dir) if entries.next().is_none() && dir.file_type()?.is_dir() => {
+            src.join(dir.file_name())
+        }
+        _ => src.to_path_buf(),
+    };
+
+    for entry in fs::read_dir(src_dir)? {
+        let entry = entry?;
+        let destination = dest.join(entry.file_name());
+        fs::rename(entry.path(), destination)?;
+    }
+
+    Ok(())
+}
+
+/// Extracts a tar archive to the specified target directory
+pub(crate) fn extract_tar(
+    archive: impl AsRef<Path>,
+    target_directory: impl AsRef<Path>,
+    log_handler: &LoggingOutputHandler,
+) -> Result<(), SourceError> {
+    let archive = archive.as_ref();
+    let target_directory = target_directory.as_ref();
+
+    let len = archive.metadata().map(|m| m.len()).unwrap_or(1);
+    let progress_bar = log_handler.add_progress_bar(
+        indicatif::ProgressBar::new(len)
+            .with_prefix("Extracting tar")
+            .with_style(log_handler.default_bytes_style()),
+    );
+
+    let file = File::open(archive).map_err(|_| SourceError::FileNotFound(archive.to_path_buf()))?;
+    let wrapped = progress_bar.wrap_read(file);
+    let buf_reader = std::io::BufReader::new(wrapped);
+
+    let mut archive = tar::Archive::new(ext_to_compression(
+        archive.file_name(),
+        Box::new(buf_reader),
+    ));
+
+    let tmp_extraction_dir = tempfile::Builder::new().tempdir_in(target_directory)?;
+    archive
+        .unpack(&tmp_extraction_dir)
+        .map_err(|e| SourceError::TarExtractionError(e.to_string()))?;
+
+    move_extracted_dir(tmp_extraction_dir.path(), target_directory)?;
+    progress_bar.finish_with_message("Extracted...");
+
+    Ok(())
+}
+
+/// Extracts a zip archive to the specified target directory
+/// currently this doesn't support bzip2 and zstd.
+///
+/// `.zip` files archived with compression other than deflate would fail.
+pub(crate) fn extract_zip(
+    archive: impl AsRef<Path>,
+    target_directory: impl AsRef<Path>,
+    log_handler: &LoggingOutputHandler,
+) -> Result<(), SourceError> {
+    let archive = archive.as_ref();
+    let target_directory = target_directory.as_ref();
+
+    let len = archive.metadata().map(|m| m.len()).unwrap_or(1);
+    let progress_bar = log_handler.add_progress_bar(
+        indicatif::ProgressBar::new(len)
+            .with_finish(indicatif::ProgressFinish::AndLeave)
+            .with_prefix("Extracting zip")
+            .with_style(log_handler.default_bytes_style()),
+    );
+
+    let mut archive = zip::ZipArchive::new(progress_bar.wrap_read(
+        File::open(archive).map_err(|_| SourceError::FileNotFound(archive.to_path_buf()))?,
+    ))
+    .map_err(|e| SourceError::InvalidZip(e.to_string()))?;
+
+    let tmp_extraction_dir = tempfile::Builder::new().tempdir_in(target_directory)?;
+    archive
+        .extract(&tmp_extraction_dir)
+        .map_err(|e| SourceError::ZipExtractionError(e.to_string()))?;
+
+    move_extracted_dir(tmp_extraction_dir.path(), target_directory)?;
+    progress_bar.finish_with_message("Extracted...");
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use std::{fs::File, io::Write};
+
+    use crate::{console_utils::LoggingOutputHandler, source::SourceError};
+
+    use super::extract_zip;
+
+    #[test]
+    fn test_extract_zip() {
+        // zip contains text.txt with "Hello, World" text
+        const HELLOW_ZIP_FILE: &[u8] = &[
+            80, 75, 3, 4, 10, 0, 0, 0, 0, 0, 244, 123, 36, 88, 144, 58, 246, 64, 13, 0, 0, 0, 13,
+            0, 0, 0, 8, 0, 28, 0, 116, 101, 120, 116, 46, 116, 120, 116, 85, 84, 9, 0, 3, 4, 130,
+            150, 101, 6, 130, 150, 101, 117, 120, 11, 0, 1, 4, 245, 1, 0, 0, 4, 20, 0, 0, 0, 72,
+            101, 108, 108, 111, 44, 32, 87, 111, 114, 108, 100, 10, 80, 75, 1, 2, 30, 3, 10, 0, 0,
+            0, 0, 0, 244, 123, 36, 88, 144, 58, 246, 64, 13, 0, 0, 0, 13, 0, 0, 0, 8, 0, 24, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 164, 129, 0, 0, 0, 0, 116, 101, 120, 116, 46, 116, 120, 116, 85,
+            84, 5, 0, 3, 4, 130, 150, 101, 117, 120, 11, 0, 1, 4, 245, 1, 0, 0, 4, 20, 0, 0, 0, 80,
+            75, 5, 6, 0, 0, 0, 0, 1, 0, 1, 0, 78, 0, 0, 0, 79, 0, 0, 0, 0, 0,
+        ];
+        let term = indicatif::InMemoryTerm::new(100, 100);
+        let multi_progress = indicatif::MultiProgress::new();
+        multi_progress.set_draw_target(indicatif::ProgressDrawTarget::term_like(Box::new(
+            term.clone(),
+        )));
+        let tempdir = tempfile::tempdir().unwrap();
+        let file_path = tempdir.path().join("test.zip");
+        let mut file = File::create(&file_path).unwrap();
+        _ = file.write_all(HELLOW_ZIP_FILE);
+
+        let fancy_log = LoggingOutputHandler::from_multi_progress(multi_progress);
+        let res = extract_zip(file_path, tempdir.path(), &fancy_log);
+        assert!(term.contents().trim().starts_with(
+            "Extracting zip       [00:00:00] [━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━]"
+        ));
+        assert!(matches!(res.err(), None));
+        assert!(tempdir.path().join("text.txt").exists());
+        assert!(std::fs::read_to_string(tempdir.path().join("text.txt"))
+            .unwrap()
+            .contains("Hello, World"));
+    }
+
+    #[test]
+    fn test_extract_fail() {
+        let fancy_log = LoggingOutputHandler::default();
+        let tempdir = tempfile::tempdir().unwrap();
+        let res = extract_zip("", tempdir.path(), &fancy_log);
+        assert!(matches!(res.err(), Some(SourceError::FileNotFound(_))));
+    }
+
+    #[test]
+    fn test_extract_fail_2() {
+        let fancy_log = LoggingOutputHandler::default();
+        let tempdir = tempfile::tempdir().unwrap();
+        let file = tempdir.path().join("test.zip");
+        _ = File::create(&file);
+        let res = extract_zip(file, tempdir.path(), &fancy_log);
+        assert!(matches!(res.err(), Some(SourceError::InvalidZip(_))));
+    }
+}

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -2,22 +2,25 @@
 
 use std::{
     ffi::OsStr,
-    io::BufRead,
-    path::{Path, PathBuf, StripPrefixError},
+    path::{PathBuf, StripPrefixError},
 };
 
 use crate::{
-    console_utils::LoggingOutputHandler,
     metadata::{Directories, Output},
     recipe::parser::{GitRev, GitSource, Source},
+    source::{
+        checksum::Checksum,
+        extract::{extract_tar, extract_zip},
+    },
     tool_configuration,
 };
 
 use fs_err as fs;
-use fs_err::File;
 
 use crate::system_tools::SystemTools;
+pub mod checksum;
 pub mod copy_dir;
+pub mod extract;
 pub mod git_source;
 pub mod patch;
 pub mod url_source;
@@ -83,7 +86,7 @@ pub enum SourceError {
     Glob(#[from] globset::Error),
 
     #[error("No checksum found for url: {0}")]
-    NoChecksum(url::Url),
+    NoChecksum(String),
 }
 
 /// Fetches all sources in a list of sources and applies specified patches
@@ -158,12 +161,7 @@ pub async fn fetch_sources(
                 {
                     extract_tar(&res, &dest_dir, &tool_configuration.fancy_log_handler)?;
                     tracing::info!("Extracted to {:?}", dest_dir);
-                } else if res
-                    .file_name()
-                    .unwrap_or_default()
-                    .to_string_lossy()
-                    .ends_with(".zip")
-                {
+                } else if res.extension() == Some(OsStr::new("zip")) {
                     extract_zip(&res, &dest_dir, &tool_configuration.fancy_log_handler)?;
                     tracing::info!("Extracted zip to {:?}", dest_dir);
                 } else {
@@ -216,6 +214,11 @@ pub async fn fetch_sources(
                         src_path,
                         dest_dir.join(&file_name)
                     );
+                    if let Some(checksum) = Checksum::from_path_source(src) {
+                        if !checksum.validate(&src_path) {
+                            return Err(SourceError::ValidationFailed);
+                        }
+                    }
                     fs::copy(&src_path, &dest_dir.join(file_name))?;
                 } else {
                     return Err(SourceError::FileNotFound(src_path));
@@ -230,145 +233,6 @@ pub async fn fetch_sources(
         }
     }
     Ok(rendered_sources)
-}
-
-/// Handle Compression formats internally
-enum TarCompression<'a> {
-    PlainTar(Box<dyn BufRead + 'a>),
-    Gzip(flate2::read::GzDecoder<Box<dyn BufRead + 'a>>),
-    Bzip2(bzip2::read::BzDecoder<Box<dyn BufRead + 'a>>),
-    Xz2(xz2::read::XzDecoder<Box<dyn BufRead + 'a>>),
-    Zstd(zstd::stream::read::Decoder<'a, std::io::BufReader<Box<dyn BufRead + 'a>>>),
-    Compress,
-    Lzip,
-    Lzop,
-}
-
-fn ext_to_compression<'a>(ext: Option<&OsStr>, file: Box<dyn BufRead + 'a>) -> TarCompression<'a> {
-    match ext
-        .and_then(OsStr::to_str)
-        .and_then(|s| s.rsplit_once('.'))
-        .map(|(_, s)| s)
-    {
-        Some("gz" | "tgz" | "taz") => TarCompression::Gzip(flate2::read::GzDecoder::new(file)),
-        Some("bz2" | "tbz" | "tbz2" | "tz2") => {
-            TarCompression::Bzip2(bzip2::read::BzDecoder::new(file))
-        }
-        Some("lzma" | "tlz" | "xz" | "txz") => TarCompression::Xz2(xz2::read::XzDecoder::new(file)),
-        Some("zst" | "tzst") => {
-            TarCompression::Zstd(zstd::stream::read::Decoder::new(file).unwrap())
-        }
-        Some("Z" | "taZ") => TarCompression::Compress,
-        Some("lz") => TarCompression::Lzip,
-        Some("lzo") => TarCompression::Lzop,
-        Some(_) | None => TarCompression::PlainTar(file),
-    }
-}
-
-impl<'a> std::io::Read for TarCompression<'a> {
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        match self {
-            TarCompression::PlainTar(reader) => reader.read(buf),
-            TarCompression::Gzip(reader) => reader.read(buf),
-            TarCompression::Bzip2(reader) => reader.read(buf),
-            TarCompression::Xz2(reader) => reader.read(buf),
-            TarCompression::Zstd(reader) => reader.read(buf),
-            TarCompression::Compress | TarCompression::Lzip | TarCompression::Lzop => {
-                todo!("unsupported for now")
-            }
-        }
-    }
-}
-/// Moves the directory content from src to dest after stripping root dir, if present.
-fn move_extracted_dir(src: &Path, dest: &Path) -> Result<(), SourceError> {
-    let mut entries = fs::read_dir(src)?;
-    let src_dir = match entries.next().transpose()? {
-        // ensure if only single directory in entries(root dir)
-        Some(dir) if entries.next().is_none() && dir.file_type()?.is_dir() => {
-            src.join(dir.file_name())
-        }
-        _ => src.to_path_buf(),
-    };
-
-    for entry in fs::read_dir(src_dir)? {
-        let entry = entry?;
-        let destination = dest.join(entry.file_name());
-        fs::rename(entry.path(), destination)?;
-    }
-
-    Ok(())
-}
-
-/// Extracts a tar archive to the specified target directory
-fn extract_tar(
-    archive: impl AsRef<Path>,
-    target_directory: impl AsRef<Path>,
-    log_handler: &LoggingOutputHandler,
-) -> Result<(), SourceError> {
-    let archive = archive.as_ref();
-    let target_directory = target_directory.as_ref();
-
-    let len = archive.metadata().map(|m| m.len()).unwrap_or(1);
-    let progress_bar = log_handler.add_progress_bar(
-        indicatif::ProgressBar::new(len)
-            .with_prefix("Extracting tar")
-            .with_style(log_handler.default_bytes_style()),
-    );
-
-    let file = File::open(archive).map_err(|_| SourceError::FileNotFound(archive.to_path_buf()))?;
-    let wrapped = progress_bar.wrap_read(file);
-    let buf_reader = std::io::BufReader::new(wrapped);
-
-    let mut archive = tar::Archive::new(ext_to_compression(
-        archive.file_name(),
-        Box::new(buf_reader),
-    ));
-
-    let tmp_extraction_dir = tempfile::Builder::new().tempdir_in(target_directory)?;
-    archive
-        .unpack(&tmp_extraction_dir)
-        .map_err(|e| SourceError::TarExtractionError(e.to_string()))?;
-
-    move_extracted_dir(tmp_extraction_dir.path(), target_directory)?;
-    progress_bar.finish_with_message("Extracted...");
-
-    Ok(())
-}
-
-/// Extracts a zip archive to the specified target directory
-/// currently this doesn't support bzip2 and zstd.
-///
-/// `.zip` files archived with compression other than deflate would fail.
-fn extract_zip(
-    archive: impl AsRef<Path>,
-    target_directory: impl AsRef<Path>,
-    log_handler: &LoggingOutputHandler,
-) -> Result<(), SourceError> {
-    let archive = archive.as_ref();
-    let target_directory = target_directory.as_ref();
-
-    let len = archive.metadata().map(|m| m.len()).unwrap_or(1);
-    let progress_bar = log_handler.add_progress_bar(
-        indicatif::ProgressBar::new(len)
-            .with_finish(indicatif::ProgressFinish::AndLeave)
-            .with_prefix("Extracting zip")
-            .with_style(log_handler.default_bytes_style()),
-    );
-
-    let mut archive = zip::ZipArchive::new(progress_bar.wrap_read(
-        File::open(archive).map_err(|_| SourceError::FileNotFound(archive.to_path_buf()))?,
-    ))
-    .map_err(|e| SourceError::InvalidZip(e.to_string()))?;
-
-    let tmp_extraction_dir = tempfile::Builder::new().tempdir_in(target_directory)?;
-    archive
-        .extract(&tmp_extraction_dir)
-        .map_err(|e| SourceError::ZipExtractionError(e.to_string()))?;
-
-    move_extracted_dir(tmp_extraction_dir.path(), target_directory)?;
-    progress_bar.finish_with_message("Extracted...");
-
-    Ok(())
 }
 
 impl Output {
@@ -404,67 +268,5 @@ impl Output {
                 ..self
             })
         }
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use std::{fs::File, io::Write};
-
-    use crate::{console_utils::LoggingOutputHandler, source::SourceError};
-
-    use super::extract_zip;
-
-    #[test]
-    fn test_extract_zip() {
-        // zip contains text.txt with "Hello, World" text
-        const HELLOW_ZIP_FILE: &[u8] = &[
-            80, 75, 3, 4, 10, 0, 0, 0, 0, 0, 244, 123, 36, 88, 144, 58, 246, 64, 13, 0, 0, 0, 13,
-            0, 0, 0, 8, 0, 28, 0, 116, 101, 120, 116, 46, 116, 120, 116, 85, 84, 9, 0, 3, 4, 130,
-            150, 101, 6, 130, 150, 101, 117, 120, 11, 0, 1, 4, 245, 1, 0, 0, 4, 20, 0, 0, 0, 72,
-            101, 108, 108, 111, 44, 32, 87, 111, 114, 108, 100, 10, 80, 75, 1, 2, 30, 3, 10, 0, 0,
-            0, 0, 0, 244, 123, 36, 88, 144, 58, 246, 64, 13, 0, 0, 0, 13, 0, 0, 0, 8, 0, 24, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 164, 129, 0, 0, 0, 0, 116, 101, 120, 116, 46, 116, 120, 116, 85,
-            84, 5, 0, 3, 4, 130, 150, 101, 117, 120, 11, 0, 1, 4, 245, 1, 0, 0, 4, 20, 0, 0, 0, 80,
-            75, 5, 6, 0, 0, 0, 0, 1, 0, 1, 0, 78, 0, 0, 0, 79, 0, 0, 0, 0, 0,
-        ];
-        let term = indicatif::InMemoryTerm::new(100, 100);
-        let multi_progress = indicatif::MultiProgress::new();
-        multi_progress.set_draw_target(indicatif::ProgressDrawTarget::term_like(Box::new(
-            term.clone(),
-        )));
-        let tempdir = tempfile::tempdir().unwrap();
-        let file_path = tempdir.path().join("test.zip");
-        let mut file = File::create(&file_path).unwrap();
-        _ = file.write_all(HELLOW_ZIP_FILE);
-
-        let fancy_log = LoggingOutputHandler::from_multi_progress(multi_progress);
-        let res = extract_zip(file_path, tempdir.path(), &fancy_log);
-        assert!(term.contents().trim().starts_with(
-            "Extracting zip       [00:00:00] [━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━]"
-        ));
-        assert!(matches!(res.err(), None));
-        assert!(tempdir.path().join("text.txt").exists());
-        assert!(std::fs::read_to_string(tempdir.path().join("text.txt"))
-            .unwrap()
-            .contains("Hello, World"));
-    }
-
-    #[test]
-    fn test_extract_fail() {
-        let fancy_log = LoggingOutputHandler::default();
-        let tempdir = tempfile::tempdir().unwrap();
-        let res = extract_zip("", tempdir.path(), &fancy_log);
-        assert!(matches!(res.err(), Some(SourceError::FileNotFound(_))));
-    }
-
-    #[test]
-    fn test_extract_fail_2() {
-        let fancy_log = LoggingOutputHandler::default();
-        let tempdir = tempfile::tempdir().unwrap();
-        let file = tempdir.path().join("test.zip");
-        _ = File::create(&file);
-        let res = extract_zip(file, tempdir.path(), &fancy_log);
-        assert!(matches!(res.err(), Some(SourceError::InvalidZip(_))));
     }
 }

--- a/src/source/url_source.rs
+++ b/src/source/url_source.rs
@@ -137,7 +137,7 @@ pub(crate) async fn url_src(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::recipe::parser::Checksum;
+    use crate::source::Checksum;
     use sha2::Sha256;
     use url::Url;
 

--- a/src/source/url_source.rs
+++ b/src/source/url_source.rs
@@ -5,52 +5,10 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::{
-    recipe::parser::{Checksum, UrlSource},
-    tool_configuration,
-};
-use rattler_digest::{compute_file_digest, Md5};
+use crate::{recipe::parser::UrlSource, tool_configuration};
 use tokio::io::AsyncWriteExt;
 
-use super::SourceError;
-
-fn validate_checksum(path: &Path, checksum: &Checksum) -> bool {
-    match checksum {
-        Checksum::Sha256(value) => {
-            let digest =
-                compute_file_digest::<sha2::Sha256>(path).expect("Could not compute SHA256");
-            let computed_sha = hex::encode(digest);
-            let checksum_sha = hex::encode(value);
-            if !computed_sha.eq(&checksum_sha) {
-                tracing::error!(
-                    "SHA256 values of downloaded file not matching!\nDownloaded = {}, should be {}",
-                    computed_sha,
-                    checksum_sha
-                );
-                false
-            } else {
-                tracing::info!("Validated SHA256 values of the downloaded file!");
-                true
-            }
-        }
-        Checksum::Md5(value) => {
-            let digest = compute_file_digest::<Md5>(path).expect("Could not compute SHA256");
-            let computed_md5 = hex::encode(digest);
-            let checksum_md5 = hex::encode(value);
-            if !computed_md5.eq(&checksum_md5) {
-                tracing::error!(
-                    "MD5 values of downloaded file not matching!\nDownloaded = {}, should be {}",
-                    computed_md5,
-                    checksum_md5
-                );
-                false
-            } else {
-                tracing::info!("Validated MD5 values of the downloaded file!");
-                true
-            }
-        }
-    }
-}
+use super::{checksum::Checksum, SourceError};
 
 fn split_filename(filename: &str) -> (String, String) {
     let stem = Path::new(filename)
@@ -91,7 +49,9 @@ pub(crate) async fn url_src(
     tool_configuration: &tool_configuration::Configuration,
 ) -> Result<PathBuf, SourceError> {
     // convert sha256 or md5 to Checksum
-    let checksum = Checksum::try_from(source)?;
+    let checksum = Checksum::from_url_source(source).ok_or_else(|| {
+        SourceError::NoChecksum(format!("No checksum found for url: {}", source.url()))
+    })?;
 
     if source.url().scheme() == "file" {
         let local_path = source.url().to_file_path().map_err(|_| {
@@ -105,7 +65,7 @@ pub(crate) async fn url_src(
             return Err(SourceError::FileNotFound(local_path));
         }
 
-        if !validate_checksum(&local_path, &checksum) {
+        if !checksum.validate(&local_path) {
             return Err(SourceError::ValidationFailed);
         }
 
@@ -119,7 +79,7 @@ pub(crate) async fn url_src(
     let cache_name = cache_dir.join(cache_name);
 
     let metadata = fs::metadata(&cache_name);
-    if metadata.is_ok() && metadata?.is_file() && validate_checksum(&cache_name, &checksum) {
+    if metadata.is_ok() && metadata?.is_file() && checksum.validate(&cache_name) {
         tracing::info!("Found valid source cache file.");
         return Ok(cache_name.clone());
     }
@@ -165,7 +125,7 @@ pub(crate) async fn url_src(
 
     file.flush().await?;
 
-    if !validate_checksum(&cache_name, &checksum) {
+    if !checksum.validate(&cache_name) {
         tracing::error!("Checksum validation failed!");
         fs::remove_file(&cache_name)?;
         return Err(SourceError::ValidationFailed);

--- a/test-data/recipes/test-parsing/single_output.yaml
+++ b/test-data/recipes/test-parsing/single_output.yaml
@@ -17,8 +17,8 @@ source:
   # path source
   - path: ./some-file.tar.gz
     # currently not valid
-    # sha256: 1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
-    # md5: 1234567890abcdef1234567890abcdef
+    sha256: 1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
+    md5: 1234567890abcdef1234567890abcdef
     patches:
       - file.patch
     file_name: test-package.tar.gz
@@ -33,7 +33,8 @@ source:
 build:
   number: 0
   string: "blabla"
-  skip: false
+  skip:
+    - false
   noarch: generic
   merge_build_and_host_envs: true
   script:

--- a/test-data/recipes/test-sources/recipe.yaml
+++ b/test-data/recipes/test-sources/recipe.yaml
@@ -12,10 +12,12 @@ source:
     sha256: 78884f64b564a3b06dc6ee731ed33b60c6d8cd864cea07f21d94ba0f90c7b310
 
   - path: ./test-folder/test-file-2.txt
+    md5: d41d8cd98f00b204e9800998ecf8427e
   - path: ./test-folder
     target_directory: just-a-test
   - path: test-file.txt
     file_name: am-i-renamed.txt
+    sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 
 build:
   script:


### PR DESCRIPTION
The extraction bars were iterating "too much" because the reader wrapper was in the wrong place. This fixes that.

Also I've implemented checksum handling for local paths. 

I am still wondering if we should make the checksums for URL sources optional.

fixes https://github.com/prefix-dev/rattler-build/issues/560