### PR TITLE
feat: use system-tools from build prefix if they are available

### DIFF
--- a/src/post_process/relink.rs
+++ b/src/post_process/relink.rs
@@ -163,6 +163,8 @@ pub fn relink(temp_files: &TempFiles, output: &Output) -> Result<(), RelinkError
     let encoded_prefix = &temp_files.encoded_prefix;
 
     let mut binaries = HashSet::new();
+    // allow to use tools from build prefix such as patchelf, install_name_tool, ...
+    let system_tools = output.system_tools.with_build_prefix(output.build_prefix());
 
     for (p, content_type) in temp_files.content_type_map() {
         let metadata = fs::symlink_metadata(p)?;
@@ -185,7 +187,7 @@ pub fn relink(temp_files: &TempFiles, output: &Output) -> Result<(), RelinkError
                 encoded_prefix,
                 &rpaths,
                 rpath_allowlist,
-                &output.system_tools,
+                &system_tools,
             )?;
             binaries.insert(p.clone());
         }

--- a/src/system_tools.rs
+++ b/src/system_tools.rs
@@ -279,6 +279,7 @@ mod tests {
             rattler_build_version: "0.0.0".to_string(),
             used_tools: Arc::new(Mutex::new(used_tools)),
             found_tools: Arc::new(Mutex::new(HashMap::new())),
+            build_prefix: None,
         };
 
         let json = serde_json::to_string_pretty(&system_tool).unwrap();

--- a/src/system_tools.rs
+++ b/src/system_tools.rs
@@ -116,9 +116,6 @@ impl SystemTools {
     fn find_tool(&self, tool: Tool) -> Result<PathBuf, which::Error> {
         let which = |tool: &str| -> Result<PathBuf, which::Error> {
             if let Some(build_prefix) = &self.build_prefix {
-                // first check if we can find the tool in the build prefix.
-                let tool_path = build_prefix.join(tool);
-
                 let build_prefix_activator =
                     Activator::from_path(build_prefix, shell::Bash, Platform::current()).unwrap();
 
@@ -126,8 +123,8 @@ impl SystemTools {
                 let mut found_tool = which::which_in_global(&tool, paths)?;
 
                 // if the tool is found in the build prefix, return it
-                if found_tool.next().is_some() {
-                    return Ok(tool_path);
+                if let Some(found_tool) = found_tool.next() {
+                    return Ok(found_tool);
                 }
             }
             which::which(tool)


### PR DESCRIPTION
This should fix issues with cross-compiling e.g. from linux-64 to osx-arm64 (where we need to invoke `codesign`). A `codesign` is installed in the `$BUILD_PREFIX` and we should preferably use that.