### PR TITLE
docs: improve jinja documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -135,7 +135,7 @@ nav:
   - References:
       - Recipe file: reference/recipe_file.md
       - CLI: reference/cli.md
-      - Jinja functions: reference/jinja.md
+      - Jinja: reference/jinja.md
 
 plugins:
   - search


### PR DESCRIPTION
I've noticed that the [CEP](https://github.com/conda/ceps/blob/81d9515782de7e896e6e4e00da05f4f31407ab78/cep-recipe-jinja.md) has nice docs on how our jinja usage works.
So I copied that part to the `rattler-build` docs