### PR TITLE
use env_clear

### DIFF
--- a/src/script.rs
+++ b/src/script.rs
@@ -138,12 +138,15 @@ impl Interpreter for BashInterpreter {
         tokio::fs::write(&build_script_path, script).await?;
 
         let build_script_path_str = build_script_path.to_string_lossy().to_string();
-        let bash = which::which("bash").map_err(|_| {
-            std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                "Could not find `bash` in PATH",
-            )
-        })?.to_string_lossy().to_string();
+        let bash = which::which("bash")
+            .map_err(|_| {
+                std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "Could not find `bash` in PATH",
+                )
+            })?
+            .to_string_lossy()
+            .to_string();
         let cmd_args = [&bash, "-e", &build_script_path_str];
 
         let output = run_process_with_replacements(


### PR DESCRIPTION
cc @DerThorsten maybe that would help with the issues you had regarding deactivation. This should start a more isolated shell for building & testing.

One can still inject environment variables "from the outside" by using the `env` part of the script object, and the `${{ env.get(...) }}` to grab them from the current process.