### PR TITLE
do not use gitignore when copying test files

### DIFF
--- a/src/package_test/serialize_test.rs
+++ b/src/package_test/serialize_test.rs
@@ -32,7 +32,7 @@ impl CommandsTest {
                 folder,
             )
             .with_globvec(globs)
-            .use_gitignore(true)
+            .use_gitignore(false)
             .run()?;
 
             test_files.extend(copy_dir.copied_paths().iter().cloned());
@@ -45,7 +45,7 @@ impl CommandsTest {
                 folder,
             )
             .with_globvec(globs)
-            .use_gitignore(true)
+            .use_gitignore(false)
             .run()?;
 
             test_files.extend(copy_dir.copied_paths().iter().cloned());

--- a/src/package_test/serialize_test.rs
+++ b/src/package_test/serialize_test.rs
@@ -32,7 +32,7 @@ impl CommandsTest {
                 folder,
             )
             .with_globvec(globs)
-            .use_gitignore(false)
+            .use_gitignore(true)
             .run()?;
 
             test_files.extend(copy_dir.copied_paths().iter().cloned());
@@ -45,7 +45,7 @@ impl CommandsTest {
                 folder,
             )
             .with_globvec(globs)
-            .use_gitignore(false)
+            .use_gitignore(true)
             .run()?;
 
             test_files.extend(copy_dir.copied_paths().iter().cloned());

--- a/src/source/copy_dir.rs
+++ b/src/source/copy_dir.rs
@@ -187,6 +187,8 @@ impl<'a> CopyDir<'a> {
         let copied_paths = WalkBuilder::new(self.from_path)
             // disregard global gitignore
             .git_global(self.use_git_global)
+            // ignore any .gitignore files from parent directories
+            .parents(false)
             .git_ignore(self.use_gitignore)
             .hidden(self.hidden)
             .build()


### PR DESCRIPTION
Should fix #1180 

I think it's fine to not use gitignore in these cases. We'll switch to [`wax`](https://docs.rs/wax/latest/wax/) for this in the future anyways.