### PR TITLE
fix: filter cache run_exports with the right ignores

### DIFF
--- a/src/recipe/parser/requirements.rs
+++ b/src/recipe/parser/requirements.rs
@@ -100,8 +100,13 @@ impl Requirements {
     }
 
     /// Get run exports that are ignored.
-    pub const fn ignore_run_exports(&self) -> &IgnoreRunExports {
-        &self.ignore_run_exports
+    pub fn ignore_run_exports(&self, merge: Option<&IgnoreRunExports>) -> IgnoreRunExports {
+        let mut ignore = self.ignore_run_exports.clone();
+        if let Some(merge) = merge {
+            ignore.by_name.extend(merge.by_name.iter().cloned());
+            ignore.from_package.extend(merge.from_package.iter().cloned());
+        }
+        ignore
     }
 
     /// Get all requirements at build time (combines build and host requirements)

--- a/src/recipe/parser/requirements.rs
+++ b/src/recipe/parser/requirements.rs
@@ -104,7 +104,9 @@ impl Requirements {
         let mut ignore = self.ignore_run_exports.clone();
         if let Some(merge) = merge {
             ignore.by_name.extend(merge.by_name.iter().cloned());
-            ignore.from_package.extend(merge.from_package.iter().cloned());
+            ignore
+                .from_package
+                .extend(merge.from_package.iter().cloned());
         }
         ignore
     }

--- a/src/render/resolved_dependencies.rs
+++ b/src/render/resolved_dependencies.rs
@@ -754,7 +754,7 @@ pub(crate) async fn resolve_dependencies(
         build_run_exports.extend(build_env.run_exports(true));
     }
 
-    let ignore_run_exports = output.recipe.requirements.ignore_run_exports();
+    let ignore_run_exports = requirements.ignore_run_exports();
     let build_run_exports = ignore_run_exports.filter(&build_run_exports, "build")?;
     host_env_specs.extend(build_run_exports.strong.iter().cloned());
 
@@ -849,7 +849,7 @@ pub(crate) async fn resolve_dependencies(
         .as_ref()
         .and_then(|cache| cache.host.as_ref().map(|b| b.run_exports(true)))
         .unwrap_or_default();
-
+    println!("Host run exports ...: {:?}", host_run_exports);
     // Add in the host run exports from the current output
     if let Some(host_env) = &host_env {
         host_run_exports.extend(host_env.run_exports(true));
@@ -857,6 +857,7 @@ pub(crate) async fn resolve_dependencies(
 
     // And filter the run exports
     let host_run_exports = ignore_run_exports.filter(&host_run_exports, "host")?;
+    println!("Host run exports after filter ...: {:?}", host_run_exports);
 
     // add the host run exports to the run dependencies
     if output.target_platform() == &Platform::NoArch {
@@ -875,7 +876,7 @@ pub(crate) async fn resolve_dependencies(
     if let Some(cache) = &output.finalized_cache_dependencies {
         // add in the run exports from the cache
         // filter run dependencies that came from run exports
-        let ignore_run_exports = output.recipe.requirements.ignore_run_exports();
+        let ignore_run_exports = requirements.ignore_run_exports();
         // Note: these run exports are already filtered
         let _cache_run_exports = cache.run.depends.iter().filter(|c| match c {
             DependencyInfo::RunExport(run_export) => {

--- a/src/render/resolved_dependencies.rs
+++ b/src/render/resolved_dependencies.rs
@@ -612,66 +612,6 @@ fn render_run_exports(
     }
 }
 
-// fn propagate_run_exports_to_run(
-//     finalized_dependencies: &mut FinalizedDependencies,
-//     output: &Output,
-// ) {
-//     // filter out the run exports from the build env
-//     let build_env = finalized_dependencies.build.as_ref();
-
-//     // Propagate run exports from host env to run env
-//     if let Some((_, run_exports)) = &host_env {
-//         match output.build_configuration.target_platform {
-//             Platform::NoArch => {
-//                 for (name, rex) in run_exports {
-//                     run_specs
-//                         .depends
-//                         .extend(add_run_export_specs(name, "host", &rex.noarch)?);
-//                 }
-//             }
-//             _ => {
-//                 for (name, rex) in run_exports {
-//                     run_specs
-//                         .depends
-//                         .extend(add_run_export_specs(name, "host", &rex.strong)?);
-//                     run_specs
-//                         .depends
-//                         .extend(add_run_export_specs(name, "host", &rex.weak)?);
-//                     run_specs.constraints.extend(add_run_export_specs(
-//                         name,
-//                         "host",
-//                         &rex.strong_constrains,
-//                     )?);
-//                     run_specs.constraints.extend(add_run_export_specs(
-//                         name,
-//                         "host",
-//                         &rex.weak_constrains,
-//                     )?);
-//                 }
-//             }
-//         }
-//     }
-
-//     // We also have to propagate the _strong_ run exports of the build environment to the run environment
-//     if let Some((_, run_exports)) = &build_env {
-//         match output.build_configuration.target_platform {
-//             Platform::NoArch => {}
-//             _ => {
-//                 for (name, rex) in run_exports {
-//                     run_specs
-//                         .depends
-//                         .extend(add_run_export_specs(name, "build", &rex.strong)?);
-//                     run_specs.constraints.extend(add_run_export_specs(
-//                         name,
-//                         "build",
-//                         &rex.strong_constrains,
-//                     )?);
-//                 }
-//             }
-//         }
-//     }
-// }
-
 /// This function resolves the dependencies of a recipe.
 /// To do this, we have to run a couple of steps:
 ///
@@ -748,8 +688,8 @@ pub(crate) async fn resolve_dependencies(
         build_run_exports.extend(build_env.run_exports(true));
     }
 
-    let ignore_run_exports = requirements.ignore_run_exports();
-    let mut build_run_exports = ignore_run_exports.filter(&build_run_exports, "build")?;
+    let output_ignore_run_exports = requirements.ignore_run_exports(None);
+    let mut build_run_exports = output_ignore_run_exports.filter(&build_run_exports, "build")?;
 
     if let Some(cache) = &output.finalized_cache_dependencies {
         if let Some(cache_build_env) = &cache.build {
@@ -760,7 +700,7 @@ pub(crate) async fn resolve_dependencies(
                 .as_ref()
                 .expect("recipe should have cache section")
                 .requirements
-                .ignore_run_exports()
+                .ignore_run_exports(Some(&output_ignore_run_exports))
                 .filter(&cache_build_run_exports, "cache-build")?;
             build_run_exports.extend(&filtered);
         }
@@ -862,7 +802,7 @@ pub(crate) async fn resolve_dependencies(
     }
 
     // And filter the run exports
-    let mut host_run_exports = ignore_run_exports.filter(&host_run_exports, "host")?;
+    let mut host_run_exports = output_ignore_run_exports.filter(&host_run_exports, "host")?;
 
     if let Some(cache) = &output.finalized_cache_dependencies {
         if let Some(cache_host_env) = &cache.host {
@@ -873,7 +813,7 @@ pub(crate) async fn resolve_dependencies(
                 .as_ref()
                 .expect("recipe should have cache section")
                 .requirements
-                .ignore_run_exports()
+                .ignore_run_exports(Some(&output_ignore_run_exports))
                 .filter(&cache_host_run_exports, "cache-host")?;
             host_run_exports.extend(&filtered);
         }
@@ -896,7 +836,7 @@ pub(crate) async fn resolve_dependencies(
     if let Some(cache) = &output.finalized_cache_dependencies {
         // add in the run exports from the cache
         // filter run dependencies that came from run exports
-        let ignore_run_exports = requirements.ignore_run_exports();
+        let ignore_run_exports = requirements.ignore_run_exports(None);
         // Note: these run exports are already filtered
         let _cache_run_exports = cache.run.depends.iter().filter(|c| match c {
             DependencyInfo::RunExport(run_export) => {

--- a/src/render/run_exports.rs
+++ b/src/render/run_exports.rs
@@ -25,6 +25,9 @@ impl IgnoreRunExports {
         from_env: &str,
     ) -> Result<FilteredRunExports, ParseMatchSpecError> {
         let mut run_export_map = run_export_map.clone();
+        println!("Self: {:?}", self);
+        println!("run_export_map: {:?}", run_export_map);
+        println!("Retaining self.from_package(): {:?}", self.from_package());
         run_export_map.retain(|name, _| !self.from_package().contains(name));
 
         let mut filtered_run_exports = FilteredRunExports::default();

--- a/src/render/run_exports.rs
+++ b/src/render/run_exports.rs
@@ -38,9 +38,6 @@ impl IgnoreRunExports {
         from_env: &str,
     ) -> Result<FilteredRunExports, ParseMatchSpecError> {
         let mut run_export_map = run_export_map.clone();
-        println!("Self: {:?}", self);
-        println!("run_export_map: {:?}", run_export_map);
-        println!("Retaining self.from_package(): {:?}", self.from_package());
         run_export_map.retain(|name, _| !self.from_package().contains(name));
 
         let mut filtered_run_exports = FilteredRunExports::default();

--- a/src/render/run_exports.rs
+++ b/src/render/run_exports.rs
@@ -18,6 +18,19 @@ pub struct FilteredRunExports {
     pub weak_constraints: Vec<DependencyInfo>,
 }
 
+impl FilteredRunExports {
+    /// Extend the current filtered run exports with another set of filtered run exports
+    pub fn extend(&mut self, other: &FilteredRunExports) {
+        self.noarch.extend(other.noarch.iter().cloned());
+        self.strong.extend(other.strong.iter().cloned());
+        self.strong_constraints
+            .extend(other.strong_constraints.iter().cloned());
+        self.weak.extend(other.weak.iter().cloned());
+        self.weak_constraints
+            .extend(other.weak_constraints.iter().cloned());
+    }
+}
+
 impl IgnoreRunExports {
     pub fn filter(
         &self,

--- a/test-data/recipes/cache_run_exports/helper.yaml
+++ b/test-data/recipes/cache_run_exports/helper.yaml
@@ -1,0 +1,14 @@
+outputs:
+  - package:
+      name: normal-run-exports
+      version: "1.0.0"
+    requirements:
+      run_exports:
+        - normal-run-exports
+  - package:
+      name: strong-run-exports
+      version: "1.0.0"
+    requirements:
+      run_exports:
+        strong:
+          - normal-run-exports

--- a/test-data/recipes/cache_run_exports/recipe_test_1.yaml
+++ b/test-data/recipes/cache_run_exports/recipe_test_1.yaml
@@ -1,0 +1,23 @@
+cache:
+  requirements:
+    host:
+      - normal-run-exports
+
+outputs:
+  - package:
+      name: cache-run-exports
+      version: "1.0.0"
+  - package:
+      name: no-cache-from-package-run-exports
+      version: "1.0.0"
+    requirements:
+      ignore_run_exports:
+        from_package:
+          - normal-run-exports
+  - package:
+      name: no-cache-by-name-run-exports
+      version: "1.0.0"
+    requirements:
+      ignore_run_exports:
+        by_name:
+          - normal-run-exports

--- a/test-data/recipes/cache_run_exports/recipe_test_2.yaml
+++ b/test-data/recipes/cache_run_exports/recipe_test_2.yaml
@@ -1,0 +1,12 @@
+cache:
+  requirements:
+    host:
+      - normal-run-exports
+    ignore_run_exports:
+      from_package:
+        - normal-run-exports
+
+outputs:
+  - package:
+      name: cache-ignore-run-exports
+      version: "1.0.0"

--- a/test-data/recipes/cache_run_exports/recipe_test_3.yaml
+++ b/test-data/recipes/cache_run_exports/recipe_test_3.yaml
@@ -1,0 +1,12 @@
+cache:
+  requirements:
+    host:
+      - normal-run-exports
+    ignore_run_exports:
+      by_name:
+        - normal-run-exports
+
+outputs:
+  - package:
+      name: cache-ignore-run-exports-by-name
+      version: "1.0.0"


### PR DESCRIPTION
this is an attempt to fix #977 

I think part of the issue was (at least!) that we didn't use the right "ignore_run_exports" (ie. not the one from the cache. 

My quick test showed that it still doesn't fix the issue, so will have to dig a little bit more tomorrow. But should be fixed swiftly!