### PR TITLE
fix: fix a serialization issue where a single-line script and cwd are set

### DIFF
--- a/src/script.rs
+++ b/src/script.rs
@@ -35,6 +35,7 @@ set -x
 
 const DEBUG_HELP : &str  = "To debug the build, run it manually in the work directory (execute the `./conda_build.sh` or `conda_build.bat` script)";
 
+#[derive(Debug)]
 pub struct ExecutionArgs {
     pub script: ResolvedScriptContents,
     pub env_vars: IndexMap<String, String>,


### PR DESCRIPTION
I overlooked a condition where we have a simple (single-line) script and a `cwd` (as injected by the test serialization. 

Under these conditions, we did not render out the `cwd` and thus the test execution stopped working.

This PR has the fix.