### PR TITLE
feat: delay jinja evaluation for script

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -187,6 +187,7 @@ impl Output {
                     &self.build_configuration.directories.recipe_dir,
                     &self.build_configuration.directories.host_prefix,
                     Some(&self.build_configuration.directories.build_prefix),
+                    None, // TODO fix this to be proper Jinja context
                 )
                 .await
                 .into_diagnostic()?;

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -29,7 +29,10 @@ use url::Url;
 use crate::{
     console_utils::github_integration_enabled,
     hash::HashInfo,
-    recipe::parser::{Recipe, Source},
+    recipe::{
+        jinja::SelectorConfig,
+        parser::{Recipe, Source},
+    },
     render::resolved_dependencies::FinalizedDependencies,
     system_tools::SystemTools,
     tool_configuration,
@@ -278,6 +281,19 @@ impl BuildConfiguration {
     /// true if the build is cross-compiling
     pub fn cross_compilation(&self) -> bool {
         self.target_platform != self.build_platform
+    }
+
+    /// Construct a `SelectorConfig` from the given `BuildConfiguration`
+    pub fn selector_config(&self) -> SelectorConfig {
+        SelectorConfig {
+            target_platform: self.target_platform,
+            host_platform: self.host_platform,
+            build_platform: self.build_platform,
+            variant: self.variant.clone(),
+            hash: Some(self.hash.clone()),
+            experimental: false,
+            allow_undefined: false,
+        }
     }
 }
 

--- a/src/package_test/run_test.rs
+++ b/src/package_test/run_test.rs
@@ -124,7 +124,7 @@ impl Tests {
                 })?;
 
                 script
-                    .run_script(env_vars, tmp_dir.path(), cwd, environment, None)
+                    .run_script(env_vars, tmp_dir.path(), cwd, environment, None, None)
                     .await
                     .map_err(|e| TestError::TestFailed(e.to_string()))?;
             }
@@ -136,7 +136,7 @@ impl Tests {
                 };
 
                 script
-                    .run_script(env_vars, tmp_dir.path(), cwd, environment, None)
+                    .run_script(env_vars, tmp_dir.path(), cwd, environment, None, None)
                     .await
                     .map_err(|e| TestError::TestFailed(e.to_string()))?;
             }
@@ -472,7 +472,7 @@ impl PythonTest {
 
         let tmp_dir = tempfile::tempdir()?;
         script
-            .run_script(Default::default(), tmp_dir.path(), path, prefix, None)
+            .run_script(Default::default(), tmp_dir.path(), path, prefix, None, None)
             .await
             .map_err(|e| TestError::TestFailed(e.to_string()))?;
 
@@ -487,7 +487,7 @@ impl PythonTest {
                 ..Script::default()
             };
             script
-                .run_script(Default::default(), path, path, prefix, None)
+                .run_script(Default::default(), path, path, prefix, None, None)
                 .await
                 .map_err(|e| TestError::TestFailed(e.to_string()))?;
 
@@ -588,7 +588,14 @@ impl CommandsTest {
 
         tracing::info!("Testing commands:");
         self.script
-            .run_script(env_vars, tmp_dir.path(), path, &run_env, build_env.as_ref())
+            .run_script(
+                env_vars,
+                tmp_dir.path(),
+                path,
+                &run_env,
+                build_env.as_ref(),
+                None,
+            )
             .await
             .map_err(|e| TestError::TestFailed(e.to_string()))?;
 

--- a/src/recipe/parser/script.rs
+++ b/src/recipe/parser/script.rs
@@ -217,16 +217,19 @@ impl TryConvertNode<Script> for RenderedNode {
 
 impl TryConvertNode<Script> for RenderedScalarNode {
     fn try_convert(&self, _name: &str) -> Result<Script, Vec<PartialParsingError>> {
-        Ok(ScriptContent::CommandOrPath(self.as_str().to_owned()).into())
+        Ok(ScriptContent::CommandOrPath(self.source().to_owned()).into())
     }
 }
 
 impl TryConvertNode<Script> for RenderedSequenceNode {
-    fn try_convert(&self, name: &str) -> Result<Script, Vec<PartialParsingError>> {
-        let strings = self
-            .iter()
-            .map(|node| node.try_convert(name))
-            .collect::<Result<Vec<String>, _>>()?;
+    fn try_convert(&self, _name: &str) -> Result<Script, Vec<PartialParsingError>> {
+        let mut strings: Vec<String> = Vec::new();
+
+        for string in self.iter() {
+            if let RenderedNode::Scalar(s) = string {
+                strings.push(s.source().to_owned());
+            }
+        }
 
         if strings.len() == 1 {
             Ok(ScriptContent::CommandOrPath(strings[0].clone()).into())

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__binary_relocation.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__binary_relocation.snap
@@ -3,6 +3,7 @@ source: src/recipe/parser.rs
 expression: recipe
 ---
 schema_version: 1
+context: {}
 package:
   name: zlib
   version: 0.1.0

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__binary_relocation_paths.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__binary_relocation_paths.snap
@@ -3,6 +3,7 @@ source: src/recipe/parser.rs
 expression: recipe
 ---
 schema_version: 1
+context: {}
 package:
   name: zlib
   version: 0.1.0

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__complete_recipe.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__complete_recipe.snap
@@ -121,7 +121,8 @@ requirements:
     from_package:
     - python
 tests:
-- script: echo FOO
+- script: |
+    echo FOO
   requirements:
     run:
     - bash

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__complete_recipe.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__complete_recipe.snap
@@ -3,6 +3,7 @@ source: src/recipe/parser.rs
 expression: "serde_yaml::to_string(&recipe).unwrap()"
 ---
 schema_version: 1
+context: {}
 package:
   name: single_output
   version: 0.1.0

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__jinja_sequence.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__jinja_sequence.snap
@@ -3,10 +3,11 @@ source: src/recipe/parser.rs
 expression: recipe
 ---
 schema_version: 1
+context: {}
 package:
   name: blib
   version: 0.1.0
 build:
   number: 0
-  script: test succeeded
+  script: "${{ \"test succeeded\" if true }}"
 requirements: {}

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__map_null_values.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__map_null_values.snap
@@ -3,12 +3,13 @@ source: src/recipe/parser.rs
 expression: recipe
 ---
 schema_version: 1
+context: {}
 package:
   name: zlib
   version: 0.1.0
 build:
   number: 0
-  script: "echo 'world'"
+  script: "${{ \"echo 'world'\" if true }}"
   prefix_detection:
     force_file_type:
       binary:

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__recipe_windows.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__recipe_windows.snap
@@ -4,6 +4,10 @@ expression: win_recipe.unwrap()
 ---
 Recipe {
     schema_version: 1,
+    context: {
+        "name": "xtensor",
+        "version": "0.24.6",
+    },
     package: Package {
         name: PackageName {
             normalized: None,
@@ -111,7 +115,7 @@ Recipe {
             env: {},
             secrets: [],
             content: CommandOrPath(
-                "cmake -G \"NMake Makefiles\" -D BUILD_TESTS=OFF -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% %SRC_DIR%\nnmake\nnmake install",
+                "cmake -G \"NMake Makefiles\" -D BUILD_TESTS=OFF -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% %SRC_DIR%\nnmake\nnmake install\n",
             ),
             cwd: None,
         },

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__unix_recipe.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__unix_recipe.snap
@@ -4,6 +4,10 @@ expression: unix_recipe.unwrap()
 ---
 Recipe {
     schema_version: 1,
+    context: {
+        "name": "xtensor",
+        "version": "0.24.6",
+    },
     package: Package {
         name: PackageName {
             normalized: None,
@@ -111,7 +115,7 @@ Recipe {
             env: {},
             secrets: [],
             content: CommandOrPath(
-                "cmake ${CMAKE_ARGS} -DBUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX=$PREFIX $SRC_DIR -DCMAKE_INSTALL_LIBDIR=lib\nmake install",
+                "cmake ${CMAKE_ARGS} -DBUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX=$PREFIX $SRC_DIR -DCMAKE_INSTALL_LIBDIR=lib\nmake install\n",
             ),
             cwd: None,
         },

--- a/src/snapshots/rattler_build__metadata__test__curl_recipe.yaml.snap
+++ b/src/snapshots/rattler_build__metadata__test__curl_recipe.yaml.snap
@@ -4,6 +4,7 @@ expression: output
 ---
 recipe:
   schema_version: 1
+  context: {}
   package:
     name: curl
     version: 8.0.1

--- a/src/snapshots/rattler_build__metadata__test__read_recipe_with_sources.snap
+++ b/src/snapshots/rattler_build__metadata__test__read_recipe_with_sources.snap
@@ -4,6 +4,7 @@ expression: git_source_output
 ---
 recipe:
   schema_version: 1
+  context: {}
   package:
     name: git_source
     version: "1"

--- a/src/snapshots/rattler_build__metadata__test__rich_recipe.yaml.snap
+++ b/src/snapshots/rattler_build__metadata__test__rich_recipe.yaml.snap
@@ -4,6 +4,7 @@ expression: output
 ---
 recipe:
   schema_version: 1
+  context: {}
   package:
     name: rich
     version: 13.4.2

--- a/test-data/rendered_recipes/curl_recipe.yaml
+++ b/test-data/rendered_recipes/curl_recipe.yaml
@@ -1,5 +1,6 @@
 recipe:
   schema_version: 1
+  context: {}
   package:
     name: curl
     version: 8.0.1

--- a/test-data/rendered_recipes/git_source.yaml
+++ b/test-data/rendered_recipes/git_source.yaml
@@ -1,5 +1,6 @@
 recipe:
   schema_version: 1
+  context: {}
   package:
     name: git_source
     version: '1'

--- a/test-data/rendered_recipes/rich_recipe.yaml
+++ b/test-data/rendered_recipes/rich_recipe.yaml
@@ -1,5 +1,6 @@
 recipe:
   schema_version: 1
+  context: {}
   package:
     name: rich
     version: 13.4.2


### PR DESCRIPTION
This delays the Jinja evaluation for the `script` contents. That means that we can also inject a lot of variables into the script by using `jinja`. 

Such as `${{ PREFIX }}` or `${{ PYTHON }}`. 

For example the following two examples work on Windows and on Unix:

```yaml
build:
  script: cargo install --root ${{ PREFIX }} .
  # or
  script: ${{ PYTHON }} -m pip install .
```

These variables are also available as environment variables. However, since we are using `cmd.exe` and `bash` on the different operating systems, the syntax to expand environment variables is not the same (`%PREFIX%` vs `$PREFIX`).

Alternatives we considered (or are considering):

- add a jinja function `env("PREFIX")` that expands to either `%PREFIX%` or `$PREFIX` depending on execution context. Might not work well with different interpreters.
- automatically convert `$PREFIX` to `%PREFIX%` as a string replacement on cmd.exe

### TODO

- [x] missing values from `context`
- [ ] Adjust the recipe rendering CEP because now we need the variables from the Context later as well