### PR TITLE
perf: reflink instead of copy from source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3118,6 +3118,8 @@ dependencies = [
  "rattler_shell",
  "rattler_solve",
  "rattler_virtual_packages",
+ "rayon",
+ "reflink-copy",
  "reqwest",
  "reqwest-middleware",
  "rstest",
@@ -3454,9 +3456,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,8 @@ crossterm = { version = "0.27.0", features = ["event-stream"], optional = true }
 ansi-to-tui = { version = "4.0.1", optional = true }
 throbber-widgets-tui = { version = "0.4.1", optional = true }
 tui-input = { version = "0.8.0", optional = true }
+reflink-copy = "0.1.15"
+rayon = "1.10.0"
 
 [dev-dependencies]
 insta = { version = "1.36.1", features = ["yaml"] }


### PR DESCRIPTION
* Reflink instead of copy files when copying from source (saves a whole bunch of diskspace).
* Cache created directories for less IO operations.
* Copy/reflink in parallel to optimally use IO.

Copying of the pytorch repo went from 55 seconds to 25 seconds on my machine.