### PR TITLE
Adds commonly used go compilers to default compiler logic

### DIFF
--- a/src/recipe/jinja.rs
+++ b/src/recipe/jinja.rs
@@ -188,36 +188,34 @@ fn jinja_pin_function(
 }
 
 fn default_compiler(platform: Platform, language: &str) -> Option<String> {
-    if platform.is_windows() {
-        match language {
-            "c" => Some("vs2017"),
-            "cxx" => Some("vs2017"),
-            "fortran" => Some("gfortran"),
-            "rust" => Some("rust"),
-            "go" => Some("go"),
-            "go-nocgo" => Some("go-nocgo"),
-            _ => None,
-        }
-    } else if platform.is_osx() {
-        match language {
-            "c" => Some("clang"),
-            "cxx" => Some("clangxx"),
-            "fortran" => Some("gfortran"),
-            "rust" => Some("rust"),
-            "go" => Some("go"),
-            "go-nocgo" => Some("go-nocgo"),
-            _ => None,
-        }
-    } else {
-        match language {
-            "c" => Some("gcc"),
-            "cxx" => Some("gxx"),
-            "fortran" => Some("gfortran"),
-            "rust" => Some("rust"),
-            "go" => Some("go"),
-            "go-nocgo" => Some("go-nocgo"),
-            _ => None,
-        }
+    match language {
+        // Platform agnostic compilers
+        "fortran" => Some("gfortran"),
+        "rust" => Some("rust"),
+        "go" => Some("go"),
+        "go-nocgo" => Some("go-nocgo"),
+        // Platform specific compilers
+        _ => {
+            if platform.is_windows() {
+                match language {
+                    "c" => Some("vs2017"),
+                    "cxx" => Some("vs2017"),
+                    _ => None,
+                }
+            } else if platform.is_osx() {
+                match language {
+                    "c" => Some("clang"),
+                    "cxx" => Some("clangxx"),
+                    _ => None,
+                }
+            } else {
+                match language {
+                    "c" => Some("gcc"),
+                    "cxx" => Some("gxx"),
+                    _ => None,
+                }
+            }
+        },
     }
     .map(|s| s.to_string())
 }

--- a/src/recipe/jinja.rs
+++ b/src/recipe/jinja.rs
@@ -194,6 +194,8 @@ fn default_compiler(platform: Platform, language: &str) -> Option<String> {
             "cxx" => Some("vs2017"),
             "fortran" => Some("gfortran"),
             "rust" => Some("rust"),
+            "go" => Some("go"),
+            "go-nocgo" => Some("go-nocgo"),
             _ => None,
         }
     } else if platform.is_osx() {
@@ -202,6 +204,8 @@ fn default_compiler(platform: Platform, language: &str) -> Option<String> {
             "cxx" => Some("clangxx"),
             "fortran" => Some("gfortran"),
             "rust" => Some("rust"),
+            "go" => Some("go"),
+            "go-nocgo" => Some("go-nocgo"),
             _ => None,
         }
     } else {
@@ -210,6 +214,8 @@ fn default_compiler(platform: Platform, language: &str) -> Option<String> {
             "cxx" => Some("gxx"),
             "fortran" => Some("gfortran"),
             "rust" => Some("rust"),
+            "go" => Some("go"),
+            "go-nocgo" => Some("go-nocgo"),
             _ => None,
         }
     }

--- a/src/recipe/jinja.rs
+++ b/src/recipe/jinja.rs
@@ -215,7 +215,7 @@ fn default_compiler(platform: Platform, language: &str) -> Option<String> {
                     _ => None,
                 }
             }
-        },
+        }
     }
     .map(|s| s.to_string())
 }


### PR DESCRIPTION
As of `0.17.0` (with the introduction of the checks for `compiler()` function usage), the integration tests for `conda-recipe-manager` showed some failures with `go` projects in `conda-forge`:

```
 ╭─ Finding outputs from recipe
 │
 ╰─────────────────── (took 0 seconds)
Error:   × Failed to parse recipe

Error:   × Parsing: failed to render Jinja expression: undefined value: No compiler found for language: go-nocgo
  │ You should add `go-nocgo_compiler` to your variant config file. (in <string>:1)
    ╭─[22:7]
 21 │   build:
 22 │     - ${{ compiler('go-nocgo') }}
    ·       ─────────────┬─────────────
    ·                    ╰─┤ undefined value: No compiler found for language: go-nocgo
    ·                      │ You should add `go-nocgo_compiler` to your variant config file.
 23 │     - if: unix
    ╰────
```

This PR attempts to address this issue by adding default compilers for golang.

I verified this locally. I am able to dry-run build recipe files that use `compiler('go')` and `compiler('go-nocgo')` with these edits.