### PR TITLE
fix: unify how script files are found and fix a regression with explicit paths

### DIFF
--- a/src/script.rs
+++ b/src/script.rs
@@ -495,7 +495,7 @@ impl Script {
             // No script was specified, so we try to read the default script. If the file cannot be
             // found we return an empty string.
             ScriptContent::Default => {
-                let recipe_file = self.find_file(recipe_dir, extensions, &Path::new("build"));
+                let recipe_file = self.find_file(recipe_dir, extensions, Path::new("build"));
                 if let Some(recipe_file) = recipe_file {
                     match fs_err::read_to_string(&recipe_file) {
                         Err(e) => Err(e),
@@ -528,7 +528,7 @@ impl Script {
                 if path.contains('\n') {
                     return Ok(ResolvedScriptContents::Inline(path.clone()));
                 }
-                let resolved_path = self.find_file(recipe_dir, extensions, &Path::new(path));
+                let resolved_path = self.find_file(recipe_dir, extensions, Path::new(path));
                 if let Some(resolved_path) = resolved_path {
                     match fs_err::read_to_string(&resolved_path) {
                         Err(e) => Err(e),

--- a/src/script.rs
+++ b/src/script.rs
@@ -459,25 +459,18 @@ impl ResolvedScriptContents {
 
 impl Script {
     fn find_file(&self, recipe_dir: &Path, extensions: &[&str], path: &Path) -> Option<PathBuf> {
+        let path = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            recipe_dir.join(path)
+        };
+
         if path.extension().is_none() {
             extensions
                 .iter()
-                .map(|ext| {
-                    let with_ext = path.with_extension(ext);
-                    if with_ext.is_absolute() {
-                        with_ext
-                    } else {
-                        recipe_dir.join(with_ext)
-                    }
-                })
+                .map(|ext| path.with_extension(ext))
                 .find(|p| p.is_file())
         } else {
-            let path = if path.is_absolute() {
-                path.to_path_buf()
-            } else {
-                recipe_dir.join(path)
-            };
-
             if path.is_file() {
                 Some(path)
             } else {

--- a/test-data/recipes/script/recipe.yaml
+++ b/test-data/recipes/script/recipe.yaml
@@ -1,0 +1,8 @@
+package:
+  name: script-test
+  version: 0.1.0
+
+build:
+  script:
+    # make sure this script is executed with either `.bat` or `.sh` extension
+    file: script

--- a/test-data/recipes/script/recipe_with_extensions.yaml
+++ b/test-data/recipes/script/recipe_with_extensions.yaml
@@ -1,0 +1,8 @@
+package:
+  name: script-test-ext
+  version: 0.1.0
+
+build:
+  script:
+    # make sure this script is executed with either `.bat` or `.sh` extension
+    file: ${{ "script.bat" if win else "script.sh" }}

--- a/test-data/recipes/script/script.bat
+++ b/test-data/recipes/script/script.bat
@@ -1,0 +1,1 @@
+echo "Script executed" > %PREFIX%/script-executed.txt

--- a/test-data/recipes/script/script.sh
+++ b/test-data/recipes/script/script.sh
@@ -1,0 +1,1 @@
+touch $PREFIX/script-executed.txt

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -902,3 +902,27 @@ def test_run_exports_from(
 
     index_json = json.loads((pkg / "info/index.json").read_text())
     assert index_json.get("depends") is None
+
+
+def test_script_execution(rattler_build: RattlerBuild, recipes: Path, tmp_path: Path):
+    rattler_build.build(
+        recipes / "script",
+        tmp_path,
+    )
+    pkg = get_extracted_package(tmp_path, "script-test")
+
+    # grab paths.json
+    paths = json.loads((pkg / "info/paths.json").read_text())
+    assert len(paths["paths"]) == 1
+    assert paths["paths"][0]["_path"] == "script-executed.txt"
+
+    rattler_build.build(
+        recipes / "script/recipe_with_extensions.yaml",
+        tmp_path,
+    )
+    pkg = get_extracted_package(tmp_path, "script-test-ext")
+
+    # grab paths.json
+    paths = json.loads((pkg / "info/paths.json").read_text())
+    assert len(paths["paths"]) == 1
+    assert paths["paths"][0]["_path"] == "script-executed.txt"


### PR DESCRIPTION
currently, explicit (relative) paths don't work. This PR unifies how we are searching for files and fixes that behavior.