### PR TITLE
Add `--no-test-if-emulate` flag 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,7 @@ pub fn get_tool_config(
         .with_compression_threads(args.compression_threads)
         .with_reqwest_client(client)
         .with_testing(!args.no_test)
+        .with_testing_if_emulate(!args.no_test_if_emulate)
         .with_zstd_repodata_enabled(args.common.use_zstd)
         .with_bz2_repodata_enabled(args.common.use_zstd)
         .with_skip_existing(args.skip_existing)

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -343,6 +343,11 @@ pub struct BuildOpts {
     #[arg(long, default_value = "false", help_heading = "Modifying result")]
     pub no_test: bool,
 
+    /// Don't run the tests after building the package if the building platform
+    /// is different than the host platform (cross-compilation)
+    #[arg(long, default_value = "false", help_heading = "Modifying result")]
+    pub no_test_if_emulate: bool,
+
     /// Don't force colors in the output of the build script
     #[arg(long, default_value = "true", help_heading = "Modifying result")]
     pub color_build_log: bool,

--- a/src/tool_configuration.rs
+++ b/src/tool_configuration.rs
@@ -45,6 +45,9 @@ pub struct Configuration {
     /// Whether to skip the test phase
     pub no_test: bool,
 
+    /// Whether to skip the test phase if cross-compiling
+    pub no_test_if_emulate: bool,
+
     /// Whether to use zstd
     pub use_zstd: bool,
 
@@ -112,6 +115,7 @@ pub struct ConfigurationBuilder {
     client: Option<ClientWithMiddleware>,
     no_clean: bool,
     no_test: bool,
+    no_test_if_emulate: bool,
     use_zstd: bool,
     use_bz2: bool,
     skip_existing: SkipExisting,
@@ -135,6 +139,7 @@ impl ConfigurationBuilder {
             client: None,
             no_clean: false,
             no_test: false,
+            no_test_if_emulate: false,
             use_zstd: true,
             use_bz2: false,
             skip_existing: SkipExisting::None,
@@ -216,6 +221,14 @@ impl ConfigurationBuilder {
         }
     }
 
+    /// Sets whether tests should be executed if cross-compiling.
+    pub fn with_testing_if_emulate(self, testing_enabled_if_emulate: bool) -> Self {
+        Self {
+            no_test_if_emulate: !testing_enabled_if_emulate,
+            ..self
+        }
+    }
+
     /// Whether downloading repodata as `.zst` files is enabled.
     pub fn with_zstd_repodata_enabled(self, zstd_repodata_enabled: bool) -> Self {
         Self {
@@ -266,6 +279,7 @@ impl ConfigurationBuilder {
             client,
             no_clean: self.no_clean,
             no_test: self.no_test,
+            no_test_if_emulate: self.no_test_if_emulate,
             use_zstd: self.use_zstd,
             use_bz2: self.use_bz2,
             skip_existing: self.skip_existing,


### PR DESCRIPTION
See https://github.com/prefix-dev/rattler-build/issues/1175 for context.

It adds a new flag to `build` that allow skipping the tests if cross compiling: `--no-test-if-emulate`

I have a few questions:

- should I prefer "emulate" or "cross compiling" for the variables as well as the CLI doc?
- how should `noarch` should be handled here? or when should we consider the build is a cross compilation or not?