### PR TITLE
docs: Remove 'pip install' options in recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ build:
   # Thanks to `noarch: python` this package works on all platforms
   noarch: python
   script:
-    - python -m pip install . -vv --no-deps --no-build-isolation
+    - python -m pip install . -vv
 
 requirements:
   host:

--- a/docs/index.md
+++ b/docs/index.md
@@ -232,7 +232,7 @@ build:
   # Thanks to `noarch: python` this package works on all platforms
   noarch: python
   script:
-    - python -m pip install . -vv --no-deps --no-build-isolation
+    - python -m pip install . -vv
 
 requirements:
   host:

--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -112,7 +112,7 @@ source:
 # build number (should be incremented if a new build is made, but version is not incrementing)
 build:
   number: 1
-  script: python -m pip install --no-deps --ignore-installed .
+  script: python -m pip install .
 
 # the requirements at build and runtime
 requirements:

--- a/examples/mamba/build_mamba.bat
+++ b/examples/mamba/build_mamba.bat
@@ -2,7 +2,7 @@
 
 if /I "%PKG_NAME%" == "mamba" (
 	cd mamba
-	%PYTHON% -m pip install . --no-deps -vv
+	%PYTHON% -m pip install . -vv
 	exit 0
 )
 
@@ -43,6 +43,6 @@ if errorlevel 1 exit 1
 if /I "%PKG_NAME%" == "libmambapy" (
 	cd ../libmambapy
 	rmdir /Q /S build
-	%PYTHON% -m pip install . --no-deps -vv
+	%PYTHON% -m pip install . -vv
 	del *.pyc /a /s
 )

--- a/examples/mamba/build_mamba.sh
+++ b/examples/mamba/build_mamba.sh
@@ -1,6 +1,6 @@
 if [[ $PKG_NAME == "mamba" ]]; then
     cd mamba
-    $PYTHON -m pip install . --no-deps -vv
+    $PYTHON -m pip install . -vv
 
     echo "Adding link to mamba into condabin";
     mkdir -p $PREFIX/condabin
@@ -40,6 +40,6 @@ ninja install
 if [[ $PKG_NAME == "libmambapy" ]]; then
     cd ../libmambapy
     rm -rf build
-    $PYTHON -m pip install . --no-deps -vv
+    $PYTHON -m pip install . -vv
     find libmambapy/bindings* -type f -print0 | xargs -0 rm -f --
 fi

--- a/examples/rich/recipe.yaml
+++ b/examples/rich/recipe.yaml
@@ -17,7 +17,7 @@ build:
   # Thanks to `noarch: python` this package works on all platforms
   noarch: python
   script:
-    - python -m pip install . -vv --no-deps --no-build-isolation
+    - python -m pip install . -vv
 
 requirements:
   host:

--- a/src/snapshots/rattler_build__metadata__test__rich_recipe.yaml.snap
+++ b/src/snapshots/rattler_build__metadata__test__rich_recipe.yaml.snap
@@ -15,7 +15,7 @@ recipe:
     number: 0
     string: pyh4616a5c_0
     script:
-      - python -m pip install . -vv --no-deps --no-build-isolation
+      - python -m pip install . -vv
     noarch: python
   requirements:
     host:

--- a/test-data/recipes/flask/recipe.yaml
+++ b/test-data/recipes/flask/recipe.yaml
@@ -16,7 +16,7 @@ source:
 build:
   number: 0
   script:
-    - python -m pip install . -vv --no-deps --no-build-isolation
+    - python -m pip install . -vv
     # make sure that PY_VER is set even for noarch packages
     - if: unix
       then:

--- a/test-data/recipes/package-content-tests/rich-recipe.yaml
+++ b/test-data/recipes/package-content-tests/rich-recipe.yaml
@@ -15,7 +15,7 @@ build:
   # Thanks to `noarch: python` this package works on all platforms
   noarch: python
   script:
-    - python -m pip install . -vv --no-deps --no-build-isolation
+    - python -m pip install . -vv
 
 requirements:
   host:

--- a/test-data/recipes/rich/recipe.yaml
+++ b/test-data/recipes/rich/recipe.yaml
@@ -15,7 +15,7 @@ build:
   # Thanks to `noarch: python` this package works on all platforms
   noarch: python
   script:
-    - python -m pip install . -vv --no-deps --no-build-isolation
+    - python -m pip install . -vv
 
 requirements:
   host:

--- a/test-data/recipes/toml/recipe.yaml
+++ b/test-data/recipes/toml/recipe.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   noarch: python
-  script: python -m pip install . --no-deps -vv
+  script: python -m pip install . -vv
 
 requirements:
   host:

--- a/test-data/recipes/variants/boltons_recipe.yaml
+++ b/test-data/recipes/variants/boltons_recipe.yaml
@@ -14,7 +14,7 @@ source:
 build:
   noarch: python
   script:
-    - python -m pip install . --no-deps -vv
+    - python -m pip install . -vv
 
 requirements:
   host:

--- a/test-data/rendered_recipes/rich_recipe.yaml
+++ b/test-data/rendered_recipes/rich_recipe.yaml
@@ -11,7 +11,7 @@ recipe:
     number: 0
     string: pyh4616a5c_0
     script:
-    - python -m pip install . -vv --no-deps --no-build-isolation
+    - python -m pip install . -vv
     noarch: python
   requirements:
     host:


### PR DESCRIPTION
Motivated by https://github.com/conda/grayskull/issues/582 and @wolfv's comment https://github.com/conda/grayskull/issues/582#issuecomment-2480480976

* Remove `--no-deps`, `--no-build-isolation`, and `--ignore-installed` `pip install` options in recipes as `rattler-build` will enforce all required `pip install` options itself at build time.

c.f.

https://github.com/prefix-dev/rattler-build/blob/665125d565c47bca84a831e9a29cb19ddcfa2773/src/env_vars.rs#L230-L239