### PR TITLE
ci: run `clippy` on the whole workspace

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           reporter: "github-pr-check"
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          clippy_flags: "--all-targets"
+          clippy_flags: "--all-targets --workspace"
 
   build:
     name: Build ${{ matrix.target }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,6 @@ repos:
       - id: clippy
         name: clippy
         description: Checks a package to catch common mistakes and improve your Rust code.
-        entry: cargo clippy --all-targets --color always
+        entry: cargo clippy --all-targets --workspace --color always
         language: system
         pass_filenames: false


### PR DESCRIPTION
Add `--workspace` flag. That way it is run on the whole workspace.