### PR TITLE
fix: copy permissions when reflinking files

### DIFF
--- a/src/source/copy_dir.rs
+++ b/src/source/copy_dir.rs
@@ -389,7 +389,7 @@ where
                 let permissions = metadata.permissions();
                 fs_err::set_permissions(to, permissions)?;
             }
-        },
+        }
         Some(_) => {}
     }
 


### PR DESCRIPTION
fs::copy copies the permissions, but reflink (on Linux, btrfs) does not.