### PR TITLE
fix: latest_tag get oldest tag

### DIFF
--- a/src/recipe/jinja.rs
+++ b/src/recipe/jinja.rs
@@ -559,7 +559,7 @@ impl Git {
     fn latest_tag_rev(&self, src: &str) -> Result<Value, minijinja::Error> {
         let result = get_command_output("git", &["ls-remote", "--tags", "--sort=-v:refname", src])?
             .lines()
-            .last()
+            .next()
             .and_then(|s| s.split_ascii_whitespace().nth(0))
             .ok_or_else(|| {
                 minijinja::Error::new(
@@ -574,7 +574,7 @@ impl Git {
     fn latest_tag(&self, src: &str) -> Result<Value, minijinja::Error> {
         let result = get_command_output("git", &["ls-remote", "--tags", "--sort=-v:refname", src])?
             .lines()
-            .last()
+            .next()
             .and_then(|s| s.split_ascii_whitespace().nth(1))
             .and_then(|s| s.strip_prefix("refs/tags/"))
             .map(|s| s.trim_end_matches("^{}"))


### PR DESCRIPTION
The current implementation of `git.latest_tag` seems a bit off. Using `-v:refname` together with `last()` is actually selecting the earliest tag, not the latest one. 

One can check this by 

```yaml
context:
  git_repo_url: https://github.com/prefix-dev/rattler-build.git
  latest_tag: ${{ git.latest_tag( git_repo_url ) }}

package:
  name: "rattler"
  version: ${{ latest_tag }}

source:
  git: ${{ git_repo_url }}
  tag: ${{ latest_tag }}


```