### PR TITLE
fix: correctly identify tarballs (#821)

### DIFF
--- a/src/source/extract.rs
+++ b/src/source/extract.rs
@@ -19,6 +19,40 @@ enum TarCompression<'a> {
     Lzop,
 }
 
+/// Checks whether file has known tarball extension
+pub fn is_tarball(file_name: &str) -> bool {
+    [
+        // Gzip
+        ".tar.gz",
+        ".tgz",
+        ".taz",
+        // Bzip2
+        ".tar.bz2",
+        ".tbz",
+        ".tbz2",
+        ".tz2",
+        // Xz2
+        ".tar.lzma",
+        ".tlz",
+        ".tar.xz",
+        ".txz",
+        // Zstd
+        ".tar.zst",
+        ".tzst",
+        // Compress
+        ".tar.Z",
+        ".taZ",
+        // Lzip
+        ".tar.lz",
+        // Lzop
+        ".tar.lzo",
+        // PlainTar
+        ".tar",
+    ]
+    .iter()
+    .any(|ext| file_name.ends_with(ext))
+}
+
 fn ext_to_compression<'a>(ext: Option<&OsStr>, file: Box<dyn BufRead + 'a>) -> TarCompression<'a> {
     match ext
         .and_then(OsStr::to_str)

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     recipe::parser::{GitRev, GitSource, Source},
     source::{
         checksum::Checksum,
-        extract::{extract_tar, extract_zip},
+        extract::{extract_tar, extract_zip, is_tarball},
     },
     system_tools::ToolError,
     tool_configuration,
@@ -170,12 +170,12 @@ pub async fn fetch_sources(
                     fs::create_dir_all(&dest_dir)?;
                 }
 
-                if res
-                    .file_name()
-                    .unwrap_or_default()
-                    .to_string_lossy()
-                    .contains(".tar")
-                {
+                if is_tarball(
+                    res.file_name()
+                        .unwrap_or_default()
+                        .to_string_lossy()
+                        .as_ref(),
+                ) {
                     extract_tar(&res, &dest_dir, &tool_configuration.fancy_log_handler)?;
                     tracing::info!("Extracted to {:?}", dest_dir);
                 } else if res.extension() == Some(OsStr::new("zip")) {
@@ -230,12 +230,13 @@ pub async fn fetch_sources(
                         "Copied {} files into isolated environment",
                         copy_result.copied_paths().len()
                     );
-                } else if src_path
-                    .file_name()
-                    .unwrap_or_default()
-                    .to_string_lossy()
-                    .contains(".tar")
-                {
+                } else if is_tarball(
+                    src_path
+                        .file_name()
+                        .unwrap_or_default()
+                        .to_string_lossy()
+                        .as_ref(),
+                ) {
                     extract_tar(&src_path, &dest_dir, &tool_configuration.fancy_log_handler)?;
                     tracing::info!("Extracted to {:?}", dest_dir);
                 } else if src_path.extension() == Some(OsStr::new("zip")) {


### PR DESCRIPTION
This is an initial proposal how to fix #821 with relatively low effort.
Maybe a better idea would be to somehow avoid duplicating strings between this new `is_tarball` function and `ext_to_compression`, but I don't have enough Rust knowledge, and I am completely new to rattler codebase.