### PR TITLE
feat: support scp-style SSH urls for Git source

### DIFF
--- a/src/recipe/parser/snapshots/rattler_build__recipe__parser__source__tests__ssh_serialization.snap
+++ b/src/recipe/parser/snapshots/rattler_build__recipe__parser__source__tests__ssh_serialization.snap
@@ -1,0 +1,5 @@
+---
+source: src/recipe/parser/source.rs
+expression: yaml
+---
+git: git@github.com:prefix-dev/rattler-build.git

--- a/src/recipe/parser/source.rs
+++ b/src/recipe/parser/source.rs
@@ -267,7 +267,7 @@ impl TryConvertNode<GitSource> for RenderedMappingNode {
                         Ok(url_) => url = Some(GitUrl::Url(url_)),
                         Err(err) => {
                             tracing::warn!("invalid url for `GitSource` `{url_str}`: {err}");
-                            if url_str.contains("@") {
+                            if url_str.contains('@') {
                                 tracing::warn!("attempting to use as SSH url");
                                 url = Some(GitUrl::Ssh(url_str));
                             } else {

--- a/src/recipe/parser/source.rs
+++ b/src/recipe/parser/source.rs
@@ -266,7 +266,6 @@ impl TryConvertNode<GitSource> for RenderedMappingNode {
                     match url_ {
                         Ok(url_) => url = Some(GitUrl::Url(url_)),
                         Err(err) => {
-
                             tracing::warn!("invalid url for `GitSource` `{url_str}`: {err}");
                             if url_str.contains("@") {
                                 tracing::warn!("attempting to use as SSH url");

--- a/src/recipe/parser/source.rs
+++ b/src/recipe/parser/source.rs
@@ -61,6 +61,9 @@ impl TryConvertNode<Vec<Source>> for RenderedNode {
                 if map.contains_key("git") {
                     let git_src = map.try_convert("source")?;
                     sources.push(Source::Git(git_src));
+                } else if map.contains_key("ssh") {
+                    let git_src = map.try_convert("source")?;
+                    sources.push(Source::Git(git_src));
                 } else if map.contains_key("url") {
                     let url_src = map.try_convert("source")?;
                     sources.push(Source::Url(url_src));
@@ -273,6 +276,10 @@ impl TryConvertNode<GitSource> for RenderedMappingNode {
                         }
                     }
                 }
+                "ssh" => {
+                    let ssh_url_str: String = v.try_convert("git")?;
+                    url = Some(GitUrl::Ssh(ssh_url_str));
+                }
                 "rev" | "tag" | "branch" => {
                     if rev.is_some() {
                         return Err(vec![_partialerror!(
@@ -314,7 +321,7 @@ impl TryConvertNode<GitSource> for RenderedMappingNode {
                     return Err(vec![_partialerror!(
                         *k.span(),
                         ErrorKind::InvalidField(k.as_str().to_owned().into()),
-                        help = "valid fields for git `source` are `git`, `rev`, `tag`, `branch`, `depth`, `patches`, `lfs` and `target_directory`"
+                        help = "valid fields for git `source` are `git`, `ssh`, `rev`, `tag`, `branch`, `depth`, `patches`, `lfs` and `target_directory`"
                     )])
                 }
             }
@@ -357,6 +364,8 @@ impl TryConvertNode<GitSource> for RenderedMappingNode {
 pub enum GitUrl {
     /// A remote Git repository URL
     Url(Url),
+    /// A remote Git repository URL in scp style
+    Ssh(String),
     /// A local path to a Git repository
     Path(PathBuf),
 }
@@ -365,6 +374,7 @@ impl fmt::Display for GitUrl {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             GitUrl::Url(url) => write!(f, "{url}"),
+            GitUrl::Ssh(url) => write!(f, "{url}"),
             GitUrl::Path(path) => write!(f, "{path:?}"),
         }
     }

--- a/src/recipe/parser/source.rs
+++ b/src/recipe/parser/source.rs
@@ -652,4 +652,25 @@ mod tests {
 
         assert_eq!(parsed_git.url, git.url);
     }
+
+    #[test]
+    fn test_ssh_serialization() {
+        let git = GitSource {
+            url: GitUrl::Ssh(String::from("git@github.com:prefix-dev/rattler-build.git")),
+            rev: GitRev::Head,
+            depth: None,
+            patches: Vec::new(),
+            target_directory: None,
+            lfs: false,
+        };
+
+        let yaml = serde_yaml::to_string(&git).unwrap();
+        println!("{}", yaml);
+
+        insta::assert_snapshot!(yaml);
+
+        let parsed_git: GitSource = serde_yaml::from_str(&yaml).unwrap();
+
+        assert_eq!(parsed_git.url, git.url);
+    }
 }

--- a/src/source/git_source.rs
+++ b/src/source/git_source.rs
@@ -134,7 +134,10 @@ pub fn git_src(
                     .output()
                     .map_err(|_e| SourceError::GitErrorStr("Failed to execute clone command"))?;
                 if !output.status.success() {
-                    return Err(SourceError::GitErrorStr("Git clone failed for source"));
+                    return Err(SourceError::GitError(format!(
+                        "Git clone failed for source: {}",
+                        String::from_utf8_lossy(&output.stderr)
+                    )));
                 }
             }
         }

--- a/src/source/git_source.rs
+++ b/src/source/git_source.rs
@@ -7,7 +7,6 @@ use std::{
 };
 
 use fs_extra::dir::remove;
-use url::Url;
 
 use crate::recipe::parser::{GitSource, GitUrl};
 use crate::system_tools::{SystemTools, Tool};
@@ -15,11 +14,11 @@ use crate::system_tools::{SystemTools, Tool};
 use super::SourceError;
 
 /// Fetch the given repository using the host `git` executable.
-pub fn fetch_repo(repo_path: &Path, url: &Url, rev: &str) -> Result<(), SourceError> {
+pub fn fetch_repo(repo_path: &Path, url: &str, rev: &str) -> Result<(), SourceError> {
     tracing::info!("Fetching repository from {} at {}", url, rev);
     let mut command = git_command("fetch");
     let output = command
-        .args([url.to_string().as_str(), rev])
+        .args([url, rev])
         .current_dir(repo_path)
         .output()
         .map_err(|_err| SourceError::ValidationFailed)?;
@@ -84,6 +83,15 @@ pub fn git_src(
     let filename = match &source.url() {
         GitUrl::Url(url) => (|| Some(url.path_segments()?.last()?.to_string()))()
             .ok_or_else(|| SourceError::GitErrorStr("failed to get filename from url"))?,
+        GitUrl::Ssh(url) => (|| {
+            Some(
+                url.trim_end_matches(".git")
+                    .split(std::path::MAIN_SEPARATOR)
+                    .last()?
+                    .to_string(),
+            )
+        })()
+        .ok_or_else(|| SourceError::GitErrorStr("failed to get filename from SSH url"))?,
         GitUrl::Path(path) => recipe_dir
             .join(path)
             .canonicalize()?
@@ -100,10 +108,15 @@ pub fn git_src(
 
     // Initialize or clone the repository depending on the source's git_url.
     match &source.url() {
-        GitUrl::Url(url) => {
+        GitUrl::Url(_) | GitUrl::Ssh(_) => {
+            let url = match &source.url() {
+                GitUrl::Url(url) => url.to_string(),
+                GitUrl::Ssh(url) => url.to_string(),
+                _ => unreachable!(),
+            };
             // If the cache_path exists, initialize the repo and fetch the specified revision.
             if cache_path.exists() {
-                fetch_repo(&cache_path, url, &rev)?;
+                fetch_repo(&cache_path, &url.to_string(), &rev)?;
             } else {
                 let mut command = system_tools
                     .call(Tool::Git)

--- a/test-data/recipes/git_source/recipe.yaml
+++ b/test-data/recipes/git_source/recipe.yaml
@@ -15,6 +15,7 @@ source:
   - git: https://github.com/prefix-dev/rattler-build
     rev: df83c1edf287a756b8fc995e03e9632af0344777
     target_directory: initial_version
+  - git: git@github.com:prefix-dev/rattler-build.git
   # - git: https://github.com/tensorflow/tensorflow
   #   target_directory: tensorflow
 

--- a/test-data/recipes/llamacpp/recipe.yaml
+++ b/test-data/recipes/llamacpp/recipe.yaml
@@ -9,7 +9,7 @@ package:
   version: "${{ version }}"
 
 source:
-  git: git@github.com:ggerganov/llama.cpp.git
+  git: https://github.com/ggerganov/llama.cpp.git
   rev: "${{ version }}"
 
 build:

--- a/test-data/recipes/llamacpp/recipe.yaml
+++ b/test-data/recipes/llamacpp/recipe.yaml
@@ -9,7 +9,7 @@ package:
   version: "${{ version }}"
 
 source:
-  git: https://github.com/ggerganov/llama.cpp.git
+  git: git@github.com:ggerganov/llama.cpp.git
   rev: "${{ version }}"
 
 build:


### PR DESCRIPTION
We now support:

```yml
source:
  git: git@github.com:killercup/cargo-edit.git
```

Todo list:

- [ ] Update documentation about this new key
- [ ] Update one of the examples to use this

closes #672
