### PR TITLE
fix dot in variant when exporting to environment

### DIFF
--- a/src/variant_config.rs
+++ b/src/variant_config.rs
@@ -753,9 +753,11 @@ impl VariantConfig {
 
                 // We also replace `-` with `_` in the keys for better compatibility
                 // with conda-build and because then we can set them directly as env vars
+                // and the same for `.` because we want to be able to set them as env vars directly
                 let used_filtered = used_filtered
                     .into_iter()
                     .map(|(k, v)| (k.replace("-", "_"), v))
+                    .map(|(k, v)| (k.replace(".", "_"), v))
                     .collect::<BTreeMap<_, _>>();
 
                 recipes.insert(DiscoveredOutput {
@@ -1066,7 +1068,7 @@ mod tests {
                 .unwrap();
 
             // assert output order
-            let order = vec!["some-pkg-a", "some-pkg", "some_pkg"];
+            let order = vec!["some-pkg.foo-a", "some-pkg.foo", "some_pkg.foo"];
             let outputs: Vec<_> = outputs_and_variants
                 .iter()
                 .map(|o| o.name.clone())

--- a/test-data/recipes/output_order/order_1.yaml
+++ b/test-data/recipes/output_order/order_1.yaml
@@ -1,5 +1,5 @@
 context:
-  name: some-pkg
+  name: some-pkg.foo
   name_a: ${{ name }}-a
   version: 1.0.0
   build_number: 0

--- a/test-data/recipes/pin_subpackage/recipe.yaml
+++ b/test-data/recipes/pin_subpackage/recipe.yaml
@@ -1,0 +1,23 @@
+# regression test that pin subpackage works with `my.package`
+context:
+  name: my.package
+  version: 0.1.0
+
+recipe:
+  version: ${{ version }}
+build:
+  number: 0
+
+outputs:
+  - package:
+      name: ${{ name }}
+    build:
+      noarch: generic
+
+  - package:
+      name: ${{ name }}-a
+    build:
+      noarch: generic
+    requirements:
+      run:
+        - ${{ pin_subpackage(name, exact=true) }}

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -998,3 +998,14 @@ def test_env_vars_override(rattler_build: RattlerBuild, recipes: Path, tmp_path:
         "variant": "pybind11-abi",
         "spec": "pybind11-abi 4.*",
     }
+
+
+def test_pin_subpackage(
+    rattler_build: RattlerBuild, recipes: Path, tmp_path: Path, snapshot_json
+):
+    rattler_build.build(
+        recipes / "pin_subpackage",
+        tmp_path,
+    )
+    pkg = get_extracted_package(tmp_path, "my.package-a")
+    assert (pkg / "info/index.json").exists()


### PR DESCRIPTION
And also fixes the "used-variables" detection for `pin_subpackage` to not detect strings, but properly detect variables.

Going to include @pavelzw test from #1120 