### PR TITLE
ci: always run on push and PR

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -1,17 +1,7 @@
 on:
   push:
     branches: [ main ]
-    paths:
-      - "src/**"
-      - "Cargo.*"
-      - "rust-tests/**"
-      - "test/end-to-end/**"
   pull_request:
-    paths:
-      - "src/**"
-      - "Cargo.*"
-      - "rust-tests/**"
-      - "test/end-to-end/**"
 
 name: End-to-End testing
 


### PR DESCRIPTION
It used to be filtered by path which doesn't mix well will required jobs