### PR TITLE
feat: make recipe generation optional

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -97,6 +97,9 @@ jobs:
       # Optimize the binary for size. This reduces the filesize at the cost of a slower binary.
       CARGO_PROFILE_OPT_LEVEL: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) && 's' || '0' }}
 
+      # Sets the default features which are always used also when `--no-default` is used.
+      REQUIRED_FEATURES: recipe-generation
+
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4
@@ -181,13 +184,22 @@ jobs:
           build
           --locked
           --release
+          --features ${{ env.REQUIRED_FEATURES }}
           --target=${{ matrix.target }}
           ${{ steps.options.outputs.cargo-build-options }}
 
       - name: Run tests
         shell: bash
         if: matrix.target != 'aarch64-apple-darwin'
-        run: ${{ matrix.use-cross && 'cross' || 'cargo' }} test --release --locked --target=${{ matrix.target }} ${{ steps.options.outputs.cargo-build-options }} ${{ steps.options.outputs.cargo-test-options }}
+        run: >-
+          ${{ matrix.use-cross && 'cross' || 'cargo' }}
+          test
+          --release
+          --locked
+          --features ${{ env.REQUIRED_FEATURES }}
+          --target=${{ matrix.target }}
+          ${{ steps.options.outputs.cargo-build-options }}
+          ${{ steps.options.outputs.cargo-test-options }}
 
       - name: Create tarball
         id: package

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,39 @@ default-run = "rattler-build"
 
 [features]
 default = ['native-tls']
-native-tls = ['reqwest/native-tls', 'rattler/native-tls', 'rattler_installs_packages/native-tls']
-rustls-tls = ['reqwest/rustls-tls', 'reqwest/rustls-tls-native-roots', 'rattler/rustls-tls', 'rattler_installs_packages/rustls-tls']
-tui = ['ratatui', 'crossterm', 'ansi-to-tui', 'throbber-widgets-tui', 'tui-input']
+native-tls = [
+    'reqwest/native-tls',
+    'rattler/native-tls',
+    'rattler_installs_packages/native-tls',
+]
+rustls-tls = [
+    'reqwest/rustls-tls',
+    'reqwest/rustls-tls-native-roots',
+    'rattler/rustls-tls',
+    'rattler_installs_packages/rustls-tls',
+]
+tui = [
+    'ratatui',
+    'crossterm',
+    'ansi-to-tui',
+    'throbber-widgets-tui',
+    'tui-input',
+]
+recipe-generation = ['rattler_installs_packages']
+
 generate-cli-docs = ["clap-markdown"]
+
+[[bin]]
+name = "rattler-build"
+required-features = ["recipe-generation"]
 
 [dependencies]
 serde = { version = "1.0.204", features = ["derive"] }
 serde_yaml = "0.9.34"
-rattler = { version = "0.27.2", default-features = false, features = ["cli-tools", "indicatif"] }
+rattler = { version = "0.27.2", default-features = false, features = [
+    "cli-tools",
+    "indicatif",
+] }
 rattler_conda_types = { version = "0.26.3", default-features = false }
 rattler_digest = { version = "0.19.5", default-features = false }
 rattler_index = { version = "0.19.21", default-features = false }
@@ -36,7 +60,7 @@ rattler_shell = { version = "0.21.3", default-features = false, features = [
 ] }
 rattler_solve = { version = "0.25.3", default-features = false, features = [
     "resolvo",
-    "serde"
+    "serde",
 ] }
 rattler_virtual_packages = { version = "0.19.20", default-features = false }
 rattler_package_streaming = { version = "0.21.7", default-features = false }
@@ -63,7 +87,7 @@ tracing-subscriber = { version = "0.3.18", features = [
     "env-filter",
     "fmt",
     "ansi",
-    "json"
+    "json",
 ] }
 marked-yaml = { version = "0.7.1" }
 miette = { version = "7.2.0", features = ["fancy"] }
@@ -106,7 +130,7 @@ zstd = "0.13.2"
 toml = "0.8.15"
 memmap2 = "0.9.4"
 reqwest-middleware = "0.3.2"
-rattler_installs_packages = { version = "0.9.0", default-features = false }
+rattler_installs_packages = { version = "0.9.0", default-features = false, optional = true }
 async-once-cell = "0.5.3"
 terminal_size = "0.3.0"
 memchr = "2.7.4"
@@ -155,7 +179,7 @@ pre-build = [
 #rattler_solve = { git = "https://github.com/baszalmstra/rattler", branch = "fix/quote_nushell_var" }
 #rattler_virtual_packages = { git = "https://github.com/baszalmstra/rattler", branch = "fix/quote_nushell_var" }
 #rattler_package_streaming = { git = "https://github.com/baszalmstra/rattler", branch = "fix/quote_nushell_var" }
-clap-markdown = { git = "https://github.com/ruben-arts/clap-markdown", branch = "main"}
+clap-markdown = { git = "https://github.com/ruben-arts/clap-markdown", branch = "main" }
 
 
 # rattler = { path = "../rattler/crates/rattler" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://prefix-dev.github.io/rattler-build"
 default-run = "rattler-build"
 
 [features]
-default = ['native-tls']
+default = ['native-tls', 'recipe-generation']
 native-tls = [
     'reqwest/native-tls',
     'rattler/native-tls',

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ serde_json = "1.0.120"
 reqwest = { version = "0.12.5", default-features = false, features = [
     "multipart",
 ] }
-tokio = { version = "1.39.1", features = ["rt", "macros", "rt-multi-thread"] }
+tokio = { version = "1.39.1", features = ["rt", "macros", "rt-multi-thread", "process"] }
 itertools = "0.13.0"
 content_inspector = "0.2.4"
 serde_with = "3.9.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ mod linux;
 mod macos;
 mod post_process;
 pub mod rebuild;
+#[cfg(feature = "recipe-generation")]
 pub mod recipe_generator;
 mod unix;
 pub mod upload;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,9 +11,8 @@ use rattler_build::{
     console_utils::init_logging,
     get_build_output, get_recipe_path, get_tool_config,
     opt::{App, ShellCompletion, SubCommands},
-    rebuild_from_args,
-    recipe_generator::generate_recipe,
-    run_build_from_args, run_test_from_args, sort_build_outputs_topologically, upload_from_args,
+    rebuild_from_args, run_build_from_args, run_test_from_args, sort_build_outputs_topologically,
+    upload_from_args,
 };
 use tempfile::tempdir;
 
@@ -134,7 +133,9 @@ async fn main() -> miette::Result<()> {
         }
         Some(SubCommands::Upload(upload_args)) => upload_from_args(upload_args).await,
         #[cfg(feature = "recipe-generator")]
-        Some(SubCommands::GenerateRecipe(args)) => generate_recipe(args).await,
+        Some(SubCommands::GenerateRecipe(args)) => {
+            rattler_build::recipe_generator::generate_recipe(args).await
+        }
         Some(SubCommands::Auth(args)) => rattler::cli::auth::execute(args).await.into_diagnostic(),
         None => {
             _ = App::command().print_long_help();

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,6 +133,7 @@ async fn main() -> miette::Result<()> {
             .await
         }
         Some(SubCommands::Upload(upload_args)) => upload_from_args(upload_args).await,
+        #[cfg(feature = "recipe-generator")]
         Some(SubCommands::GenerateRecipe(args)) => generate_recipe(args).await,
         Some(SubCommands::Auth(args)) => rattler::cli::auth::execute(args).await.into_diagnostic(),
         None => {

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -2,9 +2,11 @@
 
 use std::{path::PathBuf, str::FromStr};
 
+#[cfg(feature = "recipe-generator")]
+use crate::recipe_generator::GenerateRecipeOpts;
+
 use crate::{
     console_utils::{Color, LogStyle},
-    recipe_generator::GenerateRecipeOpts,
     tool_configuration::SkipExisting,
 };
 use clap::builder::ArgPredicate;
@@ -45,6 +47,7 @@ pub enum SubCommands {
     /// Generate shell completion script
     Completion(ShellCompletion),
 
+    #[cfg(feature = "recipe-generator")]
     /// Generate a recipe from PyPI or CRAN
     GenerateRecipe(GenerateRecipeOpts),
 


### PR DESCRIPTION
This adds rip as an optional and makes the recipe-generation module gated behind a feature. This is done only for the `lib` the `bin` has that feature as required.

~~Will be a draft until we verify that this works.~~