### PR TITLE
insert `LIB` and `INCLUDE`

### DIFF
--- a/src/script.rs
+++ b/src/script.rs
@@ -355,8 +355,6 @@ const CMDEXE_PREAMBLE: &str = r#"
 @echo on
 IF "%CONDA_BUILD%" == "" (
     @rem special behavior from conda-build for Windows
-    set "INCLUDE=((LIBRARY_INC));%INCLUDE%"
-    set "LIB=((LIBRARY_LIB));%LIB%"
     call ((script_path))
 )
 @rem re-enable echo because the activation scripts might have messed with it

--- a/src/script.rs
+++ b/src/script.rs
@@ -354,6 +354,9 @@ const CMDEXE_PREAMBLE: &str = r#"
 @chcp 65001 > nul
 @echo on
 IF "%CONDA_BUILD%" == "" (
+    @rem special behavior from conda-build for Windows
+    set "INCLUDE=((LIBRARY_INC));%INCLUDE%"
+    set "LIB=((LIBRARY_LIB));%LIB%"
     call ((script_path))
 )
 @rem re-enable echo because the activation scripts might have messed with it
@@ -373,7 +376,16 @@ impl Interpreter for CmdExeInterpreter {
 
         let build_script = format!(
             "{}\n{}",
-            CMDEXE_PREAMBLE.replace("((script_path))", &build_env_path.to_string_lossy()),
+            CMDEXE_PREAMBLE
+                .replace("((script_path))", &build_env_path.to_string_lossy())
+                .replace(
+                    "((LIBRARY_INC))",
+                    &args.env_vars.get("LIBRARY_INC").unwrap_or(&"".to_string())
+                )
+                .replace(
+                    "((LIBRARY_LIB))",
+                    &args.env_vars.get("LIBRARY_LIB").unwrap_or(&"".to_string())
+                ),
             args.script.script()
         );
         tokio::fs::write(

--- a/src/windows/env.rs
+++ b/src/windows/env.rs
@@ -47,23 +47,39 @@ pub fn default_env_vars(
     let mut vars = HashMap::<String, Option<String>>::new();
     vars.insert(
         "SCRIPTS".to_string(),
-        Some(prefix.join("Scripts").to_string_lossy().to_string()),
+        Some(prefix.join("Scripts").display().to_string()),
     );
     vars.insert(
         "LIBRARY_PREFIX".to_string(),
-        Some(library_prefix.to_string_lossy().to_string()),
+        Some(library_prefix.display().to_string()),
     );
     vars.insert(
         "LIBRARY_BIN".to_string(),
-        Some(library_prefix.join("bin").to_string_lossy().to_string()),
+        Some(library_prefix.join("bin").display().to_string()),
     );
+    let library_lib = library_prefix.join("lib");
+    let library_inc = library_prefix.join("include");
     vars.insert(
         "LIBRARY_INC".to_string(),
-        Some(library_prefix.join("include").to_string_lossy().to_string()),
+        Some(library_inc.display().to_string()),
     );
     vars.insert(
         "LIBRARY_LIB".to_string(),
-        Some(library_prefix.join("lib").to_string_lossy().to_string()),
+        Some(library_lib.display().to_string()),
+    );
+
+    // This adds the LIB and INCLUDE vars. It would not be entirely correct if someone
+    // overwrites the LIBRARY_LIB or LIBRARY_INCLUDE variables from the variants.yaml
+    // but I think for now this is fine.
+    let lib_var = std::env::var("LIB").ok().unwrap_or_default();
+    let include_var = std::env::var("INCLUDE").ok().unwrap_or_default();
+    vars.insert(
+        "LIB".to_string(),
+        Some(format!("{};{}", library_lib.display(), lib_var)),
+    );
+    vars.insert(
+        "INCLUDE".to_string(),
+        Some(format!("{};{}", library_inc.display(), include_var)),
     );
 
     let default_vars = vec![


### PR DESCRIPTION
This mirrors `conda-build` behavior that also prepends these variables:

https://github.com/conda/conda-build/blob/651b941b2db94d46f5f343acf2d7d931b10c1d90/conda_build/windows.py#L267-L270