### PR TITLE
add shebang to bash preamble

### DIFF
--- a/src/script.rs
+++ b/src/script.rs
@@ -28,8 +28,7 @@ use crate::{
     },
 };
 
-const BASH_PREAMBLE: &str = r#"
-#!/bin/bash
+const BASH_PREAMBLE: &str = r#"#!/bin/bash
 ## Start of bash preamble
 if [ -z ${CONDA_BUILD+x} ]; then
     source ((script_path))

--- a/src/script.rs
+++ b/src/script.rs
@@ -29,6 +29,7 @@ use crate::{
 };
 
 const BASH_PREAMBLE: &str = r#"
+#!/bin/bash
 ## Start of bash preamble
 if [ -z ${CONDA_BUILD+x} ]; then
     source ((script_path))


### PR DESCRIPTION
Scripts with no shebang are blocked by certain endpoint security tools, failing the rattler build at hand. Adding a bash shebang to the bash preamble should fix this issue.