### PR TITLE
refactor: rename constrains to constraints

### DIFF
--- a/src/packaging/metadata.rs
+++ b/src/packaging/metadata.rs
@@ -189,18 +189,13 @@ pub fn create_prefix_placeholder(
 
 impl Output {
     /// Create the run_exports.json file for the given output.
-    pub fn run_exports_json(&self) -> Result<Option<RunExportsJson>, PackagingError> {
-        if let Some(run_exports) = &self
+    pub fn run_exports_json(&self) -> Result<&RunExportsJson, PackagingError> {
+        Ok(&self
             .finalized_dependencies
             .as_ref()
             .ok_or(PackagingError::DependenciesNotFinalized)?
             .run
-            .run_exports
-        {
-            Ok(Some(run_exports.clone()))
-        } else {
-            Ok(None)
-        }
+            .run_exports)
     }
 
     /// Returns the contents of the `hash_input.json` file.
@@ -301,7 +296,7 @@ impl Output {
                 .collect(),
             constrains: finalized_dependencies
                 .run
-                .constrains
+                .constraints
                 .iter()
                 .map(|dep| dep.spec().to_string())
                 .dedup()
@@ -450,7 +445,8 @@ impl Output {
         serde_json::to_writer_pretty(about_json, &self.about_json())?;
         new_files.insert(about_json_path);
 
-        if let Some(run_exports) = self.run_exports_json()? {
+        let run_exports = self.run_exports_json()?;
+        if !run_exports.is_empty() {
             let run_exports_path = root_dir.join(RunExportsJson::package_path());
             let run_exports_json = File::create(&run_exports_path)?;
             serde_json::to_writer_pretty(run_exports_json, &run_exports)?;

--- a/src/render/resolved_dependencies.rs
+++ b/src/render/resolved_dependencies.rs
@@ -226,9 +226,12 @@ impl DependencyInfo {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FinalizedRunDependencies {
+    #[serde(default)]
     pub depends: Vec<DependencyInfo>,
-    pub constrains: Vec<DependencyInfo>,
-    pub run_exports: Option<RunExportsJson>,
+    #[serde(default)]
+    pub constraints: Vec<DependencyInfo>,
+    #[serde(default, skip_serializing_if = "RunExportsJson::is_empty")]
+    pub run_exports: RunExportsJson,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -337,7 +340,7 @@ impl FinalizedRunDependencies {
             });
         }
 
-        if !self.constrains.is_empty() {
+        if !self.constraints.is_empty() {
             let mut row = comfy_table::Row::new();
             row.add_cell(
                 comfy_table::Cell::new("Run constraints")
@@ -345,7 +348,7 @@ impl FinalizedRunDependencies {
             );
             table.add_row(row);
 
-            self.constrains.iter().for_each(|d| {
+            self.constraints.iter().for_each(|d| {
                 let rendered = d.render(long);
                 table.add_row(rendered.splitn(2, ' ').collect::<Vec<&str>>());
             });
@@ -747,20 +750,20 @@ async fn resolve_dependencies(
     let run_exports = output.recipe.requirements().run_exports();
 
     let run_exports = if !run_exports.is_empty() {
-        Some(RunExportsJson {
+        RunExportsJson {
             strong: render_run_exports(run_exports.strong())?,
             weak: render_run_exports(run_exports.weak())?,
             noarch: render_run_exports(run_exports.noarch())?,
             strong_constrains: render_run_exports(run_exports.strong_constraints())?,
             weak_constrains: render_run_exports(run_exports.weak_constraints())?,
-        })
+        }
     } else {
-        None
+        RunExportsJson::default()
     };
 
     let mut run_specs = FinalizedRunDependencies {
         depends,
-        constrains,
+        constraints: constrains,
         run_exports,
     };
 
@@ -782,11 +785,13 @@ async fn resolve_dependencies(
                     run_specs
                         .depends
                         .extend(clone_specs(name, "host", &rex.weak)?);
+                    run_specs.constraints.extend(clone_specs(
+                        name,
+                        "host",
+                        &rex.strong_constrains,
+                    )?);
                     run_specs
-                        .constrains
-                        .extend(clone_specs(name, "host", &rex.strong_constrains)?);
-                    run_specs
-                        .constrains
+                        .constraints
                         .extend(clone_specs(name, "host", &rex.weak_constrains)?);
                 }
             }
@@ -802,7 +807,7 @@ async fn resolve_dependencies(
                     run_specs
                         .depends
                         .extend(clone_specs(name, "build", &rex.strong)?);
-                    run_specs.constrains.extend(clone_specs(
+                    run_specs.constraints.extend(clone_specs(
                         name,
                         "build",
                         &rex.strong_constrains,
@@ -813,7 +818,7 @@ async fn resolve_dependencies(
     }
 
     // log a table of the rendered run dependencies
-    if run_specs.depends.is_empty() && run_specs.constrains.is_empty() {
+    if run_specs.depends.is_empty() && run_specs.constraints.is_empty() {
         tracing::info!("\nFinalized run dependencies: this output has no run dependencies");
     } else {
         tracing::info!("\nFinalized run dependencies:\n{}", run_specs);

--- a/src/snapshots/rattler_build__metadata__test__curl_recipe.yaml.snap
+++ b/src/snapshots/rattler_build__metadata__test__curl_recipe.yaml.snap
@@ -1,5 +1,6 @@
 ---
 source: src/metadata.rs
+assertion_line: 734
 expression: output
 ---
 recipe:
@@ -634,8 +635,7 @@ finalized_dependencies:
   host: ~
   run:
     depends: []
-    constrains: []
-    run_exports: ~
+    constraints: []
 finalized_sources: ~
 system_tools:
   rattler-build: 0.12.1

--- a/src/snapshots/rattler_build__metadata__test__read_recipe_with_sources.snap
+++ b/src/snapshots/rattler_build__metadata__test__read_recipe_with_sources.snap
@@ -1,6 +1,6 @@
 ---
 source: src/metadata.rs
-assertion_line: 742
+assertion_line: 745
 expression: git_source_output
 ---
 recipe:
@@ -55,8 +55,7 @@ finalized_dependencies:
   host: ~
   run:
     depends: []
-    constrains: []
-    run_exports: ~
+    constraints: []
 finalized_sources:
   - git: "https://github.com/prefix-dev/rattler-build"
     rev: 4ae7bd207b437c3a5955788e6516339a84358e1c

--- a/src/snapshots/rattler_build__metadata__test__rich_recipe.yaml.snap
+++ b/src/snapshots/rattler_build__metadata__test__rich_recipe.yaml.snap
@@ -1,6 +1,6 @@
 ---
 source: src/metadata.rs
-assertion_line: 732
+assertion_line: 734
 expression: output
 ---
 recipe:
@@ -379,8 +379,7 @@ finalized_dependencies:
       - spec: python
         from: host
         run_export: python
-    constrains: []
-    run_exports: ~
+    constraints: []
 finalized_sources: ~
 system_tools:
   rattler-build: 0.12.1

--- a/test-data/rendered_recipes/curl_recipe.yaml
+++ b/test-data/rendered_recipes/curl_recipe.yaml
@@ -632,7 +632,6 @@ finalized_dependencies:
   host: null
   run:
     depends: []
-    constrains: []
-    run_exports: null
+    constraints: []
 system_tools:
   rattler-build: 0.12.1

--- a/test-data/rendered_recipes/git_source.yaml
+++ b/test-data/rendered_recipes/git_source.yaml
@@ -50,8 +50,7 @@ finalized_dependencies:
   host: null
   run:
     depends: []
-    constrains: []
-    run_exports: null
+    constraints: []
 finalized_sources:
 - git: https://github.com/prefix-dev/rattler-build
   rev: 4ae7bd207b437c3a5955788e6516339a84358e1c

--- a/test-data/rendered_recipes/rich_recipe.yaml
+++ b/test-data/rendered_recipes/rich_recipe.yaml
@@ -379,7 +379,6 @@ finalized_dependencies:
     - run_export: python
       spec: python
       from: host
-    constrains: []
-    run_exports: null
+    constraints: []
 system_tools:
   rattler-build: 0.12.1


### PR DESCRIPTION
Renames `constrains` in the finalized dependencies to `constraints`. And makes run_export not an Option.