### PR TITLE
fix: use proper `host_platform` when testing `noarch` packages

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -167,7 +167,8 @@ pub async fn run_build(
             &result,
             &TestConfiguration {
                 test_prefix: directories.work_dir.join("test"),
-                target_platform: Some(output.build_configuration.host_platform),
+                target_platform: Some(output.build_configuration.target_platform),
+                host_platform: Some(output.build_configuration.host_platform),
                 keep_test_prefix: tool_configuration.no_clean,
                 //channels: output.reindex_channels().into_diagnostic()?,
                 channels: build_reindexed_channels(&output.build_configuration, tool_configuration)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -402,6 +402,7 @@ pub async fn run_test_from_args(
     let test_options = TestConfiguration {
         test_prefix: tempdir.path().to_path_buf(),
         target_platform: None,
+        host_platform: None,
         keep_test_prefix: false,
         channels,
         channel_priority: ChannelPriority::Strict,

--- a/src/package_test/run_test.rs
+++ b/src/package_test/run_test.rs
@@ -27,7 +27,6 @@ use rattler_solve::{ChannelPriority, SolveStrategy};
 use url::Url;
 
 use crate::env_vars;
-use crate::metadata::build_reindexed_channels;
 use crate::recipe::parser::{CommandsTest, DownstreamTest, Script, ScriptContent, TestType};
 use crate::source::copy_dir::CopyDir;
 use crate::{recipe::parser::PythonTest, render::solver::create_environment, tool_configuration};
@@ -313,12 +312,6 @@ pub async fn run_test(
     let prefix = canonicalize(&config.test_prefix)?;
 
     tracing::info!("Creating test environment in {:?}", prefix);
-
-    let host_platform = if target_platform != Platform::NoArch {
-        target_platform
-    } else {
-        Platform::current()
-    };
 
     let mut channels = config.channels.clone();
     channels.insert(0, Channel::from_directory(tmp_repo.path()).base_url);

--- a/src/package_test/run_test.rs
+++ b/src/package_test/run_test.rs
@@ -27,6 +27,7 @@ use rattler_solve::{ChannelPriority, SolveStrategy};
 use url::Url;
 
 use crate::env_vars;
+use crate::metadata::build_reindexed_channels;
 use crate::recipe::parser::{CommandsTest, DownstreamTest, Script, ScriptContent, TestType};
 use crate::source::copy_dir::CopyDir;
 use crate::{recipe::parser::PythonTest, render::solver::create_environment, tool_configuration};
@@ -181,8 +182,11 @@ async fn legacy_tests_from_folder(pkg: &Path) -> Result<(PathBuf, Vec<Tests>), s
 pub struct TestConfiguration {
     /// The test prefix directory (will be created)
     pub test_prefix: PathBuf,
-    /// The target platform
+    /// The target platform. If not set it will be discovered from the index.json metadata.
     pub target_platform: Option<Platform>,
+    /// The host platform for run-time dependencies. If not set it will be
+    /// discovered from the index.json metadata.
+    pub host_platform: Option<Platform>,
     /// If true, the test prefix will not be deleted after the test is run
     pub keep_test_prefix: bool,
     /// The channels to use for the test – do not forget to add the local build outputs channel
@@ -310,7 +314,7 @@ pub async fn run_test(
 
     tracing::info!("Creating test environment in {:?}", prefix);
 
-    let platform = if target_platform != Platform::NoArch {
+    let host_platform = if target_platform != Platform::NoArch {
         target_platform
     } else {
         Platform::current()
@@ -319,8 +323,17 @@ pub async fn run_test(
     let mut channels = config.channels.clone();
     channels.insert(0, Channel::from_directory(tmp_repo.path()).base_url);
 
+    let host_platform = config.host_platform.unwrap_or_else(|| {
+        if target_platform == Platform::NoArch {
+            Platform::current()
+        } else {
+            target_platform
+        }
+    });
+
     let config = TestConfiguration {
         target_platform: Some(target_platform),
+        host_platform: Some(host_platform),
         channels,
         ..config.clone()
     };
@@ -359,7 +372,7 @@ pub async fn run_test(
         create_environment(
             "test",
             &dependencies,
-            &platform,
+            &host_platform,
             &prefix,
             &config.channels,
             &config.tool_configuration,
@@ -555,7 +568,7 @@ impl CommandsTest {
             ParseStrictness::Lenient,
         )?);
 
-        let platform = config.target_platform.unwrap_or_else(Platform::current);
+        let platform = config.host_platform.unwrap_or_else(Platform::current);
 
         let run_env = prefix.join("run");
         create_environment(


### PR DESCRIPTION
This fixes #1048 