### PR TITLE
support setting `host_platform` explicitly

### DIFF
--- a/src/env_vars.rs
+++ b/src/env_vars.rs
@@ -302,11 +302,7 @@ pub fn vars(output: &Output, build_state: &str) -> HashMap<String, String> {
     } else {
         insert!(vars, "CONDA_BUILD_CROSS_COMPILATION", "0");
     }
-    insert!(
-        vars,
-        "SUBDIR",
-        output.build_configuration.target_platform.to_string()
-    );
+    insert!(vars, "SUBDIR", output.target_platform().to_string());
     insert!(
         vars,
         "build_platform",
@@ -315,8 +311,9 @@ pub fn vars(output: &Output, build_state: &str) -> HashMap<String, String> {
     insert!(
         vars,
         "target_platform",
-        output.build_configuration.target_platform.to_string()
+        output.target_platform().to_string()
     );
+    insert!(vars, "host_platform", output.host_platform().to_string());
     insert!(vars, "CONDA_BUILD_STATE", build_state);
 
     vars.extend(language_vars(output));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,12 +165,19 @@ pub async fn get_build_output(
     let target_platform = args.target_platform.unwrap_or(host_platform);
     // If target_platform is set and host_platform is not, then we default host_platform to the target_platform
     if let Some(target_platform) = args.target_platform {
-        // check if `--host-platform` is in the sysv arguments
-        let host_platform_set = std::env::args().any(|arg| arg == "--host-platform");
+        // Check if `host_platform` is set by looking at the args (not ideal)
+        let host_platform_set = std::env::args().any(|arg| arg.starts_with("--host-platform"));
         if !host_platform_set {
             host_platform = target_platform
         }
     }
+
+    tracing::debug!(
+        "Platforms: build: {}, host: {}, target: {}",
+        args.build_platform,
+        host_platform,
+        target_platform
+    );
 
     let selector_config = SelectorConfig {
         // We ignore noarch here

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,16 +154,28 @@ pub async fn get_build_output(
 
     let recipe_text = fs::read_to_string(recipe_path).into_diagnostic()?;
 
-    if args.target_platform == Platform::NoArch || args.build_platform == Platform::NoArch {
+    if args.target_platform == Some(Platform::NoArch) || args.build_platform == Platform::NoArch {
         return Err(miette::miette!(
             "target-platform / build-platform cannot be `noarch` - that should be defined in the recipe"
         ));
     }
 
+    let mut host_platform = args.host_platform;
+    // If target_platform is not set, we default to the host platform
+    let target_platform = args.target_platform.unwrap_or(host_platform);
+    // If target_platform is set and host_platform is not, then we default host_platform to the target_platform
+    if let Some(target_platform) = args.target_platform {
+        // check if `--host-platform` is in the sysv arguments
+        let host_platform_set = std::env::args().any(|arg| arg == "--host-platform");
+        if !host_platform_set {
+            host_platform = target_platform
+        }
+    }
+
     let selector_config = SelectorConfig {
         // We ignore noarch here
-        target_platform: args.target_platform,
-        host_platform: args.target_platform,
+        target_platform,
+        host_platform,
         hash: None,
         build_platform: args.build_platform,
         variant: BTreeMap::new(),
@@ -292,7 +304,7 @@ pub async fn get_build_output(
             recipe,
             build_configuration: BuildConfiguration {
                 target_platform: discovered_output.target_platform,
-                host_platform: args.target_platform,
+                host_platform,
                 build_platform: args.build_platform,
                 hash,
                 variant: discovered_output.used_vars.clone(),

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -271,8 +271,13 @@ pub struct BuildOpts {
     pub build_platform: Platform,
 
     /// The target platform for the build.
+    #[arg(long)]
+    pub target_platform: Option<Platform>,
+
+    /// The host platform for the build. If set, it will be used to determine
+    /// also the target_platform (as long as it is not noarch).
     #[arg(long, default_value_t = Platform::current())]
-    pub target_platform: Platform,
+    pub host_platform: Platform,
 
     /// Add a channel to search for dependencies in.
     #[arg(short = 'c', long, default_value = "conda-forge")]

--- a/src/recipe/jinja.rs
+++ b/src/recipe/jinja.rs
@@ -7,7 +7,7 @@ use std::{collections::BTreeMap, str::FromStr};
 
 use minijinja::value::{from_args, Kwargs, Object};
 use minijinja::{Environment, Value};
-use rattler_conda_types::{PackageName, ParseStrictness, Platform, Version, VersionSpec};
+use rattler_conda_types::{Arch, PackageName, ParseStrictness, Platform, Version, VersionSpec};
 
 use crate::render::pin::PinArgs;
 pub use crate::render::pin::{Pin, PinExpression};
@@ -364,6 +364,7 @@ fn default_filters(env: &mut Environment) {
 fn set_jinja(config: &SelectorConfig) -> minijinja::Environment<'static> {
     let SelectorConfig {
         target_platform,
+        host_platform,
         build_platform,
         variant,
         experimental,
@@ -428,8 +429,7 @@ fn set_jinja(config: &SelectorConfig) -> minijinja::Environment<'static> {
 
     let variant_clone = variant.clone();
     env.add_function("cdt", move |package_name: String| {
-        use rattler_conda_types::Arch;
-        let arch = build_platform.arch().or_else(|| target_platform.arch());
+        let arch = host_platform.arch().or_else(|| build_platform.arch());
         let arch_str = arch.map(|arch| format!("{arch}"));
 
         let cdt_arch = if let Some(s) = variant_clone.get("cdt_arch") {

--- a/src/recipe/jinja.rs
+++ b/src/recipe/jinja.rs
@@ -361,6 +361,15 @@ fn default_filters(env: &mut Environment) {
     env.add_filter("unique", minijinja::filters::unique);
 }
 
+fn parse_platform(platform: &str) -> Result<Platform, minijinja::Error> {
+    Platform::from_str(platform).map_err(|e| {
+        minijinja::Error::new(
+            minijinja::ErrorKind::InvalidOperation,
+            format!("Invalid platform: {e}"),
+        )
+    })
+}
+
 fn set_jinja(config: &SelectorConfig) -> minijinja::Environment<'static> {
     let SelectorConfig {
         target_platform,
@@ -487,6 +496,20 @@ fn set_jinja(config: &SelectorConfig) -> minijinja::Environment<'static> {
 
     env.add_function("pin_compatible", |name: String, kwargs: Kwargs| {
         jinja_pin_function(name, kwargs, InternalRepr::PinCompatible)
+    });
+
+    // Add the is_... functions
+    env.add_function("is_linux", |platform: &str| {
+        Ok(parse_platform(platform)?.is_linux())
+    });
+    env.add_function("is_osx", |platform: &str| {
+        Ok(parse_platform(platform)?.is_osx())
+    });
+    env.add_function("is_windows", |platform: &str| {
+        Ok(parse_platform(platform)?.is_windows())
+    });
+    env.add_function("is_unix", |platform: &str| {
+        Ok(parse_platform(platform)?.is_unix())
     });
 
     env.add_function("load_from_file", move |path: String| {

--- a/src/selectors.rs
+++ b/src/selectors.rs
@@ -36,6 +36,11 @@ impl SelectorConfig {
             Value::from_safe_string(self.target_platform.to_string()),
         );
 
+        context.insert(
+            "host_platform".to_string(),
+            Value::from_safe_string(self.host_platform.to_string()),
+        );
+
         if let Some(platform) = self.host_platform.only_platform() {
             context.insert(
                 platform.to_string(),


### PR DESCRIPTION
@isuruf I started a PR here to add `--host-platform` to the arguments.
 
The current logic is:

The `host_platform` is defaulted to `Platform::current()`.

If `target_platform` is unset, then we initialize it to the value of `host_platform`.

If `target_platform` is set to something (noarch is forbidden to set btw), then `host_platform` is set to this value too, if it is not set explicitly (so the current logic continues to work).

Would be great if you let me know if that makes sense to you and what use-cases you had in mind.