### PR TITLE
feat: `stdlib` implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -557,6 +557,7 @@ pub fn sort_build_outputs_topologically(
                 recipe::parser::Dependency::PinSubpackage(pin) => pin.pin_value().name.clone(),
                 recipe::parser::Dependency::PinCompatible(pin) => pin.pin_value().name.clone(),
                 recipe::parser::Dependency::Compiler(_) => continue,
+                recipe::parser::Dependency::Stdlib(_) => continue,
             };
             if let Some(&dep_idx) = name_to_index.get(&dep_name) {
                 // do not point to self (circular dependency) - this can happen with

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,6 +169,8 @@ pub async fn get_build_output(
         build_platform: args.build_platform,
         variant: BTreeMap::new(),
         experimental: args.common.experimental,
+        // allow undefined while finding the variants
+        allow_undefined: true,
     };
 
     let span = tracing::info_span!("Finding outputs from recipe");
@@ -217,6 +219,7 @@ pub async fn get_build_output(
             host_platform: selector_config.host_platform,
             build_platform: selector_config.build_platform,
             experimental: args.common.experimental,
+            allow_undefined: false,
         };
 
         let recipe =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ use metadata::Output;
 use miette::{IntoDiagnostic, WrapErr};
 use petgraph::{algo::toposort, graph::DiGraph, visit::DfsPostOrder};
 use rattler_conda_types::{package::ArchiveType, Channel, ChannelConfig, Platform};
+use recipe::parser::Dependency;
 use std::{
     collections::{BTreeMap, HashMap},
     env::current_dir,
@@ -550,14 +551,12 @@ pub fn sort_build_outputs_topologically(
             .expect("We just inserted it");
         for dep in output.recipe.requirements().all() {
             let dep_name = match dep {
-                recipe::parser::Dependency::Spec(spec) => spec
+                Dependency::Spec(spec) => spec
                     .name
                     .clone()
                     .expect("MatchSpec should always have a name"),
-                recipe::parser::Dependency::PinSubpackage(pin) => pin.pin_value().name.clone(),
-                recipe::parser::Dependency::PinCompatible(pin) => pin.pin_value().name.clone(),
-                recipe::parser::Dependency::Compiler(_) => continue,
-                recipe::parser::Dependency::Stdlib(_) => continue,
+                Dependency::PinSubpackage(pin) => pin.pin_value().name.clone(),
+                Dependency::PinCompatible(pin) => pin.pin_value().name.clone(),
             };
             if let Some(&dep_idx) = name_to_index.get(&dep_name) {
                 // do not point to self (circular dependency) - this can happen with

--- a/src/recipe/jinja.rs
+++ b/src/recipe/jinja.rs
@@ -93,7 +93,6 @@ fn jinja_pin_function(
         )
     })?;
 
-    // we translate the compiler into a YAML string
     let mut pin_subpackage = Pin {
         name,
         args: PinArgs::default(),
@@ -222,6 +221,11 @@ fn set_jinja(config: &SelectorConfig) -> minijinja::Environment<'static> {
     env.add_function("compiler", |lang: String| {
         // we translate the compiler into a YAML string
         Ok(format!("__COMPILER {}", lang.to_lowercase()))
+    });
+
+    env.add_function("stdlib", |lang: String| {
+        // we translate the stdlib into a YAML string
+        Ok(format!("__STDLIB {}", lang.to_lowercase()))
     });
 
     env.add_function("pin_subpackage", |name: String, kwargs: Option<Value>| {

--- a/src/recipe/jinja.rs
+++ b/src/recipe/jinja.rs
@@ -1,11 +1,12 @@
 //! Module for types and functions related to miniJinja setup for recipes.
 
 use std::process::Command;
+use std::sync::Arc;
 use std::{collections::BTreeMap, str::FromStr};
 
 use minijinja::value::Object;
 use minijinja::{Environment, Value};
-use rattler_conda_types::{PackageName, ParseStrictness, Version};
+use rattler_conda_types::{PackageName, ParseStrictness, Platform, Version};
 
 use crate::render::pin::PinArgs;
 pub use crate::render::pin::{Pin, PinExpression};
@@ -143,9 +144,91 @@ fn jinja_pin_function(
     }
 }
 
+fn default_compiler(platform: Platform, language: &str) -> Option<String> {
+    if platform.is_windows() {
+        match language {
+            "c" => Some("vs2017"),
+            "cxx" => Some("vs2017"),
+            "fortran" => Some("gfortran"),
+            "rust" => Some("rust"),
+            _ => None,
+        }
+    } else if platform.is_osx() {
+        match language {
+            "c" => Some("clang"),
+            "cxx" => Some("clangxx"),
+            "fortran" => Some("gfortran"),
+            "rust" => Some("rust"),
+            _ => None,
+        }
+    } else {
+        match language {
+            "c" => Some("gcc"),
+            "cxx" => Some("gxx"),
+            "fortran" => Some("gfortran"),
+            "rust" => Some("rust"),
+            _ => None,
+        }
+    }
+    .map(|s| s.to_string())
+}
+
+fn compiler_stdlib_eval(
+    lang: &str,
+    platform: Platform,
+    variant: &Arc<BTreeMap<String, String>>,
+    prefix: &str,
+) -> Result<String, minijinja::Error> {
+    let variant_key = format!("{lang}_{prefix}");
+    let variant_key_version = format!("{lang}_{prefix}_version");
+
+    let default_fn = if prefix == "compiler" {
+        default_compiler
+    } else {
+        |_: Platform, _: &str| None
+    };
+
+    let res = if let Some(name) = variant
+        .get(&variant_key)
+        .cloned()
+        .or_else(|| default_fn(platform, lang))
+    {
+        // check if we also have a compiler version
+        if let Some(version) = variant.get(&variant_key_version) {
+            Some(format!("{name}_{platform} {version}"))
+        } else {
+            Some(format!("{name}_{platform}"))
+        }
+    } else {
+        None
+    };
+
+    if let Some(res) = res {
+        Ok(res)
+    } else {
+        Err(minijinja::Error::new(
+            minijinja::ErrorKind::UndefinedError,
+            format!(
+                "No {prefix} found for language: {lang}\nYou should add `{lang}_{prefix}` to your variant config file.",
+            ),
+        ))
+    }
+}
+
 fn set_jinja(config: &SelectorConfig) -> minijinja::Environment<'static> {
     use rattler_conda_types::version_spec::VersionSpec;
+
+    let SelectorConfig {
+        target_platform,
+        build_platform,
+        variant,
+        experimental,
+        ..
+    } = config.clone();
+
     let mut env = minijinja::Environment::new();
+
+    let variant = Arc::new(variant.clone());
 
     // Ok to unwrap here because we know that the syntax is valid
     env.set_syntax(minijinja::Syntax {
@@ -185,20 +268,13 @@ fn set_jinja(config: &SelectorConfig) -> minijinja::Environment<'static> {
         }
     });
 
-    let SelectorConfig {
-        target_platform,
-        build_platform,
-        variant,
-        experimental,
-        ..
-    } = config.clone();
-
+    let variant_clone = variant.clone();
     env.add_function("cdt", move |package_name: String| {
         use rattler_conda_types::Arch;
         let arch = build_platform.arch().or_else(|| target_platform.arch());
         let arch_str = arch.map(|arch| format!("{arch}"));
 
-        let cdt_arch = if let Some(s) = variant.get("cdt_arch") {
+        let cdt_arch = if let Some(s) = variant_clone.get("cdt_arch") {
             s.as_str()
         } else {
             match arch {
@@ -215,7 +291,7 @@ fn set_jinja(config: &SelectorConfig) -> minijinja::Environment<'static> {
             }
         };
 
-        let cdt_name = variant.get("cdt_name").map_or_else(
+        let cdt_name = variant_clone.get("cdt_name").map_or_else(
             || match arch {
                 Some(Arch::S390X | Arch::Aarch64 | Arch::Ppc64le | Arch::Ppc64) => "cos7",
                 _ => "cos6",
@@ -231,14 +307,15 @@ fn set_jinja(config: &SelectorConfig) -> minijinja::Environment<'static> {
         Ok(res)
     });
 
-    env.add_function("compiler", |lang: String| {
-        // we translate the compiler into a YAML string
-        Ok(format!("__COMPILER {}", lang.to_lowercase()))
+    // "${{ PREFIX }}" delay the expansion. -> $PREFIX on unix and %PREFIX% on windows?
+    let variant_clone = variant.clone();
+    env.add_function("compiler", move |lang: String| {
+        compiler_stdlib_eval(&lang, target_platform, &variant_clone, "compiler")
     });
 
-    env.add_function("stdlib", |lang: String| {
-        // we translate the stdlib into a YAML string
-        Ok(format!("__STDLIB {}", lang.to_lowercase()))
+    let variant_clone = variant.clone();
+    env.add_function("stdlib", move |lang: String| {
+        compiler_stdlib_eval(&lang, target_platform, &variant_clone, "stdlib")
     });
 
     env.add_function("pin_subpackage", |name: String, kwargs: Option<Value>| {

--- a/src/recipe/parser.rs
+++ b/src/recipe/parser.rs
@@ -454,8 +454,13 @@ mod tests {
 
     #[test]
     fn test_complete_recipe() {
+        let selector_config = SelectorConfig {
+            target_platform: Platform::Linux64,
+            host_platform: Platform::Linux64,
+            ..SelectorConfig::default()
+        };
         let recipe = include_str!("../../test-data/recipes/test-parsing/single_output.yaml");
-        let recipe = Recipe::from_yaml(recipe, SelectorConfig::default()).unwrap();
+        let recipe = Recipe::from_yaml(recipe, selector_config).unwrap();
         assert_snapshot!(serde_yaml::to_string(&recipe).unwrap());
     }
 }

--- a/src/recipe/parser.rs
+++ b/src/recipe/parser.rs
@@ -39,7 +39,8 @@ pub use self::{
     package::{OutputPackage, Package},
     regex::SerializableRegex,
     requirements::{
-        Dependency, IgnoreRunExports, Language, PinSubpackage, Requirements, RunExports,
+        Dependency, IgnoreRunExports, Language, PinCompatible, PinSubpackage, Requirements,
+        RunExports,
     },
     script::{Script, ScriptContent},
     source::{GitRev, GitSource, GitUrl, PathSource, Source, UrlSource},

--- a/src/recipe/parser.rs
+++ b/src/recipe/parser.rs
@@ -39,7 +39,7 @@ pub use self::{
     package::{OutputPackage, Package},
     regex::SerializableRegex,
     requirements::{
-        Compiler, Dependency, IgnoreRunExports, PinSubpackage, Requirements, RunExports,
+        Dependency, IgnoreRunExports, Language, PinSubpackage, Requirements, RunExports,
     },
     script::{Script, ScriptContent},
     source::{GitRev, GitSource, GitUrl, PathSource, Source, UrlSource},

--- a/src/recipe/parser/requirements.rs
+++ b/src/recipe/parser/requirements.rs
@@ -510,27 +510,6 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_compiler_serde() {
-        let compiler = Language("cxx".to_string());
-
-        let serialized = serde_yaml::to_string(&compiler).unwrap();
-        assert_eq!(serialized, "cxx\n");
-
-        let requirements = Requirements {
-            build: vec![Dependency::Compiler(compiler)],
-            ..Default::default()
-        };
-
-        insta::assert_yaml_snapshot!(requirements);
-
-        let yaml = serde_yaml::to_string(&requirements).unwrap();
-        assert_eq!(yaml, "build:\n- compiler: cxx\n");
-
-        let deserialized: Requirements = serde_yaml::from_str(&yaml).unwrap();
-        insta::assert_yaml_snapshot!(deserialized);
-    }
-
-    #[test]
     fn test_pin_package() {
         let pin_subpackage = PinSubpackage {
             pin_subpackage: Pin {
@@ -566,7 +545,6 @@ mod test {
         };
 
         let spec = MatchSpec::from_str("foo >=3.1", ParseStrictness::Strict).unwrap();
-        let compiler = Language("cxx".to_string());
 
         let requirements = Requirements {
             build: vec![
@@ -574,7 +552,6 @@ mod test {
                 Dependency::PinSubpackage(pin_subpackage),
                 Dependency::PinCompatible(pin_compatible),
                 Dependency::PinCompatible(pin_compatible_2),
-                Dependency::Compiler(compiler),
             ],
             ..Default::default()
         };

--- a/src/recipe/parser/requirements.rs
+++ b/src/recipe/parser/requirements.rs
@@ -238,7 +238,7 @@ impl TryConvertNode<Dependency> for RenderedScalarNode {
             // try to convert from a YAML dictionary
             let dependency: Dependency =
                 serde_yaml::from_str(self.as_str()).expect("Internal repr error");
-            return Ok(dependency);
+            Ok(dependency)
         } else {
             let spec = self.try_convert(name)?;
             Ok(Dependency::Spec(spec))

--- a/src/recipe/parser/snapshots/rattler_build__recipe__parser__requirements__test__compiler_serde-2.snap
+++ b/src/recipe/parser/snapshots/rattler_build__recipe__parser__requirements__test__compiler_serde-2.snap
@@ -3,5 +3,4 @@ source: src/recipe/parser/requirements.rs
 expression: deserialized
 ---
 build:
-  - compiler: gcc
-
+  - compiler: cxx

--- a/src/recipe/parser/snapshots/rattler_build__recipe__parser__requirements__test__compiler_serde.snap
+++ b/src/recipe/parser/snapshots/rattler_build__recipe__parser__requirements__test__compiler_serde.snap
@@ -3,5 +3,4 @@ source: src/recipe/parser/requirements.rs
 expression: requirements
 ---
 build:
-  - compiler: gcc
-
+  - compiler: cxx

--- a/src/recipe/parser/snapshots/rattler_build__recipe__parser__requirements__test__pin_package.snap
+++ b/src/recipe/parser/snapshots/rattler_build__recipe__parser__requirements__test__pin_package.snap
@@ -1,6 +1,5 @@
 ---
 source: src/recipe/parser/requirements.rs
-assertion_line: 619
 expression: "serde_yaml::to_string(&requirements).unwrap()"
 ---
 build:
@@ -17,4 +16,4 @@ build:
     name: bar
     min_pin: x.x
     exact: true
-- compiler: gcc
+- compiler: cxx

--- a/src/recipe/parser/snapshots/rattler_build__recipe__parser__requirements__test__pin_package.snap
+++ b/src/recipe/parser/snapshots/rattler_build__recipe__parser__requirements__test__pin_package.snap
@@ -16,4 +16,3 @@ build:
     name: bar
     min_pin: x.x
     exact: true
-- compiler: cxx

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__complete_recipe.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__complete_recipe.snap
@@ -84,7 +84,7 @@ build:
     replacement: simple_string
 requirements:
   build:
-  - compiler: c
+  - clang_osx-arm64
   - cmake
   host:
   - openssl

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__complete_recipe.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__complete_recipe.snap
@@ -84,7 +84,7 @@ build:
     replacement: simple_string
 requirements:
   build:
-  - clang_osx-arm64
+  - gcc_linux-64
   - cmake
   host:
   - openssl

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__recipe_windows.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__recipe_windows.snap
@@ -148,9 +148,9 @@ Recipe {
     requirements: Requirements {
         build: [
             Compiler(
-                Compiler {
-                    language: "cxx",
-                },
+                Language(
+                    "cxx",
+                ),
             ),
             Spec(
                 MatchSpec {

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__recipe_windows.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__recipe_windows.snap
@@ -147,10 +147,24 @@ Recipe {
     },
     requirements: Requirements {
         build: [
-            Compiler(
-                Language(
-                    "cxx",
-                ),
+            Spec(
+                MatchSpec {
+                    name: Some(
+                        PackageName {
+                            normalized: None,
+                            source: "vs2017_win-64",
+                        },
+                    ),
+                    version: None,
+                    build: None,
+                    build_number: None,
+                    file_name: None,
+                    channel: None,
+                    subdir: None,
+                    namespace: None,
+                    md5: None,
+                    sha256: None,
+                },
             ),
             Spec(
                 MatchSpec {

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__unix_recipe.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__unix_recipe.snap
@@ -147,10 +147,24 @@ Recipe {
     },
     requirements: Requirements {
         build: [
-            Compiler(
-                Language(
-                    "cxx",
-                ),
+            Spec(
+                MatchSpec {
+                    name: Some(
+                        PackageName {
+                            normalized: None,
+                            source: "gxx_linux-64",
+                        },
+                    ),
+                    version: None,
+                    build: None,
+                    build_number: None,
+                    file_name: None,
+                    channel: None,
+                    subdir: None,
+                    namespace: None,
+                    md5: None,
+                    sha256: None,
+                },
             ),
             Spec(
                 MatchSpec {

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__unix_recipe.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__unix_recipe.snap
@@ -148,9 +148,9 @@ Recipe {
     requirements: Requirements {
         build: [
             Compiler(
-                Compiler {
-                    language: "cxx",
-                },
+                Language(
+                    "cxx",
+                ),
             ),
             Spec(
                 MatchSpec {

--- a/src/render/pin.rs
+++ b/src/render/pin.rs
@@ -152,66 +152,6 @@ impl Pin {
         Ok(MatchSpec::from_str(spec.as_str(), ParseStrictness::Strict)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))?)
     }
-
-    pub(crate) fn internal_repr(&self) -> String {
-        let max_pin_str = if let Some(max_pin) = &self.args.max_pin {
-            format!("{}", max_pin)
-        } else {
-            "".to_string()
-        };
-
-        let min_pin_str = if let Some(min_pin) = &self.args.min_pin {
-            format!("{}", min_pin)
-        } else {
-            "".to_string()
-        };
-
-        format!(
-            "{} MAX_PIN={} MIN_PIN={} EXACT={}",
-            self.name.as_normalized(),
-            max_pin_str,
-            min_pin_str,
-            self.args.exact
-        )
-    }
-
-    pub(crate) fn from_internal_repr(s: &str) -> Self {
-        let parts = s.split(' ').collect::<Vec<_>>();
-        let name = parts[0].to_string();
-        let max_pin = parts[1];
-        let min_pin = parts[2];
-        let exact = parts[3];
-
-        let max_pin = if max_pin == "MAX_PIN=" {
-            None
-        } else {
-            let max_pin = max_pin
-                .strip_prefix("MAX_PIN=")
-                .expect("Could not parse max pin: invalid prefix");
-            Some(PinExpression::from_str(max_pin).expect("Could not parse max pin"))
-        };
-
-        let min_pin = if min_pin == "MIN_PIN=" {
-            None
-        } else {
-            let min_pin = min_pin
-                .strip_prefix("MIN_PIN=")
-                .expect("Could not parse min pin: invalid prefix");
-            Some(PinExpression::from_str(min_pin).expect("Could not parse min pin"))
-        };
-
-        let exact = exact == "EXACT=true";
-        let package_name = PackageName::try_from(name)
-            .expect("could not parse back package name from internal representation");
-        Pin {
-            name: package_name,
-            args: PinArgs {
-                max_pin,
-                min_pin,
-                exact,
-            },
-        }
-    }
 }
 
 #[cfg(test)]

--- a/src/render/resolved_dependencies.rs
+++ b/src/render/resolved_dependencies.rs
@@ -584,7 +584,7 @@ pub fn apply_variant(
                 },
                 Dependency::Stdlib(_stdlib) => {
                     // TODO: implement stdlib
-                    return Ok(SourceDependency { spec: "foo".parse().unwrap() }.into());
+                    Ok(SourceDependency { spec: "foo".parse().unwrap() }.into())
                 }
             }
         })

--- a/src/render/resolved_dependencies.rs
+++ b/src/render/resolved_dependencies.rs
@@ -581,6 +581,10 @@ pub fn apply_variant(
                         language: compiler_name,
                         spec: MatchSpec::from_str(&final_compiler, ParseStrictness::Strict)?,
                     }.into())
+                },
+                Dependency::Stdlib(_stdlib) => {
+                    // TODO: implement stdlib
+                    return Ok(SourceDependency { spec: "foo".parse().unwrap() }.into());
                 }
             }
         })

--- a/src/render/snapshots/rattler_build__render__resolved_dependencies__tests__dependency_info_render.snap
+++ b/src/render/snapshots/rattler_build__render__resolved_dependencies__tests__dependency_info_render.snap
@@ -1,12 +1,9 @@
 ---
 source: src/render/resolved_dependencies.rs
-assertion_line: 994
 expression: yaml_str
 ---
 - source: xyz
 - variant: bar
-  spec: foo
-- compiler: c
   spec: foo
 - pin_subpackage: baz
   max_pin: x.x

--- a/src/selectors.rs
+++ b/src/selectors.rs
@@ -22,6 +22,8 @@ pub struct SelectorConfig {
     pub variant: BTreeMap<String, String>,
     /// Enable experimental features
     pub experimental: bool,
+    /// Allow undefined variables
+    pub allow_undefined: bool,
 }
 
 impl SelectorConfig {
@@ -98,6 +100,7 @@ impl Default for SelectorConfig {
             hash: None,
             variant: Default::default(),
             experimental: false,
+            allow_undefined: false,
         }
     }
 }

--- a/src/snapshots/rattler_build__metadata__test__curl_recipe.yaml.snap
+++ b/src/snapshots/rattler_build__metadata__test__curl_recipe.yaml.snap
@@ -1,6 +1,5 @@
 ---
 source: src/metadata.rs
-assertion_line: 732
 expression: output
 ---
 recipe:
@@ -16,7 +15,7 @@ recipe:
     string: h60d57d3_0
   requirements:
     build:
-      - compiler: c
+      - clang_osx-arm64
       - make
       - perl
       - pkg-config
@@ -58,8 +57,7 @@ build_configuration:
 finalized_dependencies:
   build:
     specs:
-      - compiler: c
-        spec: clang_osx-arm64
+      - source: clang_osx-arm64
       - source: make
       - source: perl
       - source: pkg-config

--- a/src/used_variables.rs
+++ b/src/used_variables.rs
@@ -66,6 +66,11 @@ fn extract_variable_from_expression(expr: &Expr, variables: &mut HashSet<String>
                         variables.insert(format!("{}_compiler", &constant.value));
                         variables.insert(format!("{}_compiler_version", &constant.value));
                     }
+                } else if function == "stdlib" {
+                    if let Expr::Const(constant) = &call.args[0] {
+                        variables.insert(format!("{}_stdlib", &constant.value));
+                        variables.insert(format!("{}_stdlib_version", &constant.value));
+                    }
                 } else if function == "pin_subpackage" {
                     if let Expr::Const(constant) = &call.args[0] {
                         variables.insert(format!("{}", &constant.value));

--- a/src/used_variables.rs
+++ b/src/used_variables.rs
@@ -303,6 +303,7 @@ mod test {
             - if: osx
               then: osx-clang
             - ${{ compiler('c') }}
+            - ${{ stdlib('c') }}
             - ${{ pin_subpackage('abcdef') }}
         "#;
 
@@ -313,6 +314,8 @@ mod test {
         assert!(used_vars.contains("osx"));
         assert!(used_vars.contains("c_compiler"));
         assert!(used_vars.contains("c_compiler_version"));
+        assert!(used_vars.contains("c_stdlib"));
+        assert!(used_vars.contains("c_stdlib_version"));
         assert!(used_vars.contains("abcdef"));
     }
 

--- a/src/variant_config.rs
+++ b/src/variant_config.rs
@@ -644,6 +644,7 @@ impl VariantConfig {
                     }
                     // Be explicit about the other cases, so we can add them later
                     Dependency::Compiler(_) => (),
+                    Dependency::Stdlib(_) => (),
                 });
 
                 // actually used vars

--- a/src/variant_config.rs
+++ b/src/variant_config.rs
@@ -642,9 +642,6 @@ impl VariantConfig {
                             exact_pins.insert(val);
                         }
                     }
-                    // Be explicit about the other cases, so we can add them later
-                    Dependency::Compiler(_) => (),
-                    Dependency::Stdlib(_) => (),
                 });
 
                 // actually used vars

--- a/test-data/rendered_recipes/curl_recipe.yaml
+++ b/test-data/rendered_recipes/curl_recipe.yaml
@@ -11,7 +11,7 @@ recipe:
     string: h60d57d3_0
   requirements:
     build:
-    - compiler: c
+    - clang_osx-arm64
     - make
     - perl
     - pkg-config
@@ -55,8 +55,7 @@ build_configuration:
 finalized_dependencies:
   build:
     specs:
-    - compiler: c
-      spec: clang_osx-arm64
+    - source: clang_osx-arm64
     - source: make
     - source: perl
     - source: pkg-config


### PR DESCRIPTION
For compatibility with recent conda-forge efforts we're implementing the `stdlib` jinja function. 

Open questions:

- should there be any default values?
- compiler and stdlib currently evaluate to an intermediate form. Should we keep that?
- If we decide for the intermediate form, we should allow the function only in specific sections such as:
   - requirements.*
   - ignore_run_exports / from_package
- And then we should also disallow it in the `test` section and only allow the `compiler-c` or `compiler-cxx` packages in the test section.
