### PR TITLE
refactor: remove compression threads

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,7 +289,6 @@ pub async fn get_build_output(
                 packaging_settings: PackagingSettings::from_args(
                     args.package_format.archive_type,
                     args.package_format.compression_level,
-                    args.compression_threads,
                 ),
                 store_recipe: !args.no_include_recipe,
                 force_colors: args.color_build_log && console::colors_enabled(),
@@ -383,7 +382,8 @@ pub async fn run_test_from_args(
             fancy_log_handler,
             // duplicate from `keep_test_prefix`?
             no_clean: false,
-            ..Default::default()
+            compression_threads: args.compression_threads,
+            ..Configuration::default()
         },
     };
 
@@ -446,6 +446,7 @@ pub async fn rebuild_from_args(
         no_test: args.no_test,
         use_zstd: args.common.use_zstd,
         use_bz2: args.common.use_bz2,
+        compression_threads: args.compression_threads,
         ..Configuration::default()
     };
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -184,41 +184,20 @@ pub struct PackagingSettings {
     pub archive_type: ArchiveType,
     /// The compression level from 1-9 or -7-22 for `tar.bz2` and `conda` archives
     pub compression_level: i32,
-    /// How many threads to use for compression (only relevant for `.conda` archives)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub compression_threads: Option<u32>,
 }
 
 impl PackagingSettings {
     /// Create a new `PackagingSettings` from the command line arguments
     /// and the selected archive type.
-    pub fn from_args(
-        archive_type: ArchiveType,
-        compression_level: CompressionLevel,
-        compression_threads: Option<u32>,
-    ) -> Self {
+    pub fn from_args(archive_type: ArchiveType, compression_level: CompressionLevel) -> Self {
         let compression_level: i32 = match archive_type {
             ArchiveType::TarBz2 => compression_level.to_bzip2_level().unwrap().level() as i32,
             ArchiveType::Conda => compression_level.to_zstd_level().unwrap(),
         };
 
-        if compression_threads.is_some()
-            && compression_threads.unwrap() > 1
-            && archive_type != ArchiveType::Conda
-        {
-            tracing::warn!("Multi-threaded compression is only supported for conda archives");
-        }
-
-        let compression_threads = if archive_type == ArchiveType::Conda {
-            Some(compression_threads.unwrap_or(1))
-        } else {
-            None
-        };
-
         Self {
             archive_type,
             compression_level,
-            compression_threads,
         }
     }
 }

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -275,6 +275,10 @@ pub struct TestOpts {
     #[arg(short, long)]
     pub package_file: PathBuf,
 
+    /// The number of threads to use for compression.
+    #[clap(long, env = "RATTLER_COMPRESSION_THREADS")]
+    pub compression_threads: Option<u32>,
+
     /// Common options.
     #[clap(flatten)]
     pub common: CommonOpts,
@@ -290,6 +294,10 @@ pub struct RebuildOpts {
     /// Do not run tests after building
     #[arg(long, default_value = "false")]
     pub no_test: bool,
+
+    /// The number of threads to use for compression.
+    #[clap(long, env = "RATTLER_COMPRESSION_THREADS")]
+    pub compression_threads: Option<u32>,
 
     /// Common options.
     #[clap(flatten)]

--- a/src/packaging.rs
+++ b/src/packaging.rs
@@ -315,7 +315,7 @@ pub fn package_conda(
                 tmp.temp_dir.path(),
                 &tmp.files.iter().cloned().collect::<Vec<_>>(),
                 CompressionLevel::Numeric(packaging_settings.compression_level),
-                packaging_settings.compression_threads,
+                tool_configuration.compression_threads,
                 &identifier,
                 Some(&output.build_configuration.timestamp),
                 Some(Box::new(ProgressBar { progress_bar })),

--- a/src/snapshots/rattler_build__metadata__test__curl_recipe.yaml.snap
+++ b/src/snapshots/rattler_build__metadata__test__curl_recipe.yaml.snap
@@ -53,7 +53,6 @@ build_configuration:
   packaging_settings:
     archive_type: tar_bz2
     compression_level: 3
-    compression_threads: 1
 finalized_dependencies:
   build:
     specs:

--- a/src/snapshots/rattler_build__metadata__test__rich_recipe.yaml.snap
+++ b/src/snapshots/rattler_build__metadata__test__rich_recipe.yaml.snap
@@ -71,7 +71,6 @@ build_configuration:
   packaging_settings:
     archive_type: conda
     compression_level: 21
-    compression_threads: 5
 finalized_dependencies:
   build: ~
   host:

--- a/src/tool_configuration.rs
+++ b/src/tool_configuration.rs
@@ -55,6 +55,10 @@ pub struct Configuration {
 
     /// The channel configuration to use when parsing channels.
     pub channel_config: ChannelConfig,
+
+    /// How many threads to use for compression (only relevant for `.conda` archives).
+    /// This value is not serialized because the number of threads does not matter for the final result.
+    pub compression_threads: Option<u32>,
 }
 
 /// Get the authentication storage from the given file
@@ -107,6 +111,7 @@ impl Default for Configuration {
             channel_config: ChannelConfig::default_with_root_dir(
                 std::env::current_dir().unwrap_or_else(|_err| PathBuf::from("/")),
             ),
+            compression_threads: None,
         }
     }
 }

--- a/test-data/rendered_recipes/curl_recipe.yaml
+++ b/test-data/rendered_recipes/curl_recipe.yaml
@@ -51,7 +51,6 @@ build_configuration:
   packaging_settings:
     archive_type: tar_bz2
     compression_level: 3
-    compression_threads: 1
 finalized_dependencies:
   build:
     specs:

--- a/test-data/rendered_recipes/rich_recipe.yaml
+++ b/test-data/rendered_recipes/rich_recipe.yaml
@@ -71,7 +71,6 @@ build_configuration:
   packaging_settings:
     archive_type: conda
     compression_level: 21
-    compression_threads: 5
 finalized_dependencies:
   build: null
   host:


### PR DESCRIPTION
This PR moves the `compression_thread` out of the rendered recipe since the number of threads does not influence the bits outputted.

I tested this by rebuilding a package a couple of times with a different number of compression threads. I also verified using the `zstd` command line tool and compression a large file with a differing number of threads.