### PR TITLE
WIP: new variant resolving / rendering 

### DIFF
--- a/examples/rich/recipe.yaml
+++ b/examples/rich/recipe.yaml
@@ -38,6 +38,11 @@ tests:
   - python:
       imports:
         - rich
+  - script:
+      - python -e "print(\"foo\")"
+    requirements:
+      run:
+        - python
 
 about:
   homepage: https://github.com/Textualize/rich

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ pub mod rebuild;
 pub mod recipe_generator;
 mod unix;
 pub mod upload;
+mod variant_render;
 mod windows;
 
 use std::{

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -325,6 +325,7 @@ pub struct Output {
     pub finalized_dependencies: Option<FinalizedDependencies>,
     /// The finalized dependencies from the cache (if there is a cache
     /// instruction)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub finalized_cache_dependencies: Option<FinalizedDependencies>,
     /// The finalized sources for this output. Contain the exact git hashes for
     /// the sources that are used to build this output.

--- a/src/recipe/parser/requirements.rs
+++ b/src/recipe/parser/requirements.rs
@@ -116,6 +116,21 @@ impl Requirements {
         self.build.iter().chain(self.host.iter())
     }
 
+    /// Return all dependencies including any constraints, run exports
+    /// This is mainly used to find any pin expressions that need to be resolved or added as requirements
+    pub fn all_requirements(&self) -> impl Iterator<Item = &Dependency> {
+        self.build
+            .iter()
+            .chain(self.host.iter())
+            .chain(self.run.iter())
+            .chain(self.run_constraints.iter())
+            .chain(self.run_exports.weak.iter())
+            .chain(self.run_exports.weak_constraints.iter())
+            .chain(self.run_exports.strong.iter())
+            .chain(self.run_exports.strong_constraints.iter())
+            .chain(self.run_exports.noarch.iter())
+    }
+
     /// Get all requirements in one iterator.
     pub fn all(&self) -> impl Iterator<Item = &Dependency> {
         self.build

--- a/src/variant_config.rs
+++ b/src/variant_config.rs
@@ -355,7 +355,7 @@ impl VariantConfig {
     pub fn combinations(
         &self,
         used_vars: &HashSet<String>,
-        already_used_vars: Option<BTreeMap<String, String>>,
+        already_used_vars: Option<&BTreeMap<String, String>>,
     ) -> Result<Vec<BTreeMap<String, String>>, VariantError> {
         self.validate_zip_keys()?;
         let zip_keys = self.zip_keys.clone().unwrap_or_default();
@@ -397,7 +397,7 @@ impl VariantConfig {
         let mut combinations = Vec::new();
         let mut current = Vec::new();
         find_combinations(&variant_keys, 0, &mut current, &mut combinations);
-
+        println!("CCC {:?}", combinations);
         // zip the combinations
         let result: Vec<_> = combinations
             .iter()
@@ -1108,7 +1108,7 @@ mod tests {
 
         let already_used_vars = BTreeMap::from_iter(vec![("a".to_string(), "1".to_string())]);
         let c2 = config
-            .combinations(&used_vars, Some(already_used_vars))
+            .combinations(&used_vars, Some(&already_used_vars))
             .unwrap();
         println!("{:?}", c2);
         for c in &c2 {

--- a/src/variant_config.rs
+++ b/src/variant_config.rs
@@ -12,7 +12,6 @@ use serde::{Deserialize, Serialize};
 
 use thiserror::Error;
 
-use crate::utils::NormalizedKeyBTreeMap;
 use crate::{
     _partialerror,
     recipe::{
@@ -23,6 +22,7 @@ use crate::{
     selectors::SelectorConfig,
     variant_render::stage_0_render,
 };
+use crate::{utils::NormalizedKeyBTreeMap, variant_render::stage_1_render};
 
 #[allow(missing_docs)]
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
@@ -399,7 +399,7 @@ impl VariantConfig {
         find_combinations(&variant_keys, 0, &mut current, &mut combinations);
 
         // zip the combinations
-        let result : Vec<_> = combinations
+        let result: Vec<_> = combinations
             .iter()
             .map(|combination| {
                 combination
@@ -442,8 +442,8 @@ impl VariantConfig {
         selector_config: &SelectorConfig,
     ) -> Result<IndexSet<DiscoveredOutput>, VariantError> {
         /// find all jinja variables
-        let stage_0 = stage_0_render(outputs, recipe, selector_config, self);
-
+        let stage_0 = stage_0_render(outputs, recipe, selector_config, self)?;
+        let stage_1 = stage_1_render(stage_0, self);
         Ok(Default::default())
     }
     // pub fn find_variants(
@@ -1107,7 +1107,9 @@ mod tests {
         assert_eq!(combinations.len(), 2 * 2 * 3);
 
         let already_used_vars = BTreeMap::from_iter(vec![("a".to_string(), "1".to_string())]);
-        let c2 = config.combinations(&used_vars, Some(already_used_vars)).unwrap();
+        let c2 = config
+            .combinations(&used_vars, Some(already_used_vars))
+            .unwrap();
         println!("{:?}", c2);
         for c in &c2 {
             assert!(c.get("a").unwrap() == "1");

--- a/src/variant_config.rs
+++ b/src/variant_config.rs
@@ -12,20 +12,17 @@ use serde::{Deserialize, Serialize};
 
 use thiserror::Error;
 
+use crate::utils::NormalizedKeyBTreeMap;
 use crate::{
     _partialerror,
-    hash::HashInfo,
     recipe::{
         custom_yaml::{HasSpan, Node, RenderedMappingNode, RenderedNode, TryConvertNode},
         error::{ErrorKind, ParsingError, PartialParsingError},
-        parser::Recipe,
         Jinja, Render,
     },
     selectors::SelectorConfig,
-    used_variables::used_vars_from_expressions,
+    variant_render::stage_0_render,
 };
-use crate::{recipe::parser::Dependency, utils::NormalizedKeyBTreeMap};
-use petgraph::{algo::toposort, graph::DiGraph};
 
 #[allow(missing_docs)]
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
@@ -170,6 +167,49 @@ pub enum VariantConfigError {
     NewParseError(#[from] ParsingError),
 }
 
+// pub struct OutputTree {
+//     /// All the discovered outputs after stage 0
+//     pub stage0: Vec<Vec<Stage0EvaluatedOutput>>,
+
+//     /// All the discovered outputs after stage 1
+//     pub stage1: Vec<Vec<Stage1EvaluatedOutput>>,
+
+//     variant_config: VariantConfig,
+// }
+
+// /// Storage for a partially evaluated recipe / output
+// pub struct Stage0EvaluatedOutput {
+//     /// The output
+//     pub output: Output,
+//     /// The (found) used vars
+//     pub used_vars_from_jinja: HashMap<String, String>,
+//     /// The target_platform that we determined
+//     pub target_platform: Platform,
+// }
+
+// impl Stage0EvaluatedOutput {
+//     fn new(output: &Node, src: &str, variant_config: &VariantConfig) -> Stage0EvaluatedOutput {
+//         let used_vars_from_jinja = used_vars_from_expressions(output, src).unwrap();
+
+//         Stage0EvaluatedOutput {
+//             output: output.clone(),
+//             used_vars_from_jinja:
+
+//         }
+//     }
+// }
+
+// pub struct Stage1EvaluatedOutput {
+//     /// Stage 0 output
+//     pub stage_0: Stage0EvaluatedOutput,
+
+//     /// The used variables from requirements in build and host
+//     pub used_vars_from_deps: HashSet<String>,
+
+//     /// The variant keys used to render the stage 0
+//     pub variant: HashSet<String, String>,
+// }
+
 impl VariantConfig {
     /// This function loads multiple variant configuration files and merges them into a single
     /// configuration. The configuration files are loaded in the order they are provided in the
@@ -308,9 +348,14 @@ impl VariantConfig {
 
     /// This function returns all possible combinations of variants for the given set of used
     /// variables.
+    ///
+    /// The `used_vars` argument is a set of variables that are used in the recipe. The `already_used_vars`
+    /// argument is a mapping of variables that are already used in the recipe. This is used to remove variants
+    /// that are already in other parts of the "tree".
     pub fn combinations(
         &self,
         used_vars: &HashSet<String>,
+        already_used_vars: Option<BTreeMap<String, String>>,
     ) -> Result<Vec<BTreeMap<String, String>>, VariantError> {
         self.validate_zip_keys()?;
         let zip_keys = self.zip_keys.clone().unwrap_or_default();
@@ -354,7 +399,7 @@ impl VariantConfig {
         find_combinations(&variant_keys, 0, &mut current, &mut combinations);
 
         // zip the combinations
-        let result = combinations
+        let result : Vec<_> = combinations
             .iter()
             .map(|combination| {
                 combination
@@ -363,7 +408,20 @@ impl VariantConfig {
                     .collect::<BTreeMap<String, String>>()
             })
             .collect();
-        Ok(result)
+
+        if let Some(already_used_vars) = already_used_vars {
+            let result = result
+                .into_iter()
+                .filter(|combination| {
+                    already_used_vars
+                        .iter()
+                        .any(|(key, value)| combination.get(key).map_or(false, |v| v == value))
+                })
+                .collect();
+            Ok(result)
+        } else {
+            Ok(result)
+        }
     }
 
     /// This function finds all used variables in a recipe and expands the recipe to the full
@@ -383,383 +441,399 @@ impl VariantConfig {
         recipe: &str,
         selector_config: &SelectorConfig,
     ) -> Result<IndexSet<DiscoveredOutput>, VariantError> {
-        let mut outputs_map = HashMap::new();
+        /// find all jinja variables
+        let stage_0 = stage_0_render(outputs, recipe, selector_config, self);
 
-        // sort the outputs by topological order
-        for output in outputs.iter() {
-            // for the topological sort we only take into account `pin_subpackage` expressions
-            // in the recipe which are captured by the `used vars`
-            let mut used_vars = used_vars_from_expressions(output, recipe).map_err(|e| {
-                let errs: ParseErrors = e.into();
-                errs
-            })?;
-            let parsed_recipe =
-                Recipe::from_node(output, selector_config.clone()).map_err(|err| {
-                    let errs: ParseErrors = err
-                        .into_iter()
-                        .map(|err| ParsingError::from_partial(recipe, err))
-                        .collect::<Vec<ParsingError>>()
-                        .into();
-                    errs
-                })?;
-
-            let noarch_type = parsed_recipe.build().noarch();
-            // add in any host and build dependencies
-            used_vars.extend(parsed_recipe.requirements().build_time().filter_map(|dep| {
-                match dep {
-                    Dependency::Spec(spec) => {
-                        // here we filter python as a variant and don't take it's passed variants
-                        // when noarch is python
-                        spec.name.as_ref().and_then(|name| {
-                            let normalized_name = name.as_normalized();
-                            if normalized_name == "python" && noarch_type.is_python() {
-                                return None;
-                            }
-                            normalized_name.to_string().into()
-                        })
-                    }
-                    _ => None,
-                }
-            }));
-
-            used_vars.extend(
-                parsed_recipe
-                    .requirements()
-                    .all()
-                    .filter_map(|dep| match dep {
-                        Dependency::PinSubpackage(pin) => {
-                            Some(pin.pin_value().name.as_normalized().to_string())
-                        }
-                        _ => None,
-                    }),
-            );
-
-            let use_keys = &parsed_recipe.build().variant().use_keys;
-            used_vars.extend(use_keys.iter().cloned());
-
-            let target_platform = if noarch_type.is_none() {
-                selector_config.target_platform
-            } else {
-                Platform::NoArch
-            };
-            if outputs_map
-                .insert(
-                    parsed_recipe.package().name().as_normalized().to_string(),
-                    (output, used_vars, target_platform),
-                )
-                .is_some()
-            {
-                return Err(VariantError::DuplicateOutputs(
-                    parsed_recipe.package().name().as_normalized().to_string(),
-                ));
-            }
-        }
-
-        // now topologically sort the outputs and find cycles
-
-        // Create an empty directed graph
-        let mut graph = DiGraph::<_, ()>::new();
-
-        // Create a map from output names to node indices
-        let mut node_indices = HashMap::new();
-
-        // TODO: this code can be improved in general
-        // Add a node for each output
-        for output in outputs_map.keys() {
-            let node_index = graph.add_node(output.clone());
-            node_indices.insert(output.clone(), node_index);
-        }
-
-        // Add an edge for each pair of outputs where one uses a variable defined by the other
-        for (output, (_, used_vars, _)) in &outputs_map {
-            let output_node_index = *node_indices
-                .get(output)
-                .expect("unreachable, we insert keys in the loop above");
-            for used_var in used_vars {
-                if outputs_map.contains_key(used_var) {
-                    let defining_output_node_index = *node_indices
-                        .get(used_var)
-                        .expect("unreachable, we insert keys in the loop above");
-                    // self referencing is possible, but not a cycle
-                    if defining_output_node_index == output_node_index {
-                        continue;
-                    }
-                    graph.add_edge(defining_output_node_index, output_node_index, ());
-                }
-            }
-        }
-
-        // Perform a topological sort
-        let outputs: Vec<_> = match toposort(&graph, None) {
-            Ok(sorted_node_indices) => {
-                // Replace the original list of outputs with the sorted list
-                sorted_node_indices
-                    .into_iter()
-                    .map(|node_index| graph[node_index].clone())
-                    .collect()
-            }
-            Err(err) => {
-                // There is a cycle in the graph
-                return Err(VariantError::CycleInRecipeOutputs(
-                    graph[err.node_id()].clone(),
-                ));
-            }
-        };
-
-        // sort the outputs map by the topological order
-        let outputs_map = outputs
-            .iter()
-            .enumerate()
-            .map(|(idx, name)| {
-                let (node, used_vars, target_platform) = outputs_map[name].clone();
-                (idx, (name, node, used_vars, target_platform))
-            })
-            .collect::<BTreeMap<_, _>>();
-
-        let mut all_build_dependencies = Vec::new();
-        for (_, (_, output, _, _)) in outputs_map.iter() {
-            let parsed_recipe =
-                Recipe::from_node(output, selector_config.clone()).map_err(|err| {
-                    let errs: ParseErrors = err
-                        .into_iter()
-                        .map(|err| ParsingError::from_partial(recipe, err))
-                        .collect::<Vec<ParsingError>>()
-                        .into();
-                    errs
-                })?;
-            let noarch_type = parsed_recipe.build().noarch();
-            let build_time_requirements =
-                parsed_recipe.build_time_requirements().filter_map(|dep| {
-                    // here we filter python as a variant and don't take it's passed variants
-                    // when noarch is python
-                    if let Dependency::Spec(spec) = &dep {
-                        if let Some(name) = &spec.name {
-                            if name.as_normalized() == "python" && noarch_type.is_python() {
-                                return None;
-                            }
-                        }
-                    }
-                    Some(dep.clone())
-                });
-            all_build_dependencies.extend(build_time_requirements);
-        }
-
-        let mut all_variables = all_build_dependencies
-            .iter()
-            .filter_map(|dep| match dep {
-                Dependency::Spec(spec) => {
-                    // filter all matchspecs that override the version or build
-                    let is_simple = spec.version.is_none() && spec.build.is_none();
-                    if is_simple && spec.name.is_some() {
-                        spec.name
-                            .as_ref()
-                            .and_then(|name| name.as_normalized().to_string().into())
-                    } else {
-                        None
-                    }
-                }
-                Dependency::PinSubpackage(pin_sub) => {
-                    Some(pin_sub.pin_value().name.as_normalized().to_string())
-                }
-                _ => None,
-            })
-            .collect::<HashSet<_>>();
-
-        // also add all used variables from the outputs
-        for (_, (_, _, used_vars, _)) in outputs_map.iter() {
-            all_variables.extend(used_vars.clone());
-        }
-
-        // remove all existing outputs from all_variables
-        let output_names = outputs.iter().cloned().collect::<HashSet<_>>();
-        let mut all_variables = all_variables
-            .difference(&output_names)
-            .cloned()
-            .collect::<HashSet<_>>();
-
-        // special handling of CONDA_BUILD_SYSROOT
-        if all_variables.contains("c_compiler") || all_variables.contains("cxx_compiler") {
-            all_variables.insert("CONDA_BUILD_SYSROOT".to_string());
-        }
-
-        // also always add `target_platform` and `channel_targets`
-        all_variables.insert("target_platform".to_string());
-        all_variables.insert("channel_targets".to_string());
-
-        let combinations = self.combinations(&all_variables)?;
-
-        // Then find all used variables from the each output recipe
-        // let mut variants = Vec::new();
-        let mut recipes = IndexSet::new();
-        for combination in combinations {
-            let mut other_recipes =
-                HashMap::<String, (String, String, BTreeMap<String, String>)>::new();
-
-            for (_, (name, output, used_vars, target_platform)) in outputs_map.iter() {
-                let mut used_variables = used_vars.clone();
-                let mut exact_pins = HashSet::new();
-
-                // special handling of CONDA_BUILD_SYSROOT
-                if used_variables.contains("c_compiler") || used_variables.contains("cxx_compiler")
-                {
-                    used_variables.insert("CONDA_BUILD_SYSROOT".to_string());
-                }
-
-                // also always add `target_platform` and `channel_targets`
-                used_variables.insert("target_platform".to_string());
-                used_variables.insert("channel_targets".to_string());
-
-                let mut combination = combination.clone();
-                // we need to overwrite the target_platform in case of `noarch`.
-                combination.insert("target_platform".to_string(), target_platform.to_string());
-
-                let selector_config_with_variant =
-                    selector_config.new_with_variant(combination.clone(), *target_platform);
-
-                let parsed_recipe = Recipe::from_node(output, selector_config_with_variant.clone())
-                    .map_err(|err| {
-                        let errs: ParseErrors = err
-                            .into_iter()
-                            .map(|err| ParsingError::from_partial(recipe, err))
-                            .collect::<Vec<ParsingError>>()
-                            .into();
-                        errs
-                    })?;
-
-                // find the variables that were actually used in the recipe and that count towards the hash
-                parsed_recipe.build_time_requirements().for_each(|dep| {
-                    if let Dependency::Spec(spec) = dep {
-                        if let Some(name) = &spec.name {
-                            let val = name.as_normalized().to_owned();
-                            used_variables.insert(val);
-                        }
-                    }
-                });
-
-                parsed_recipe
-                    .requirements()
-                    .all()
-                    .for_each(|dep| match dep {
-                        Dependency::PinSubpackage(pin_sub) => {
-                            let pin = pin_sub.pin_value();
-                            let val = pin.name.as_normalized().to_owned();
-                            if pin.args.exact {
-                                exact_pins.insert(val);
-                            }
-                        }
-                        Dependency::PinCompatible(pin_compatible) => {
-                            let pin = pin_compatible.pin_value();
-                            let val = pin.name.as_normalized().to_owned();
-                            if pin.args.exact {
-                                exact_pins.insert(val);
-                            }
-                        }
-                        _ => {}
-                    });
-
-                // actually used vars
-                let mut used_filtered = combination
-                    .clone()
-                    .into_iter()
-                    .filter(|(k, _)| used_variables.contains(k))
-                    .collect::<BTreeMap<_, _>>();
-
-                // exact pins
-                for p in exact_pins {
-                    match other_recipes.get(&p) {
-                        Some((version, build, _)) => {
-                            used_filtered.insert(p.clone(), format!("{} {}", version, build));
-                        }
-                        None => {
-                            return Err(VariantError::MissingOutput(p));
-                        }
-                    }
-                }
-
-                parsed_recipe
-                    .requirements()
-                    .run
-                    .iter()
-                    .chain(parsed_recipe.requirements().run_constraints.iter())
-                    .chain(parsed_recipe.requirements().run_exports().all())
-                    .try_for_each(|dep| -> Result<(), VariantError> {
-                        if let Dependency::PinSubpackage(pin_sub) = dep {
-                            let pin = pin_sub.pin_value();
-                            if pin.args.exact {
-                                let val = pin.name.as_normalized();
-                                if val != *name {
-                                    // if other_recipes does not contain val, throw an error
-                                    match other_recipes.get(val) {
-                                        Some((version, build, _)) => {
-                                            used_filtered.insert(
-                                                val.to_owned(),
-                                                format!("{} {}", version, build),
-                                            );
-                                        }
-                                        None => {
-                                            return Err(VariantError::MissingOutput(val.into()));
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        Ok(())
-                    })?;
-
-                // compute hash for the recipe
-                let hash = HashInfo::from_variant(&used_filtered, parsed_recipe.build().noarch());
-                // TODO(wolf) can we make this computation better by having some nice API on Output?
-                // get the real build string from the recipe
-                let selector_config_with_hash = SelectorConfig {
-                    hash: Some(hash.clone()),
-                    ..selector_config_with_variant
-                };
-                let parsed_recipe =
-                    Recipe::from_node(output, selector_config_with_hash).map_err(|err| {
-                        let errs: ParseErrors = err
-                            .into_iter()
-                            .map(|err| ParsingError::from_partial(recipe, err))
-                            .collect::<Vec<ParsingError>>()
-                            .into();
-                        errs
-                    })?;
-
-                let build_string = parsed_recipe
-                    .build()
-                    .string()
-                    .resolve(&hash, parsed_recipe.build().number)
-                    .into_owned();
-
-                other_recipes.insert(
-                    parsed_recipe.package().name().as_normalized().to_string(),
-                    (
-                        parsed_recipe.package().version().to_string(),
-                        parsed_recipe
-                            .build()
-                            .string()
-                            .resolve(&hash, parsed_recipe.build().number)
-                            .into_owned(),
-                        used_filtered.clone(),
-                    ),
-                );
-                let version = parsed_recipe.package().version().to_string();
-
-                let ignore_keys = &parsed_recipe.build().variant().ignore_keys;
-                used_filtered.retain(|k, _| ignore_keys.is_empty() || !ignore_keys.contains(k));
-
-                recipes.insert(DiscoveredOutput {
-                    name: name.to_string(),
-                    version,
-                    build_string,
-                    noarch_type: *parsed_recipe.build().noarch(),
-                    target_platform: *target_platform,
-                    node: (*output).to_owned(),
-                    used_vars: used_filtered,
-                });
-            }
-        }
-        Ok(recipes)
+        Ok(Default::default())
     }
+    // pub fn find_variants(
+    //     &self,
+    //     outputs: &[Node],
+    //     recipe: &str,
+    //     selector_config: &SelectorConfig,
+    // ) -> Result<IndexSet<DiscoveredOutput>, VariantError> {
+    //     let mut outputs_map = HashMap::new();
+
+    //     // sort the outputs by topological order
+    //     for output in outputs.iter() {
+    //         // for the topological sort we only take into account `pin_subpackage` expressions
+    //         // in the recipe which are captured by the `used vars`
+    //         let mut used_vars = used_vars_from_expressions(output, recipe).map_err(|e| {
+    //             let errs: ParseErrors = e.into();
+    //             errs
+    //         })?;
+
+    //         /// We need o
+    //         let parsed_recipe =
+    //             Recipe::from_node(output, selector_config.clone()).map_err(|err| {
+    //                 let errs: ParseErrors = err
+    //                     .into_iter()
+    //                     .map(|err| ParsingError::from_partial(recipe, err))
+    //                     .collect::<Vec<ParsingError>>()
+    //                     .into();
+    //                 errs
+    //             })?;
+
+    //         let noarch_type = parsed_recipe.build().noarch();
+    //         // add in any host and build dependencies
+    //         used_vars.extend(parsed_recipe.requirements().build_time().filter_map(|dep| {
+    //             match dep {
+    //                 Dependency::Spec(spec) => {
+    //                     // here we filter python as a variant and don't take it's passed variants
+    //                     // when noarch is python
+    //                     spec.name.as_ref().and_then(|name| {
+    //                         let normalized_name = name.as_normalized();
+    //                         if normalized_name == "python" && noarch_type.is_python() {
+    //                             return None;
+    //                         }
+    //                         normalized_name.to_string().into()
+    //                     })
+    //                 }
+    //                 _ => None,
+    //             }
+    //         }));
+
+    //         used_vars.extend(
+    //             parsed_recipe
+    //                 .requirements()
+    //                 .all()
+    //                 .filter_map(|dep| match dep {
+    //                     Dependency::PinSubpackage(pin) => {
+    //                         Some(pin.pin_value().name.as_normalized().to_string())
+    //                     }
+    //                     _ => None,
+    //                 }),
+    //         );
+
+    //         let use_keys = &parsed_recipe.build().variant().use_keys;
+    //         used_vars.extend(use_keys.iter().cloned());
+
+    //         let target_platform = if noarch_type.is_none() {
+    //             selector_config.target_platform
+    //         } else {
+    //             Platform::NoArch
+    //         };
+    //         if outputs_map
+    //             .insert(
+    //                 parsed_recipe.package().name().as_normalized().to_string(),
+    //                 (output, used_vars, target_platform),
+    //             )
+    //             .is_some()
+    //         {
+    //             return Err(VariantError::DuplicateOutputs(
+    //                 parsed_recipe.package().name().as_normalized().to_string(),
+    //             ));
+    //         }
+    //     }
+
+    //     // now topologically sort the outputs and find cycles
+
+    //     // Create an empty directed graph
+    //     let mut graph = DiGraph::<_, ()>::new();
+
+    //     // Create a map from output names to node indices
+    //     let mut node_indices = HashMap::new();
+
+    //     // TODO: this code can be improved in general
+    //     // Add a node for each output
+    //     for output in outputs_map.keys() {
+    //         let node_index = graph.add_node(output.clone());
+    //         node_indices.insert(output.clone(), node_index);
+    //     }
+
+    //     // Add an edge for each pair of outputs where one uses a variable defined by the other
+    //     for (output, (_, used_vars, _)) in &outputs_map {
+    //         let output_node_index = *node_indices
+    //             .get(output)
+    //             .expect("unreachable, we insert keys in the loop above");
+    //         for used_var in used_vars {
+    //             if outputs_map.contains_key(used_var) {
+    //                 let defining_output_node_index = *node_indices
+    //                     .get(used_var)
+    //                     .expect("unreachable, we insert keys in the loop above");
+    //                 // self referencing is possible, but not a cycle
+    //                 if defining_output_node_index == output_node_index {
+    //                     continue;
+    //                 }
+    //                 graph.add_edge(defining_output_node_index, output_node_index, ());
+    //             }
+    //         }
+    //     }
+
+    //     // Perform a topological sort
+    //     let outputs: Vec<_> = match toposort(&graph, None) {
+    //         Ok(sorted_node_indices) => {
+    //             // Replace the original list of outputs with the sorted list
+    //             sorted_node_indices
+    //                 .into_iter()
+    //                 .map(|node_index| graph[node_index].clone())
+    //                 .collect()
+    //         }
+    //         Err(err) => {
+    //             // There is a cycle in the graph
+    //             return Err(VariantError::CycleInRecipeOutputs(
+    //                 graph[err.node_id()].clone(),
+    //             ));
+    //         }
+    //     };
+
+    //     // sort the outputs map by the topological order
+    //     let outputs_map = outputs
+    //         .iter()
+    //         .enumerate()
+    //         .map(|(idx, name)| {
+    //             let (node, used_vars, target_platform) = outputs_map[name].clone();
+    //             (idx, (name, node, used_vars, target_platform))
+    //         })
+    //         .collect::<BTreeMap<_, _>>();
+
+    //     let mut all_build_dependencies = Vec::new();
+    //     for (_, (_, output, _, _)) in outputs_map.iter() {
+    //         let parsed_recipe =
+    //             Recipe::from_node(output, selector_config.clone()).map_err(|err| {
+    //                 let errs: ParseErrors = err
+    //                     .into_iter()
+    //                     .map(|err| ParsingError::from_partial(recipe, err))
+    //                     .collect::<Vec<ParsingError>>()
+    //                     .into();
+    //                 errs
+    //             })?;
+    //         let noarch_type = parsed_recipe.build().noarch();
+    //         let build_time_requirements =
+    //             parsed_recipe.build_time_requirements().filter_map(|dep| {
+    //                 // here we filter python as a variant and don't take it's passed variants
+    //                 // when noarch is python
+    //                 if let Dependency::Spec(spec) = &dep {
+    //                     if let Some(name) = &spec.name {
+    //                         if name.as_normalized() == "python" && noarch_type.is_python() {
+    //                             return None;
+    //                         }
+    //                     }
+    //                 }
+    //                 Some(dep.clone())
+    //             });
+    //         all_build_dependencies.extend(build_time_requirements);
+    //     }
+
+    //     let mut all_variables = all_build_dependencies
+    //         .iter()
+    //         .filter_map(|dep| match dep {
+    //             Dependency::Spec(spec) => {
+    //                 // filter all matchspecs that override the version or build
+    //                 let is_simple = spec.version.is_none() && spec.build.is_none();
+    //                 if is_simple && spec.name.is_some() {
+    //                     spec.name
+    //                         .as_ref()
+    //                         .and_then(|name| name.as_normalized().to_string().into())
+    //                 } else {
+    //                     None
+    //                 }
+    //             }
+    //             Dependency::PinSubpackage(pin_sub) => {
+    //                 Some(pin_sub.pin_value().name.as_normalized().to_string())
+    //             }
+    //             _ => None,
+    //         })
+    //         .collect::<HashSet<_>>();
+
+    //     // also add all used variables from the outputs
+    //     for (_, (_, _, used_vars, _)) in outputs_map.iter() {
+    //         all_variables.extend(used_vars.clone());
+    //     }
+
+    //     // remove all existing outputs from all_variables
+    //     let output_names = outputs.iter().cloned().collect::<HashSet<_>>();
+    //     let mut all_variables = all_variables
+    //         .difference(&output_names)
+    //         .cloned()
+    //         .collect::<HashSet<_>>();
+
+    //     // special handling of CONDA_BUILD_SYSROOT
+    //     if all_variables.contains("c_compiler") || all_variables.contains("cxx_compiler") {
+    //         all_variables.insert("CONDA_BUILD_SYSROOT".to_string());
+    //     }
+
+    //     // also always add `target_platform` and `channel_targets`
+    //     all_variables.insert("target_platform".to_string());
+    //     all_variables.insert("channel_targets".to_string());
+
+    //     let combinations = self.combinations(&all_variables)?;
+
+    //     // Then find all used variables from the each output recipe
+    //     // let mut variants = Vec::new();
+    //     let mut recipes = IndexSet::new();
+    //     for combination in combinations {
+    //         let mut other_recipes =
+    //             HashMap::<String, (String, String, BTreeMap<String, String>)>::new();
+
+    //         for (_, (name, output, used_vars, target_platform)) in outputs_map.iter() {
+    //             let mut used_variables = used_vars.clone();
+    //             let mut exact_pins = HashSet::new();
+
+    //             // special handling of CONDA_BUILD_SYSROOT
+    //             if used_variables.contains("c_compiler") || used_variables.contains("cxx_compiler")
+    //             {
+    //                 used_variables.insert("CONDA_BUILD_SYSROOT".to_string());
+    //             }
+
+    //             // also always add `target_platform` and `channel_targets`
+    //             used_variables.insert("target_platform".to_string());
+    //             used_variables.insert("channel_targets".to_string());
+
+    //             let mut combination = combination.clone();
+    //             // we need to overwrite the target_platform in case of `noarch`.
+    //             combination.insert("target_platform".to_string(), target_platform.to_string());
+
+    //             let selector_config_with_variant =
+    //                 selector_config.new_with_variant(combination.clone(), *target_platform);
+
+    //             let parsed_recipe = Recipe::from_node(output, selector_config_with_variant.clone())
+    //                 .map_err(|err| {
+    //                     let errs: ParseErrors = err
+    //                         .into_iter()
+    //                         .map(|err| ParsingError::from_partial(recipe, err))
+    //                         .collect::<Vec<ParsingError>>()
+    //                         .into();
+    //                     errs
+    //                 })?;
+
+    //             // find the variables that were actually used in the recipe and that count towards the hash
+    //             parsed_recipe.build_time_requirements().for_each(|dep| {
+    //                 if let Dependency::Spec(spec) = dep {
+    //                     if let Some(name) = &spec.name {
+    //                         let val = name.as_normalized().to_owned();
+    //                         used_variables.insert(val);
+    //                     }
+    //                 }
+    //             });
+
+    //             parsed_recipe
+    //                 .requirements()
+    //                 .all()
+    //                 .for_each(|dep| match dep {
+    //                     Dependency::PinSubpackage(pin_sub) => {
+    //                         let pin = pin_sub.pin_value();
+    //                         let val = pin.name.as_normalized().to_owned();
+    //                         if pin.args.exact {
+    //                             exact_pins.insert(val);
+    //                         }
+    //                     }
+    //                     Dependency::PinCompatible(pin_compatible) => {
+    //                         let pin = pin_compatible.pin_value();
+    //                         let val = pin.name.as_normalized().to_owned();
+    //                         if pin.args.exact {
+    //                             exact_pins.insert(val);
+    //                         }
+    //                     }
+    //                     _ => {}
+    //                 });
+
+    //             // actually used vars
+    //             let mut used_filtered = combination
+    //                 .clone()
+    //                 .into_iter()
+    //                 .filter(|(k, _)| used_variables.contains(k))
+    //                 .collect::<BTreeMap<_, _>>();
+
+    //             // exact pins
+    //             for p in exact_pins {
+    //                 match other_recipes.get(&p) {
+    //                     Some((version, build, _)) => {
+    //                         used_filtered.insert(p.clone(), format!("{} {}", version, build));
+    //                     }
+    //                     None => {
+    //                         return Err(VariantError::MissingOutput(p));
+    //                     }
+    //                 }
+    //             }
+
+    //             parsed_recipe
+    //                 .requirements()
+    //                 .run
+    //                 .iter()
+    //                 .chain(parsed_recipe.requirements().run_constraints.iter())
+    //                 .chain(parsed_recipe.requirements().run_exports().all())
+    //                 .try_for_each(|dep| -> Result<(), VariantError> {
+    //                     if let Dependency::PinSubpackage(pin_sub) = dep {
+    //                         let pin = pin_sub.pin_value();
+    //                         if pin.args.exact {
+    //                             let val = pin.name.as_normalized();
+    //                             if val != *name {
+    //                                 // if other_recipes does not contain val, throw an error
+    //                                 match other_recipes.get(val) {
+    //                                     Some((version, build, _)) => {
+    //                                         used_filtered.insert(
+    //                                             val.to_owned(),
+    //                                             format!("{} {}", version, build),
+    //                                         );
+    //                                     }
+    //                                     None => {
+    //                                         return Err(VariantError::MissingOutput(val.into()));
+    //                                     }
+    //                                 }
+    //                             }
+    //                         }
+    //                     }
+    //                     Ok(())
+    //                 })?;
+
+    //             // compute hash for the recipe
+    //             let hash = HashInfo::from_variant(&used_filtered, parsed_recipe.build().noarch());
+
+    //             // TODO(wolf) can we make this computation better by having some nice API on Output?
+    //             // get the real build string from the recipe
+    //             let selector_config_with_hash = SelectorConfig {
+    //                 hash: Some(hash.clone()),
+    //                 ..selector_config_with_variant
+    //             };
+
+    //             let parsed_recipe =
+    //                 Recipe::from_node(output, selector_config_with_hash).map_err(|err| {
+    //                     let errs: ParseErrors = err
+    //                         .into_iter()
+    //                         .map(|err| ParsingError::from_partial(recipe, err))
+    //                         .collect::<Vec<ParsingError>>()
+    //                         .into();
+    //                     errs
+    //                 })?;
+
+    //             let build_string = parsed_recipe
+    //                 .build()
+    //                 .string()
+    //                 .resolve(&hash, parsed_recipe.build().number)
+    //                 .into_owned();
+
+    //             other_recipes.insert(
+    //                 parsed_recipe.package().name().as_normalized().to_string(),
+    //                 (
+    //                     parsed_recipe.package().version().to_string(),
+    //                     parsed_recipe
+    //                         .build()
+    //                         .string()
+    //                         .resolve(&hash, parsed_recipe.build().number)
+    //                         .into_owned(),
+    //                     used_filtered.clone(),
+    //                 ),
+    //             );
+
+    //             let version = parsed_recipe.package().version().to_string();
+
+    //             let ignore_keys = &parsed_recipe.build().variant().ignore_keys;
+    //             used_filtered.retain(|k, _| ignore_keys.is_empty() || !ignore_keys.contains(k));
+
+    //             recipes.insert(DiscoveredOutput {
+    //                 name: name.to_string(),
+    //                 version,
+    //                 build_string,
+    //                 noarch_type: *parsed_recipe.build().noarch(),
+    //                 target_platform: *target_platform,
+    //                 node: (*output).to_owned(),
+    //                 used_vars: used_filtered,
+    //             });
+    //         }
+    //     }
+    //     Ok(recipes)
+    // }
 }
 
 impl TryConvertNode<VariantConfig> for RenderedNode {
@@ -1008,11 +1082,11 @@ mod tests {
             pin_run_as_build: None,
         };
 
-        let combinations = config.combinations(&used_vars).unwrap();
+        let combinations = config.combinations(&used_vars, None).unwrap();
         assert_eq!(combinations.len(), 2);
 
         let used_vars = vec!["a".to_string(), "b".to_string()].into_iter().collect();
-        let combinations = config.combinations(&used_vars).unwrap();
+        let combinations = config.combinations(&used_vars, None).unwrap();
         assert_eq!(combinations.len(), 2);
 
         config.variants.insert(
@@ -1022,15 +1096,23 @@ mod tests {
         let used_vars = vec!["a".to_string(), "b".to_string(), "c".to_string()]
             .into_iter()
             .collect();
-        let combinations = config.combinations(&used_vars).unwrap();
+        let combinations = config.combinations(&used_vars, None).unwrap();
         assert_eq!(combinations.len(), 2 * 3);
 
         let used_vars = vec!["a".to_string(), "b".to_string(), "c".to_string()]
             .into_iter()
             .collect();
         config.zip_keys = None;
-        let combinations = config.combinations(&used_vars).unwrap();
+        let combinations = config.combinations(&used_vars, None).unwrap();
         assert_eq!(combinations.len(), 2 * 2 * 3);
+
+        let already_used_vars = BTreeMap::from_iter(vec![("a".to_string(), "1".to_string())]);
+        let c2 = config.combinations(&used_vars, Some(already_used_vars)).unwrap();
+        println!("{:?}", c2);
+        for c in &c2 {
+            assert!(c.get("a").unwrap() == "1");
+        }
+        assert!(c2.len() == 2 * 3);
     }
 
     #[test]

--- a/src/variant_render.rs
+++ b/src/variant_render.rs
@@ -1,0 +1,107 @@
+use std::collections::{BTreeMap, HashSet};
+
+use crate::{
+    recipe::{custom_yaml::Node, ParsingError, Recipe},
+    selectors::SelectorConfig,
+    used_variables::used_vars_from_expressions,
+    variant_config::{ParseErrors, VariantConfig, VariantError},
+};
+
+/// All the raw outputs of a single recipe.yaml
+#[derive(Clone, Debug)]
+struct RawOutputVec {
+    /// The raw node (slightly preprocessed by making sure all keys are there)
+    vec: Vec<Node>,
+
+    /// The used variables in each of the nodes
+    used_vars_jinja: Vec<HashSet<String>>,
+
+    /// The recipe string
+    recipe: String,
+}
+
+/// Stage 0 render of a single recipe.yaml
+#[derive(Clone, Debug)]
+pub(crate) struct Stage0Render {
+    /// The used variables with their values
+    variables: BTreeMap<String, String>,
+
+    /// The raw outputs of the recipe
+    raw_outputs: RawOutputVec,
+    // Pre-rendered recipe nodes
+    // TODO figure out the variable for this
+    rendered_outputs: Vec<Recipe>,
+}
+
+pub(crate) fn stage_0_render(
+    outputs: &[Node],
+    recipe: &str,
+    selector_config: &SelectorConfig,
+    variant_config: &VariantConfig,
+) -> Result<Vec<Stage0Render>, VariantError> {
+    let used_vars = outputs
+        .iter()
+        .map(|output| used_vars_from_expressions(output, recipe))
+        .collect::<Result<Vec<HashSet<String>>, Vec<ParsingError>>>();
+
+    // If there are any parsing errors, return them
+    if let Err(errors) = used_vars {
+        let err: ParseErrors = errors.into();
+        return Err(VariantError::RecipeParseErrors(err));
+    }
+
+    let raw_output_vec = RawOutputVec {
+        vec: outputs.to_vec(),
+        used_vars_jinja: used_vars.unwrap(),
+        recipe: recipe.to_string(),
+    };
+
+    // find all the jinja variables from all the expressions
+    let mut used_vars = HashSet::<String>::new();
+    for output in outputs {
+        used_vars.extend(used_vars_from_expressions(output, recipe).unwrap());
+    }
+
+    // Now we need to create all the combinations of the variables x variant config
+    let mut stage0_renders = Vec::new();
+    let combinations = variant_config.combinations(&used_vars, None)?;
+
+    for combination in combinations {
+        let mut rendered_outputs = Vec::new();
+        // TODO: figure out if we can pre-compute the `noarch` value.
+        for output in outputs {
+            let config_with_variant = selector_config
+                .new_with_variant(combination.clone(), selector_config.target_platform);
+
+            let parsed_recipe = Recipe::from_node(output, config_with_variant).map_err(|err| {
+                let errs: ParseErrors = err
+                    .into_iter()
+                    .map(|err| ParsingError::from_partial(recipe, err))
+                    .collect::<Vec<ParsingError>>()
+                    .into();
+                errs
+            })?;
+
+            rendered_outputs.push(parsed_recipe);
+        }
+
+        stage0_renders.push(Stage0Render {
+            variables: combination,
+            raw_outputs: raw_output_vec.clone(),
+            rendered_outputs,
+        });
+    }
+
+    println!("{:?}", stage0_renders);
+    Ok(stage0_renders)
+}
+
+struct Stage1Render {
+    variables: BTreeMap<String, String>,
+    stage_0_render: Stage0Render,
+}
+
+/// Render the stage 1 of the recipe by adding in variants from the dependencies
+fn stage_1_render(_stage0_renders: Vec<Stage0Render>) -> Result<Vec<Stage1Render>, VariantError> {
+    Ok(Vec::new())
+}


### PR DESCRIPTION
This is an attempt to separate things better into "stage 1" and "stage 2" rendering.

### Stage 1:

Get all used variables from Jinja and conditional expressions and then render these out for all combinations that are found based on the variant config. This already creates a number of different combinations.

### Stage 2:

From the rendered recipes (no more Jinja, conditionals) we need to get all the `requirements` at build/link time and create additional variants.

### Stage 3:

Topologically sort and de-duplicate outputs (with multiple outputs, these renders might create duplicate outputs, for example if you have a C library and multiple variants for Python bindings).