### PR TITLE
feat: support reading recipe from stdin

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,7 @@ pub fn get_tool_config(
 /// Returns the output for the build.
 pub async fn get_build_output(
     args: &BuildOpts,
-    recipe_path: PathBuf,
+    recipe_path: &Path,
     tool_config: &Configuration,
 ) -> miette::Result<Vec<Output>> {
     let output_dir = args
@@ -148,7 +148,7 @@ pub async fn get_build_output(
         , output_dir.to_string_lossy()));
     }
 
-    let recipe_text = fs::read_to_string(&recipe_path).into_diagnostic()?;
+    let recipe_text = fs::read_to_string(recipe_path).into_diagnostic()?;
 
     let host_platform = if let Some(target_platform) = &args.target_platform {
         Platform::from_str(target_platform).into_diagnostic()?
@@ -262,7 +262,7 @@ pub async fn get_build_output(
                 variant: discovered_output.used_vars.clone(),
                 directories: Directories::setup(
                     name.as_normalized(),
-                    &recipe_path,
+                    recipe_path,
                     &output_dir,
                     args.no_build_id,
                     &timestamp,

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,10 @@ async fn main() -> miette::Result<()> {
         }
         Some(SubCommands::Build(build_args)) => {
             let mut recipe_paths = Vec::new();
-            if !std::io::stdin().is_terminal() {
+            if !std::io::stdin().is_terminal()
+                && build_args.recipe.len() == 1
+                && get_recipe_path(&build_args.recipe[0]).is_err()
+            {
                 let package_name =
                     format!("{}-{}", env!("CARGO_PKG_NAME"), get_current_timestamp()?);
                 let temp_dir = env::temp_dir().join(package_name);

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -168,13 +168,10 @@ pub async fn run<B: Backend>(
                 tokio::spawn(async move {
                     let mut outputs = Vec::new();
                     for recipe_path in &recipe_paths {
-                        let output = get_build_output(
-                            &state.build_opts,
-                            recipe_path.clone(),
-                            &state.tool_config,
-                        )
-                        .await
-                        .unwrap();
+                        let output =
+                            get_build_output(&state.build_opts, recipe_path, &state.tool_config)
+                                .await
+                                .unwrap();
                         outputs.extend(output);
                     }
                     log_sender

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,11 @@
 //! Utility functions for working with paths.
 
-use std::path::{Component, Path, PathBuf};
+use std::{
+    path::{Component, Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use miette::IntoDiagnostic;
 
 /// Converts `p` to an absolute path, but doesn't resolve symlinks.
 /// The function does normalize the path by resolving any `.` and `..` components which are present.
@@ -60,6 +65,14 @@ pub fn to_forward_slash_lossy(path: &Path) -> std::borrow::Cow<'_, str> {
     {
         path.to_string_lossy()
     }
+}
+
+/// Returns the UNIX epoch time in seconds.
+pub fn get_current_timestamp() -> miette::Result<u64> {
+    Ok(SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .into_diagnostic()?
+        .as_secs())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
closes #734

This is not a bulletproof implementation but it does the job:

```sh
cat examples/cargo-edit/recipe.yaml | rattler-build build --render-only
```

Couple of things:

- We heavily depend on recipe path during our build process and it is also required for the _reload_ functionality in TUI - that's why I decided to create a temp dir along with a `recipe.yaml` when stdin is used.
- In the cases where the build requires more than `recipe.yaml` this will fail. But that's fine because it is intended to pass only one file through stdin.

Either way, I think it is a neat feature! Let me know what you think.
