### PR TITLE
feat: add override for virtual packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,12 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
 dependencies = [
  "gimli",
 ]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "adler2"
@@ -147,9 +141,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
 name = "arbitrary"
@@ -239,9 +233,9 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7ebdfa2ebdab6b1760375fa7d6f382b9f486eac35fc994625a00e89280bdbb7"
+checksum = "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec"
 dependencies = [
  "async-task",
  "concurrent-queue",
@@ -259,7 +253,7 @@ dependencies = [
  "async-trait",
  "cfg-if",
  "pin-project",
- "rustix 0.38.35",
+ "rustix 0.38.37",
  "thiserror",
  "tokio",
  "windows-sys 0.52.0",
@@ -321,7 +315,7 @@ dependencies = [
  "futures-lite 2.3.0",
  "parking",
  "polling 3.7.3",
- "rustix 0.38.35",
+ "rustix 0.38.37",
  "slab",
  "tracing",
  "windows-sys 0.59.0",
@@ -366,15 +360,15 @@ dependencies = [
  "cfg-if",
  "event-listener 3.1.0",
  "futures-lite 1.13.0",
- "rustix 0.38.35",
+ "rustix 0.38.37",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "async-process"
-version = "2.2.4"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a07789659a4d385b79b18b9127fc27e1a59e1e89117c78c5ea3b806f016374"
+checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
 dependencies = [
  "async-channel",
  "async-io 2.3.4",
@@ -385,9 +379,8 @@ dependencies = [
  "cfg-if",
  "event-listener 5.3.1",
  "futures-lite 2.3.0",
- "rustix 0.38.35",
+ "rustix 0.38.37",
  "tracing",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -413,7 +406,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 0.38.35",
+ "rustix 0.38.37",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
@@ -446,7 +439,7 @@ dependencies = [
  "futures",
  "http-content-range",
  "itertools 0.12.1",
- "memmap2 0.9.4",
+ "memmap2 0.9.5",
  "reqwest 0.12.7",
  "reqwest-middleware",
  "thiserror",
@@ -485,17 +478,17 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
- "miniz_oxide 0.7.4",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -625,9 +618,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "bzip2"
@@ -709,9 +702,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.15"
+version = "1.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
+checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
 dependencies = [
  "jobserver",
  "libc",
@@ -784,9 +777,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.16"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
+checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -813,9 +806,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.15"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
+checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
 dependencies = [
  "anstream",
  "anstyle",
@@ -825,9 +818,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.24"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7db6eca8c205649e8d3ccd05aa5042b1800a784e56bc7c43524fde8abbfa9b"
+checksum = "9b378c786d3bde9442d2c6dd7e6080b2a818db2b96e30d6e7f1b6d224eb617d3"
 dependencies = [
  "clap",
 ]
@@ -952,9 +945,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
+checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
 dependencies = [
  "libc",
 ]
@@ -1093,9 +1086,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.0.1"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804c8821570c3f8b70230c2ba75ffa5c0f9a4189b9a432b6656c536712acae28"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1402,6 +1395,17 @@ checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 [[package]]
 name = "file_url"
 version = "0.1.5"
+dependencies = [
+ "itertools 0.13.0",
+ "percent-encoding",
+ "thiserror",
+ "typed-path",
+ "url",
+]
+
+[[package]]
+name = "file_url"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b8d0fe7b11e53d71e1484766a00187bc239910dcacb5bf8909f1f3ffd9b4aa"
 dependencies = [
@@ -1437,7 +1441,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.8.0",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1504,7 +1508,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7e180ac76c23b45e767bd7ae9579bc0bb458618c4bc71835926e098e61d15f8"
 dependencies = [
- "rustix 0.38.35",
+ "rustix 0.38.37",
  "windows-sys 0.52.0",
 ]
 
@@ -1515,7 +1519,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c6b3bd49c37d2aa3f3f2220233b29a7cd23f79d1fe70e5337d25fb390793de"
 dependencies = [
  "fs-err",
- "rustix 0.38.35",
+ "rustix 0.38.37",
  "windows-sys 0.52.0",
 ]
 
@@ -1699,9 +1703,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
 
 [[package]]
 name = "glob"
@@ -1711,9 +1715,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "globset"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
+checksum = "15f1ce686646e7f1e19bf7d5533fe443a45dbfb990e00629110797578b42fb19"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -2108,16 +2112,16 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
+checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
  "http 1.1.0",
  "hyper 1.4.1",
  "hyper-util",
- "rustls 0.23.12",
- "rustls-native-certs",
+ "rustls 0.23.13",
+ "rustls-native-certs 0.8.0",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -2156,9 +2160,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
+checksum = "da62f120a8a37763efb0cf8fdf264b884c7b8b9ac8660b900c8661030c00e6ba"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2176,9 +2180,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.60"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -2215,9 +2219,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1"
+checksum = "6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -2296,9 +2300,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.39.0"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "810ae6042d48e2c9e9215043563a58a80b877bc863228a74cf10c49d4620a6f5"
+checksum = "6593a41c7a73841868772495db7dc1e8ecab43bb5c0b6da2059246c4b506ab60"
 dependencies = [
  "console",
  "lazy_static",
@@ -2329,9 +2333,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
 
 [[package]]
 name = "is_ci"
@@ -2441,9 +2445,9 @@ dependencies = [
 
 [[package]]
 name = "keyring"
-version = "3.2.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030a9b84bb2a2f3673d4c8b8236091ed5d8f6b66a56d8085471d8abd5f3c6a80"
+checksum = "5fa83d1ca02db069b5fbe94b23b584d588e989218310c9c15015bb5571ef1a94"
 dependencies = [
  "byteorder",
  "dbus-secret-service",
@@ -2705,9 +2709,9 @@ dependencies = [
 
 [[package]]
 name = "memmap2"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
+checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
 dependencies = [
  "libc",
 ]
@@ -2815,15 +2819,6 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
-dependencies = [
- "adler",
-]
 
 [[package]]
 name = "miniz_oxide"
@@ -3165,9 +3160,9 @@ checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
 
 [[package]]
 name = "parking"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -3457,7 +3452,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi 0.4.0",
  "pin-project-lite",
- "rustix 0.38.35",
+ "rustix 0.38.37",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -3499,7 +3494,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
- "toml_edit 0.22.20",
+ "toml_edit 0.22.21",
 ]
 
 [[package]]
@@ -3563,16 +3558,16 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d2fb862b7ba45e615c1429def928f2e15f815bdf933b27a2d3824e224c1f46"
+checksum = "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684"
 dependencies = [
  "bytes",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.12",
+ "rustls 0.23.13",
  "socket2 0.5.7",
  "thiserror",
  "tokio",
@@ -3581,15 +3576,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0a9b3a42929fad8a7c3de7f86ce0814cfa893328157672680e9fb1145549c5"
+checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
 dependencies = [
  "bytes",
  "rand",
  "ring",
  "rustc-hash",
- "rustls 0.23.12",
+ "rustls 0.23.13",
  "slab",
  "thiserror",
  "tinyvec",
@@ -3598,15 +3593,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bffec3605b73c6f1754535084a85229fa8a30f86014e6c81aeec4abb68b0285"
+checksum = "4fe68c2e9e1a1234e218683dbdf9f9dfcb094113c5ac2b938dfcb9bab4c4140b"
 dependencies = [
  "libc",
  "once_cell",
  "socket2 0.5.7",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3676,9 +3671,7 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.27.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65df1b9ee6414776fdf552d6d8f80de876babe5d9c64d1604ff5fbea73d0dd6"
+version = "0.27.11"
 dependencies = [
  "anyhow",
  "clap",
@@ -3692,14 +3685,14 @@ dependencies = [
  "indicatif",
  "itertools 0.13.0",
  "memchr",
- "memmap2 0.9.4",
+ "memmap2 0.9.5",
  "once_cell",
  "parking_lot",
  "rattler_cache",
- "rattler_conda_types 0.27.5",
+ "rattler_conda_types 0.27.6",
  "rattler_digest 1.0.2",
  "rattler_networking 0.21.4",
- "rattler_package_streaming 0.22.6",
+ "rattler_package_streaming 0.22.7",
  "rattler_shell",
  "reflink-copy",
  "regex",
@@ -3749,7 +3742,7 @@ dependencies = [
  "itertools 0.13.0",
  "marked-yaml",
  "memchr",
- "memmap2 0.9.4",
+ "memmap2 0.9.5",
  "miette 7.2.0",
  "minijinja",
  "num_cpus",
@@ -3759,12 +3752,12 @@ dependencies = [
  "ratatui",
  "rattler",
  "rattler_cache",
- "rattler_conda_types 0.27.5",
+ "rattler_conda_types 0.27.6",
  "rattler_digest 1.0.2",
  "rattler_index",
  "rattler_installs_packages",
  "rattler_networking 0.21.4",
- "rattler_package_streaming 0.22.6",
+ "rattler_package_streaming 0.22.7",
  "rattler_redaction",
  "rattler_repodata_gateway",
  "rattler_shell",
@@ -3808,9 +3801,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8699896b5cc495af86937024a1e6fead33fc921efec171e13348cee5ef7f86"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -3821,10 +3812,10 @@ dependencies = [
  "fxhash",
  "itertools 0.13.0",
  "parking_lot",
- "rattler_conda_types 0.27.5",
+ "rattler_conda_types 0.27.6",
  "rattler_digest 1.0.2",
  "rattler_networking 0.21.4",
- "rattler_package_streaming 0.22.6",
+ "rattler_package_streaming 0.22.7",
  "reqwest 0.12.7",
  "reqwest-middleware",
  "simple_spawn_blocking",
@@ -3841,7 +3832,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa8a3f6f355aebb8a7af60bf5d961adce58689892d646616201d1f5daba1c525"
 dependencies = [
  "chrono",
- "file_url",
+ "file_url 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fxhash",
  "glob",
  "hex",
@@ -3870,13 +3861,11 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.27.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aac998898b49659f9fa9bdaad9e6c4272cd5306a704c4f1f2928dcdfff6ea8bd"
+version = "0.27.6"
 dependencies = [
  "chrono",
  "dirs",
- "file_url",
+ "file_url 0.1.5",
  "fxhash",
  "glob",
  "hex",
@@ -3923,8 +3912,6 @@ dependencies = [
 [[package]]
 name = "rattler_digest"
 version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a87e1ed2c7df1dbbfaa79d8f520c347d511231c77f4dd5327a6c389758a98db0"
 dependencies = [
  "blake2",
  "digest",
@@ -3939,14 +3926,12 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.19.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31343cdaeb4ae1c5bfa5e0c701f6feb4b7d1737d972068b75b0b2947c13474f"
+version = "0.19.28"
 dependencies = [
  "fs-err",
- "rattler_conda_types 0.27.5",
+ "rattler_conda_types 0.27.6",
  "rattler_digest 1.0.2",
- "rattler_package_streaming 0.22.6",
+ "rattler_package_streaming 0.22.7",
  "serde_json",
  "tracing",
  "walkdir",
@@ -4026,8 +4011,6 @@ dependencies = [
 [[package]]
 name = "rattler_macros"
 version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0306a96eb7216c786fa6234fd26207bf3769cbb48b2373d682eabb36ff11c175"
 dependencies = [
  "quote",
  "syn 2.0.77",
@@ -4063,8 +4046,6 @@ dependencies = [
 [[package]]
 name = "rattler_networking"
 version = "0.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ada69629cc3ea204055f4d13604b32cb108fca456cc87d97d4280f041ac5708"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4076,7 +4057,7 @@ dependencies = [
  "google-cloud-auth",
  "http 1.1.0",
  "itertools 0.13.0",
- "keyring 3.2.1",
+ "keyring 3.3.0",
  "netrc-rs",
  "reqwest 0.12.7",
  "reqwest-middleware",
@@ -4114,15 +4095,13 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.22.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c889bfc333fc6e8ea67fc1731a4da3e51f74e3231f770dc3a1fe6ee1fc23a8"
+version = "0.22.7"
 dependencies = [
  "bzip2",
  "chrono",
  "futures-util",
  "num_cpus",
- "rattler_conda_types 0.27.5",
+ "rattler_conda_types 0.27.6",
  "rattler_digest 1.0.2",
  "rattler_networking 0.21.4",
  "rattler_redaction",
@@ -4143,8 +4122,6 @@ dependencies = [
 [[package]]
 name = "rattler_redaction"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b3a430398cc4ecd0350204087377bc31d977dfd897d3b6930f195f39c515b"
 dependencies = [
  "reqwest 0.12.7",
  "reqwest-middleware",
@@ -4153,9 +4130,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35eb42953ae7dba91aa53881667e8c6541c1e265a10a8b66a96c6870d1a70d39"
+version = "0.21.13"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -4167,7 +4142,7 @@ dependencies = [
  "chrono",
  "dashmap",
  "dirs",
- "file_url",
+ "file_url 0.1.5",
  "futures",
  "hex",
  "http 1.1.0",
@@ -4178,12 +4153,12 @@ dependencies = [
  "json-patch",
  "libc",
  "md-5",
- "memmap2 0.9.4",
+ "memmap2 0.9.5",
  "ouroboros",
  "parking_lot",
  "pin-project-lite",
  "rattler_cache",
- "rattler_conda_types 0.27.5",
+ "rattler_conda_types 0.27.6",
  "rattler_digest 1.0.2",
  "rattler_networking 0.21.4",
  "rattler_redaction",
@@ -4207,14 +4182,12 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c4ea6b51960de7c37330b80446a97acfd7d2cf24aac40131013afd1c2e902"
+version = "0.22.1"
 dependencies = [
  "enum_dispatch",
  "indexmap 2.5.0",
  "itertools 0.13.0",
- "rattler_conda_types 0.27.5",
+ "rattler_conda_types 0.27.6",
  "serde_json",
  "shlex",
  "sysinfo",
@@ -4225,16 +4198,14 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b907ab9441c5b1617fd0b640f4218c14aec4e09b8e730688330db2710b7e3738"
+version = "1.0.7"
 dependencies = [
  "chrono",
  "futures",
  "itertools 0.13.0",
- "rattler_conda_types 0.27.5",
+ "rattler_conda_types 0.27.6",
  "rattler_digest 1.0.2",
- "resolvo 0.7.0",
+ "resolvo 0.8.0",
  "serde",
  "tempfile",
  "thiserror",
@@ -4244,16 +4215,14 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae3df3470a9b4fbbece991c5d3969efabb375e696f1f138111e69221cbd19733"
+version = "1.1.4"
 dependencies = [
  "archspec",
  "libloading",
  "nom",
  "once_cell",
  "plist",
- "rattler_conda_types 0.27.5",
+ "rattler_conda_types 0.27.6",
  "regex",
  "serde",
  "thiserror",
@@ -4282,9 +4251,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -4327,7 +4296,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc31414597d1cd7fdd2422798b7652a6329dda0fe0219e6335a13d5bcaa9aeb6"
 dependencies = [
  "cfg-if",
- "rustix 0.38.35",
+ "rustix 0.38.37",
  "windows 0.58.0",
 ]
 
@@ -4441,7 +4410,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.4.1",
- "hyper-rustls 0.27.2",
+ "hyper-rustls 0.27.3",
  "hyper-tls 0.6.0",
  "hyper-util",
  "ipnet",
@@ -4454,8 +4423,8 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.12",
- "rustls-native-certs",
+ "rustls 0.23.13",
+ "rustls-native-certs 0.7.3",
  "rustls-pemfile 2.1.3",
  "rustls-pki-types",
  "serde",
@@ -4509,9 +4478,9 @@ dependencies = [
 
 [[package]]
 name = "resolvo"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "014783b06e2d02bee01fe3c3247454fb34d0fc35765334e825034cdadec422fa"
+checksum = "1a472ebbac5a18c9e235e874df3aa0c8fb0b55611155dd5e5515a55a16520d76"
 dependencies = [
  "ahash",
  "bitvec",
@@ -4647,9 +4616,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.35"
+version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a85d50532239da68e9addb745ba38ff4612a242c1c7ceea689c4bc7c2f43c36f"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -4672,14 +4641,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.12"
+version = "0.23.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
+checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
 dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.7",
+ "rustls-webpki 0.102.8",
  "subtle",
  "zeroize",
 ]
@@ -4689,6 +4658,19 @@ name = "rustls-native-certs"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.1.3",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile 2.1.3",
@@ -4734,9 +4716,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.7"
+version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84678086bd54edf2b415183ed7a94d0efb049f1b646a33e22a36f3794be6ae56"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4766,11 +4748,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+checksum = "e9aaafd5a2b6e3d657ff009d82fbd630b6bd54dd4eb06f21693925cdf80f9b8b"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4878,9 +4860,9 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.209"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
@@ -4898,9 +4880,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.209"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4909,9 +4891,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.127"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
  "indexmap 2.5.0",
  "itoa",
@@ -5132,8 +5114,6 @@ dependencies = [
 [[package]]
 name = "simple_spawn_blocking"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b31ed96d1593e129cc76cb7aca364fb5c173558bfda922c15aac4e2f2f5844e"
 dependencies = [
  "tokio",
 ]
@@ -5427,7 +5407,7 @@ dependencies = [
  "cfg-if",
  "fastrand 2.1.1",
  "once_cell",
- "rustix 0.38.35",
+ "rustix 0.38.37",
  "windows-sys 0.59.0",
 ]
 
@@ -5437,7 +5417,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
- "rustix 0.38.35",
+ "rustix 0.38.37",
  "windows-sys 0.48.0",
 ]
 
@@ -5599,7 +5579,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.12",
+ "rustls 0.23.13",
  "rustls-pki-types",
  "tokio",
 ]
@@ -5618,9 +5598,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
 dependencies = [
  "bytes",
  "futures-core",
@@ -5639,7 +5619,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.20",
+ "toml_edit 0.22.21",
 ]
 
 [[package]]
@@ -5664,9 +5644,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.20"
+version = "0.22.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+checksum = "3b072cee73c449a636ffd6f32bd8de3a9f7119139aff882f44943ce2986dc5cf"
 dependencies = [
  "indexmap 2.5.0",
  "serde",
@@ -5828,9 +5808,9 @@ dependencies = [
 
 [[package]]
 name = "typed-path"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04645b6c01cfb2ddabffc7c67ae6bfe7c3e28a5c37d729f6bb498e784f1fd70c"
+checksum = "50c0c7479c430935701ff2532e3091e6680ec03f2f89ffcd9988b08e885b90a5"
 
 [[package]]
 name = "typeid"
@@ -5872,9 +5852,9 @@ checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-linebreak"
@@ -5884,9 +5864,9 @@ checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
@@ -5910,9 +5890,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -6173,7 +6153,7 @@ checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
 dependencies = [
  "either",
  "home",
- "rustix 0.38.35",
+ "rustix 0.38.37",
  "winsafe",
 ]
 
@@ -6501,7 +6481,7 @@ checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
 dependencies = [
  "libc",
  "linux-raw-sys 0.4.14",
- "rustix 0.38.35",
+ "rustix 0.38.37",
 ]
 
 [[package]]
@@ -6598,7 +6578,7 @@ dependencies = [
  "async-fs 2.1.2",
  "async-io 2.3.4",
  "async-lock 3.4.0",
- "async-process 2.2.4",
+ "async-process 2.3.0",
  "async-recursion",
  "async-task",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,13 +43,13 @@ name = "rattler-build"
 required-features = ["recipe-generation"]
 
 [dependencies]
-serde = { version = "1.0.209", features = ["derive"] }
+serde = { version = "1.0.210", features = ["derive"] }
 serde_yaml = "0.9.34"
-anyhow = "1.0.86"
+anyhow = "1.0.89"
 walkdir = "2.5.0"
 sha2 = "0.10.8"
 hex = "0.4.3"
-serde_json = "1.0.127"
+serde_json = "1.0.128"
 reqwest = { version = "0.12.7", default-features = false, features = [
     "multipart",
 ] }
@@ -59,7 +59,7 @@ content_inspector = "0.2.4"
 serde_with = "3.9.0"
 url = "2.5.2"
 tracing = "0.1.40"
-clap = { version = "4.5.16", features = ["derive", "env", "cargo"] }
+clap = { version = "4.5.17", features = ["derive", "env", "cargo"] }
 minijinja = { version = "=1.0.14", features = [
     "unstable_machinery",
     "custom_syntax",
@@ -85,8 +85,8 @@ tempfile = "3.12.0"
 chrono = "0.4.38"
 sha1 = "0.10.6"
 spdx = "0.10.6"
-ignore = "0.4.22"
-globset = "0.4.14"
+ignore = "0.4.23"
+globset = "0.4.15"
 clap-verbosity-flag = "2.2.1"
 tracing-core = "0.1.32"
 petgraph = "0.6.5"
@@ -94,9 +94,9 @@ indexmap = "2.5.0"
 dunce = "1.0.5"
 fs-err = "2.11.0"
 which = "6.0.3"
-clap_complete = "4.5.24"
+clap_complete = "4.5.28"
 clap_complete_nushell = "4.5.3"
-tokio-util = "0.7.11"
+tokio-util = "0.7.12"
 
 tar = "0.4.41"
 zip = { version = "2.2.0", default-features = false, features = [
@@ -109,7 +109,7 @@ flate2 = "1.0.33"
 xz2 = "0.1.7"
 zstd = "0.13.2"
 toml = "0.8.19"
-memmap2 = "0.9.4"
+memmap2 = "0.9.5"
 reqwest-middleware = "0.3.3"
 rattler_installs_packages = { version = "0.9.0", default-features = false, optional = true }
 async-once-cell = "0.5.3"
@@ -129,21 +129,21 @@ clap-markdown = { version = "=0.1.3", optional = true }
 async-recursion = "1.1.1"
 
 # Rattler crates
-rattler = { version = "0.27.10", default-features = false, features = ["cli-tools", "indicatif"] }
-rattler_cache = { version = "0.2.2", default-features = false }
-rattler_conda_types = { version = "0.27.5", default-features = false }
+rattler = { version = "0.27.11", default-features = false, features = ["cli-tools", "indicatif"] }
+rattler_cache = { version = "0.2.3", default-features = false }
+rattler_conda_types = { version = "0.27.6", default-features = false }
 rattler_digest = { version = "1.0.2", default-features = false, features = ["serde"] }
-rattler_index = { version = "0.19.27", default-features = false }
+rattler_index = { version = "0.19.28", default-features = false }
 rattler_networking = { version = "0.21.4", default-features = false }
 rattler_redaction = { version = "0.1.2" }
-rattler_repodata_gateway = { version = "0.21.12", default-features = false, features = ["gateway"] }
-rattler_shell = { version = "0.22.0", default-features = false, features = ["sysinfo"] }
-rattler_solve = { version = "1.0.6", default-features = false, features = ["resolvo", "serde"] }
-rattler_virtual_packages = { version = "1.1.3", default-features = false }
-rattler_package_streaming = { version = "0.22.6", default-features = false }
+rattler_repodata_gateway = { version = "0.21.13", default-features = false, features = ["gateway"] }
+rattler_shell = { version = "0.22.1", default-features = false, features = ["sysinfo"] }
+rattler_solve = { version = "1.0.7", default-features = false, features = ["resolvo", "serde"] }
+rattler_virtual_packages = { version = "1.1.4", default-features = false }
+rattler_package_streaming = { version = "0.22.7", default-features = false }
 
 [dev-dependencies]
-insta = { version = "1.39.0", features = ["yaml"] }
+insta = { version = "1.40.0", features = ["yaml"] }
 rstest = "0.21.0"
 tracing-test = "0.2.5"
 tracing-indicatif = "0.3.6"
@@ -178,16 +178,16 @@ pre-build = [
 clap-markdown = { git = "https://github.com/ruben-arts/clap-markdown", branch = "main" }
 
 
-#rattler = { path = "../rattler/crates/rattler" }
-#rattler_cache = { path = "../rattler/crates/rattler_cache" }
-#rattler_conda_types = { path = "../rattler/crates/rattler_conda_types" }
-#rattler_digest = { path = "../rattler/crates/rattler_digest" }
-#rattler_index = { path = "../rattler/crates/rattler_index" }
-#rattler_networking = { path = "../rattler/crates/rattler_networking" }
-#rattler_repodata_gateway = { path = "../rattler/crates/rattler_repodata_gateway" }
-#rattler_shell = { path = "../rattler/crates/rattler_shell" }
-#rattler_solve = { path = "../rattler/crates/rattler_solve" }
-#rattler_redaction = { path = "../rattler/crates/rattler_redaction" }
-#rattler_virtual_packages = { path = "../rattler/crates/rattler_virtual_packages" }
-#rattler_package_streaming = { path = "../rattler/crates/rattler_package_streaming" }
+rattler = { path = "../rattler/crates/rattler" }
+rattler_cache = { path = "../rattler/crates/rattler_cache" }
+rattler_conda_types = { path = "../rattler/crates/rattler_conda_types" }
+rattler_digest = { path = "../rattler/crates/rattler_digest" }
+rattler_index = { path = "../rattler/crates/rattler_index" }
+rattler_networking = { path = "../rattler/crates/rattler_networking" }
+rattler_repodata_gateway = { path = "../rattler/crates/rattler_repodata_gateway" }
+rattler_shell = { path = "../rattler/crates/rattler_shell" }
+rattler_solve = { path = "../rattler/crates/rattler_solve" }
+rattler_redaction = { path = "../rattler/crates/rattler_redaction" }
+rattler_virtual_packages = { path = "../rattler/crates/rattler_virtual_packages" }
+rattler_package_streaming = { path = "../rattler/crates/rattler_package_streaming" }
 #clap-markdown = { path = "../clap-markdown" }

--- a/rust-tests/Cargo.toml
+++ b/rust-tests/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2021"
 [dependencies]
 glob = "0.3.1"
 rattler_package_streaming = { version = "0.21.7", default-features = false }
-serde_json = "1.0.127"
+serde_json = "1.0.128"
 sha1 = "0.10.6"
 duct = "0.13.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,6 +137,7 @@ pub async fn get_build_output(
     recipe_path: &Path,
     tool_config: &Configuration,
 ) -> miette::Result<Vec<Output>> {
+    println!("Building recipe: {:?}", args.virtual_package_for_host);
     let output_dir = args
         .common
         .output_dir
@@ -314,6 +315,7 @@ pub async fn get_build_output(
                     args.package_format.compression_level,
                 ),
                 store_recipe: !args.no_include_recipe,
+                virtual_packages_for_host: args.virtual_package_for_host.clone(),
                 force_colors: args.color_build_log && console::colors_enabled(),
             },
             finalized_dependencies: None,

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -15,8 +15,7 @@ use dunce::canonicalize;
 use fs_err as fs;
 use indicatif::HumanBytes;
 use rattler_conda_types::{
-    package::{ArchiveType, PathType, PathsEntry, PathsJson},
-    Channel, PackageName, Platform, RepoDataRecord, Version,
+    package::{ArchiveType, PathType, PathsEntry, PathsJson}, Channel, GenericVirtualPackage, PackageName, Platform, RepoDataRecord, Version
 };
 use rattler_index::index;
 use rattler_package_streaming::write::CompressionLevel;
@@ -264,6 +263,9 @@ pub struct BuildConfiguration {
     pub subpackages: BTreeMap<PackageName, PackageIdentifier>,
     /// Package format (.tar.bz2 or .conda)
     pub packaging_settings: PackagingSettings,
+    /// Override virtual packages for the host platform
+    #[serde(skip_serializing, default)]
+    pub virtual_packages_for_host: Vec<GenericVirtualPackage>,
     /// Whether to store the recipe and build instructions in the final package
     /// or not
     #[serde(skip_serializing, default = "default_true")]

--- a/src/package_test/run_test.rs
+++ b/src/package_test/run_test.rs
@@ -365,6 +365,7 @@ pub async fn run_test(
             &config.tool_configuration,
             config.channel_priority,
             config.solve_strategy,
+            None,
         )
         .await
         .map_err(TestError::TestEnvironmentSetup)?;
@@ -455,6 +456,7 @@ impl PythonTest {
             &config.tool_configuration,
             config.channel_priority,
             config.solve_strategy,
+            None,
         )
         .await
         .map_err(TestError::TestEnvironmentSetup)?;
@@ -535,6 +537,7 @@ impl CommandsTest {
                 &config.tool_configuration,
                 config.channel_priority,
                 config.solve_strategy,
+                None,
             )
             .await
             .map_err(TestError::TestEnvironmentSetup)?;
@@ -567,6 +570,7 @@ impl CommandsTest {
             &config.tool_configuration,
             config.channel_priority,
             config.solve_strategy,
+            None,
         )
         .await
         .map_err(TestError::TestEnvironmentSetup)?;
@@ -631,6 +635,7 @@ impl DownstreamTest {
             &config.tool_configuration,
             config.channel_priority,
             config.solve_strategy,
+            None,
         )
         .await;
 

--- a/src/render/resolved_dependencies.rs
+++ b/src/render/resolved_dependencies.rs
@@ -715,6 +715,7 @@ pub(crate) async fn resolve_dependencies(
             tool_configuration,
             output.build_configuration.channel_priority,
             output.build_configuration.solve_strategy,
+            None,
         )
         .await
         .map_err(ResolveError::from)?;
@@ -809,6 +810,7 @@ pub(crate) async fn resolve_dependencies(
             tool_configuration,
             output.build_configuration.channel_priority,
             output.build_configuration.solve_strategy,
+            Some(&output.build_configuration.virtual_packages_for_host),
         )
         .await
         .map_err(ResolveError::from)?;


### PR DESCRIPTION
This adds the ability to override detected virtual packages with ones defined on the CLI for the host environment during build (and for the run environment during test).

This should make it easier for cross-platform building & testing, as well as for "cross-platform" solvability checks.

TODO:

- [ ] decide if `--virtual-package-for-host __cuda=12.0` is the best way to do this
- [ ] wire up the virtual packages for test time

Long-term we would like to figure out a more robust solution for virtual packages and cross-platform building. Ideally it would look a bit more like what we have in pixi (system-requirements).

It would make sense for the recipes themselves to decide on minimum system requirements. For example, a certain recipe might only build with `macos: 12.0`. That should be expressable in the recipe itself.

Additionally, conda-forge should be able to set global minimum system requirements so that we know what default values to pick for every system. This should go in the next generation "variant configuration" file.