### PR TITLE
feat: simplify jinja pin expressions

### DIFF
--- a/src/recipe/jinja.rs
+++ b/src/recipe/jinja.rs
@@ -1106,11 +1106,11 @@ mod tests {
         );
         assert_eq!(
             ps("upper_bound=None"),
-            "{\"pin_subpackage\":{\"name\":\"foo\",\"lower_bound\":\"x.x.x.x.x.x\",\"upper_bound\":null}}"
+            "{\"pin_subpackage\":{\"name\":\"foo\",\"lower_bound\":\"x.x.x.x.x.x\"}}"
         );
         assert_eq!(
             ps("upper_bound=None, lower_bound=None"),
-            "{\"pin_subpackage\":{\"name\":\"foo\",\"lower_bound\":null,\"upper_bound\":null}}"
+            "{\"pin_subpackage\":{\"name\":\"foo\"}}"
         );
         assert_eq!(ps("lower_bound='1.2.3'"), "{\"pin_subpackage\":{\"name\":\"foo\",\"lower_bound\":\"1.2.3\",\"upper_bound\":\"x\"}}");
     }

--- a/src/recipe/jinja.rs
+++ b/src/recipe/jinja.rs
@@ -129,46 +129,37 @@ fn jinja_pin_function(
         args: PinArgs::default(),
     };
 
-    let pin_expr_from_value =
-        |pin_expr: &minijinja::value::Value| -> Result<Option<PinExpression>, minijinja::Error> {
-            if pin_expr.is_none() {
-                Ok(None)
-            } else {
-                let pin_expr = PinExpression::from_str(&pin_expr.to_string()).map_err(|e| {
-                    minijinja::Error::new(
-                        minijinja::ErrorKind::SyntaxError,
-                        format!("Invalid pin expression: {}", e),
-                    )
-                })?;
-                Ok(Some(pin_expr))
-            }
-        };
-
-    if let Ok(max_pin) = kwargs.get::<Value>("max_pin") {
-        pin.args.max_pin = pin_expr_from_value(&max_pin)?;
-    }
-    if let Ok(min_pin) = kwargs.get::<Value>("min_pin") {
-        pin.args.min_pin = pin_expr_from_value(&min_pin)?;
-    }
-
-    if let Ok(lower_bound) = kwargs.get::<String>("lower_bound") {
-        pin.args.lower_bound = Some(lower_bound.parse().map_err(|e| {
-            minijinja::Error::new(
-                minijinja::ErrorKind::SyntaxError,
-                format!("Invalid lower bound: {}", e),
-            )
-        })?);
-    }
-    if let Ok(upper_bound) = kwargs.get::<String>("upper_bound") {
-        pin.args.upper_bound = Some(upper_bound.parse().map_err(|e| {
-            minijinja::Error::new(
-                minijinja::ErrorKind::SyntaxError,
-                format!("Invalid upper bound: {}", e),
-            )
-        })?);
-    }
     if let Ok(exact) = kwargs.get::<bool>("exact") {
         pin.args.exact = exact;
+        // No more arguments should be accepted if `exact` is set
+        kwargs.assert_all_used()?;
+        pin.args.lower_bound = None;
+        pin.args.upper_bound = None;
+    }
+
+    if let Ok(lower_bound) = kwargs.get::<Option<String>>("lower_bound") {
+        if let Some(lower_bound) = lower_bound {
+            pin.args.lower_bound = Some(lower_bound.parse().map_err(|e| {
+                minijinja::Error::new(
+                    minijinja::ErrorKind::SyntaxError,
+                    format!("Invalid lower bound: {}", e),
+                )
+            })?);
+        } else if kwargs.has("lower_bound") {
+            pin.args.lower_bound = None;
+        }
+    }
+    if let Ok(upper_bound) = kwargs.get::<Option<String>>("upper_bound") {
+        if let Some(upper_bound) = upper_bound {
+            pin.args.upper_bound = Some(upper_bound.parse().map_err(|e| {
+                minijinja::Error::new(
+                    minijinja::ErrorKind::SyntaxError,
+                    format!("Invalid upper bound: {}", e),
+                )
+            })?);
+        } else if kwargs.has("upper_bound") {
+            pin.args.upper_bound = None;
+        }
     }
 
     Ok(internal_repr.to_json(&pin))
@@ -1111,17 +1102,17 @@ mod tests {
 
         assert_eq!(
             ps(""),
-            "{\"pin_subpackage\":{\"name\":\"foo\",\"min_pin\":\"x.x.x.x.x.x\",\"max_pin\":\"x\"}}"
+            "{\"pin_subpackage\":{\"name\":\"foo\",\"lower_bound\":\"x.x.x.x.x.x\",\"upper_bound\":\"x\"}}"
         );
         assert_eq!(
-            ps("max_pin=None"),
-            "{\"pin_subpackage\":{\"name\":\"foo\",\"min_pin\":\"x.x.x.x.x.x\",\"max_pin\":null}}"
+            ps("upper_bound=None"),
+            "{\"pin_subpackage\":{\"name\":\"foo\",\"lower_bound\":\"x.x.x.x.x.x\",\"upper_bound\":null}}"
         );
         assert_eq!(
-            ps("max_pin=None, min_pin=None"),
-            "{\"pin_subpackage\":{\"name\":\"foo\",\"min_pin\":null,\"max_pin\":null}}"
+            ps("upper_bound=None, lower_bound=None"),
+            "{\"pin_subpackage\":{\"name\":\"foo\",\"lower_bound\":null,\"upper_bound\":null}}"
         );
-        assert_eq!(ps("lower_bound='1.2.3'"), "{\"pin_subpackage\":{\"name\":\"foo\",\"min_pin\":\"x.x.x.x.x.x\",\"max_pin\":\"x\",\"lower_bound\":\"1.2.3\"}}");
+        assert_eq!(ps("lower_bound='1.2.3'"), "{\"pin_subpackage\":{\"name\":\"foo\",\"lower_bound\":\"1.2.3\",\"upper_bound\":\"x\"}}");
     }
 
     #[test]

--- a/src/recipe/parser/requirements.rs
+++ b/src/recipe/parser/requirements.rs
@@ -505,7 +505,6 @@ impl TryConvertNode<IgnoreRunExports> for RenderedMappingNode {
 mod test {
     use std::str::FromStr;
 
-    use crate::recipe::jinja::PinExpression;
     use crate::render::pin::PinArgs;
 
     use super::*;

--- a/src/recipe/parser/requirements.rs
+++ b/src/recipe/parser/requirements.rs
@@ -516,10 +516,8 @@ mod test {
             pin_subpackage: Pin {
                 name: PackageName::from_str("foo").unwrap(),
                 args: PinArgs {
-                    max_pin: Some(PinExpression::from_str("x.x").unwrap()),
-                    min_pin: Some(PinExpression::from_str("x.x.x.x").unwrap()),
-                    lower_bound: None,
-                    upper_bound: None,
+                    lower_bound: Some("x.x.x.x".parse().unwrap()),
+                    upper_bound: Some("x.x".parse().unwrap()),
                     exact: false,
                 },
             },
@@ -529,10 +527,8 @@ mod test {
             pin_compatible: Pin {
                 name: PackageName::from_str("bar").unwrap(),
                 args: PinArgs {
-                    max_pin: Some(PinExpression::from_str("x.x.x").unwrap()),
-                    min_pin: Some(PinExpression::from_str("x.x").unwrap()),
-                    lower_bound: None,
-                    upper_bound: None,
+                    lower_bound: Some("x.x".parse().unwrap()),
+                    upper_bound: Some("x.x.x".parse().unwrap()),
                     exact: false,
                 },
             },
@@ -542,9 +538,7 @@ mod test {
             pin_compatible: Pin {
                 name: PackageName::from_str("bar").unwrap(),
                 args: PinArgs {
-                    max_pin: None,
-                    min_pin: Some(PinExpression::from_str("x.x").unwrap()),
-                    lower_bound: None,
+                    lower_bound: Some("x.x".parse().unwrap()),
                     upper_bound: None,
                     exact: true,
                 },
@@ -568,7 +562,7 @@ mod test {
 
     #[test]
     fn test_deserialize_pin() {
-        let pin = "{ pin_subpackage: { name: foo, max_pin: x.x.x, min_pin: x.x, exact: true, spec: foo }}";
+        let pin = "{ pin_subpackage: { name: foo, upper_bound: x.x.x, lower_bound: x.x, exact: true, spec: foo }}";
         let _: Dependency = serde_yaml::from_str(pin).unwrap();
     }
 }

--- a/src/recipe/parser/snapshots/rattler_build__recipe__parser__requirements__test__pin_package.snap
+++ b/src/recipe/parser/snapshots/rattler_build__recipe__parser__requirements__test__pin_package.snap
@@ -6,14 +6,14 @@ build:
 - foo >=3.1
 - pin_subpackage:
     name: foo
-    min_pin: x.x.x.x
-    max_pin: x.x
+    lower_bound: x.x.x.x
+    upper_bound: x.x
 - pin_compatible:
     name: bar
-    min_pin: x.x
-    max_pin: x.x.x
+    lower_bound: x.x
+    upper_bound: x.x.x
 - pin_compatible:
     name: bar
-    min_pin: x.x
-    max_pin: null
+    lower_bound: x.x
+    upper_bound: null
     exact: true

--- a/src/recipe/parser/snapshots/rattler_build__recipe__parser__requirements__test__pin_package.snap
+++ b/src/recipe/parser/snapshots/rattler_build__recipe__parser__requirements__test__pin_package.snap
@@ -15,5 +15,4 @@ build:
 - pin_compatible:
     name: bar
     lower_bound: x.x
-    upper_bound: null
     exact: true

--- a/src/render/pin.rs
+++ b/src/render/pin.rs
@@ -78,11 +78,11 @@ pub struct Pin {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PinArgs {
     /// A minimum pin to a version, using `x.x.x...` as syntax
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lower_bound: Option<PinBound>,
 
     /// A pin to a version, using `x.x.x...` as syntax
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub upper_bound: Option<PinBound>,
 
     /// If an exact pin is given, we pin the exact version & hash

--- a/src/render/pin.rs
+++ b/src/render/pin.rs
@@ -37,6 +37,27 @@ impl FromStr for PinExpression {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum PinBound {
+    Expression(PinExpression),
+    Version(Version),
+}
+
+impl FromStr for PinBound {
+    type Err = std::io::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.chars().any(|c| c != 'x' && c != '.') {
+            Ok(PinBound::Version(s.parse().map_err(|e| {
+                std::io::Error::new(std::io::ErrorKind::InvalidInput, e)
+            })?))
+        } else {
+            Ok(PinBound::Expression(s.parse()?))
+        }
+    }
+}
+
 impl Display for PinExpression {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
@@ -58,19 +79,11 @@ pub struct Pin {
 pub struct PinArgs {
     /// A minimum pin to a version, using `x.x.x...` as syntax
     #[serde(default)]
-    pub min_pin: Option<PinExpression>,
+    pub lower_bound: Option<PinBound>,
 
     /// A pin to a version, using `x.x.x...` as syntax
     #[serde(default)]
-    pub max_pin: Option<PinExpression>,
-
-    /// A lower bound to a version, using a regular version string
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub lower_bound: Option<Version>,
-
-    /// A upper bound to a version, using a regular version string
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub upper_bound: Option<Version>,
+    pub upper_bound: Option<PinBound>,
 
     /// If an exact pin is given, we pin the exact version & hash
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
@@ -80,10 +93,8 @@ pub struct PinArgs {
 impl Default for PinArgs {
     fn default() -> Self {
         Self {
-            max_pin: Some(PinExpression("x".to_string())),
-            min_pin: Some(PinExpression("x.x.x.x.x.x".to_string())),
-            lower_bound: None,
-            upper_bound: None,
+            lower_bound: Some("x.x.x.x.x.x".parse().unwrap()),
+            upper_bound: Some("x".parse().unwrap()),
             exact: false,
         }
     }
@@ -124,10 +135,10 @@ pub fn increment(version: &Version, segments: i32) -> Result<Version, VersionBum
 impl Pin {
     /// Apply the pin to a version and hash of a resolved package. If a max_pin, min_pin or exact pin
     /// are given, the pin is applied to the version accordingly.
-    pub fn apply(&self, version: &Version, hash: &str) -> Result<MatchSpec, PinError> {
+    pub fn apply(&self, version: &Version, build_string: &str) -> Result<MatchSpec, PinError> {
         if self.args.exact {
             return Ok(MatchSpec::from_str(
-                &format!("{} {} {}", self.name.as_normalized(), version, hash),
+                &format!("{} {} {}", self.name.as_normalized(), version, build_string),
                 ParseStrictness::Strict,
             )
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))?);
@@ -136,44 +147,52 @@ impl Pin {
         let mut pin_str = String::new();
 
         // extract same amount of digits as the pin expression (in the form of x.x.x) from version str
-        if let Some(lower_bound) = &self.args.lower_bound {
-            pin_str.push_str(&format!(">={}", lower_bound));
-        } else if let Some(min_pin) = &self.args.min_pin {
-            // number of digits in pin expression
-            let pin_digits = min_pin.0.chars().filter(|c| *c == 'x').count();
-            if pin_digits == 0 {
-                return Err(PinError::EmptyPinExpression);
-            }
+        match self.args.lower_bound.as_ref() {
+            Some(PinBound::Expression(expression)) => {
+                // number of digits in pin expression
+                let pin_digits = expression.0.chars().filter(|c| *c == 'x').count();
+                if pin_digits == 0 {
+                    return Err(PinError::EmptyPinExpression);
+                }
 
-            // get version string up the to pin_digits dot
-            let pin = version
-                .clone()
-                .with_segments(..cmp::min(pin_digits, version.segment_count()))
-                .ok_or_else(|| {
-                    PinError::CouldNotPin("Failed to extract min_pin from version".to_string())
-                })?;
-            pin_str.push_str(&format!(">={}", pin));
+                // get version string up the to pin_digits dot
+                let pin = version
+                    .clone()
+                    .with_segments(..cmp::min(pin_digits, version.segment_count()))
+                    .ok_or_else(|| {
+                        PinError::CouldNotPin("Failed to extract min_pin from version".to_string())
+                    })?;
+                pin_str.push_str(&format!(">={}", pin));
+            }
+            Some(PinBound::Version(version)) => {
+                pin_str.push_str(&format!(">={}", version));
+            }
+            None => {}
         };
 
-        if let Some(upper_bound) = &self.args.upper_bound {
-            if !pin_str.is_empty() {
-                pin_str.push(',')
-            }
-            pin_str.push_str(&format!("<{}", upper_bound));
-        } else if let Some(max_pin) = &self.args.max_pin {
-            // number of digits in pin expression
-            let pin_digits = max_pin.0.chars().filter(|c| *c == 'x').count();
-            if pin_digits == 0 {
-                return Err(PinError::EmptyPinExpression);
-            }
+        match self.args.upper_bound.as_ref() {
+            Some(PinBound::Expression(expression)) => {
+                // number of digits in pin expression
+                let pin_digits = expression.0.chars().filter(|c| *c == 'x').count();
+                if pin_digits == 0 {
+                    return Err(PinError::EmptyPinExpression);
+                }
 
-            // increment last digit
-            let pin = increment(version, pin_digits as i32)?;
+                // increment last digit
+                let pin = increment(version, pin_digits as i32)?;
 
-            if !pin_str.is_empty() {
-                pin_str.push(',')
+                if !pin_str.is_empty() {
+                    pin_str.push(',')
+                }
+                pin_str.push_str(&format!("<{}", pin));
             }
-            pin_str.push_str(&format!("<{}", pin));
+            Some(PinBound::Version(version)) => {
+                if !pin_str.is_empty() {
+                    pin_str.push(',')
+                }
+                pin_str.push_str(&format!("<{}", version));
+            }
+            None => {}
         }
 
         let name = self.name.as_normalized().to_string();
@@ -223,10 +242,8 @@ mod test {
         let pin = Pin {
             name: PackageName::from_str("foo").unwrap(),
             args: PinArgs {
-                max_pin: Some(PinExpression("x.x.x".to_string())),
-                min_pin: Some(PinExpression("x.x.x".to_string())),
-                lower_bound: None,
-                upper_bound: None,
+                lower_bound: Some("x.x.x".parse().unwrap()),
+                upper_bound: Some("x.x.x".parse().unwrap()),
                 exact: false,
             },
         };
@@ -243,10 +260,8 @@ mod test {
         let pin = Pin {
             name: PackageName::from_str("foo").unwrap(),
             args: PinArgs {
-                max_pin: Some(PinExpression("x.x.x".to_string())),
-                min_pin: None,
+                upper_bound: Some("x.x.x".parse().unwrap()),
                 lower_bound: None,
-                upper_bound: None,
                 exact: false,
             },
         };
@@ -257,9 +272,7 @@ mod test {
         let pin = Pin {
             name: PackageName::from_str("foo").unwrap(),
             args: PinArgs {
-                max_pin: None,
-                min_pin: Some(PinExpression("x.x.x".to_string())),
-                lower_bound: None,
+                lower_bound: Some("x.x.x".parse().unwrap()),
                 upper_bound: None,
                 exact: false,
             },
@@ -274,10 +287,8 @@ mod test {
         let pin = Pin {
             name: PackageName::from_str("foo").unwrap(),
             args: PinArgs {
-                max_pin: Some(PinExpression("x.x.x".to_string())),
-                min_pin: Some(PinExpression("x.x.x".to_string())),
-                lower_bound: None,
-                upper_bound: None,
+                lower_bound: Some("x.x.x".parse().unwrap()),
+                upper_bound: Some("x.x.x".parse().unwrap()),
                 exact: true,
             },
         };
@@ -293,9 +304,7 @@ mod test {
         let pin = Pin {
             name: PackageName::from_str("foo").unwrap(),
             args: PinArgs {
-                min_pin: Some(PinExpression("x.x.x".to_string())),
-                max_pin: None,
-                lower_bound: None,
+                lower_bound: Some("x.x.x".parse().unwrap()),
                 upper_bound: Some("2.4".parse().unwrap()),
                 exact: false,
             },

--- a/src/render/resolved_dependencies.rs
+++ b/src/render/resolved_dependencies.rs
@@ -917,8 +917,8 @@ mod tests {
                 name: "baz".to_string(),
                 spec: MatchSpec::from_str("baz", ParseStrictness::Strict).unwrap(),
                 args: PinArgs {
-                    max_pin: Some("x.x".parse().unwrap()),
-                    min_pin: Some("x.x.x".parse().unwrap()),
+                    upper_bound: Some("x.x".parse().unwrap()),
+                    lower_bound: Some("x.x.x".parse().unwrap()),
                     exact: true,
                     ..Default::default()
                 },
@@ -928,8 +928,8 @@ mod tests {
                 name: "bat".to_string(),
                 spec: MatchSpec::from_str("bat", ParseStrictness::Strict).unwrap(),
                 args: PinArgs {
-                    max_pin: Some("x.x".parse().unwrap()),
-                    min_pin: Some("x.x.x".parse().unwrap()),
+                    upper_bound: Some("x.x".parse().unwrap()),
+                    lower_bound: Some("x.x.x".parse().unwrap()),
                     exact: true,
                     ..Default::default()
                 },

--- a/src/render/snapshots/rattler_build__render__resolved_dependencies__tests__dependency_info_render.snap
+++ b/src/render/snapshots/rattler_build__render__resolved_dependencies__tests__dependency_info_render.snap
@@ -6,12 +6,12 @@ expression: yaml_str
 - variant: bar
   spec: foo
 - pin_subpackage: baz
-  min_pin: x.x.x
-  max_pin: x.x
+  lower_bound: x.x.x
+  upper_bound: x.x
   exact: true
   spec: baz
 - pin_compatible: bat
-  min_pin: x.x.x
-  max_pin: x.x
+  lower_bound: x.x.x
+  upper_bound: x.x
   exact: true
   spec: bat

--- a/test-data/pins.yaml
+++ b/test-data/pins.yaml
@@ -1,64 +1,64 @@
 - pin:
     name: "foo"
-    min_pin: "x.x"
-    max_pin: "x.x.x"
+    lower_bound: "x.x"
+    upper_bound: "x.x.x"
   spec: 9.0 hash
   expected: "foo >=9.0,<9.0.1.0a0"
 - pin:
     name: "foo"
-    min_pin: "x.x.x.x"
-    max_pin: "x.x.x"
+    lower_bound: "x.x.x.x"
+    upper_bound: "x.x.x"
   spec: 9 hash
   expected: "foo >=9,<9.0.1.0a0"
 - pin:
     name: jpeg
-    max_pin: "x.x"
+    upper_bound: "x.x"
   spec: 9d hash
   expected: "jpeg <9d.1.0a0"
 - pin:
     name: jpeg
-    max_pin: "x"
+    upper_bound: "x"
   spec: 9d hash
   expected: "jpeg <10a"
 - pin:
     name: jpeg
-    min_pin: "x"
-    max_pin: "x"
+    lower_bound: "x"
+    upper_bound: "x"
   spec: 9d hash
   expected: "jpeg >=9d,<10a"
 - pin:
     name: "test"
-    min_pin: "x.x.x"
+    lower_bound: "x.x.x"
   spec: 1.2.3 hash
   expected: "test >=1.2.3"
 - pin:
     name: "test"
-    min_pin: "x.x.x"
-    max_pin: "x.x"
+    lower_bound: "x.x.x"
+    upper_bound: "x.x"
   spec: 1.2.3 hash
   expected: "test >=1.2.3,<1.3.0a0"
 - pin:
     name: openssl
-    max_pin: "x.x.x"
-    min_pin: "x.x.x"
+    upper_bound: "x.x.x"
+    lower_bound: "x.x.x"
   spec: 1.0.2j hash
   expected: "openssl >=1.0.2j,<1.0.3a"
 - pin:
     name: openssl
-    min_pin: "x.x.x"
-    max_pin: "x.x.x.x"
+    lower_bound: "x.x.x"
+    upper_bound: "x.x.x.x"
   spec: 1.0.2j hash
   expected: "openssl >=1.0.2j,<1.0.2j.1.0a0"
 - pin:
     name: epoch
-    min_pin: "x.x"
-    max_pin: "x.x.x"
+    lower_bound: "x.x"
+    upper_bound: "x.x.x"
   spec: 5!1.2.3 hash
   expected: "epoch >=5!1.2,<5!1.2.4.0a0"
 - pin:
     name: local
-    min_pin: "x.x"
-    max_pin: "x.x.x"
+    lower_bound: "x.x"
+    upper_bound: "x.x.x"
   spec: 5!1.2.3+3.4 hash
   expected: "local >=5!1.2+3.4,<5!1.2.4.0a0"
 - pin:
@@ -69,23 +69,19 @@
   expected: "bounds >=1.2,<1.2.5"
 - pin:
     name: "bounds"
-    # these should be ignored, only bounds should be used
-    min_pin: x
-    max_pin: x.x
     lower_bound: "1.2"
     upper_bound: "1.2.5"
   spec: 1.2.3 hash
   expected: "bounds >=1.2,<1.2.5"
 - pin:
     name: "bounds"
-    min_pin: x
-    max_pin: x.x # should be ignored
+    lower_bound: x
     upper_bound: "1.2.9"
   spec: 1.2.3 hash
   expected: "bounds >=1,<1.2.9"
 - pin:
     name: "bounds"
     lower_bound: '1.0.1'
-    max_pin: x.x
+    upper_bound: x.x
   spec: 1.2.3 hash
   expected: "bounds >=1.0.1,<1.3.0a0"

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -717,8 +717,6 @@ def test_noarch_variants(rattler_build: RattlerBuild, recipes: Path, tmp_path: P
     pin = {
         "pin_subpackage": {
             "name": "rattler-build-demo",
-            "min_pin": "x.x.x.x.x.x",
-            "max_pin": "x",
             "exact": True,
         }
     }
@@ -743,8 +741,6 @@ def test_noarch_variants(rattler_build: RattlerBuild, recipes: Path, tmp_path: P
     pin = {
         "pin_subpackage": {
             "name": "rattler-build-demo",
-            "min_pin": "x.x.x.x.x.x",
-            "max_pin": "x",
             "exact": True,
         }
     }


### PR DESCRIPTION
This follows the comment by @h-vetinari and @chenghlee. 

It removes `max_pin` and `min_pin` arguments, and instead only `lower_bound` and `upper_bound` are accepted with three values:

- None (no upper or lower bound)
- `x.x...` "pin expression"
- `1.2.3` a version