### PR TITLE
fix: url source extraction for file:/// urls

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -42,6 +42,13 @@ This document contains the help content for the `rattler-build` command-line pro
 			Use plain logging output
 
 
+- `--wrap-log-lines <WRAP_LOG_LINES>`
+
+	Wrap log lines at the terminal width. This is automatically disabled on CI (by detecting the `CI` environment variable)
+
+	- Possible values: `true`, `false`
+
+
 - `--color <COLOR>`
 
 	Enable or disable colored output from rattler-build. Also honors the `CLICOLOR` and `CLICOLOR_FORCE` environment variable

--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -186,6 +186,17 @@ If an extracted archive contains only 1 folder at its top level, its contents
 will be moved 1 level up, so that the extracted package contents sit in the root
 of the work folder.
 
+##### Specifying a file name
+
+For URL and local paths you can specify a file name. If the source is an archive and a file name is set, automatic extraction is disabled.
+
+```yaml
+source:
+  url: https://pypi.python.org/packages/source/b/bsdiff4/bsdiff4-1.1.4.tar.gz
+  # will put the file in the work directory as `bsdiff4-1.1.4.tar.gz`
+  file_name: bsdiff4-1.1.4.tar.gz
+```
+
 #### Source from `git`
 
 ```yaml

--- a/docs/tutorials/javascript.md
+++ b/docs/tutorials/javascript.md
@@ -1,0 +1,41 @@
+# Packaging a Javascript (NPM/NodeJS) package
+
+This tutorial will guide you though making a NodeJS package with `rattler-build`.
+
+## Building a NodeJS Package
+
+In this example, we will build a package for the NodeJS package `bibtex-tidy`.
+We use `nodejs` in build and run requirements, and install the package using `npm`.
+NPM comes as part of the NodeJS installation, so we do not need to install it separately.
+
+```yaml title="recipe.yaml"
+context:
+  version: "1.14.0"
+
+package:
+  name: bibtex-tidy
+  version: ${{ version }}
+
+source:
+  url: https://registry.npmjs.org/bibtex-tidy/-/bibtex-tidy-${{ version }}.tgz
+  sha256: 0a2c1bb73911a7cee36a30ce1fc86feffe39b2d39acd4c94d02aac6f84a00285
+  # we do not extract the source code and install the tarball directly as that works better
+  file_name: bibtex-tidy-${{ version }}.tgz
+
+build:
+  number: 0
+  script:
+    # we use NPM to globally install the bibtex-tidy package
+    - npm install -g bibtex-tidy-${{ version }}.tgz --prefix ${{ PREFIX }}
+
+requirements:
+  build:
+    - nodejs
+  run:
+    - nodejs
+
+tests:
+  - script:
+    - bibtex-tidy --version
+```
+

--- a/docs/tutorials/python.md
+++ b/docs/tutorials/python.md
@@ -4,6 +4,7 @@ Writing a Python package is fairly straightforward, especially for "Python-only"
 In the second example we will build a package for `numpy` which contains compiled code.
 
 ## A Python-only package
+
 The following recipe uses the `noarch: python` setting to build a `noarch` package that can be installed on any platform without modification.
 This is very handy for packages that are pure Python and do not contain any compiled extensions.
 
@@ -63,6 +64,7 @@ about:
    installed correctly and can be imported.
 
 ### Running the recipe
+
 To build this recipe, simply run:
 
 ```bash
@@ -180,6 +182,7 @@ for /f %%f in ('dir /b /S .\dist') do (
 ```
 
 ### Running the recipe
+
 Running this recipe with the variant config file will build a total of 2 `numpy` packages:
 
 ```bash

--- a/examples/rich/recipe.yaml
+++ b/examples/rich/recipe.yaml
@@ -8,12 +8,10 @@ package:
   version: ${{ version }}
 
 source:
-  url: file:///Users/wolfv/Downloads/rich-13.9.4.tar.gz
-  sha256: 439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098
-  # - url:
-  #     - https://example.com/rich-${{ version }}.tar.gz  # this will give a 404!
-  #     - https://pypi.io/packages/source/r/rich/rich-${{ version }}.tar.gz
-  #   sha256: d653d6bccede5844304c605d5aac802c7cf9621efd700b46c7ec2b51ea914898
+  - url:
+      - https://example.com/rich-${{ version }}.tar.gz  # this will give a 404!
+      - https://pypi.io/packages/source/r/rich/rich-${{ version }}.tar.gz
+    sha256: d653d6bccede5844304c605d5aac802c7cf9621efd700b46c7ec2b51ea914898
 
 build:
   # Thanks to `noarch: python` this package works on all platforms

--- a/examples/rich/recipe.yaml
+++ b/examples/rich/recipe.yaml
@@ -8,10 +8,12 @@ package:
   version: ${{ version }}
 
 source:
-  - url:
-      - https://example.com/rich-${{ version }}.tar.gz  # this will give a 404!
-      - https://pypi.io/packages/source/r/rich/rich-${{ version }}.tar.gz
-    sha256: d653d6bccede5844304c605d5aac802c7cf9621efd700b46c7ec2b51ea914898
+  url: file:///Users/wolfv/Downloads/rich-13.9.4.tar.gz
+  sha256: 439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098
+  # - url:
+  #     - https://example.com/rich-${{ version }}.tar.gz  # this will give a 404!
+  #     - https://pypi.io/packages/source/r/rich/rich-${{ version }}.tar.gz
+  #   sha256: d653d6bccede5844304c605d5aac802c7cf9621efd700b46c7ec2b51ea914898
 
 build:
   # Thanks to `noarch: python` this package works on all platforms

--- a/src/recipe/parser/source.rs
+++ b/src/recipe/parser/source.rs
@@ -401,9 +401,11 @@ pub struct UrlSource {
     /// Optionally a file name to rename the downloaded file (does not apply to archives)
     #[serde(skip_serializing_if = "Option::is_none")]
     file_name: Option<String>,
+
     /// Patches to apply to the source code
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     patches: Vec<PathBuf>,
+
     /// Optionally a folder name under the `work` directory to place the source code
     #[serde(skip_serializing_if = "Option::is_none")]
     target_directory: Option<PathBuf>,


### PR DESCRIPTION
This improves the URL source type in two ways:

- file:/// urls are treated exactly the same as remote urls. We copy the file to the cache, and extract it.
- Extraction is now conditional on a "file_name". If a file_name is set, we will rename the archive to the file_name value and insert it as an archive in the work dir. This helps for example when packaging a NPM package as it seems to work better from an archive :)