### PR TITLE
fix: mamba on windows

### DIFF
--- a/examples/mamba/build_mamba.bat
+++ b/examples/mamba/build_mamba.bat
@@ -1,0 +1,48 @@
+@echo ON
+
+if /I "%PKG_NAME%" == "mamba" (
+	cd mamba
+	%PYTHON% -m pip install . --no-deps -vv
+	exit 0
+)
+
+rmdir /Q /S build
+mkdir build
+cd build
+
+rem most likely don't needed on Windows, just for OSX
+rem set "CXXFLAGS=%CXXFLAGS% /D_LIBCPP_DISABLE_AVAILABILITY=1"
+
+if /I "%PKG_NAME%" == "libmamba" (
+	cmake .. ^
+	    %CMAKE_ARGS% ^
+		-GNinja ^
+		-DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+		-DCMAKE_PREFIX_PATH=%PREFIX% ^
+		-DBUILD_LIBMAMBA=ON ^
+		-DBUILD_SHARED=ON  ^
+		-DBUILD_MAMBA_PACKAGE=ON
+)
+if /I "%PKG_NAME%" == "libmambapy" (
+	cmake .. ^
+	    %CMAKE_ARGS% ^
+		-GNinja ^
+		-DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+		-DCMAKE_PREFIX_PATH=%PREFIX% ^
+                -DPython_EXECUTABLE=%PYTHON% ^
+		-DBUILD_LIBMAMBAPY=ON
+)
+if errorlevel 1 exit 1
+
+ninja
+if errorlevel 1 exit 1
+
+ninja install
+if errorlevel 1 exit 1
+
+if /I "%PKG_NAME%" == "libmambapy" (
+	cd ../libmambapy
+	rmdir /Q /S build
+	%PYTHON% -m pip install . --no-deps -vv
+	del *.pyc /a /s
+)

--- a/examples/mamba/recipe.yaml
+++ b/examples/mamba/recipe.yaml
@@ -2,10 +2,10 @@
 
 context:
   name: mamba
-  libmamba_version: "1.5.3"
-  libmambapy_version: "1.5.3"
-  mamba_version: "1.5.3"
-  release: "2023.10.30"
+  libmamba_version: "1.5.8"
+  libmambapy_version: "1.5.8"
+  mamba_version: "1.5.8"
+  release: "2024.03.25"
   build_number: 2
   # libmamba_version_split: ${{ libmamba_version.split('.') }}
 
@@ -14,7 +14,7 @@ recipe:
 
 source:
   url: https://github.com/mamba-org/mamba/archive/refs/tags/${{ release }}.tar.gz
-  sha256: 36d617de5971ad2b4460f5446bee7622f33cf3a8a079df8f97bc24e9a5873071
+  sha256: 6ddaf4b0758eb7ca1250f427bc40c2c3ede43257a60bac54e4320a4de66759a6
 
 build:
   number: ${{ build_number }}

--- a/examples/mamba/variant_config.yaml
+++ b/examples/mamba/variant_config.yaml
@@ -2,3 +2,6 @@ python:
   - "3.11.* *cpython"
   # - "3.12.* *cpython"
   # - "3.9.* *cpython"
+
+cxx_compiler:
+  - vs2019


### PR DESCRIPTION
To be able to build mamba on windows, you need `build_mamba.bat` and vs2019 is required as a minimum.