### PR TITLE
fix: apply patches in target_directory

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: '(\.snap|test-data/recipes/test-parsing/.+)$'
+exclude: '(\.patch|\.diff|\.snap|test-data/recipes/test-parsing/.+)$'
 
 repos:
   -   repo: https://github.com/pre-commit/pre-commit-hooks

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -133,7 +133,7 @@ pub async fn fetch_sources(
                     .use_gitignore(false)
                     .run()?;
                 if !src.patches().is_empty() {
-                    patch::apply_patches(system_tools, src.patches(), work_dir, recipe_dir)?;
+                    patch::apply_patches(system_tools, src.patches(), &dest_dir, recipe_dir)?;
                 }
             }
             Source::Url(src) => {
@@ -179,7 +179,7 @@ pub async fn fetch_sources(
                 }
 
                 if !src.patches().is_empty() {
-                    patch::apply_patches(system_tools, src.patches(), work_dir, recipe_dir)?;
+                    patch::apply_patches(system_tools, src.patches(), &dest_dir, recipe_dir)?;
                 }
 
                 rendered_sources.push(Source::Url(src.clone()));
@@ -229,7 +229,7 @@ pub async fn fetch_sources(
                 }
 
                 if !src.patches().is_empty() {
-                    patch::apply_patches(system_tools, src.patches(), work_dir, recipe_dir)?;
+                    patch::apply_patches(system_tools, src.patches(), &dest_dir, recipe_dir)?;
                 }
 
                 rendered_sources.push(Source::Path(src.clone()));

--- a/test-data/recipes/git_source_patch/patch/ros-humble-ament-package.patch
+++ b/test-data/recipes/git_source_patch/patch/ros-humble-ament-package.patch
@@ -1,0 +1,87 @@
+diff --git a/ament_package/template/environment_hook/library_path.sh b/ament_package/template/environment_hook/library_path.sh
+deleted file mode 100644
+index 292e518..0000000
+--- a/ament_package/template/environment_hook/library_path.sh
++++ /dev/null
+@@ -1,16 +0,0 @@
+-# copied from ament_package/template/environment_hook/library_path.sh
+-
+-# detect if running on Darwin platform
+-_UNAME=`uname -s`
+-_IS_DARWIN=0
+-if [ "$_UNAME" = "Darwin" ]; then
+-  _IS_DARWIN=1
+-fi
+-unset _UNAME
+-
+-if [ $_IS_DARWIN -eq 0 ]; then
+-  ament_prepend_unique_value LD_LIBRARY_PATH "$AMENT_CURRENT_PREFIX/lib"
+-else
+-  ament_prepend_unique_value DYLD_LIBRARY_PATH "$AMENT_CURRENT_PREFIX/lib"
+-fi
+-unset _IS_DARWIN
+diff --git a/ament_package/templates.py b/ament_package/templates.py
+index 885b972..463453c 100644
+--- a/ament_package/templates.py
++++ b/ament_package/templates.py
+@@ -17,15 +17,21 @@ import re
+ 
+ try:
+     import importlib.resources as importlib_resources
+-except ModuleNotFoundError:
++    assert importlib_resources.files, "importlib reousrces too old to support files, please install importlib_resources"
++except (ModuleNotFoundError, AttributeError):
+     import importlib_resources
+ 
+ IS_WINDOWS = os.name == 'nt'
+ 
++# importlib
++# DeprecationWarning: path is deprecated. Use files() instead.
++# Refer to https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy 
++# for migration advice.
+ 
+ def get_environment_hook_template_path(name):
+-    with importlib_resources.path('ament_package.template.environment_hook', name) as path:
+-        return str(path)
++    # with importlib_resources.path('ament_package.template.environment_hook', name) as path:
++    path =  importlib_resources.files('ament_package.template.environment_hook').joinpath(name)
++    return str(path)
+ 
+ 
+ def get_package_level_template_names(all_platforms=False):
+@@ -41,8 +47,9 @@ def get_package_level_template_names(all_platforms=False):
+ 
+ 
+ def get_package_level_template_path(name):
+-    with importlib_resources.path('ament_package.template.package_level', name) as path:
+-        return str(path)
++    # with importlib_resources.path('ament_package.template.package_level', name) as path:
++    path = importlib_resources.files('ament_package.template.package_level').joinpath(name)
++    return str(path)
+ 
+ 
+ def get_prefix_level_template_names(*, all_platforms=False):
+@@ -61,8 +68,9 @@ def get_prefix_level_template_names(*, all_platforms=False):
+ 
+ 
+ def get_prefix_level_template_path(name):
+-    with importlib_resources.path('ament_package.template.prefix_level', name) as path:
+-        return str(path)
++    # with importlib_resources.path('ament_package.template.prefix_level', name) as path:
++    path = importlib_resources.files('ament_package.template.prefix_level').joinpath(name)
++    return str(path)
+ 
+ 
+ def get_isolated_prefix_level_template_names(*, all_platforms=False):
+@@ -81,8 +89,9 @@ def get_isolated_prefix_level_template_names(*, all_platforms=False):
+ 
+ 
+ def get_isolated_prefix_level_template_path(name):
+-    with importlib_resources.path('ament_package.template.isolated_prefix_level', name) as path:
+-        return str(path)
++    #with importlib_resources.path('ament_package.template.isolated_prefix_level', name) as path:
++    path = importlib_resources.files('ament_package.template.isolated_prefix_level').joinpath(name)
++    return str(path)
+ 
+ 
+ def configure_file(template_file, environment):

--- a/test-data/recipes/git_source_patch/patch/ros-humble-ament-package.patch
+++ b/test-data/recipes/git_source_patch/patch/ros-humble-ament-package.patch
@@ -25,63 +25,63 @@ index 885b972..463453c 100644
 --- a/ament_package/templates.py
 +++ b/ament_package/templates.py
 @@ -17,15 +17,21 @@ import re
- 
+
  try:
      import importlib.resources as importlib_resources
 -except ModuleNotFoundError:
 +    assert importlib_resources.files, "importlib reousrces too old to support files, please install importlib_resources"
 +except (ModuleNotFoundError, AttributeError):
      import importlib_resources
- 
+
  IS_WINDOWS = os.name == 'nt'
- 
+
 +# importlib
 +# DeprecationWarning: path is deprecated. Use files() instead.
-+# Refer to https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy 
++# Refer to https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy
 +# for migration advice.
- 
+
  def get_environment_hook_template_path(name):
 -    with importlib_resources.path('ament_package.template.environment_hook', name) as path:
 -        return str(path)
 +    # with importlib_resources.path('ament_package.template.environment_hook', name) as path:
 +    path =  importlib_resources.files('ament_package.template.environment_hook').joinpath(name)
 +    return str(path)
- 
- 
+
+
  def get_package_level_template_names(all_platforms=False):
 @@ -41,8 +47,9 @@ def get_package_level_template_names(all_platforms=False):
- 
- 
+
+
  def get_package_level_template_path(name):
 -    with importlib_resources.path('ament_package.template.package_level', name) as path:
 -        return str(path)
 +    # with importlib_resources.path('ament_package.template.package_level', name) as path:
 +    path = importlib_resources.files('ament_package.template.package_level').joinpath(name)
 +    return str(path)
- 
- 
+
+
  def get_prefix_level_template_names(*, all_platforms=False):
 @@ -61,8 +68,9 @@ def get_prefix_level_template_names(*, all_platforms=False):
- 
- 
+
+
  def get_prefix_level_template_path(name):
 -    with importlib_resources.path('ament_package.template.prefix_level', name) as path:
 -        return str(path)
 +    # with importlib_resources.path('ament_package.template.prefix_level', name) as path:
 +    path = importlib_resources.files('ament_package.template.prefix_level').joinpath(name)
 +    return str(path)
- 
- 
+
+
  def get_isolated_prefix_level_template_names(*, all_platforms=False):
 @@ -81,8 +89,9 @@ def get_isolated_prefix_level_template_names(*, all_platforms=False):
- 
- 
+
+
  def get_isolated_prefix_level_template_path(name):
 -    with importlib_resources.path('ament_package.template.isolated_prefix_level', name) as path:
 -        return str(path)
 +    #with importlib_resources.path('ament_package.template.isolated_prefix_level', name) as path:
 +    path = importlib_resources.files('ament_package.template.isolated_prefix_level').joinpath(name)
 +    return str(path)
- 
- 
+
+
  def configure_file(template_file, environment):

--- a/test-data/recipes/git_source_patch/patch/ros-humble-ament-package.patch
+++ b/test-data/recipes/git_source_patch/patch/ros-humble-ament-package.patch
@@ -25,63 +25,63 @@ index 885b972..463453c 100644
 --- a/ament_package/templates.py
 +++ b/ament_package/templates.py
 @@ -17,15 +17,21 @@ import re
-
+ 
  try:
      import importlib.resources as importlib_resources
 -except ModuleNotFoundError:
 +    assert importlib_resources.files, "importlib reousrces too old to support files, please install importlib_resources"
 +except (ModuleNotFoundError, AttributeError):
      import importlib_resources
-
+ 
  IS_WINDOWS = os.name == 'nt'
-
+ 
 +# importlib
 +# DeprecationWarning: path is deprecated. Use files() instead.
-+# Refer to https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy
++# Refer to https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy 
 +# for migration advice.
-
+ 
  def get_environment_hook_template_path(name):
 -    with importlib_resources.path('ament_package.template.environment_hook', name) as path:
 -        return str(path)
 +    # with importlib_resources.path('ament_package.template.environment_hook', name) as path:
 +    path =  importlib_resources.files('ament_package.template.environment_hook').joinpath(name)
 +    return str(path)
-
-
+ 
+ 
  def get_package_level_template_names(all_platforms=False):
 @@ -41,8 +47,9 @@ def get_package_level_template_names(all_platforms=False):
-
-
+ 
+ 
  def get_package_level_template_path(name):
 -    with importlib_resources.path('ament_package.template.package_level', name) as path:
 -        return str(path)
 +    # with importlib_resources.path('ament_package.template.package_level', name) as path:
 +    path = importlib_resources.files('ament_package.template.package_level').joinpath(name)
 +    return str(path)
-
-
+ 
+ 
  def get_prefix_level_template_names(*, all_platforms=False):
 @@ -61,8 +68,9 @@ def get_prefix_level_template_names(*, all_platforms=False):
-
-
+ 
+ 
  def get_prefix_level_template_path(name):
 -    with importlib_resources.path('ament_package.template.prefix_level', name) as path:
 -        return str(path)
 +    # with importlib_resources.path('ament_package.template.prefix_level', name) as path:
 +    path = importlib_resources.files('ament_package.template.prefix_level').joinpath(name)
 +    return str(path)
-
-
+ 
+ 
  def get_isolated_prefix_level_template_names(*, all_platforms=False):
 @@ -81,8 +89,9 @@ def get_isolated_prefix_level_template_names(*, all_platforms=False):
-
-
+ 
+ 
  def get_isolated_prefix_level_template_path(name):
 -    with importlib_resources.path('ament_package.template.isolated_prefix_level', name) as path:
 -        return str(path)
 +    #with importlib_resources.path('ament_package.template.isolated_prefix_level', name) as path:
 +    path = importlib_resources.files('ament_package.template.isolated_prefix_level').joinpath(name)
 +    return str(path)
-
-
+ 
+ 
  def configure_file(template_file, environment):

--- a/test-data/recipes/git_source_patch/recipe.yaml
+++ b/test-data/recipes/git_source_patch/recipe.yaml
@@ -1,0 +1,10 @@
+package:
+    name: ament_package
+    version: "0.14.0"
+
+source:
+  git: https://github.com/ros2-gbp/ament_package-release.git
+  rev: release/humble/ament_package/0.14.0-4
+  target_directory: ros-humble-ament-package/src/work
+  patches:
+    - patch/ros-humble-ament-package.patch

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -601,6 +601,7 @@ def test_git_submodule(rattler_build: RattlerBuild, recipes: Path, tmp_path: Pat
     assert source["git"] == "https://github.com/wjakob/nanobind/"
     assert source["rev"] == "8e1f8408b37d994fb987440859eb977af39be8c3"
 
+
 @pytest.mark.skipif(
     os.name == "nt", reason="recipe does not support execution on windows"
 )

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -583,7 +583,7 @@ def test_git_submodule(rattler_build: RattlerBuild, recipes: Path, tmp_path: Pat
         tmp_path,
     )
 
-    output = check_output([str(rattler_build.path), *args], stderr=STDOUT, text=True)
+    _ = check_output([str(rattler_build.path), *args], stderr=STDOUT, text=True)
     pkg = get_extracted_package(tmp_path, "nanobind")
 
     assert (pkg / "info/paths.json").exists()
@@ -612,7 +612,7 @@ def test_git_patch(rattler_build: RattlerBuild, recipes: Path, tmp_path: Path):
         tmp_path,
     )
 
-    output = check_output([str(rattler_build.path), *args], stderr=STDOUT, text=True)
+    _ = check_output([str(rattler_build.path), *args], stderr=STDOUT, text=True)
     pkg = get_extracted_package(tmp_path, "ament_package")
 
     assert (pkg / "info/paths.json").exists()

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -600,3 +600,31 @@ def test_git_submodule(rattler_build: RattlerBuild, recipes: Path, tmp_path: Pat
     source = sources[0]
     assert source["git"] == "https://github.com/wjakob/nanobind/"
     assert source["rev"] == "8e1f8408b37d994fb987440859eb977af39be8c3"
+
+@pytest.mark.skipif(
+    os.name == "nt", reason="recipe does not support execution on windows"
+)
+def test_git_patch(rattler_build: RattlerBuild, recipes: Path, tmp_path: Path):
+    path_to_recipe = recipes / "git_source_patch"
+    args = rattler_build.build_args(
+        path_to_recipe,
+        tmp_path,
+    )
+
+    output = check_output([str(rattler_build.path), *args], stderr=STDOUT, text=True)
+    pkg = get_extracted_package(tmp_path, "ament_package")
+
+    assert (pkg / "info/paths.json").exists()
+    assert (pkg / "info/recipe/rendered_recipe.yaml").exists()
+    # load recipe as YAML
+
+    text = (pkg / "info/recipe/rendered_recipe.yaml").read_text()
+
+    # parse the rendered recipe
+    rendered_recipe = yaml.safe_load(text)
+    sources = rendered_recipe["finalized_sources"]
+
+    assert len(sources) == 1
+    source = sources[0]
+    assert source["git"] == "https://github.com/ros2-gbp/ament_package-release.git"
+    assert source["rev"] == "00da147b17c19bc225408dc693ed8fdc14c314ab"


### PR DESCRIPTION
If the `target_directory` is set, we should use that as the cwd to apply patches. 