### PR TITLE
refactor: remove run exports from finalized deps

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -685,7 +685,6 @@ mod test {
                     .unwrap(),
                 channel: "test".into(),
             }],
-            run_exports: Default::default(),
         };
 
         // test yaml roundtrip

--- a/src/snapshots/rattler_build__metadata__test__curl_recipe.yaml.snap
+++ b/src/snapshots/rattler_build__metadata__test__curl_recipe.yaml.snap
@@ -131,6 +131,11 @@ finalized_dependencies:
         license: GPL-1.0-or-later OR Artistic-1.0-Perl
         md5: d9389447361c7b53e3bbfc947cae0973
         name: perl
+        run_exports:
+          weak:
+            - "perl >=5.32.1,<5.33.0a0 *_perl5"
+          noarch:
+            - "perl >=5.32.1,<6.0a0 *_perl5"
         sha256: 3bf5e43b9c7127f6d0529393535ac69c25483b3b8b76cb71ffa454f6aa73f5a3
         size: 14472770
         subdir: osx-arm64
@@ -626,12 +631,6 @@ finalized_dependencies:
         fn: ca-certificates-2023.11.17-hf0a4a13_0.conda
         url: "https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2023.11.17-hf0a4a13_0.conda"
         channel: "https://conda.anaconda.org/conda-forge/"
-    run_exports:
-      perl:
-        weak:
-          - "perl >=5.32.1,<5.33.0a0 *_perl5"
-        noarch:
-          - "perl >=5.32.1,<6.0a0 *_perl5"
   host: ~
   run:
     depends: []

--- a/src/snapshots/rattler_build__metadata__test__resolved_dependencies_rendering.snap
+++ b/src/snapshots/rattler_build__metadata__test__resolved_dependencies_rendering.snap
@@ -1,6 +1,5 @@
 ---
 source: src/metadata.rs
-assertion_line: 703
 expression: resolved_dependencies
 ---
 specs:
@@ -22,4 +21,3 @@ resolved:
     fn: test-1.2.3-h123.tar.bz2
     url: "https://test.com/test/linux-64/test-1.2.3-h123.tar.bz2"
     channel: test
-run_exports: {}

--- a/src/snapshots/rattler_build__metadata__test__rich_recipe.yaml.snap
+++ b/src/snapshots/rattler_build__metadata__test__rich_recipe.yaml.snap
@@ -98,6 +98,11 @@ finalized_dependencies:
         license: Python-2.0
         md5: 79f489d167f29b2f1d6d628b34dad49c
         name: python
+        run_exports:
+          weak:
+            - python_abi 3.10.* *_cp310
+          noarch:
+            - python
         sha256: 2c116191cf46984ae171973beb86fe8914f3833db23865b052db3bdf1276c92c
         size: 12899235
         subdir: osx-arm64
@@ -364,12 +369,6 @@ finalized_dependencies:
         fn: setuptools-68.2.2-pyhd8ed1ab_0.conda
         url: "https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda"
         channel: "https://conda.anaconda.org/conda-forge/"
-    run_exports:
-      python:
-        weak:
-          - python_abi 3.10.* *_cp310
-        noarch:
-          - python
   run:
     depends:
       - source: markdown-it-py >=2.2.0

--- a/test-data/rendered_recipes/curl_recipe.yaml
+++ b/test-data/rendered_recipes/curl_recipe.yaml
@@ -137,6 +137,11 @@ finalized_dependencies:
       fn: perl-5.32.1-4_hf2054a2_perl5.conda
       url: https://conda.anaconda.org/conda-forge/osx-arm64/perl-5.32.1-4_hf2054a2_perl5.conda
       channel: https://conda.anaconda.org/conda-forge/
+      run_exports:
+        weak:
+          - perl >=5.32.1,<5.33.0a0 *_perl5
+        noarch:
+          - perl >=5.32.1,<6.0a0 *_perl5
     - build: hb438215_1
       build_number: 1
       constrains:
@@ -624,12 +629,6 @@ finalized_dependencies:
       fn: ca-certificates-2023.11.17-hf0a4a13_0.conda
       url: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2023.11.17-hf0a4a13_0.conda
       channel: https://conda.anaconda.org/conda-forge/
-    run_exports:
-      perl:
-        weak:
-        - perl >=5.32.1,<5.33.0a0 *_perl5
-        noarch:
-        - perl >=5.32.1,<6.0a0 *_perl5
   host: null
   run:
     depends: []

--- a/test-data/rendered_recipes/rich_recipe.yaml
+++ b/test-data/rendered_recipes/rich_recipe.yaml
@@ -107,6 +107,11 @@ finalized_dependencies:
       fn: python-3.10.0-h43b31ca_3_cpython.tar.bz2
       url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.10.0-h43b31ca_3_cpython.tar.bz2
       channel: https://conda.anaconda.org/conda-forge/
+      run_exports:
+        weak:
+          - python_abi 3.10.* *_cp310
+        noarch:
+          - python
     - build: h57fd34a_0
       build_number: 0
       depends: []
@@ -365,12 +370,6 @@ finalized_dependencies:
       fn: setuptools-68.2.2-pyhd8ed1ab_0.conda
       url: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
       channel: https://conda.anaconda.org/conda-forge/
-    run_exports:
-      python:
-        weak:
-        - python_abi 3.10.* *_cp310
-        noarch:
-        - python
   run:
     depends:
     - source: markdown-it-py >=2.2.0


### PR DESCRIPTION
Removes `run_exports` from the finalized dependency and amends the repodata records with run exports from the cache.