### PR TITLE
chore: fix clippy warnings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,6 +55,7 @@ jobs:
         with:
           reporter: "github-pr-check"
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          args: "--all-targets"
 
   build:
     name: Build ${{ matrix.target }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,15 +3,7 @@ on:
     branches: [main]
     tags:
       - "v*.*.*"
-    paths:
-      - "src/**"
-      - "Cargo.*"
-      - ".github/workflows/*"
   pull_request:
-    paths:
-      - "src/**"
-      - "Cargo.*"
-      - ".github/workflows/*"
 
   workflow_dispatch:
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           reporter: "github-pr-check"
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          args: "--all-targets"
+          clippy_flags: "--all-targets"
 
   build:
     name: Build ${{ matrix.target }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,6 @@ repos:
       - id: clippy
         name: clippy
         description: Checks a package to catch common mistakes and improve your Rust code.
-        entry: cargo clippy --all --color always
+        entry: cargo clippy --all-targets --color always
         language: system
         pass_filenames: false

--- a/src/package_test/content_test.rs
+++ b/src/package_test/content_test.rs
@@ -336,10 +336,7 @@ mod tests {
         NoMatch,
     }
 
-    fn test_glob_matches(
-        globs: &Vec<(String, GlobSet)>,
-        paths: &[String],
-    ) -> Result<(), MatchError> {
+    fn test_glob_matches(globs: &[(String, GlobSet)], paths: &[String]) -> Result<(), MatchError> {
         let mut matches = Vec::new();
         for path in paths {
             let mut has_match = false;

--- a/src/recipe/jinja.rs
+++ b/src/recipe/jinja.rs
@@ -697,9 +697,9 @@ mod tests {
     fn with_temp_dir(key: &'static str, f: impl Fn(&std::path::Path)) {
         let tempdir = tempfile::tempdir().unwrap();
         let dir = tempdir.path().join(key);
-        _ = std::fs::create_dir_all(&dir).unwrap();
+        std::fs::create_dir_all(&dir).unwrap();
         f(&dir);
-        _ = std::fs::remove_dir_all(dir).unwrap();
+        std::fs::remove_dir_all(dir).unwrap();
     }
 
     // git version is too old in cross container for aarch64
@@ -774,7 +774,7 @@ mod tests {
             assert_eq!(jinja.eval(&format!("git.latest_tag({:?})", path)).expect("test 0").as_str().unwrap(), "v0.1.0");
             assert_eq!(jinja.eval(&format!("git.latest_tag_rev({:?})", path)).expect("test 1 left").as_str().unwrap(), jinja.eval(&format!("git.head_rev({:?})", path)).expect("test 1 right").as_str().unwrap());
             assert_eq!(
-                jinja_wo_experimental.eval(&format!("git.latest_tag({:?})", path)).err().expect("test 2").to_string(),
+                jinja_wo_experimental.eval(&format!("git.latest_tag({:?})", path)).expect_err("test 2").to_string(),
                 "invalid operation: Experimental feature: provide the `--experimental` flag to enable this feature (in <expression>:1)",
             );
         });

--- a/src/recipe/parser.rs
+++ b/src/recipe/parser.rs
@@ -384,7 +384,7 @@ mod tests {
             let err = recipe.unwrap_err();
             let err: ParseErrors = err
                 .into_iter()
-                .map(|err| ParsingError::from_partial(&raw_recipe, err))
+                .map(|err| ParsingError::from_partial(raw_recipe, err))
                 .collect::<Vec<_>>()
                 .into();
             assert_miette_snapshot!(err);

--- a/src/recipe/parser/glob_vec.rs
+++ b/src/recipe/parser/glob_vec.rs
@@ -200,7 +200,7 @@ impl GlobVec {
             include,
             exclude,
             include_globset: globset,
-            exclude_globset: exclude_globset,
+            exclude_globset,
         }
     }
 }

--- a/src/recipe/parser/test.rs
+++ b/src/recipe/parser/test.rs
@@ -365,6 +365,7 @@ impl TryConvertNode<PackageContentsTest> for RenderedMappingNode {
 }
 
 #[cfg(test)]
+#[allow(clippy::module_inception)]
 mod test {
     use std::fs;
 
@@ -395,12 +396,12 @@ mod test {
 
         // from yaml
         let tests: Vec<TestType> = serde_yaml::from_str(&yaml_serde).unwrap();
-        let t = tests.get(0);
+        let t = tests.first();
 
         match t {
             Some(TestType::Python { python }) => {
                 assert_eq!(python.imports, vec!["numpy.testing", "numpy.matrix"]);
-                assert_eq!(python.pip_check, true);
+                assert!(python.pip_check);
             }
             _ => panic!("expected python test"),
         }

--- a/src/render/pin.rs
+++ b/src/render/pin.rs
@@ -232,7 +232,7 @@ mod test {
             let (version, hash) = spec.split_whitespace().collect_tuple().unwrap();
             let version: Version = version.parse().unwrap();
             let spec = test.pin.apply(&version, hash).unwrap();
-            println!("{} -> {}", spec.to_string(), test.expected);
+            println!("{} -> {}", spec, test.expected);
             assert_eq!(spec.to_string(), test.expected);
         }
     }

--- a/src/render/resolved_dependencies.rs
+++ b/src/render/resolved_dependencies.rs
@@ -977,7 +977,6 @@ mod tests {
                     upper_bound: Some("x.x".parse().unwrap()),
                     lower_bound: Some("x.x.x".parse().unwrap()),
                     exact: true,
-                    ..Default::default()
                 },
             }
             .into(),
@@ -988,7 +987,6 @@ mod tests {
                     upper_bound: Some("x.x".parse().unwrap()),
                     lower_bound: Some("x.x.x".parse().unwrap()),
                     exact: true,
-                    ..Default::default()
                 },
             }
             .into(),

--- a/src/source/extract.rs
+++ b/src/source/extract.rs
@@ -219,7 +219,7 @@ mod test {
         assert!(term.contents().trim().starts_with(
             "Extracting zip       [00:00:00] [━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━]"
         ));
-        assert!(matches!(res.err(), None));
+        assert!(res.err().is_none());
         assert!(tempdir.path().join("text.txt").exists());
         assert!(std::fs::read_to_string(tempdir.path().join("text.txt"))
             .unwrap()


### PR DESCRIPTION
Also remove `paths` filter for CI.
It doesn't play well with concurrency.
If you add a job that doesn't touch the correct files, it will cancel other jobs, but not start a new one.