### PR TITLE
fix: do not take python variant when noarch:python

### DIFF
--- a/src/snapshots/rattler_build__variant_config__tests__python_is_not_used_as_variant_when_noarch.snap
+++ b/src/snapshots/rattler_build__variant_config__tests__python_is_not_used_as_variant_when_noarch.snap
@@ -1,0 +1,5 @@
+---
+source: src/variant_config.rs
+expression: used_variables_all
+---
+- target_platform: noarch

--- a/test-data/recipes/variants/boltons_recipe.yaml
+++ b/test-data/recipes/variants/boltons_recipe.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+
+context:
+  version: "23.0.0"
+
+package:
+  name: "boltons"
+  version: ${{ version }}
+
+source:
+  url: https://github.com/mahmoud/boltons/archive/refs/tags/${{ version }}.tar.gz
+  sha256: 9b2998cd9525ed472079c7dd90fbd216a887202e8729d5969d4f33878f0ff668
+
+build:
+  noarch: python
+  script:
+    - python -m pip install . --no-deps -vv
+
+requirements:
+  host:
+    - python
+    - pip
+    - setuptools
+  run:
+    - pip
+    - python
+
+about:
+  license: BSD-3-Clause
+  license_file: LICENSE

--- a/test-data/recipes/variants/python_variant.yaml
+++ b/test-data/recipes/variants/python_variant.yaml
@@ -1,0 +1,3 @@
+python:
+  - 3.8.* *_cpython
+  - 3.9.* *_cpython


### PR DESCRIPTION
When having noarch: python in recipe 
```
requirements:
  host:

    - python
    - pip
    - setuptools
  run:
    - pip
```


and also variants.yaml 
```
python:
  # part of a zip_keys: python, python_impl, numpy
  - 3.8.* *_cpython
  - 3.9.* *_cpython

python_impl:
  # part of a zip_keys: python, python_impl, numpy
  - cpython
  - cpython
numpy:
  # part of a zip_keys: python, python_impl, numpy
  - 1.22
  - 1.22
```

rattler-build should render only one recipe and don't take into account python variants ( like how conda render do ) 