### PR TITLE
chore: add site directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 
 # mkdocs
 .cache
+site
 
 # pixi environments
 .pixi


### PR DESCRIPTION
I realized `pixi run build-docs` creates the `site/` directory and it shouldn't be committed :bear:
