### PR TITLE
fix: set release as latest after CI succeeds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -228,6 +228,6 @@ jobs:
       - name: Set as latest release
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
-          gh release edit "${{ github.ref_name }}" --draft=false
+          gh release edit "${{ github.ref_name }}" --draft=false --latest
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
we should also set https://github.com/prefix-dev/rattler-build/releases/tag/v0.12.0 as latest :bear:
