### PR TITLE
feat: support building multiple recipes

### DIFF
--- a/docs/highlevel.md
+++ b/docs/highlevel.md
@@ -50,6 +50,12 @@ A custom channel that is not conda-forge (the default) can be specified like so:
 rattler-build build -c robostack --recipe myrecipe/recipe.yaml
 ```
 
+You can also use the `--recipe-dir` argument if you want to build all the packages in a directory:
+
+```sh
+rattler-build build --recipe-dir myrecipes/
+```
+
 ### Overview of a `recipe.yaml`
 
 A `recipe.yaml` file is separated into multiple sections and can conditionally

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,13 +135,14 @@ pub fn get_recipe_path(path: &Path) -> miette::Result<PathBuf> {
 
 /// Returns the output for the build.
 pub async fn get_build_output(
-    args: BuildOpts,
+    args: &BuildOpts,
     recipe_path: PathBuf,
-    fancy_log_handler: LoggingOutputHandler,
+    fancy_log_handler: &LoggingOutputHandler,
 ) -> miette::Result<BuildOutput> {
     let output_dir = args
         .common
         .output_dir
+        .clone()
         .unwrap_or(current_dir().into_diagnostic()?.join("output"));
     if output_dir.starts_with(
         recipe_path
@@ -155,8 +156,8 @@ pub async fn get_build_output(
 
     let recipe_text = fs::read_to_string(&recipe_path).into_diagnostic()?;
 
-    let host_platform = if let Some(target_platform) = args.target_platform {
-        Platform::from_str(&target_platform).into_diagnostic()?
+    let host_platform = if let Some(target_platform) = &args.target_platform {
+        Platform::from_str(target_platform).into_diagnostic()?
     } else {
         Platform::current()
     };
@@ -203,7 +204,8 @@ pub async fn get_build_output(
     }
     drop(enter);
 
-    let client = tool_configuration::reqwest_client_from_auth_storage(args.common.auth_file);
+    let client =
+        tool_configuration::reqwest_client_from_auth_storage(args.common.auth_file.clone());
 
     let tool_config = tool_configuration::Configuration {
         client,

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -8,7 +8,6 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 use super::state::{BuildProgress, Package};
-use crate::BuildOutput;
 
 /// Terminal events.
 pub enum Event {
@@ -21,9 +20,9 @@ pub enum Event {
     /// Terminal resize.
     Resize(u16, u16),
     /// Resolves packages to build.
-    ResolvePackages(PathBuf),
+    ResolvePackages(Vec<PathBuf>),
     /// Handles the result of resolving packages.
-    ProcessResolvedPackages(BuildOutput, Vec<Package>),
+    ProcessResolvedPackages(Vec<Package>),
     /// Start building.
     StartBuild(usize),
     /// Set build state.


### PR DESCRIPTION
This PR adds support for building multiple recipes.

1. You can provide `--recipe` argument multiple times.

```sh
$ rattler-build build -r examples/linking -r examples/mamba
```

This will build the packages in the given order.

2. You can build all the recipes in a directory with using `--recipe-dir` argument.

```sh
$ git clone https://github.com/wolfv/rust-forge

$ rattler-build build --recipe-dir rust-forge/
```

3. TUI is also supported:

![rec_20240321T160107](https://github.com/prefix-dev/rattler-build/assets/24392180/bb1db644-804a-4a8a-aee1-75ebdd290f9f)
