### PR TITLE
chore: add pixi badge to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,15 @@
 ![License][license-badge]
 [![Build Status][build-badge]][build]
 [![Project Chat][chat-badge]][chat-url]
+[![Pixi Badge][pixi-badge]][pixi-url]
 
 [license-badge]: https://img.shields.io/badge/license-BSD--3--Clause-blue?style=flat-square
 [build-badge]: https://img.shields.io/github/actions/workflow/status/prefix-dev/rattler-build/rust.yml?style=flat-square&branch=main
 [build]: https://github.com/prefix-dev/rattler-build/actions/
 [chat-badge]: https://img.shields.io/discord/1082332781146800168.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2&style=flat-square
 [chat-url]: https://discord.gg/kKV8ZxyzY4
+[pixi-badge]:https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/prefix-dev/pixi/main/assets/badge/v0.json
+[pixi-url]: https://pixi.sh
 
 </h1>
 


### PR DESCRIPTION
Adds this badge: [![Pixi Badge](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/prefix-dev/pixi/main/assets/badge/v0.json)](https://pixi.sh)