### PR TITLE
add in env vars from variant config

### DIFF
--- a/src/env_vars.rs
+++ b/src/env_vars.rs
@@ -329,5 +329,8 @@ pub fn vars(output: &Output, build_state: &str) -> HashMap<String, String> {
         timestamp_epoch_secs.to_string(),
     );
 
+    // Insert all variant variables into the environment
+    vars.extend(output.variant().clone().into_iter());
+
     vars
 }


### PR DESCRIPTION
@h-vetinari this is the initial fix for the problem.

However, it will exhibit some problems:

A python variant would overwrite the PYTHON env var on Windows (because env vars are not case sensitive on Windows).

We should rethink how to do this. Maybe only inject them in addition to other env vars when they are not set?

Any ideas?