### PR TITLE
feat: remove hash_input from rendered recipe

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -622,6 +622,7 @@ mod tests {
 
 #[cfg(test)]
 mod test {
+    use rstest::*;
     use std::str::FromStr;
 
     use chrono::TimeZone;
@@ -716,21 +717,16 @@ mod test {
         assert_eq!("pip", parsed_yaml3.specs[0].render(false));
     }
 
-    #[test]
-    fn read_full_recipe() {
+    #[rstest]
+    #[case::rich("rich_recipe.yaml")]
+    #[case::curl("curl_recipe.yaml")]
+    fn read_full_recipe(#[case] recipe_path: String) {
         let test_data_dir =
             std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("test-data/rendered_recipes");
-        let recipe_1 = test_data_dir.join("rich_recipe.yaml");
 
-        let recipe_1 = std::fs::read_to_string(recipe_1).unwrap();
-
-        let output_rich: Output = serde_yaml::from_str(&recipe_1).unwrap();
-        assert_yaml_snapshot!(output_rich);
-
-        let recipe_2 = test_data_dir.join("curl_recipe.yaml");
-        let recipe_2 = std::fs::read_to_string(recipe_2).unwrap();
-        let output_curl: Output = serde_yaml::from_str(&recipe_2).unwrap();
-        assert_yaml_snapshot!(output_curl);
+        let recipe = std::fs::read_to_string(test_data_dir.join(&recipe_path)).unwrap();
+        let output: Output = serde_yaml::from_str(&recipe).unwrap();
+        assert_yaml_snapshot!(recipe_path, output);
     }
 
     #[test]

--- a/src/snapshots/rattler_build__metadata__test__curl_recipe.yaml.snap
+++ b/src/snapshots/rattler_build__metadata__test__curl_recipe.yaml.snap
@@ -1,6 +1,7 @@
 ---
 source: src/metadata.rs
-expression: output_curl
+assertion_line: 729
+expression: output
 ---
 recipe:
   schema_version: 1
@@ -37,8 +38,6 @@ build_configuration:
     target_platform: osx-arm64
   hash:
     hash: 60d57d3
-    hash_input: "{\"target_platform\": \"osx-arm64\"}"
-    hash_prefix: ""
   directories:
     host_prefix: /Users/wolfv/Programs/rattler-build/output/bld/rattler-build_curl_1700573293/host_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold
     build_prefix: /Users/wolfv/Programs/rattler-build/output/bld/rattler-build_curl_1700573293/build_env

--- a/src/snapshots/rattler_build__metadata__test__read_recipe_with_sources.snap
+++ b/src/snapshots/rattler_build__metadata__test__read_recipe_with_sources.snap
@@ -1,5 +1,6 @@
 ---
 source: src/metadata.rs
+assertion_line: 744
 expression: git_source_output
 ---
 recipe:
@@ -33,8 +34,6 @@ build_configuration:
     target_platform: osx-arm64
   hash:
     hash: 60d57d3
-    hash_input: "{\"target_platform\": \"osx-arm64\"}"
-    hash_prefix: ""
   directories:
     host_prefix: /Users/wolfv/Programs/rattler-build/output/bld/rattler-build_git_source_1704379826/host_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pla
     build_prefix: /Users/wolfv/Programs/rattler-build/output/bld/rattler-build_git_source_1704379826/build_env

--- a/src/snapshots/rattler_build__metadata__test__rich_recipe.yaml.snap
+++ b/src/snapshots/rattler_build__metadata__test__rich_recipe.yaml.snap
@@ -1,6 +1,7 @@
 ---
 source: src/metadata.rs
-expression: output_rich
+assertion_line: 729
+expression: output
 ---
 recipe:
   schema_version: 1
@@ -53,8 +54,7 @@ build_configuration:
     target_platform: noarch
   hash:
     hash: 4616a5c
-    hash_input: "{\"target_platform\": \"noarch\"}"
-    hash_prefix: py
+    prefix: py
   directories:
     host_prefix: /Users/wolfv/Programs/rattler-build/output/bld/rattler-build_rich_1702492812/host_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold
     build_prefix: /Users/wolfv/Programs/rattler-build/output/bld/rattler-build_rich_1702492812/build_env

--- a/test-data/rendered_recipes/curl_recipe.yaml
+++ b/test-data/rendered_recipes/curl_recipe.yaml
@@ -35,8 +35,6 @@ build_configuration:
     target_platform: osx-arm64
   hash:
     hash: 60d57d3
-    hash_input: '{"target_platform": "osx-arm64"}'
-    hash_prefix: ''
   directories:
     host_prefix: /Users/wolfv/Programs/rattler-build/output/bld/rattler-build_curl_1700573293/host_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold
     build_prefix: /Users/wolfv/Programs/rattler-build/output/bld/rattler-build_curl_1700573293/build_env

--- a/test-data/rendered_recipes/git_source.yaml
+++ b/test-data/rendered_recipes/git_source.yaml
@@ -29,8 +29,6 @@ build_configuration:
     target_platform: osx-arm64
   hash:
     hash: 60d57d3
-    hash_input: '{"target_platform": "osx-arm64"}'
-    hash_prefix: ''
   directories:
     host_prefix: /Users/wolfv/Programs/rattler-build/output/bld/rattler-build_git_source_1704379826/host_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pla
     build_prefix: /Users/wolfv/Programs/rattler-build/output/bld/rattler-build_git_source_1704379826/build_env

--- a/test-data/rendered_recipes/rich_recipe.yaml
+++ b/test-data/rendered_recipes/rich_recipe.yaml
@@ -54,8 +54,7 @@ build_configuration:
     target_platform: noarch
   hash:
     hash: 4616a5c
-    hash_input: '{"target_platform": "noarch"}'
-    hash_prefix: py
+    prefix: py
   directories:
     host_prefix: /Users/wolfv/Programs/rattler-build/output/bld/rattler-build_rich_1702492812/host_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold
     build_prefix: /Users/wolfv/Programs/rattler-build/output/bld/rattler-build_rich_1702492812/build_env


### PR DESCRIPTION
Fixes #867

Changes:

* Removes `hash_input` from rendered recipe.
* Renames `hash.hash_prefix` to `hash.prefix`.

Modification to the CEP: [conda/ceps@`0cdf2f1` (#74)](https://github.com/conda/ceps/pull/74/commits/0cdf2f11426064e25b3c59fda9387776648540fc)