### PR TITLE
detect virtual packages from environment

### DIFF
--- a/src/render/solver.rs
+++ b/src/render/solver.rs
@@ -71,7 +71,7 @@ pub async fn solve_environment(
     let virtual_packages = tool_configuration.fancy_log_handler.wrap_in_progress(
         "determining virtual packages",
         move || {
-            VirtualPackage::detect(&VirtualPackageOverrides::default()).map(|vpkgs| {
+            VirtualPackage::detect(&VirtualPackageOverrides::from_env()).map(|vpkgs| {
                 vpkgs
                     .iter()
                     .map(|vpkg| GenericVirtualPackage::from(vpkg.clone()))


### PR DESCRIPTION
@hadim this is the fix for `CONDA_OVERRIDE_CUDA` to work 🤦 

To be honest though, I would like to remove this in favor of explicit `system-requirements` in the recipe at some point.