### PR TITLE
glob folders as well from simple name

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -67,12 +67,10 @@ jobs:
           - target: x86_64-pc-windows-msvc
             os: windows-2022
     env:
-      #
       # These are some environment variables that configure the build so that the binary size is reduced.
       # Inspiration was taken from this blog: https://arusahni.net/blog/2020/03/optimizing-rust-binary-size.html
       # They're only enable it on main and releases.
       #
-
       # Enable Link Time Optimization (LTO) for our release builds. This increases link time but drastically reduces
       # binary size.
       CARGO_PROFILE_RELEASE_LTO: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) && 'true' || 'false' }}
@@ -134,13 +132,6 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: cross
-
-      - name: Add macOS cross build capability
-        if: matrix.target == 'aarch64-apple-darwin'
-        run: |
-          echo "SDKROOT=$(xcrun -sdk macosx --show-sdk-path)" >> $GITHUB_ENV
-          echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx --show-sdk-platform-version)" >> $GITHUB_ENV
-          rustup default stable-aarch64-apple-darwin
 
       - name: Show version information (Rust, cargo, GCC)
         run: |

--- a/rust-tests/src/lib.rs
+++ b/rust-tests/src/lib.rs
@@ -344,7 +344,7 @@ mod tests {
             .filter(|s| s.is_ok())
             .count();
         _ = std::env::set_current_dir(path);
-        assert_eq!(glen, 6);
+        assert_eq!(glen, 8);
     }
 
     fn check_info(folder: PathBuf, expected: PathBuf) {

--- a/src/package_test/content_test.rs
+++ b/src/package_test/content_test.rs
@@ -33,9 +33,9 @@ impl PackageContentsTest {
         let mut result = Vec::new();
         for include in self.include.include_globs() {
             let glob = if target_platform.is_windows() {
-                format!("Library/include/{include}")
+                format!("Library/include/{}", include.source())
             } else {
-                format!("include/{include}")
+                format!("include/{}", include.source())
             };
 
             result.push((
@@ -55,26 +55,27 @@ impl PackageContentsTest {
         let mut result = Vec::new();
 
         for bin in self.bin.include_globs() {
+            let bin_raw = bin.source();
             let globset = if target_platform.is_windows() {
                 // This is usually encoded as `PATHEXT` in the environment
                 let path_ext = "{,.exe,.bat,.cmd,.com,.ps1}";
                 GlobSet::builder()
-                    .add(build_glob(format!("{bin}{path_ext}"))?)
+                    .add(build_glob(format!("{bin_raw}{path_ext}"))?)
                     .add(build_glob(format!(
-                        "Library/mingw-w64/bin/{bin}{path_ext}"
+                        "Library/mingw-w64/bin/{bin_raw}{path_ext}"
                     ))?)
-                    .add(build_glob(format!("Library/usr/bin/{bin}{path_ext}"))?)
-                    .add(build_glob(format!("Library/bin/{bin}{path_ext}"))?)
-                    .add(build_glob(format!("Scripts/{bin}{path_ext}"))?)
-                    .add(build_glob(format!("bin/{bin}{path_ext}"))?)
+                    .add(build_glob(format!("Library/usr/bin/{bin_raw}{path_ext}"))?)
+                    .add(build_glob(format!("Library/bin/{bin_raw}{path_ext}"))?)
+                    .add(build_glob(format!("Scripts/{bin_raw}{path_ext}"))?)
+                    .add(build_glob(format!("bin/{bin_raw}{path_ext}"))?)
                     .build()
             } else {
                 GlobSet::builder()
-                    .add(Glob::new(&format!("bin/{bin}"))?)
+                    .add(Glob::new(&format!("bin/{bin_raw}"))?)
                     .build()
             }?;
 
-            result.push((bin.glob().to_string(), globset));
+            result.push((bin.source().to_string(), globset));
         }
 
         Ok(result)
@@ -90,68 +91,70 @@ impl PackageContentsTest {
         if target_platform.is_windows() {
             // Windows is special because it requires both a `.dll` and a `.bin` file
             for lib in self.lib.include_globs() {
-                if lib.glob().ends_with(".dll") {
+                let raw = lib.source();
+                if raw.ends_with(".dll") {
                     result.push((
-                        lib.glob().to_string(),
+                        raw.to_string(),
                         GlobSet::builder()
-                            .add(Glob::new(&format!("Library/bin/{lib}"))?)
+                            .add(Glob::new(&format!("Library/bin/{raw}"))?)
                             .build()?,
                     ));
-                } else if lib.glob().ends_with(".lib") {
+                } else if raw.ends_with(".lib") {
                     result.push((
-                        lib.glob().to_string(),
+                        raw.to_string(),
                         GlobSet::builder()
-                            .add(Glob::new(&format!("Library/lib/{lib}"))?)
+                            .add(Glob::new(&format!("Library/lib/{raw}"))?)
                             .build()?,
                     ));
                 } else {
                     result.push((
-                        lib.glob().to_string(),
+                        raw.to_string(),
                         GlobSet::builder()
-                            .add(Glob::new(&format!("Library/bin/{lib}.dll"))?)
+                            .add(Glob::new(&format!("Library/bin/{raw}.dll"))?)
                             .build()?,
                     ));
                     result.push((
-                        lib.glob().to_string(),
+                        raw.to_string(),
                         GlobSet::builder()
-                            .add(Glob::new(&format!("Library/lib/{lib}.lib"))?)
+                            .add(Glob::new(&format!("Library/lib/{raw}.lib"))?)
                             .build()?,
                     ));
                 }
             }
         } else {
             for lib in self.lib.include_globs() {
+                let raw = lib.source();
                 let globset = if target_platform.is_osx() {
-                    if lib.glob().ends_with(".dylib") || lib.glob().ends_with(".a") {
+                    if raw.ends_with(".dylib") || raw.ends_with(".a") {
                         GlobSet::builder()
-                            .add(Glob::new(&format!("lib/{lib}"))?)
+                            .add(Glob::new(&format!("lib/{raw}"))?)
                             .build()
                     } else {
                         GlobSet::builder()
-                            .add(build_glob(format!("lib/{{,lib}}{lib}.dylib"))?)
-                            .add(build_glob(format!("lib/{{,lib}}{lib}.*.dylib"))?)
+                            .add(build_glob(format!("lib/{{,lib}}{raw}.dylib"))?)
+                            .add(build_glob(format!("lib/{{,lib}}{raw}.*.dylib"))?)
                             .build()
                     }
                 } else if target_platform.is_linux() || target_platform.arch() == Some(Arch::Wasm32)
                 {
-                    if lib.glob().ends_with(".so")
-                        || lib.glob().contains(".so.")
-                        || lib.glob().ends_with(".a")
+                    if raw.ends_with(".so")
+                        || raw.contains(".so.")
+                        || raw.ends_with(".a")
                     {
                         GlobSet::builder()
-                            .add(Glob::new(&format!("lib/{lib}"))?)
+                            .add(Glob::new(&format!("lib/{raw}"))?)
                             .build()
                     } else {
                         GlobSet::builder()
-                            .add(build_glob(format!("lib/{{,lib}}{lib}.so"))?)
-                            .add(build_glob(format!("lib/{{,lib}}{lib}.so.*"))?)
+                            .add(build_glob(format!("lib/{{,lib}}{raw}.so"))?)
+                            .add(build_glob(format!("lib/{{,lib}}{raw}.so.*"))?)
                             .build()
                     }
                 } else {
                     // TODO
                     unimplemented!("lib_as_globs for target platform: {:?}", target_platform)
                 }?;
-                result.push((lib.glob().to_string(), globset));
+                result.push((raw.to_string(), globset));
             }
         }
 
@@ -177,10 +180,10 @@ impl PackageContentsTest {
         for site_package in self.site_packages.include_globs() {
             let mut globset = GlobSet::builder();
 
-            if site_package.glob().contains('/') {
-                globset.add(build_glob(format!("{site_packages_base}/{site_package}"))?);
+            if site_package.source().contains('/') {
+                globset.add(build_glob(format!("{site_packages_base}/{}", site_package.source()))?);
             } else {
-                let mut split = site_package.glob().split('.').collect::<Vec<_>>();
+                let mut split = site_package.source().split('.').collect::<Vec<_>>();
                 let last_elem = split.pop().unwrap_or_default();
                 let mut site_package_path = split.join("/");
                 if !site_package_path.is_empty() {
@@ -207,7 +210,8 @@ impl PackageContentsTest {
         let mut result = Vec::new();
 
         for file in self.files.include_globs() {
-            let globset = GlobSet::builder().add(file.clone()).build()?;
+            let glob = Glob::new(&file.source())?;
+            let globset = GlobSet::builder().add(glob).build()?;
             result.push((file.glob().to_string(), globset));
         }
 

--- a/src/package_test/content_test.rs
+++ b/src/package_test/content_test.rs
@@ -137,10 +137,7 @@ impl PackageContentsTest {
                     }
                 } else if target_platform.is_linux() || target_platform.arch() == Some(Arch::Wasm32)
                 {
-                    if raw.ends_with(".so")
-                        || raw.contains(".so.")
-                        || raw.ends_with(".a")
-                    {
+                    if raw.ends_with(".so") || raw.contains(".so.") || raw.ends_with(".a") {
                         GlobSet::builder()
                             .add(Glob::new(&format!("lib/{raw}"))?)
                             .build()
@@ -181,7 +178,10 @@ impl PackageContentsTest {
             let mut globset = GlobSet::builder();
 
             if site_package.source().contains('/') {
-                globset.add(build_glob(format!("{site_packages_base}/{}", site_package.source()))?);
+                globset.add(build_glob(format!(
+                    "{site_packages_base}/{}",
+                    site_package.source()
+                ))?);
             } else {
                 let mut split = site_package.source().split('.').collect::<Vec<_>>();
                 let last_elem = split.pop().unwrap_or_default();
@@ -210,7 +210,7 @@ impl PackageContentsTest {
         let mut result = Vec::new();
 
         for file in self.files.include_globs() {
-            let glob = Glob::new(&file.source())?;
+            let glob = Glob::new(file.source())?;
             let globset = GlobSet::builder().add(glob).build()?;
             result.push((file.glob().to_string(), globset));
         }

--- a/src/recipe/parser.rs
+++ b/src/recipe/parser.rs
@@ -37,7 +37,7 @@ pub use self::{
     about::About,
     build::{Build, BuildString, DynamicLinking, PrefixDetection, Python},
     cache::Cache,
-    glob_vec::GlobVec,
+    glob_vec::{GlobVec, GlobWithSource},
     output::find_outputs_from_src,
     package::{OutputPackage, Package},
     regex::SerializableRegex,

--- a/src/recipe/parser/glob_vec.rs
+++ b/src/recipe/parser/glob_vec.rs
@@ -14,15 +14,24 @@ use crate::recipe::custom_yaml::{
 };
 use crate::recipe::error::{ErrorKind, PartialParsingError};
 
+/// A glob with the source string
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct GlobWithSource {
+pub struct GlobWithSource {
+    /// The glob
     glob: Glob,
+    /// The source string
     source: String,
 }
 
 impl GlobWithSource {
-    pub fn glob(&self) -> &str {
-        &self.glob.glob()
+    /// Returns the glob
+    pub fn glob(&self) -> &Glob {
+        &self.glob
+    }
+
+    /// Returns the source string
+    pub fn source(&self) -> &str {
+        &self.source
     }
 }
 
@@ -245,7 +254,7 @@ impl TryConvertNode<GlobVec> for RenderedNode {
 
 fn to_vector_of_globs(
     sequence: &RenderedSequenceNode,
-) -> Result<Vec<Glob>, Vec<PartialParsingError>> {
+) -> Result<Vec<GlobWithSource>, Vec<PartialParsingError>> {
     let mut vec = Vec::with_capacity(sequence.len());
     for item in sequence.iter() {
         let str: String = item.try_convert("globs")?;

--- a/src/recipe/parser/snapshots/rattler_build__recipe__parser__glob_vec__tests__parsing_all_or_globvec.snap
+++ b/src/recipe/parser/snapshots/rattler_build__recipe__parser__glob_vec__tests__parsing_all_or_globvec.snap
@@ -3,7 +3,6 @@ source: src/recipe/parser/glob_vec.rs
 expression: "&as_yaml"
 ---
 globs:
-- foo
-- bar
-- baz/**/qux
-
+- foo{,/**}
+- bar{,/**}
+- baz/**/qux{,/**}

--- a/src/recipe/parser/snapshots/rattler_build__recipe__parser__glob_vec__tests__parsing_all_or_globvec.snap
+++ b/src/recipe/parser/snapshots/rattler_build__recipe__parser__glob_vec__tests__parsing_all_or_globvec.snap
@@ -3,6 +3,6 @@ source: src/recipe/parser/glob_vec.rs
 expression: "&as_yaml"
 ---
 globs:
-- foo{,/**}
-- bar{,/**}
-- baz/**/qux{,/**}
+- foo
+- bar
+- baz/**/qux

--- a/src/recipe/parser/snapshots/rattler_build__recipe__parser__glob_vec__tests__parsing_globvec-2.snap
+++ b/src/recipe/parser/snapshots/rattler_build__recipe__parser__glob_vec__tests__parsing_globvec-2.snap
@@ -3,7 +3,7 @@ source: src/recipe/parser/glob_vec.rs
 expression: "&as_yaml"
 ---
 include:
-- foo/**
+- foo/
 - bar
 - baz/**/qux
 exclude:

--- a/src/recipe/parser/snapshots/rattler_build__recipe__parser__glob_vec__tests__parsing_globvec.snap
+++ b/src/recipe/parser/snapshots/rattler_build__recipe__parser__glob_vec__tests__parsing_globvec.snap
@@ -2,7 +2,6 @@
 source: src/recipe/parser/glob_vec.rs
 expression: "&as_yaml"
 ---
-- foo
-- bar
-- baz/**/qux
-
+- foo{,/**}
+- bar{,/**}
+- baz/**/qux{,/**}

--- a/src/recipe/parser/snapshots/rattler_build__recipe__parser__glob_vec__tests__parsing_globvec.snap
+++ b/src/recipe/parser/snapshots/rattler_build__recipe__parser__glob_vec__tests__parsing_globvec.snap
@@ -2,6 +2,6 @@
 source: src/recipe/parser/glob_vec.rs
 expression: "&as_yaml"
 ---
-- foo{,/**}
-- bar{,/**}
-- baz/**/qux{,/**}
+- foo
+- bar
+- baz/**/qux

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__complete_recipe.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__complete_recipe.snap
@@ -81,7 +81,7 @@ build:
   post_process:
   - files:
     - '*.cmake'
-    - bla/**
+    - bla/
     regex: complicated(.*)regex
     replacement: simple_string
   files:
@@ -93,7 +93,7 @@ build:
     exclude:
     - foo/*
     - bar.txt
-    - baz/**
+    - baz/
 requirements:
   build:
   - gcc_linux-64
@@ -139,7 +139,7 @@ tests:
     - bash
   files:
     source:
-    - include/**
+    - include/
     - src/*.c
     - src_file.txt
 - package_contents:

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__recipe_windows.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__recipe_windows.snap
@@ -136,7 +136,7 @@ Recipe {
             ),
             missing_dso_allowlist: [],
             rpath_allowlist: [
-                "/usr/lib/**",
+                "/usr/lib/**{,/**}",
             ],
             overdepending_behavior: Ignore,
             overlinking_behavior: Ignore,
@@ -352,14 +352,14 @@ Recipe {
         PackageContents {
             package_contents: PackageContentsTest {
                 files: [
-                    "share/cmake/xtensor/xtensorConfig.cmake",
-                    "share/cmake/xtensor/xtensorConfigVersion.cmake",
+                    "share/cmake/xtensor/xtensorConfig.cmake{,/**}",
+                    "share/cmake/xtensor/xtensorConfigVersion.cmake{,/**}",
                 ],
                 site_packages: [],
                 bin: [],
                 lib: [],
                 include: [
-                    "xtensor/xarray.hpp",
+                    "xtensor/xarray.hpp{,/**}",
                 ],
             },
         },
@@ -449,7 +449,7 @@ Recipe {
         ),
         license_family: None,
         license_file: [
-            "LICENSE",
+            "LICENSE{,/**}",
         ],
         license_url: None,
         summary: Some(

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__unix_recipe.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__unix_recipe.snap
@@ -136,7 +136,7 @@ Recipe {
             ),
             missing_dso_allowlist: [],
             rpath_allowlist: [
-                "/usr/lib/**",
+                "/usr/lib/**{,/**}",
             ],
             overdepending_behavior: Ignore,
             overlinking_behavior: Ignore,
@@ -373,14 +373,14 @@ Recipe {
         PackageContents {
             package_contents: PackageContentsTest {
                 files: [
-                    "share/cmake/xtensor/xtensorConfig.cmake",
-                    "share/cmake/xtensor/xtensorConfigVersion.cmake",
+                    "share/cmake/xtensor/xtensorConfig.cmake{,/**}",
+                    "share/cmake/xtensor/xtensorConfigVersion.cmake{,/**}",
                 ],
                 site_packages: [],
                 bin: [],
                 lib: [],
                 include: [
-                    "xtensor/xarray.hpp",
+                    "xtensor/xarray.hpp{,/**}",
                 ],
             },
         },
@@ -471,7 +471,7 @@ Recipe {
         ),
         license_family: None,
         license_file: [
-            "LICENSE",
+            "LICENSE{,/**}",
         ],
         license_url: None,
         summary: Some(

--- a/src/source/copy_dir.rs
+++ b/src/source/copy_dir.rs
@@ -10,7 +10,7 @@ use globset::Glob;
 use ignore::WalkBuilder;
 use rayon::iter::{ParallelBridge, ParallelIterator};
 
-use crate::recipe::parser::GlobVec;
+use crate::recipe::parser::{GlobVec, GlobWithSource};
 
 use super::SourceError;
 
@@ -398,8 +398,8 @@ where
 
 pub(crate) struct CopyDirResult {
     copied_paths: Vec<PathBuf>,
-    include_globs: HashMap<Glob, Match>,
-    exclude_globs: HashMap<Glob, Match>,
+    include_globs: HashMap<String, Match>,
+    exclude_globs: HashMap<String, Match>,
 }
 
 impl CopyDirResult {
@@ -407,11 +407,11 @@ impl CopyDirResult {
         &self.copied_paths
     }
 
-    pub fn include_globs(&self) -> &HashMap<Glob, Match> {
+    pub fn include_globs(&self) -> &HashMap<String, Match> {
         &self.include_globs
     }
 
-    fn include_globs_mut(&mut self) -> &mut HashMap<Glob, Match> {
+    fn include_globs_mut(&mut self) -> &mut HashMap<String, Match> {
         &mut self.include_globs
     }
 
@@ -420,11 +420,11 @@ impl CopyDirResult {
     }
 
     #[allow(unused)]
-    pub fn exclude_globs(&self) -> &HashMap<Glob, Match> {
+    pub fn exclude_globs(&self) -> &HashMap<String, Match> {
         &self.exclude_globs
     }
 
-    fn exclude_globs_mut(&mut self) -> &mut HashMap<Glob, Match> {
+    fn exclude_globs_mut(&mut self) -> &mut HashMap<String, Match> {
         &mut self.exclude_globs
     }
 
@@ -434,12 +434,12 @@ impl CopyDirResult {
     }
 }
 
-fn make_glob_match_map(globs: &[Glob]) -> Result<HashMap<Glob, Match>, SourceError> {
+fn make_glob_match_map(globs: &[GlobWithSource]) -> Result<HashMap<String, Match>, SourceError> {
     globs
         .iter()
         .map(|glob| {
-            let matcher = Match::new(glob);
-            Ok(((*glob).clone(), matcher))
+            let matcher = Match::new(glob.glob());
+            Ok((glob.source().to_string(), matcher))
         })
         .collect()
 }

--- a/test-data/recipes/globtest/recipe.yaml
+++ b/test-data/recipes/globtest/recipe.yaml
@@ -1,5 +1,3 @@
-
-
 context:
   name: globtest
   version: "0.24.6"
@@ -19,3 +17,5 @@ about:
     - LICENSE
     - cmake/
     - docs/*.yml
+    # this should include the entire `tools` directory
+    - tools

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -29,10 +29,11 @@ def test_license_glob(rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
     assert (pkg / "info/licenses/cmake/FindTBB.cmake").exists()
     assert (pkg / "info/licenses/docs/ghp_environment.yml").exists()
     assert (pkg / "info/licenses/docs/rtd_environment.yml").exists()
+    assert (pkg / "info/licenses/tools/check_circular.py").exists()
 
     # Check that the total number of files under the license folder is correct
-    # 4 files + 2 folders = 6
-    assert len(list(pkg.glob("info/licenses/**/*"))) == 6
+    # 5 files + 3 folders = 8
+    assert len(list(pkg.glob("info/licenses/**/*"))) == 8
 
 
 def check_info(folder: Path, expected: Path):


### PR DESCRIPTION
This would fix #1055 but needs more work because it doesn't compile right now. Idea is to store the "source" glob alongside the evaluated glob for better serialization. Also later we need this sometimes to change how the glob behaves in the package content tests (where we amend it with e.g. `*.so`.