### PR TITLE
style: improve spdx license error

### DIFF
--- a/src/recipe/error.rs
+++ b/src/recipe/error.rs
@@ -240,7 +240,15 @@ impl fmt::Display for ErrorKind {
             ErrorKind::UrlParsing(err) => write!(f, "failed to parse URL: {}", err),
             ErrorKind::IntegerParsing(err) => write!(f, "failed to parse integer: {}", err),
             ErrorKind::SpdxParsing(err) => {
-                write!(f, "failed to parse SPDX license: {}", err.reason)
+                writeln!(f, "failed to parse SPDX license: {}", err.reason)?;
+                writeln!(
+                    f,
+                    "See <https://spdx.org/licenses> for the list of valid licenses."
+                )?;
+                writeln!(
+                    f,
+                    "Use 'LicenseRef-<MyLicense>' if you are using a custom license."
+                )
             }
             ErrorKind::MatchSpecParsing(err) => {
                 write!(f, "failed to parse match spec: {}", err)

--- a/src/recipe/error.rs
+++ b/src/recipe/error.rs
@@ -245,7 +245,7 @@ impl fmt::Display for ErrorKind {
                     f,
                     "See <https://spdx.org/licenses> for the list of valid licenses."
                 )?;
-                writeln!(
+                write!(
                     f,
                     "Use 'LicenseRef-<MyLicense>' if you are using a custom license."
                 )

--- a/src/recipe/parser/snapshots/rattler_build__recipe__parser__about__test__invalid_license.snap
+++ b/src/recipe/parser/snapshots/rattler_build__recipe__parser__about__test__invalid_license.snap
@@ -5,6 +5,8 @@ expression: err
   × Failed to parse recipe
 
 Error:   × Parsing: failed to parse SPDX license: invalid character(s)
+  │ See <https://spdx.org/licenses> for the list of valid licenses.
+  │ Use 'LicenseRef-<MyLicense>' if you are using a custom license.
    ╭─[7:22]
  6 │         about:
  7 │             license: MIT/X derivate
@@ -12,4 +14,3 @@ Error:   × Parsing: failed to parse SPDX license: invalid character(s)
    ·                             ╰── here
  8 │         
    ╰────
-


### PR DESCRIPTION
```
Error:   × Parsing: failed to parse SPDX license: invalid character(s)
  │ See <https://spdx.org/licenses> for the list of valid licenses.
  │ Use 'LicenseRef-<MyLicense>' if you are using a custom license.
```


closes #675
