### PR TITLE
fix: filter files like conda-build does

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -13,20 +13,74 @@ relocatable:
 
 1. **Binary object file conversion**: Binary object files are converted to use
    relative paths using `install_name_tool` on macOS and `patchelf` on Linux.
-   This uses `$ORIGIN` for elf files on Linux and `@loader_path` for Mach-O files
-   on macOS to make the `rpath` relative to the executable / shared library.
+   This uses `$ORIGIN` for elf files on Linux and `@loader_path` for Mach-O
+   files on macOS to make the `rpath` relative to the executable / shared
+   library.
 2. **Text file prefix registration**: Any text file without `NULL` bytes
-   containing the placeholder prefix have the registered prefix replaced with the
-   install prefix.
+   containing the placeholder prefix have the registered prefix replaced with
+   the install prefix.
 3. **Binary file prefix detection and registration**: Binary files containing
-   the build prefix can be automatically registered. The registered files will
-   have their build prefix replaced with the install prefix at install time.
-   This works by padding the install prefix with null terminators, such that the
-   length of the binary file remains the same. The build prefix must be long
-   enough to accommodate any reasonable installation prefix. On macOS and Linux,
-   `rattler-build` pads the build prefix to 255 characters by appending
-   `_placehold` to the end of the build directory name.
+the build prefix can be automatically registered. The registered files will have
+their build prefix replaced with the install prefix at install time. This works
+by padding the install prefix with null terminators, such that the length of the
+binary file remains the same. The build prefix must be long enough to
+accommodate any reasonable installation prefix. On macOS and Linux,
+`rattler-build` pads the build prefix to 255 characters by appending
+`_placehold` to the end of the build directory name.
 <!--4. **Prefix replacement for specific binary files**: There may be cases where a
    file is identified as binary but requires the build prefix to be replaced as
    if it were text—without padding with null terminators. Such files can be
    listed in `build/has_prefix_files` in `meta.yaml`.-->
+
+## What goes into a package?
+
+Generally speaking, any new files that are copied into the `$PREFIX` directory
+at build time are part of the new package. However, there is some filtering
+going on to exclude unwanted files, and `noarch: python` packages have special
+handling as well. The rules are as follows:
+
+### Filtering
+
+#### General File Filtering
+
+Certain files are filtered out to prevent them from being included in the
+package. These include:
+
+- **.pyo files**: Optimized Python files are not included [because they are
+  considered harmful](https://www.python.org/dev/peps/pep-0488/).
+- **.la files**: Libtool archive files that are not needed at runtime.
+- **.DS_Store files**: macOS-specific files that are irrelevant to the package.
+- **.git files and directories**: Version control files, including `.gitignore`
+  and the `.git` directory, which are not needed in the package.
+- **share/info/dir** This file is ignored because it would be written from
+  multiple packages.
+
+#### Special Handling for `noarch: python` Packages
+
+For packages marked as `noarch: python`, special transformations are applied to
+ensure compatibility across different platforms:
+
+- **Stripping Python Library Prefix**: The "lib/pythonX.X" prefix is removed,
+  retaining only the "site-packages" part of the path.
+- **Skipping `__pycache__` Directories and `.pyc` Files**: These are excluded
+  and recreated during installation (they are specific to the Python version).
+- **Replacing `bin` and `Scripts` Directories**:
+  - On Unix systems, the `bin` directory is replaced with `python-scripts`.
+  - On Windows systems, the `Scripts` directory is replaced with
+    `python-scripts`.
+- **Remove explicitly mentioned entrypoints**: For `noarch: python` packages,
+  entry points registered in the package are also taken into account. Files in
+  the `bin` or `Scripts` directories that match entry points are excluded to
+  avoid duplications.
+
+### Symlink Handling
+
+Symlinks are carefully managed to ensure they are relative rather than absolute,
+which aids in making the package relocatable:
+
+- Absolute symlinks pointing within the `$PREFIX` are converted to relative
+  symlinks.
+- On Unix systems, this conversion is handled directly by creating new relative
+  symlinks.
+- On Windows, a warning is issued since symlink creation requires administrator
+  privileges.

--- a/src/packaging/file_mapper.rs
+++ b/src/packaging/file_mapper.rs
@@ -46,6 +46,41 @@ pub fn filter_pyc(path: &Path, new_files: &HashSet<PathBuf>) -> bool {
     false
 }
 
+/// Filter certain files to prevent them from being packaged:
+///
+/// - .pyo files are considered "harmful" (optimized python files)
+/// - .la files are not needed at runtime and are unnecessary bloat
+/// - .DS_Store files are not needed and macOS specific
+/// - .git* files are not needed in a package and are version control specific (incl. .git folder and .gitignore)
+pub fn filter_file(relative_path: &Path) -> bool {
+    let ext = relative_path.extension().unwrap_or_default();
+
+    // skip the share/info/dir file because multiple packages would write
+    // to the same index file
+    if relative_path.starts_with("share/info/dir") {
+        return true;
+    }
+
+    // pyo considered harmful: https://www.python.org/dev/peps/pep-0488/
+    if ext == "pyo" {
+        return true;
+    }
+
+    // we skip `.la` files because conda-build does it - la files are not needed at runtime
+    if ext == "la" {
+        return true;
+    }
+
+    // filter any paths with .DS_Store, .git*, or conda-meta in them
+    if relative_path.components().any(|c| {
+        let s = c.as_os_str().to_string_lossy();
+        s.starts_with(".git") || s == ".DS_Store" || s == "conda-meta"
+    }) {
+        return true;
+    }
+    false
+}
+
 impl Output {
     /// This function copies the given file to the destination folder and
     /// transforms it on the way if needed.
@@ -68,19 +103,13 @@ impl Output {
         let entry_points = &self.recipe.build().python().entry_points;
 
         let path_rel = path.strip_prefix(prefix)?;
-        let mut dest_path = dest_folder.join(path_rel);
 
-        // skip the share/info/dir file because multiple packages would write
-        // to the same index file
-        if path_rel == Path::new("share/info/dir") {
+        if filter_file(path_rel) {
             return Ok(None);
         }
 
+        let mut dest_path = dest_folder.join(path_rel);
         let ext = path.extension().unwrap_or_default();
-        // pyo considered harmful: https://www.python.org/dev/peps/pep-0488/
-        if ext == "pyo" {
-            return Ok(None); // skip .pyo files
-        }
 
         if ext == "py" || ext == "pyc" {
             // if we have a .so file of the same name, skip this path
@@ -257,6 +286,35 @@ impl Output {
             tracing::trace!("Copying file {:?} to {:?}", path, dest_path);
             fs::copy(path, &dest_path)?;
             Ok(Some(dest_path))
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn test_filter_file() {
+        let test_cases = vec![
+            ("test.pyo", true),
+            ("test.la", true),
+            (".DS_Store", true),
+            (".gitignore", true),
+            (".git/HEAD", true),
+            ("foo/.DS_Store", true),
+            ("lib/libarchive.la", true),
+            ("bla/.git/config", true),
+            ("share/info/dir", true),
+            ("share/info/dir/foo", true),
+            ("lib/python3.9/site-packages/test/fast.pyo", true),
+            ("lib/python3.9/site-packages/test/fast.py", false),
+            ("lib/python3.9/site-packages/test/fast.pyc", false),
+            ("lib/libarchive.a", false),
+            ("lib/libarchive.so", false),
+        ];
+
+        for (file, expected) in test_cases {
+            let path = std::path::Path::new(file);
+            assert_eq!(super::filter_file(path), expected);
         }
     }
 }

--- a/test-data/recipes/filter_files/recipe.yaml
+++ b/test-data/recipes/filter_files/recipe.yaml
@@ -1,0 +1,15 @@
+package:
+  name: filter_files
+  version: 0.1.0
+
+build:
+  script:
+    - mkdir -p $PREFIX/
+    - touch $PREFIX/.DS_Store
+    - touch $PREFIX/.gitignore
+    - mkdir -p $PREFIX/share/info
+    - touch $PREFIX/share/info/dir
+    - touch $PREFIX/test.pyo
+    - mkdir -p $PREFIX/lib
+    - touch $PREFIX/lib/libarchive.la
+    - touch $PREFIX/exists.txt

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -803,3 +803,25 @@ def test_regex_post_process(rattler_build: RattlerBuild, recipes: Path, tmp_path
     assert text_cmake.startswith(
         'target_compile_definitions(test PRIVATE "some_path;{CONDA_BUILD_SYSROOT}/and/more;some_other_path;{CONDA_BUILD_SYSROOT}/and/more")'  # noqa: E501
     )
+
+
+@pytest.mark.skipif(
+    os.name == "nt", reason="recipe does not support execution on windows"
+)
+def test_filter_files(rattler_build: RattlerBuild, recipes: Path, tmp_path: Path):
+    path_to_recipe = recipes / "filter_files"
+    args = rattler_build.build_args(
+        path_to_recipe,
+        tmp_path,
+    )
+
+    rattler_build(*args)
+    pkg = get_extracted_package(tmp_path, "filter_files")
+
+    assert (pkg / "info/paths.json").exists()
+
+    # parse paths json
+    paths = json.loads((pkg / "info/paths.json").read_text())
+    pp = paths["paths"]
+    assert len(pp) == 1
+    assert pp[0]["_path"] == "exists.txt"


### PR DESCRIPTION
conda-build filters a few more files before packaging. We're aligning with that. Includes:

- .DS_Store files
- *.la files
- .git* files (incl. .git directories)

https://github.com/conda/conda-build/blob/5f5eebe54b577cc4d9a5fd3f2d0f6516265c2923/conda_build/utils.py#L1572-L1580