### PR TITLE
fix: take into consideration non-canonical variant also

### DIFF
--- a/src/snapshots/rattler_build__variant_config__tests__flatten_selectors-2.snap
+++ b/src/snapshots/rattler_build__variant_config__tests__flatten_selectors-2.snap
@@ -4,14 +4,10 @@ expression: res
 ---
 pin_run_as_build: ~
 zip_keys: ~
-c-compiler:
-  - vs2019
 c_compiler:
   - vs2019
 cplusplus:
   - "100"
-cxx-compiler:
-  - vs2019
 cxx_compiler:
   - vs2019
 python:

--- a/src/snapshots/rattler_build__variant_config__tests__flatten_selectors-2.snap
+++ b/src/snapshots/rattler_build__variant_config__tests__flatten_selectors-2.snap
@@ -4,12 +4,15 @@ expression: res
 ---
 pin_run_as_build: ~
 zip_keys: ~
+c-compiler:
+  - vs2019
 c_compiler:
   - vs2019
 cplusplus:
   - "100"
+cxx-compiler:
+  - vs2019
 cxx_compiler:
   - vs2019
 python:
   - "3.10"
-

--- a/src/snapshots/rattler_build__variant_config__tests__flatten_selectors.snap
+++ b/src/snapshots/rattler_build__variant_config__tests__flatten_selectors.snap
@@ -4,21 +4,15 @@ expression: res
 ---
 pin_run_as_build: ~
 zip_keys: ~
-c-compiler:
-  - super_g++
 c_compiler:
   - super_g++
 cplusplus:
   - "10"
   - "1000"
-cxx-compiler:
-  - super_gcc
 cxx_compiler:
   - super_gcc
 python:
   - "3.7"
   - "3.8"
-unix-level:
-  - "1"
 unix_level:
   - "1"

--- a/src/snapshots/rattler_build__variant_config__tests__flatten_selectors.snap
+++ b/src/snapshots/rattler_build__variant_config__tests__flatten_selectors.snap
@@ -4,16 +4,21 @@ expression: res
 ---
 pin_run_as_build: ~
 zip_keys: ~
+c-compiler:
+  - super_g++
 c_compiler:
   - super_g++
 cplusplus:
   - "10"
   - "1000"
+cxx-compiler:
+  - super_gcc
 cxx_compiler:
   - super_gcc
 python:
   - "3.7"
   - "3.8"
+unix-level:
+  - "1"
 unix_level:
   - "1"
-

--- a/src/snapshots/rattler_build__variant_config__tests__load_config.snap
+++ b/src/snapshots/rattler_build__variant_config__tests__load_config.snap
@@ -45,23 +45,14 @@ zip_keys:
     - python_impl
   - - arrow_cpp
     - libarrow
-abseil-cpp:
-  - "20220623.0"
 abseil_cpp:
   - "20220623.0"
-alsa-lib:
-  - 1.2.8
 alsa_lib:
   - 1.2.8
 arb:
   - "2.23"
 arpack:
   - "3.7"
-arrow-cpp:
-  - 11.0.0
-  - 10.0.1
-  - 9.0.0
-  - 8.0.1
 arrow_cpp:
   - 11.0.0
   - 10.0.1
@@ -69,12 +60,8 @@ arrow_cpp:
   - 8.0.1
 assimp:
   - 5.2.5
-aws-sdk-cpp:
+aws_sdk_cpp:
   - "4.5"
-blas-impl:
-  - openblas
-  - mkl
-  - blis
 blas_impl:
   - openblas
   - mkl

--- a/src/snapshots/rattler_build__variant_config__tests__load_config.snap
+++ b/src/snapshots/rattler_build__variant_config__tests__load_config.snap
@@ -45,14 +45,23 @@ zip_keys:
     - python_impl
   - - arrow_cpp
     - libarrow
+abseil-cpp:
+  - "20220623.0"
 abseil_cpp:
   - "20220623.0"
+alsa-lib:
+  - 1.2.8
 alsa_lib:
   - 1.2.8
 arb:
   - "2.23"
 arpack:
   - "3.7"
+arrow-cpp:
+  - 11.0.0
+  - 10.0.1
+  - 9.0.0
+  - 8.0.1
 arrow_cpp:
   - 11.0.0
   - 10.0.1
@@ -62,6 +71,10 @@ assimp:
   - 5.2.5
 aws-sdk-cpp:
   - "4.5"
+blas-impl:
+  - openblas
+  - mkl
+  - blis
 blas_impl:
   - openblas
   - mkl
@@ -78,4 +91,3 @@ liblapacke:
   - 3.9 *netlib
 target_platform:
   - linux-64
-

--- a/src/snapshots/rattler_build__variant_config__tests__load_config_and_find_variants.snap
+++ b/src/snapshots/rattler_build__variant_config__tests__load_config_and_find_variants.snap
@@ -3,5 +3,5 @@ source: src/variant_config.rs
 expression: used_variables_all
 ---
 - libblas: 3.9 *netlib
+  r-base: "4.2"
   target_platform: linux-64
-

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,10 @@
 //! Utility functions for working with paths.
 
+use serde::{Deserialize, Serialize};
+use serde_with::{formats::PreferOne, serde_as, OneOrMany};
+use std::collections::btree_map::Entry;
+use std::collections::btree_map::IntoIter;
+use std::collections::BTreeMap;
 use std::{
     path::{Component, Path, PathBuf},
     time::{SystemTime, UNIX_EPOCH},
@@ -64,6 +69,88 @@ pub fn to_forward_slash_lossy(path: &Path) -> std::borrow::Cow<'_, str> {
     #[cfg(not(target_os = "windows"))]
     {
         path.to_string_lossy()
+    }
+}
+
+#[serde_as]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+
+/// Struct where keys upon insertion and retrieval are normalized
+pub struct NormalizedKeyBTreeMap {
+    #[serde_as(deserialize_as = "BTreeMap<_, OneOrMany<_, PreferOne>>")]
+    #[serde(flatten)]
+    /// the inner map
+    pub map: BTreeMap<String, Vec<String>>,
+}
+
+impl NormalizedKeyBTreeMap {
+    /// Makes a new, empty `BTreeMap`
+    pub fn new() -> Self {
+        NormalizedKeyBTreeMap {
+            map: BTreeMap::new(),
+        }
+    }
+
+    /// Replaces all matches of a `-` with `_`.
+    pub fn normalize_key(key: &str) -> String {
+        key.replace('-', "_")
+    }
+
+    /// Inserts a key-value pair into the map, where key is normalized
+    pub fn insert(&mut self, key: String, value: Vec<String>) {
+        let normalized_key = Self::normalize_key(&key);
+        self.map.insert(normalized_key, value);
+    }
+
+    /// Returns a reference to the value corresponding to the key.
+    /// Key is normalized
+    pub fn get(&self, key: &str) -> Option<&Vec<String>> {
+        // Change value type as needed
+        let normalized_key = Self::normalize_key(key);
+        self.map.get(&normalized_key)
+    }
+}
+
+impl Extend<(String, Vec<String>)> for NormalizedKeyBTreeMap {
+    fn extend<T>(&mut self, iter: T)
+    where
+        T: IntoIterator<Item = (String, Vec<String>)>,
+    {
+        for (key, value) in iter {
+            match self.map.entry(Self::normalize_key(&key)) {
+                Entry::Occupied(mut entry) => {
+                    entry.get_mut().extend(value);
+                }
+                Entry::Vacant(entry) => {
+                    entry.insert(value);
+                }
+            }
+        }
+    }
+}
+
+impl NormalizedKeyBTreeMap {
+    /// Gets an iterator over the entries of the map, sorted by key.
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &Vec<String>)> {
+        self.map.iter()
+    }
+}
+
+impl IntoIterator for NormalizedKeyBTreeMap {
+    type Item = (String, Vec<String>);
+    type IntoIter = IntoIter<String, Vec<String>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.map.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a NormalizedKeyBTreeMap {
+    type Item = (&'a String, &'a Vec<String>);
+    type IntoIter = std::collections::btree_map::Iter<'a, String, Vec<String>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.map.iter()
     }
 }
 

--- a/src/variant_config.rs
+++ b/src/variant_config.rs
@@ -149,6 +149,7 @@ pub struct VariantConfig {
 
     /// The variants are a mapping of package names to a list of versions. Each version represents
     /// a variant for the build matrix.
+    #[serde(flatten)]
     pub variants: NormalizedKeyBTreeMap,
 }
 

--- a/src/variant_config.rs
+++ b/src/variant_config.rs
@@ -772,7 +772,13 @@ impl TryConvertNode<VariantConfig> for RenderedMappingNode {
                 _ => {
                     let variants: Option<Vec<_>> = value.try_convert(key_str)?;
                     if let Some(variants) = variants {
-                        config.variants.insert(key_str.to_string(), variants);
+                        // store both lower_case and upper_case
+                        config
+                            .variants
+                            .insert(key_str.to_string(), variants.clone());
+                        config
+                            .variants
+                            .insert(key_str.to_string().replace("_", "-"), variants);
                     }
                 }
             }

--- a/src/variant_config.rs
+++ b/src/variant_config.rs
@@ -9,10 +9,9 @@ use indexmap::IndexSet;
 use miette::Diagnostic;
 use rattler_conda_types::{NoArchType, ParseVersionError, Platform};
 use serde::{Deserialize, Serialize};
-use serde_with::{formats::PreferOne, serde_as, OneOrMany};
+
 use thiserror::Error;
 
-use crate::recipe::parser::Dependency;
 use crate::{
     _partialerror,
     hash::HashInfo,
@@ -25,6 +24,7 @@ use crate::{
     selectors::SelectorConfig,
     used_variables::used_vars_from_expressions,
 };
+use crate::{recipe::parser::Dependency, utils::NormalizedKeyBTreeMap};
 use petgraph::{algo::toposort, graph::DiGraph};
 
 #[allow(missing_docs)]
@@ -84,7 +84,7 @@ impl TryConvertNode<Pin> for RenderedMappingNode {
     }
 }
 
-#[serde_as]
+// #[serde_as]
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 /// The variant configuration.
 /// This is usually loaded from a YAML file and contains a mapping of package names to a list of
@@ -149,9 +149,7 @@ pub struct VariantConfig {
 
     /// The variants are a mapping of package names to a list of versions. Each version represents
     /// a variant for the build matrix.
-    #[serde_as(deserialize_as = "BTreeMap<_, OneOrMany<_, PreferOne>>")]
-    #[serde(flatten)]
-    pub variants: BTreeMap<String, Vec<String>>,
+    pub variants: NormalizedKeyBTreeMap,
 }
 
 #[allow(missing_docs)]
@@ -333,12 +331,16 @@ impl VariantConfig {
             })
             .collect::<Vec<_>>();
 
-        let variant_keys = self
-            .variants
+        let variant_keys = used_vars
             .iter()
-            .filter(|(key, _)| used_vars.contains(*key))
-            .filter(|(key, _)| !zip_keys.iter().any(|zip| zip.contains(*key)))
-            .map(|(key, values)| VariantKey::Key(key.clone(), values.clone()))
+            .filter_map(|key| {
+                if let Some(values) = self.variants.get(key) {
+                    if !zip_keys.iter().any(|zip| zip.contains(key)) {
+                        return Some(VariantKey::Key(key.clone(), values.clone()));
+                    }
+                }
+                None
+            })
             .collect::<Vec<_>>();
 
         let variant_keys = used_zip_keys
@@ -776,9 +778,6 @@ impl TryConvertNode<VariantConfig> for RenderedMappingNode {
                         config
                             .variants
                             .insert(key_str.to_string(), variants.clone());
-                        config
-                            .variants
-                            .insert(key_str.to_string().replace('_', "-"), variants);
                     }
                 }
             }
@@ -982,7 +981,7 @@ mod tests {
 
     #[test]
     fn test_variant_combinations() {
-        let mut variants = BTreeMap::new();
+        let mut variants = NormalizedKeyBTreeMap::new();
         variants.insert("a".to_string(), vec!["1".to_string(), "2".to_string()]);
         variants.insert("b".to_string(), vec!["3".to_string(), "4".to_string()]);
         let zip_keys = vec![vec!["a".to_string(), "b".to_string()].into_iter().collect()];

--- a/src/variant_config.rs
+++ b/src/variant_config.rs
@@ -84,7 +84,6 @@ impl TryConvertNode<Pin> for RenderedMappingNode {
     }
 }
 
-// #[serde_as]
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 /// The variant configuration.
 /// This is usually loaded from a YAML file and contains a mapping of package names to a list of

--- a/src/variant_config.rs
+++ b/src/variant_config.rs
@@ -778,7 +778,7 @@ impl TryConvertNode<VariantConfig> for RenderedMappingNode {
                             .insert(key_str.to_string(), variants.clone());
                         config
                             .variants
-                            .insert(key_str.to_string().replace("_", "-"), variants);
+                            .insert(key_str.to_string().replace('_', "-"), variants);
                     }
                 }
             }

--- a/src/variant_config.rs
+++ b/src/variant_config.rs
@@ -775,7 +775,6 @@ impl TryConvertNode<VariantConfig> for RenderedMappingNode {
                 _ => {
                     let variants: Option<Vec<_>> = value.try_convert(key_str)?;
                     if let Some(variants) = variants {
-                        // store both lower_case and upper_case
                         config
                             .variants
                             .insert(key_str.to_string(), variants.clone());

--- a/test-data/recipes/variants/recipe.yaml
+++ b/test-data/recipes/variants/recipe.yaml
@@ -29,6 +29,7 @@ requirements:
     - ${{ compiler('c') }}
     - cmake
     - libcblas
+    - r-base
     - if: win
       then: ninja
 

--- a/test-data/recipes/variants/variant_config.yaml
+++ b/test-data/recipes/variants/variant_config.yaml
@@ -3,3 +3,5 @@ libblas:
   - 3.9 *netlib
 libcblas:
   - 3.9 *netlib
+r_base:
+  - 4.2


### PR DESCRIPTION
when having in `recipe` requirements:
`-r-base`

and in `variant_config` 
```
r_base:
"4.2"
```

it will not be take into consideration as variant.

In  [ conda_build_config ](https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/conda_build_config.yaml#L812)
they store it as underscore so my idea is to check both r_base and r-base if it's in used vars


