### PR TITLE
Avoid fetching all tags on git clone/fetch

### DIFF
--- a/src/source/git_source.rs
+++ b/src/source/git_source.rs
@@ -46,6 +46,8 @@ pub fn fetch_repo(
             // This should be safe, as we do a `git checkout` below to refresh
             // the working copy.
             "--update-head-ok",
+            // Avoid overhead of fetching unused tags.
+            "--no-tags",
             url,
             refspec.as_str(),
         ])
@@ -195,7 +197,13 @@ pub fn git_src(
             if !cache_path.exists() {
                 let mut command = git_command(system_tools, "clone")?;
                 command
-                    .args(["--progress", "-n", source.url().to_string().as_str()])
+                    .args([
+                        // Avoid overhead of fetching unused tags.
+                        "--no-tags",
+                        "--progress",
+                        "-n",
+                        source.url().to_string().as_str(),
+                    ])
                     .arg(cache_path.as_os_str());
 
                 let output = command

--- a/test-data/recipes/git_source_patch/recipe.yaml
+++ b/test-data/recipes/git_source_patch/recipe.yaml
@@ -4,7 +4,7 @@ package:
 
 source:
   git: https://github.com/ros2-gbp/ament_package-release.git
-  rev: release/humble/ament_package/0.14.0-4
+  tag: release/humble/ament_package/0.14.0-4
   target_directory: ros-humble-ament-package/src/work
   patches:
     - patch/ros-humble-ament-package.patch

--- a/test-data/recipes/llamacpp/recipe.yaml
+++ b/test-data/recipes/llamacpp/recipe.yaml
@@ -10,7 +10,7 @@ package:
 
 source:
   git: https://github.com/ggerganov/llama.cpp.git
-  rev: "${{ version }}"
+  tag: "${{ version }}"
 
 build:
   number: 0

--- a/test-data/recipes/package-content-tests/llama-recipe.yaml
+++ b/test-data/recipes/package-content-tests/llama-recipe.yaml
@@ -10,7 +10,7 @@ package:
 
 source:
   git: https://github.com/ggerganov/llama.cpp.git
-  rev: "${{ version }}"
+  tag: "${{ version }}"
 
 build:
   number: 0

--- a/test-data/recipes/variants/recipe.yaml
+++ b/test-data/recipes/variants/recipe.yaml
@@ -10,7 +10,7 @@ package:
 
 source:
   git: https://github.com/ggerganov/llama.cpp.git
-  rev: "${{ version }}"
+  tag: "${{ version }}"
 
 build:
   variant:


### PR DESCRIPTION
By default, git fetch/clone will download all tags from the remote repo, so pass `--no-tags` to avoid some unnecessary downloading -- we'll still explicitly fetch any tag we need to checkout.