### PR TITLE
fix: CLI docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,10 +725,10 @@ dependencies = [
 [[package]]
 name = "clap-markdown"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325f50228f76921784b6d9f2d62de6778d834483248eefecd27279174797e579"
+source = "git+https://github.com/ruben-arts/clap-markdown?branch=main#bc771f47df47b7b3968c8d08c89372fcd91b5be3"
 dependencies = [
  "clap",
+ "indexmap 2.4.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,7 +169,7 @@ pre-build = [
     "apt-get update && apt-get install --assume-yes libssl-dev:$CROSS_DEB_ARCH",
 ]
 
-# [patch.crates-io]
+[patch.crates-io]
 # rattler = { git = "https://github.com/nichmor/rattler", branch = "feat/add-extra-field-on-about-json" }
 # rattler_conda_types = { git = "https://github.com/nichmor/rattler", branch = "feat/add-extra-field-on-about-json" }
 # rattler_digest = { git = "https://github.com/nichmor/rattler", branch = "feat/add-extra-field-on-about-json" }
@@ -181,7 +181,7 @@ pre-build = [
 # rattler_solve = { git = "https://github.com/nichmor/rattler", branch = "feat/add-extra-field-on-about-json" }
 # rattler_virtual_packages = { git = "https://github.com/nichmor/rattler", branch = "feat/add-extra-field-on-about-json" }
 # rattler_package_streaming = { git = "https://github.com/nichmor/rattler", branch = "feat/add-extra-field-on-about-json" }
-# clap-markdown = { git = "https://github.com/ruben-arts/clap-markdown", branch = "main" }
+clap-markdown = { git = "https://github.com/ruben-arts/clap-markdown", branch = "main" }
 
 
 # rattler = { path = "../rattler/crates/rattler" }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2,11 +2,30 @@
 
 This document contains the help content for the `rattler-build` command-line program.
 
+**Command Overview:**
+
+* [`rattler-build`↴](#rattler-build)
+* [`rattler-build build`↴](#rattler-build-build)
+* [`rattler-build test`↴](#rattler-build-test)
+* [`rattler-build rebuild`↴](#rattler-build-rebuild)
+* [`rattler-build upload`↴](#rattler-build-upload)
+* [`rattler-build upload quetz`↴](#rattler-build-upload-quetz)
+* [`rattler-build upload artifactory`↴](#rattler-build-upload-artifactory)
+* [`rattler-build upload prefix`↴](#rattler-build-upload-prefix)
+* [`rattler-build upload anaconda`↴](#rattler-build-upload-anaconda)
+* [`rattler-build completion`↴](#rattler-build-completion)
+* [`rattler-build generate-recipe`↴](#rattler-build-generate-recipe)
+* [`rattler-build generate-recipe pypi`↴](#rattler-build-generate-recipe-pypi)
+* [`rattler-build generate-recipe cran`↴](#rattler-build-generate-recipe-cran)
+* [`rattler-build auth`↴](#rattler-build-auth)
+* [`rattler-build auth login`↴](#rattler-build-auth-login)
+* [`rattler-build auth logout`↴](#rattler-build-auth-logout)
+
 ## `rattler-build`
 
 **Usage:** `rattler-build [OPTIONS] [COMMAND]`
 
-##### **Subcommands:**
+###### **Subcommands:**
 
 * `build` — Build a package from a recipe
 * `test` — Run a test for a single package
@@ -16,228 +35,144 @@ This document contains the help content for the `rattler-build` command-line pro
 * `generate-recipe` — Generate a recipe from PyPI or CRAN
 * `auth` — Handle authentication to external channels
 
-##### **Options:**
+###### **Options:**
 
-- `-v`, `--verbose`
+* `-v`, `--verbose` — Increase logging verbosity
+* `-q`, `--quiet` — Decrease logging verbosity
+* `--log-style <LOG_STYLE>` — Logging style
 
-	Increase logging verbosity
+  Default value: `fancy`
 
+  Possible values:
+  - `fancy`:
+    Use fancy logging output
+  - `json`:
+    Use JSON logging output
+  - `plain`:
+    Use plain logging output
 
-- `-q`, `--quiet`
+* `--color <COLOR>` — Enable or disable colored output from rattler-build. Also honors the `CLICOLOR` and `CLICOLOR_FORCE` environment variable
 
-	Decrease logging verbosity
+  Default value: `auto`
 
-
-- `--log-style <LOG_STYLE>`
-
-	Logging style
-
-	- Default value: `fancy`
-	- Possible values:
-		- `fancy`:
-			Use fancy logging output
-		- `json`:
-			Use JSON logging output
-		- `plain`:
-			Use plain logging output
-
-
-- `--color <COLOR>`
-
-	Enable or disable colored output from rattler-build. Also honors the `CLICOLOR` and `CLICOLOR_FORCE` environment variable
-
-	- Default value: `auto`
-	- Possible values:
-		- `always`:
-			Always use colors
-		- `never`:
-			Never use colors
-		- `auto`:
-			Use colors when the output is a terminal
+  Possible values:
+  - `always`:
+    Always use colors
+  - `never`:
+    Never use colors
+  - `auto`:
+    Use colors when the output is a terminal
 
 
 
 
-
-### `build`
+## `rattler-build build`
 
 Build a package from a recipe
 
 **Usage:** `rattler-build build [OPTIONS]`
 
-##### **Options:**
+###### **Options:**
 
-- `-r`, `--recipe <RECIPE>`
+* `-r`, `--recipe <RECIPE>` — The recipe file or directory containing `recipe.yaml`. Defaults to the current directory
 
-	The recipe file or directory containing `recipe.yaml`. Defaults to the current directory
+  Default value: `.`
+* `--recipe-dir <RECIPE_DIR>` — The directory that contains recipes
+* `--up-to <UP_TO>` — Build recipes up to the specified package
+* `--build-platform <BUILD_PLATFORM>` — The build platform to use for the build (e.g. for building with emulation, or rendering)
 
-	- Default value: `.`
+  Default value: current platform
+* `--target-platform <TARGET_PLATFORM>` — The target platform for the build
 
-- `--recipe-dir <RECIPE_DIR>`
+  Default value: current platform
+* `-c`, `--channel <CHANNEL>` — Add a channel to search for dependencies in
 
-	The directory that contains recipes
+  Default value: `conda-forge`
+* `-m`, `--variant-config <VARIANT_CONFIG>` — Variant configuration files for the build
+* `--ignore-recipe-variants` — Do not read the `variants.yaml` file next to a recipe
 
+  Possible values: `true`, `false`
 
-- `--up-to <UP_TO>`
+* `--render-only` — Render the recipe files without executing the build
 
-	Build recipes up to the specified package
+  Possible values: `true`, `false`
 
+* `--with-solve` — Render the recipe files with solving dependencies
 
-- `--build-platform <BUILD_PLATFORM>`
+  Possible values: `true`, `false`
 
-	The build platform to use for the build (e.g. for building with emulation, or rendering)
+* `--keep-build` — Keep intermediate build artifacts after the build
 
-	- Default value: current platform
+  Possible values: `true`, `false`
 
-- `--target-platform <TARGET_PLATFORM>`
+* `--no-build-id` — Don't use build id(timestamp) when creating build directory name
 
-	The target platform for the build
+  Possible values: `true`, `false`
 
-	- Default value: current platform
-
-- `-c`, `--channel <CHANNEL>`
-
-	Add a channel to search for dependencies in
-
-	- Default value: `conda-forge`
-
-- `-m`, `--variant-config <VARIANT_CONFIG>`
-
-	Variant configuration files for the build
-
-
-- `--ignore-recipe-variants`
-
-	Do not read the `variants.yaml` file next to a recipe
-
-	- Possible values: `true`, `false`
-
-
-- `--render-only`
-
-	Render the recipe files without executing the build
-
-	- Possible values: `true`, `false`
-
-
-- `--with-solve`
-
-	Render the recipe files with solving dependencies
-
-	- Possible values: `true`, `false`
-
-
-- `--keep-build`
-
-	Keep intermediate build artifacts after the build
-
-	- Possible values: `true`, `false`
-
-
-- `--no-build-id`
-
-	Don't use build id(timestamp) when creating build directory name
-
-	- Possible values: `true`, `false`
-
-
-- `--compression-threads <COMPRESSION_THREADS>`
-
-	The number of threads to use for compression (only relevant when also using `--package-format conda`)
-
-
-- `--use-zstd`
-
-	Enable support for repodata.json.zst
-
-	- Default value: `true`
-	- Possible values: `true`, `false`
-
-
-- `--use-bz2`
-
-	Enable support for repodata.json.bz2
-
-	- Default value: `true`
-	- Possible values: `true`, `false`
-
-
-- `--experimental`
-
-	Enable experimental features
-
-	- Possible values: `true`, `false`
-
-
-- `--auth-file <AUTH_FILE>`
-
-	Path to an auth-file to read authentication information from
-
-
-- `--tui`
-
-	Launch the terminal user interface
-
-	- Default value: `false`
-	- Possible values: `true`, `false`
-
-
-###### **Modifying result**
-
-- `--package-format <PACKAGE_FORMAT>`
-
-	The package format to use for the build. Can be one of `tar-bz2` or `conda`.
+* `--package-format <PACKAGE_FORMAT>` — The package format to use for the build. Can be one of `tar-bz2` or `conda`.
 You can also add a compression level to the package format, e.g. `tar-bz2:<number>` (from 1 to 9) or `conda:<number>` (from -7 to 22).
 
-	- Default value: `conda`
+  Default value: `conda`
+* `--compression-threads <COMPRESSION_THREADS>` — The number of threads to use for compression (only relevant when also using `--package-format conda`)
+* `--no-include-recipe` — Don't store the recipe in the final package
 
-- `--no-include-recipe`
+  Possible values: `true`, `false`
 
-	Don't store the recipe in the final package
+* `--no-test` — Don't run the tests after building the package
 
-	- Possible values: `true`, `false`
+  Default value: `false`
+
+  Possible values: `true`, `false`
+
+* `--color-build-log` — Don't force colors in the output of the build script
+
+  Default value: `true`
+
+  Possible values: `true`, `false`
+
+* `--output-dir <OUTPUT_DIR>` — Output directory for build artifacts.
+
+  Default value: `./output`
+* `--use-zstd` — Enable support for repodata.json.zst
+
+  Default value: `true`
+
+  Possible values: `true`, `false`
+
+* `--use-bz2` — Enable support for repodata.json.bz2
+
+  Default value: `true`
+
+  Possible values: `true`, `false`
+
+* `--experimental` — Enable experimental features
+
+  Possible values: `true`, `false`
+
+* `--auth-file <AUTH_FILE>` — Path to an auth-file to read authentication information from
+* `--tui` — Launch the terminal user interface
+
+  Default value: `false`
+
+  Possible values: `true`, `false`
+
+* `--skip-existing <SKIP_EXISTING>` — Whether to skip packages that already exist in any channel If set to `none`, do not skip any packages, default when not specified. If set to `local`, only skip packages that already exist locally, default when using `--skip-existing. If set to `all`, skip packages that already exist in any channel
+
+  Default value: `none`
+
+  Possible values:
+  - `none`:
+    Do not skip any packages
+  - `local`:
+    Skip packages that already exist locally
+  - `all`:
+    Skip packages that already exist in any channel
+
+* `--extra-meta <EXTRA_META>` — Extra metadata to include in about.json
 
 
-- `--no-test`
 
-	Don't run the tests after building the package
-
-	- Default value: `false`
-	- Possible values: `true`, `false`
-
-
-- `--color-build-log`
-
-	Don't force colors in the output of the build script
-
-	- Default value: `true`
-	- Possible values: `true`, `false`
-
-
-- `--output-dir <OUTPUT_DIR>`
-
-	Output directory for build artifacts.
-
-	- Default value: `./output`
-
-- `--skip-existing <SKIP_EXISTING>`
-
-	Whether to skip packages that already exist in any channel If set to `none`, do not skip any packages, default when not specified. If set to `local`, only skip packages that already exist locally, default when using `--skip-existing. If set to `all`, skip packages that already exist in any channel
-
-	- Default value: `none`
-	- Possible values:
-		- `none`:
-			Do not skip any packages
-		- `local`:
-			Skip packages that already exist locally
-		- `all`:
-			Skip packages that already exist in any channel
-
-
-
-
-
-### `test`
+## `rattler-build test`
 
 Run a test for a single package
 
@@ -251,501 +186,319 @@ These test files are written at "package creation time" and are part of the pack
 
 **Usage:** `rattler-build test [OPTIONS] --package-file <PACKAGE_FILE>`
 
-##### **Options:**
+###### **Options:**
 
-- `-c`, `--channel <CHANNEL>`
+* `-c`, `--channel <CHANNEL>` — Channels to use when testing
+* `-p`, `--package-file <PACKAGE_FILE>` — The package file to test
+* `--compression-threads <COMPRESSION_THREADS>` — The number of threads to use for compression
+* `--output-dir <OUTPUT_DIR>` — Output directory for build artifacts.
 
-	Channels to use when testing
+  Default value: `./output`
+* `--use-zstd` — Enable support for repodata.json.zst
 
+  Default value: `true`
 
-- `-p`, `--package-file <PACKAGE_FILE>`
+  Possible values: `true`, `false`
 
-	The package file to test
+* `--use-bz2` — Enable support for repodata.json.bz2
 
+  Default value: `true`
 
-- `--compression-threads <COMPRESSION_THREADS>`
+  Possible values: `true`, `false`
 
-	The number of threads to use for compression
+* `--experimental` — Enable experimental features
 
+  Possible values: `true`, `false`
 
-- `--use-zstd`
-
-	Enable support for repodata.json.zst
-
-	- Default value: `true`
-	- Possible values: `true`, `false`
-
-
-- `--use-bz2`
-
-	Enable support for repodata.json.bz2
-
-	- Default value: `true`
-	- Possible values: `true`, `false`
-
-
-- `--experimental`
-
-	Enable experimental features
-
-	- Possible values: `true`, `false`
-
-
-- `--auth-file <AUTH_FILE>`
-
-	Path to an auth-file to read authentication information from
-
-
-###### **Modifying result**
-
-- `--output-dir <OUTPUT_DIR>`
-
-	Output directory for build artifacts.
-
-	- Default value: `./output`
+* `--auth-file <AUTH_FILE>` — Path to an auth-file to read authentication information from
 
 
 
-
-### `rebuild`
+## `rattler-build rebuild`
 
 Rebuild a package from a package file instead of a recipe
 
 **Usage:** `rattler-build rebuild [OPTIONS] --package-file <PACKAGE_FILE>`
 
-##### **Options:**
+###### **Options:**
 
-- `-p`, `--package-file <PACKAGE_FILE>`
+* `-p`, `--package-file <PACKAGE_FILE>` — The package file to rebuild
+* `--no-test` — Do not run tests after building
 
-	The package file to rebuild
+  Default value: `false`
 
+  Possible values: `true`, `false`
 
-- `--no-test`
+* `--compression-threads <COMPRESSION_THREADS>` — The number of threads to use for compression
+* `--output-dir <OUTPUT_DIR>` — Output directory for build artifacts.
 
-	Do not run tests after building
+  Default value: `./output`
+* `--use-zstd` — Enable support for repodata.json.zst
 
-	- Default value: `false`
-	- Possible values: `true`, `false`
+  Default value: `true`
 
+  Possible values: `true`, `false`
 
-- `--compression-threads <COMPRESSION_THREADS>`
+* `--use-bz2` — Enable support for repodata.json.bz2
 
-	The number of threads to use for compression
+  Default value: `true`
 
+  Possible values: `true`, `false`
 
-- `--use-zstd`
+* `--experimental` — Enable experimental features
 
-	Enable support for repodata.json.zst
+  Possible values: `true`, `false`
 
-	- Default value: `true`
-	- Possible values: `true`, `false`
-
-
-- `--use-bz2`
-
-	Enable support for repodata.json.bz2
-
-	- Default value: `true`
-	- Possible values: `true`, `false`
-
-
-- `--experimental`
-
-	Enable experimental features
-
-	- Possible values: `true`, `false`
-
-
-- `--auth-file <AUTH_FILE>`
-
-	Path to an auth-file to read authentication information from
-
-
-###### **Modifying result**
-
-- `--output-dir <OUTPUT_DIR>`
-
-	Output directory for build artifacts.
-
-	- Default value: `./output`
+* `--auth-file <AUTH_FILE>` — Path to an auth-file to read authentication information from
 
 
 
-
-### `upload`
+## `rattler-build upload`
 
 Upload a package
 
 **Usage:** `rattler-build upload [OPTIONS] [PACKAGE_FILES]... <COMMAND>`
 
-##### **Subcommands:**
+###### **Subcommands:**
 
 * `quetz` — Upload to aQuetz server. Authentication is used from the keychain / auth-file
 * `artifactory` — Options for uploading to a Artifactory channel. Authentication is used from the keychain / auth-file
 * `prefix` — Options for uploading to a prefix.dev server. Authentication is used from the keychain / auth-file
 * `anaconda` — Options for uploading to a Anaconda.org server
 
-##### **Arguments:**
+###### **Arguments:**
 
-- `<PACKAGE_FILES>`
+* `<PACKAGE_FILES>` — The package file to upload
 
-	The package file to upload
+###### **Options:**
 
+* `--output-dir <OUTPUT_DIR>` — Output directory for build artifacts.
 
+  Default value: `./output`
+* `--use-zstd` — Enable support for repodata.json.zst
 
-##### **Options:**
+  Default value: `true`
 
-- `--use-zstd`
+  Possible values: `true`, `false`
 
-	Enable support for repodata.json.zst
+* `--use-bz2` — Enable support for repodata.json.bz2
 
-	- Default value: `true`
-	- Possible values: `true`, `false`
+  Default value: `true`
 
+  Possible values: `true`, `false`
 
-- `--use-bz2`
+* `--experimental` — Enable experimental features
 
-	Enable support for repodata.json.bz2
+  Possible values: `true`, `false`
 
-	- Default value: `true`
-	- Possible values: `true`, `false`
-
-
-- `--experimental`
-
-	Enable experimental features
-
-	- Possible values: `true`, `false`
-
-
-- `--auth-file <AUTH_FILE>`
-
-	Path to an auth-file to read authentication information from
-
-
-###### **Modifying result**
-
-- `--output-dir <OUTPUT_DIR>`
-
-	Output directory for build artifacts.
-
-	- Default value: `./output`
+* `--auth-file <AUTH_FILE>` — Path to an auth-file to read authentication information from
 
 
 
-
-#### `quetz`
+## `rattler-build upload quetz`
 
 Upload to aQuetz server. Authentication is used from the keychain / auth-file
 
 **Usage:** `rattler-build upload quetz [OPTIONS] --url <URL> --channel <CHANNEL>`
 
-##### **Options:**
+###### **Options:**
 
-- `-u`, `--url <URL>`
-
-	The URL to your Quetz server
-
-
-- `-c`, `--channel <CHANNEL>`
-
-	The URL to your channel
-
-
-- `-a`, `--api-key <API_KEY>`
-
-	The Quetz API key, if none is provided, the token is read from the keychain / auth-file
+* `-u`, `--url <URL>` — The URL to your Quetz server
+* `-c`, `--channel <CHANNEL>` — The URL to your channel
+* `-a`, `--api-key <API_KEY>` — The Quetz API key, if none is provided, the token is read from the keychain / auth-file
 
 
 
-
-
-#### `artifactory`
+## `rattler-build upload artifactory`
 
 Options for uploading to a Artifactory channel. Authentication is used from the keychain / auth-file
 
 **Usage:** `rattler-build upload artifactory [OPTIONS] --url <URL> --channel <CHANNEL>`
 
-##### **Options:**
+###### **Options:**
 
-- `-u`, `--url <URL>`
-
-	The URL to your Artifactory server
-
-
-- `-c`, `--channel <CHANNEL>`
-
-	The URL to your channel
-
-
-- `-r`, `--username <USERNAME>`
-
-	Your Artifactory username
-
-
-- `-p`, `--password <PASSWORD>`
-
-	Your Artifactory password
+* `-u`, `--url <URL>` — The URL to your Artifactory server
+* `-c`, `--channel <CHANNEL>` — The URL to your channel
+* `-r`, `--username <USERNAME>` — Your Artifactory username
+* `-p`, `--password <PASSWORD>` — Your Artifactory password
 
 
 
-
-
-#### `prefix`
+## `rattler-build upload prefix`
 
 Options for uploading to a prefix.dev server. Authentication is used from the keychain / auth-file
 
 **Usage:** `rattler-build upload prefix [OPTIONS] --channel <CHANNEL>`
 
-##### **Options:**
+###### **Options:**
 
-- `-u`, `--url <URL>`
+* `-u`, `--url <URL>` — The URL to the prefix.dev server (only necessary for self-hosted instances)
 
-	The URL to the prefix.dev server (only necessary for self-hosted instances)
-
-	- Default value: `https://prefix.dev`
-
-- `-c`, `--channel <CHANNEL>`
-
-	The channel to upload the package to
-
-
-- `-a`, `--api-key <API_KEY>`
-
-	The prefix.dev API key, if none is provided, the token is read from the keychain / auth-file
+  Default value: `https://prefix.dev`
+* `-c`, `--channel <CHANNEL>` — The channel to upload the package to
+* `-a`, `--api-key <API_KEY>` — The prefix.dev API key, if none is provided, the token is read from the keychain / auth-file
 
 
 
-
-
-#### `anaconda`
+## `rattler-build upload anaconda`
 
 Options for uploading to a Anaconda.org server
 
 **Usage:** `rattler-build upload anaconda [OPTIONS] --owner <OWNER>`
 
-##### **Options:**
+###### **Options:**
 
-- `-o`, `--owner <OWNER>`
+* `-o`, `--owner <OWNER>` — The owner of the distribution (e.g. conda-forge or your username)
+* `-c`, `--channel <CHANNEL>` — The channel / label to upload the package to (e.g. main / rc)
 
-	The owner of the distribution (e.g. conda-forge or your username)
+  Default value: `main`
+* `-a`, `--api-key <API_KEY>` — The Anaconda API key, if none is provided, the token is read from the keychain / auth-file
+* `-u`, `--url <URL>` — The URL to the Anaconda server
 
+  Default value: `https://api.anaconda.org`
+* `-f`, `--force` — Replace files on conflict
 
-- `-c`, `--channel <CHANNEL>`
+  Default value: `false`
 
-	The channel / label to upload the package to (e.g. main / rc)
-
-	- Default value: `main`
-
-- `-a`, `--api-key <API_KEY>`
-
-	The Anaconda API key, if none is provided, the token is read from the keychain / auth-file
-
-
-- `-u`, `--url <URL>`
-
-	The URL to the Anaconda server
-
-	- Default value: `https://api.anaconda.org`
-
-- `-f`, `--force`
-
-	Replace files on conflict
-
-	- Default value: `false`
-	- Possible values: `true`, `false`
+  Possible values: `true`, `false`
 
 
 
 
-
-### `completion`
+## `rattler-build completion`
 
 Generate shell completion script
 
 **Usage:** `rattler-build completion --shell <SHELL>`
 
-##### **Options:**
+###### **Options:**
 
-- `-s`, `--shell <SHELL>`
+* `-s`, `--shell <SHELL>` — Specifies the shell for which the completions should be generated
 
-	Specifies the shell for which the completions should be generated
-
-	- Possible values:
-		- `bash`:
-			Bourne Again SHell (bash)
-		- `elvish`:
-			Elvish shell
-		- `fish`:
-			Friendly Interactive SHell (fish)
-		- `nushell`:
-			Nushell
-		- `powershell`:
-			PowerShell
-		- `zsh`:
-			Z SHell (zsh)
+  Possible values:
+  - `bash`:
+    Bourne Again SHell (bash)
+  - `elvish`:
+    Elvish shell
+  - `fish`:
+    Friendly Interactive SHell (fish)
+  - `nushell`:
+    Nushell
+  - `powershell`:
+    PowerShell
+  - `zsh`:
+    Z SHell (zsh)
 
 
 
 
-
-### `generate-recipe`
+## `rattler-build generate-recipe`
 
 Generate a recipe from PyPI or CRAN
 
 **Usage:** `rattler-build generate-recipe <COMMAND>`
 
-##### **Subcommands:**
+###### **Subcommands:**
 
 * `pypi` — Generate a recipe for a Python package from PyPI
 * `cran` — Generate a recipe for an R package from CRAN
 
 
 
-#### `pypi`
+## `rattler-build generate-recipe pypi`
 
 Generate a recipe for a Python package from PyPI
 
 **Usage:** `rattler-build generate-recipe pypi [OPTIONS] <PACKAGE>`
 
-##### **Arguments:**
+###### **Arguments:**
 
-- `<PACKAGE>`
+* `<PACKAGE>` — Name of the package to generate
 
-	Name of the package to generate
+###### **Options:**
 
+* `-w`, `--write` — Whether to write the recipe to a folder
 
+  Possible values: `true`, `false`
 
-##### **Options:**
+* `-u`, `--use-mapping` — Whether to use the conda-forge PyPI name mapping
 
-- `-w`, `--write`
+  Default value: `true`
 
-	Whether to write the recipe to a folder
+  Possible values: `true`, `false`
 
-	- Possible values: `true`, `false`
+* `-t`, `--tree` — Whether to generate recipes for all dependencies
 
-
-- `-u`, `--use-mapping`
-
-	Whether to use the conda-forge PyPI name mapping
-
-	- Default value: `true`
-	- Possible values: `true`, `false`
-
-
-- `-t`, `--tree`
-
-	Whether to generate recipes for all dependencies
-
-	- Possible values: `true`, `false`
+  Possible values: `true`, `false`
 
 
 
 
-
-#### `cran`
+## `rattler-build generate-recipe cran`
 
 Generate a recipe for an R package from CRAN
 
 **Usage:** `rattler-build generate-recipe cran [OPTIONS] <PACKAGE>`
 
-##### **Arguments:**
+###### **Arguments:**
 
-- `<PACKAGE>`
+* `<PACKAGE>` — Name of the package to generate
 
-	Name of the package to generate
+###### **Options:**
 
+* `-u`, `--universe <UNIVERSE>` — The R Universe to fetch the package from (defaults to `cran`)
+* `-t`, `--tree` — Whether to create recipes for the whole dependency tree or not
 
+  Possible values: `true`, `false`
 
-##### **Options:**
+* `-w`, `--write` — Whether to write the recipe to a folder
 
-- `-u`, `--universe <UNIVERSE>`
-
-	The R Universe to fetch the package from (defaults to `cran`)
-
-
-- `-t`, `--tree`
-
-	Whether to create recipes for the whole dependency tree or not
-
-	- Possible values: `true`, `false`
-
-
-- `-w`, `--write`
-
-	Whether to write the recipe to a folder
-
-	- Possible values: `true`, `false`
+  Possible values: `true`, `false`
 
 
 
 
-
-### `auth`
+## `rattler-build auth`
 
 Handle authentication to external channels
 
 **Usage:** `rattler-build auth <COMMAND>`
 
-##### **Subcommands:**
+###### **Subcommands:**
 
 * `login` — Store authentication information for a given host
 * `logout` — Remove authentication information for a given host
 
 
 
-#### `login`
+## `rattler-build auth login`
 
 Store authentication information for a given host
 
 **Usage:** `rattler-build auth login [OPTIONS] <HOST>`
 
-##### **Arguments:**
+###### **Arguments:**
 
-- `<HOST>`
+* `<HOST>` — The host to authenticate with (e.g. repo.prefix.dev)
 
-	The host to authenticate with (e.g. repo.prefix.dev)
+###### **Options:**
 
-
-
-##### **Options:**
-
-- `--token <TOKEN>`
-
-	The token to use (for authentication with prefix.dev)
-
-
-- `--username <USERNAME>`
-
-	The username to use (for basic HTTP authentication)
-
-
-- `--password <PASSWORD>`
-
-	The password to use (for basic HTTP authentication)
-
-
-- `--conda-token <CONDA_TOKEN>`
-
-	The token to use on anaconda.org / quetz authentication
+* `--token <TOKEN>` — The token to use (for authentication with prefix.dev)
+* `--username <USERNAME>` — The username to use (for basic HTTP authentication)
+* `--password <PASSWORD>` — The password to use (for basic HTTP authentication)
+* `--conda-token <CONDA_TOKEN>` — The token to use on anaconda.org / quetz authentication
 
 
 
-
-
-#### `logout`
+## `rattler-build auth logout`
 
 Remove authentication information for a given host
 
 **Usage:** `rattler-build auth logout <HOST>`
 
-##### **Arguments:**
+###### **Arguments:**
 
-- `<HOST>`
-
-	The host to remove authentication for
-
-
+* `<HOST>` — The host to remove authentication for
 
 
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2,30 +2,11 @@
 
 This document contains the help content for the `rattler-build` command-line program.
 
-**Command Overview:**
-
-* [`rattler-build`↴](#rattler-build)
-* [`rattler-build build`↴](#rattler-build-build)
-* [`rattler-build test`↴](#rattler-build-test)
-* [`rattler-build rebuild`↴](#rattler-build-rebuild)
-* [`rattler-build upload`↴](#rattler-build-upload)
-* [`rattler-build upload quetz`↴](#rattler-build-upload-quetz)
-* [`rattler-build upload artifactory`↴](#rattler-build-upload-artifactory)
-* [`rattler-build upload prefix`↴](#rattler-build-upload-prefix)
-* [`rattler-build upload anaconda`↴](#rattler-build-upload-anaconda)
-* [`rattler-build completion`↴](#rattler-build-completion)
-* [`rattler-build generate-recipe`↴](#rattler-build-generate-recipe)
-* [`rattler-build generate-recipe pypi`↴](#rattler-build-generate-recipe-pypi)
-* [`rattler-build generate-recipe cran`↴](#rattler-build-generate-recipe-cran)
-* [`rattler-build auth`↴](#rattler-build-auth)
-* [`rattler-build auth login`↴](#rattler-build-auth-login)
-* [`rattler-build auth logout`↴](#rattler-build-auth-logout)
-
 ## `rattler-build`
 
 **Usage:** `rattler-build [OPTIONS] [COMMAND]`
 
-###### **Subcommands:**
+##### **Subcommands:**
 
 * `build` — Build a package from a recipe
 * `test` — Run a test for a single package
@@ -35,144 +16,233 @@ This document contains the help content for the `rattler-build` command-line pro
 * `generate-recipe` — Generate a recipe from PyPI or CRAN
 * `auth` — Handle authentication to external channels
 
-###### **Options:**
+##### **Options:**
 
-* `-v`, `--verbose` — Increase logging verbosity
-* `-q`, `--quiet` — Decrease logging verbosity
-* `--log-style <LOG_STYLE>` — Logging style
+- `-v`, `--verbose`
 
-  Default value: `fancy`
-
-  Possible values:
-  - `fancy`:
-    Use fancy logging output
-  - `json`:
-    Use JSON logging output
-  - `plain`:
-    Use plain logging output
-
-* `--color <COLOR>` — Enable or disable colored output from rattler-build. Also honors the `CLICOLOR` and `CLICOLOR_FORCE` environment variable
-
-  Default value: `auto`
-
-  Possible values:
-  - `always`:
-    Always use colors
-  - `never`:
-    Never use colors
-  - `auto`:
-    Use colors when the output is a terminal
+	Increase logging verbosity
 
 
+- `-q`, `--quiet`
+
+	Decrease logging verbosity
 
 
-## `rattler-build build`
+- `--log-style <LOG_STYLE>`
+
+	Logging style
+
+	- Default value: `fancy`
+	- Possible values:
+		- `fancy`:
+			Use fancy logging output
+		- `json`:
+			Use JSON logging output
+		- `plain`:
+			Use plain logging output
+
+
+- `--color <COLOR>`
+
+	Enable or disable colored output from rattler-build. Also honors the `CLICOLOR` and `CLICOLOR_FORCE` environment variable
+
+	- Default value: `auto`
+	- Possible values:
+		- `always`:
+			Always use colors
+		- `never`:
+			Never use colors
+		- `auto`:
+			Use colors when the output is a terminal
+
+
+
+
+
+### `build`
 
 Build a package from a recipe
 
 **Usage:** `rattler-build build [OPTIONS]`
 
-###### **Options:**
+##### **Options:**
 
-* `-r`, `--recipe <RECIPE>` — The recipe file or directory containing `recipe.yaml`. Defaults to the current directory
+- `-r`, `--recipe <RECIPE>`
 
-  Default value: `.`
-* `--recipe-dir <RECIPE_DIR>` — The directory that contains recipes
-* `--up-to <UP_TO>` — Build recipes up to the specified package
-* `--build-platform <BUILD_PLATFORM>` — The build platform to use for the build (e.g. for building with emulation, or rendering)
+	The recipe file or directory containing `recipe.yaml`. Defaults to the current directory
 
-  Default value: current platform
-* `--target-platform <TARGET_PLATFORM>` — The target platform for the build
+	- Default value: `.`
 
-  Default value: current platform
-* `-c`, `--channel <CHANNEL>` — Add a channel to search for dependencies in
+- `--recipe-dir <RECIPE_DIR>`
 
-  Default value: `conda-forge`
-* `-m`, `--variant-config <VARIANT_CONFIG>` — Variant configuration files for the build
-* `--ignore-recipe-variants` — Do not read the `variants.yaml` file next to a recipe
+	The directory that contains recipes
 
-  Possible values: `true`, `false`
 
-* `--render-only` — Render the recipe files without executing the build
+- `--up-to <UP_TO>`
 
-  Possible values: `true`, `false`
+	Build recipes up to the specified package
 
-* `--with-solve` — Render the recipe files with solving dependencies
 
-  Possible values: `true`, `false`
+- `--build-platform <BUILD_PLATFORM>`
 
-* `--keep-build` — Keep intermediate build artifacts after the build
+	The build platform to use for the build (e.g. for building with emulation, or rendering)
 
-  Possible values: `true`, `false`
+	- Default value: current platform
 
-* `--no-build-id` — Don't use build id(timestamp) when creating build directory name
+- `--target-platform <TARGET_PLATFORM>`
 
-  Possible values: `true`, `false`
+	The target platform for the build
 
-* `--package-format <PACKAGE_FORMAT>` — The package format to use for the build. Can be one of `tar-bz2` or `conda`.
+	- Default value: current platform
+
+- `-c`, `--channel <CHANNEL>`
+
+	Add a channel to search for dependencies in
+
+	- Default value: `conda-forge`
+
+- `-m`, `--variant-config <VARIANT_CONFIG>`
+
+	Variant configuration files for the build
+
+
+- `--ignore-recipe-variants`
+
+	Do not read the `variants.yaml` file next to a recipe
+
+	- Possible values: `true`, `false`
+
+
+- `--render-only`
+
+	Render the recipe files without executing the build
+
+	- Possible values: `true`, `false`
+
+
+- `--with-solve`
+
+	Render the recipe files with solving dependencies
+
+	- Possible values: `true`, `false`
+
+
+- `--keep-build`
+
+	Keep intermediate build artifacts after the build
+
+	- Possible values: `true`, `false`
+
+
+- `--no-build-id`
+
+	Don't use build id(timestamp) when creating build directory name
+
+	- Possible values: `true`, `false`
+
+
+- `--compression-threads <COMPRESSION_THREADS>`
+
+	The number of threads to use for compression (only relevant when also using `--package-format conda`)
+
+
+- `--use-zstd`
+
+	Enable support for repodata.json.zst
+
+	- Default value: `true`
+	- Possible values: `true`, `false`
+
+
+- `--use-bz2`
+
+	Enable support for repodata.json.bz2
+
+	- Default value: `true`
+	- Possible values: `true`, `false`
+
+
+- `--experimental`
+
+	Enable experimental features
+
+	- Possible values: `true`, `false`
+
+
+- `--auth-file <AUTH_FILE>`
+
+	Path to an auth-file to read authentication information from
+
+
+- `--tui`
+
+	Launch the terminal user interface
+
+	- Default value: `false`
+	- Possible values: `true`, `false`
+
+
+- `--extra-meta <EXTRA_META>`
+
+	Extra metadata to include in about.json
+
+
+###### **Modifying result**
+
+- `--package-format <PACKAGE_FORMAT>`
+
+	The package format to use for the build. Can be one of `tar-bz2` or `conda`.
 You can also add a compression level to the package format, e.g. `tar-bz2:<number>` (from 1 to 9) or `conda:<number>` (from -7 to 22).
 
-  Default value: `conda`
-* `--compression-threads <COMPRESSION_THREADS>` — The number of threads to use for compression (only relevant when also using `--package-format conda`)
-* `--no-include-recipe` — Don't store the recipe in the final package
+	- Default value: `conda`
 
-  Possible values: `true`, `false`
+- `--no-include-recipe`
 
-* `--no-test` — Don't run the tests after building the package
+	Don't store the recipe in the final package
 
-  Default value: `false`
+	- Possible values: `true`, `false`
 
-  Possible values: `true`, `false`
 
-* `--color-build-log` — Don't force colors in the output of the build script
+- `--no-test`
 
-  Default value: `true`
+	Don't run the tests after building the package
 
-  Possible values: `true`, `false`
+	- Default value: `false`
+	- Possible values: `true`, `false`
 
-* `--output-dir <OUTPUT_DIR>` — Output directory for build artifacts.
 
-  Default value: `./output`
-* `--use-zstd` — Enable support for repodata.json.zst
+- `--color-build-log`
 
-  Default value: `true`
+	Don't force colors in the output of the build script
 
-  Possible values: `true`, `false`
+	- Default value: `true`
+	- Possible values: `true`, `false`
 
-* `--use-bz2` — Enable support for repodata.json.bz2
 
-  Default value: `true`
+- `--output-dir <OUTPUT_DIR>`
 
-  Possible values: `true`, `false`
+	Output directory for build artifacts.
 
-* `--experimental` — Enable experimental features
+	- Default value: `./output`
 
-  Possible values: `true`, `false`
+- `--skip-existing <SKIP_EXISTING>`
 
-* `--auth-file <AUTH_FILE>` — Path to an auth-file to read authentication information from
-* `--tui` — Launch the terminal user interface
+	Whether to skip packages that already exist in any channel If set to `none`, do not skip any packages, default when not specified. If set to `local`, only skip packages that already exist locally, default when using `--skip-existing. If set to `all`, skip packages that already exist in any channel
 
-  Default value: `false`
-
-  Possible values: `true`, `false`
-
-* `--skip-existing <SKIP_EXISTING>` — Whether to skip packages that already exist in any channel If set to `none`, do not skip any packages, default when not specified. If set to `local`, only skip packages that already exist locally, default when using `--skip-existing. If set to `all`, skip packages that already exist in any channel
-
-  Default value: `none`
-
-  Possible values:
-  - `none`:
-    Do not skip any packages
-  - `local`:
-    Skip packages that already exist locally
-  - `all`:
-    Skip packages that already exist in any channel
-
-* `--extra-meta <EXTRA_META>` — Extra metadata to include in about.json
+	- Default value: `none`
+	- Possible values:
+		- `none`:
+			Do not skip any packages
+		- `local`:
+			Skip packages that already exist locally
+		- `all`:
+			Skip packages that already exist in any channel
 
 
 
-## `rattler-build test`
+
+
+### `test`
 
 Run a test for a single package
 
@@ -186,319 +256,501 @@ These test files are written at "package creation time" and are part of the pack
 
 **Usage:** `rattler-build test [OPTIONS] --package-file <PACKAGE_FILE>`
 
-###### **Options:**
+##### **Options:**
 
-* `-c`, `--channel <CHANNEL>` — Channels to use when testing
-* `-p`, `--package-file <PACKAGE_FILE>` — The package file to test
-* `--compression-threads <COMPRESSION_THREADS>` — The number of threads to use for compression
-* `--output-dir <OUTPUT_DIR>` — Output directory for build artifacts.
+- `-c`, `--channel <CHANNEL>`
 
-  Default value: `./output`
-* `--use-zstd` — Enable support for repodata.json.zst
-
-  Default value: `true`
-
-  Possible values: `true`, `false`
-
-* `--use-bz2` — Enable support for repodata.json.bz2
-
-  Default value: `true`
-
-  Possible values: `true`, `false`
-
-* `--experimental` — Enable experimental features
-
-  Possible values: `true`, `false`
-
-* `--auth-file <AUTH_FILE>` — Path to an auth-file to read authentication information from
+	Channels to use when testing
 
 
+- `-p`, `--package-file <PACKAGE_FILE>`
 
-## `rattler-build rebuild`
+	The package file to test
+
+
+- `--compression-threads <COMPRESSION_THREADS>`
+
+	The number of threads to use for compression
+
+
+- `--use-zstd`
+
+	Enable support for repodata.json.zst
+
+	- Default value: `true`
+	- Possible values: `true`, `false`
+
+
+- `--use-bz2`
+
+	Enable support for repodata.json.bz2
+
+	- Default value: `true`
+	- Possible values: `true`, `false`
+
+
+- `--experimental`
+
+	Enable experimental features
+
+	- Possible values: `true`, `false`
+
+
+- `--auth-file <AUTH_FILE>`
+
+	Path to an auth-file to read authentication information from
+
+
+###### **Modifying result**
+
+- `--output-dir <OUTPUT_DIR>`
+
+	Output directory for build artifacts.
+
+	- Default value: `./output`
+
+
+
+
+### `rebuild`
 
 Rebuild a package from a package file instead of a recipe
 
 **Usage:** `rattler-build rebuild [OPTIONS] --package-file <PACKAGE_FILE>`
 
-###### **Options:**
+##### **Options:**
 
-* `-p`, `--package-file <PACKAGE_FILE>` — The package file to rebuild
-* `--no-test` — Do not run tests after building
+- `-p`, `--package-file <PACKAGE_FILE>`
 
-  Default value: `false`
-
-  Possible values: `true`, `false`
-
-* `--compression-threads <COMPRESSION_THREADS>` — The number of threads to use for compression
-* `--output-dir <OUTPUT_DIR>` — Output directory for build artifacts.
-
-  Default value: `./output`
-* `--use-zstd` — Enable support for repodata.json.zst
-
-  Default value: `true`
-
-  Possible values: `true`, `false`
-
-* `--use-bz2` — Enable support for repodata.json.bz2
-
-  Default value: `true`
-
-  Possible values: `true`, `false`
-
-* `--experimental` — Enable experimental features
-
-  Possible values: `true`, `false`
-
-* `--auth-file <AUTH_FILE>` — Path to an auth-file to read authentication information from
+	The package file to rebuild
 
 
+- `--no-test`
 
-## `rattler-build upload`
+	Do not run tests after building
+
+	- Default value: `false`
+	- Possible values: `true`, `false`
+
+
+- `--compression-threads <COMPRESSION_THREADS>`
+
+	The number of threads to use for compression
+
+
+- `--use-zstd`
+
+	Enable support for repodata.json.zst
+
+	- Default value: `true`
+	- Possible values: `true`, `false`
+
+
+- `--use-bz2`
+
+	Enable support for repodata.json.bz2
+
+	- Default value: `true`
+	- Possible values: `true`, `false`
+
+
+- `--experimental`
+
+	Enable experimental features
+
+	- Possible values: `true`, `false`
+
+
+- `--auth-file <AUTH_FILE>`
+
+	Path to an auth-file to read authentication information from
+
+
+###### **Modifying result**
+
+- `--output-dir <OUTPUT_DIR>`
+
+	Output directory for build artifacts.
+
+	- Default value: `./output`
+
+
+
+
+### `upload`
 
 Upload a package
 
 **Usage:** `rattler-build upload [OPTIONS] [PACKAGE_FILES]... <COMMAND>`
 
-###### **Subcommands:**
+##### **Subcommands:**
 
 * `quetz` — Upload to aQuetz server. Authentication is used from the keychain / auth-file
 * `artifactory` — Options for uploading to a Artifactory channel. Authentication is used from the keychain / auth-file
 * `prefix` — Options for uploading to a prefix.dev server. Authentication is used from the keychain / auth-file
 * `anaconda` — Options for uploading to a Anaconda.org server
 
-###### **Arguments:**
+##### **Arguments:**
 
-* `<PACKAGE_FILES>` — The package file to upload
+- `<PACKAGE_FILES>`
 
-###### **Options:**
-
-* `--output-dir <OUTPUT_DIR>` — Output directory for build artifacts.
-
-  Default value: `./output`
-* `--use-zstd` — Enable support for repodata.json.zst
-
-  Default value: `true`
-
-  Possible values: `true`, `false`
-
-* `--use-bz2` — Enable support for repodata.json.bz2
-
-  Default value: `true`
-
-  Possible values: `true`, `false`
-
-* `--experimental` — Enable experimental features
-
-  Possible values: `true`, `false`
-
-* `--auth-file <AUTH_FILE>` — Path to an auth-file to read authentication information from
+	The package file to upload
 
 
 
-## `rattler-build upload quetz`
+##### **Options:**
+
+- `--use-zstd`
+
+	Enable support for repodata.json.zst
+
+	- Default value: `true`
+	- Possible values: `true`, `false`
+
+
+- `--use-bz2`
+
+	Enable support for repodata.json.bz2
+
+	- Default value: `true`
+	- Possible values: `true`, `false`
+
+
+- `--experimental`
+
+	Enable experimental features
+
+	- Possible values: `true`, `false`
+
+
+- `--auth-file <AUTH_FILE>`
+
+	Path to an auth-file to read authentication information from
+
+
+###### **Modifying result**
+
+- `--output-dir <OUTPUT_DIR>`
+
+	Output directory for build artifacts.
+
+	- Default value: `./output`
+
+
+
+
+#### `quetz`
 
 Upload to aQuetz server. Authentication is used from the keychain / auth-file
 
 **Usage:** `rattler-build upload quetz [OPTIONS] --url <URL> --channel <CHANNEL>`
 
-###### **Options:**
+##### **Options:**
 
-* `-u`, `--url <URL>` — The URL to your Quetz server
-* `-c`, `--channel <CHANNEL>` — The URL to your channel
-* `-a`, `--api-key <API_KEY>` — The Quetz API key, if none is provided, the token is read from the keychain / auth-file
+- `-u`, `--url <URL>`
+
+	The URL to your Quetz server
+
+
+- `-c`, `--channel <CHANNEL>`
+
+	The URL to your channel
+
+
+- `-a`, `--api-key <API_KEY>`
+
+	The Quetz API key, if none is provided, the token is read from the keychain / auth-file
 
 
 
-## `rattler-build upload artifactory`
+
+
+#### `artifactory`
 
 Options for uploading to a Artifactory channel. Authentication is used from the keychain / auth-file
 
 **Usage:** `rattler-build upload artifactory [OPTIONS] --url <URL> --channel <CHANNEL>`
 
-###### **Options:**
+##### **Options:**
 
-* `-u`, `--url <URL>` — The URL to your Artifactory server
-* `-c`, `--channel <CHANNEL>` — The URL to your channel
-* `-r`, `--username <USERNAME>` — Your Artifactory username
-* `-p`, `--password <PASSWORD>` — Your Artifactory password
+- `-u`, `--url <URL>`
 
+	The URL to your Artifactory server
 
 
-## `rattler-build upload prefix`
+- `-c`, `--channel <CHANNEL>`
+
+	The URL to your channel
+
+
+- `-r`, `--username <USERNAME>`
+
+	Your Artifactory username
+
+
+- `-p`, `--password <PASSWORD>`
+
+	Your Artifactory password
+
+
+
+
+
+#### `prefix`
 
 Options for uploading to a prefix.dev server. Authentication is used from the keychain / auth-file
 
 **Usage:** `rattler-build upload prefix [OPTIONS] --channel <CHANNEL>`
 
-###### **Options:**
+##### **Options:**
 
-* `-u`, `--url <URL>` — The URL to the prefix.dev server (only necessary for self-hosted instances)
+- `-u`, `--url <URL>`
 
-  Default value: `https://prefix.dev`
-* `-c`, `--channel <CHANNEL>` — The channel to upload the package to
-* `-a`, `--api-key <API_KEY>` — The prefix.dev API key, if none is provided, the token is read from the keychain / auth-file
+	The URL to the prefix.dev server (only necessary for self-hosted instances)
+
+	- Default value: `https://prefix.dev`
+
+- `-c`, `--channel <CHANNEL>`
+
+	The channel to upload the package to
+
+
+- `-a`, `--api-key <API_KEY>`
+
+	The prefix.dev API key, if none is provided, the token is read from the keychain / auth-file
 
 
 
-## `rattler-build upload anaconda`
+
+
+#### `anaconda`
 
 Options for uploading to a Anaconda.org server
 
 **Usage:** `rattler-build upload anaconda [OPTIONS] --owner <OWNER>`
 
-###### **Options:**
+##### **Options:**
 
-* `-o`, `--owner <OWNER>` — The owner of the distribution (e.g. conda-forge or your username)
-* `-c`, `--channel <CHANNEL>` — The channel / label to upload the package to (e.g. main / rc)
+- `-o`, `--owner <OWNER>`
 
-  Default value: `main`
-* `-a`, `--api-key <API_KEY>` — The Anaconda API key, if none is provided, the token is read from the keychain / auth-file
-* `-u`, `--url <URL>` — The URL to the Anaconda server
-
-  Default value: `https://api.anaconda.org`
-* `-f`, `--force` — Replace files on conflict
-
-  Default value: `false`
-
-  Possible values: `true`, `false`
+	The owner of the distribution (e.g. conda-forge or your username)
 
 
+- `-c`, `--channel <CHANNEL>`
+
+	The channel / label to upload the package to (e.g. main / rc)
+
+	- Default value: `main`
+
+- `-a`, `--api-key <API_KEY>`
+
+	The Anaconda API key, if none is provided, the token is read from the keychain / auth-file
 
 
-## `rattler-build completion`
+- `-u`, `--url <URL>`
+
+	The URL to the Anaconda server
+
+	- Default value: `https://api.anaconda.org`
+
+- `-f`, `--force`
+
+	Replace files on conflict
+
+	- Default value: `false`
+	- Possible values: `true`, `false`
+
+
+
+
+
+### `completion`
 
 Generate shell completion script
 
 **Usage:** `rattler-build completion --shell <SHELL>`
 
-###### **Options:**
+##### **Options:**
 
-* `-s`, `--shell <SHELL>` — Specifies the shell for which the completions should be generated
+- `-s`, `--shell <SHELL>`
 
-  Possible values:
-  - `bash`:
-    Bourne Again SHell (bash)
-  - `elvish`:
-    Elvish shell
-  - `fish`:
-    Friendly Interactive SHell (fish)
-  - `nushell`:
-    Nushell
-  - `powershell`:
-    PowerShell
-  - `zsh`:
-    Z SHell (zsh)
+	Specifies the shell for which the completions should be generated
+
+	- Possible values:
+		- `bash`:
+			Bourne Again SHell (bash)
+		- `elvish`:
+			Elvish shell
+		- `fish`:
+			Friendly Interactive SHell (fish)
+		- `nushell`:
+			Nushell
+		- `powershell`:
+			PowerShell
+		- `zsh`:
+			Z SHell (zsh)
 
 
 
 
-## `rattler-build generate-recipe`
+
+### `generate-recipe`
 
 Generate a recipe from PyPI or CRAN
 
 **Usage:** `rattler-build generate-recipe <COMMAND>`
 
-###### **Subcommands:**
+##### **Subcommands:**
 
 * `pypi` — Generate a recipe for a Python package from PyPI
 * `cran` — Generate a recipe for an R package from CRAN
 
 
 
-## `rattler-build generate-recipe pypi`
+#### `pypi`
 
 Generate a recipe for a Python package from PyPI
 
 **Usage:** `rattler-build generate-recipe pypi [OPTIONS] <PACKAGE>`
 
-###### **Arguments:**
+##### **Arguments:**
 
-* `<PACKAGE>` — Name of the package to generate
+- `<PACKAGE>`
 
-###### **Options:**
-
-* `-w`, `--write` — Whether to write the recipe to a folder
-
-  Possible values: `true`, `false`
-
-* `-u`, `--use-mapping` — Whether to use the conda-forge PyPI name mapping
-
-  Default value: `true`
-
-  Possible values: `true`, `false`
-
-* `-t`, `--tree` — Whether to generate recipes for all dependencies
-
-  Possible values: `true`, `false`
+	Name of the package to generate
 
 
 
+##### **Options:**
 
-## `rattler-build generate-recipe cran`
+- `-w`, `--write`
+
+	Whether to write the recipe to a folder
+
+	- Possible values: `true`, `false`
+
+
+- `-u`, `--use-mapping`
+
+	Whether to use the conda-forge PyPI name mapping
+
+	- Default value: `true`
+	- Possible values: `true`, `false`
+
+
+- `-t`, `--tree`
+
+	Whether to generate recipes for all dependencies
+
+	- Possible values: `true`, `false`
+
+
+
+
+
+#### `cran`
 
 Generate a recipe for an R package from CRAN
 
 **Usage:** `rattler-build generate-recipe cran [OPTIONS] <PACKAGE>`
 
-###### **Arguments:**
+##### **Arguments:**
 
-* `<PACKAGE>` — Name of the package to generate
+- `<PACKAGE>`
 
-###### **Options:**
-
-* `-u`, `--universe <UNIVERSE>` — The R Universe to fetch the package from (defaults to `cran`)
-* `-t`, `--tree` — Whether to create recipes for the whole dependency tree or not
-
-  Possible values: `true`, `false`
-
-* `-w`, `--write` — Whether to write the recipe to a folder
-
-  Possible values: `true`, `false`
+	Name of the package to generate
 
 
 
+##### **Options:**
 
-## `rattler-build auth`
+- `-u`, `--universe <UNIVERSE>`
+
+	The R Universe to fetch the package from (defaults to `cran`)
+
+
+- `-t`, `--tree`
+
+	Whether to create recipes for the whole dependency tree or not
+
+	- Possible values: `true`, `false`
+
+
+- `-w`, `--write`
+
+	Whether to write the recipe to a folder
+
+	- Possible values: `true`, `false`
+
+
+
+
+
+### `auth`
 
 Handle authentication to external channels
 
 **Usage:** `rattler-build auth <COMMAND>`
 
-###### **Subcommands:**
+##### **Subcommands:**
 
 * `login` — Store authentication information for a given host
 * `logout` — Remove authentication information for a given host
 
 
 
-## `rattler-build auth login`
+#### `login`
 
 Store authentication information for a given host
 
 **Usage:** `rattler-build auth login [OPTIONS] <HOST>`
 
-###### **Arguments:**
+##### **Arguments:**
 
-* `<HOST>` — The host to authenticate with (e.g. repo.prefix.dev)
+- `<HOST>`
 
-###### **Options:**
-
-* `--token <TOKEN>` — The token to use (for authentication with prefix.dev)
-* `--username <USERNAME>` — The username to use (for basic HTTP authentication)
-* `--password <PASSWORD>` — The password to use (for basic HTTP authentication)
-* `--conda-token <CONDA_TOKEN>` — The token to use on anaconda.org / quetz authentication
+	The host to authenticate with (e.g. repo.prefix.dev)
 
 
 
-## `rattler-build auth logout`
+##### **Options:**
+
+- `--token <TOKEN>`
+
+	The token to use (for authentication with prefix.dev)
+
+
+- `--username <USERNAME>`
+
+	The username to use (for basic HTTP authentication)
+
+
+- `--password <PASSWORD>`
+
+	The password to use (for basic HTTP authentication)
+
+
+- `--conda-token <CONDA_TOKEN>`
+
+	The token to use on anaconda.org / quetz authentication
+
+
+
+
+
+#### `logout`
 
 Remove authentication information for a given host
 
 **Usage:** `rattler-build auth logout <HOST>`
 
-###### **Arguments:**
+##### **Arguments:**
 
-* `<HOST>` — The host to remove authentication for
+- `<HOST>`
+
+	The host to remove authentication for
+
+
 
 
 


### PR DESCRIPTION
The CLI docs were outdated. I've updated them by running `pixi run generate-cli-docs`.
No idea why so much changed here.