### PR TITLE
fix: reindex output cache after build (#1149)

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -180,6 +180,9 @@ pub async fn run_build(
 
     if skip_test {
         tracing::info!("Skipping tests because {}", skip_test_reason);
+        build_reindexed_channels(&output.build_configuration, tool_configuration)
+            .into_diagnostic()
+            .context("failed to reindex output channel")?;
     } else {
         package_test::run_test(
             &result,


### PR DESCRIPTION
Fix https://github.com/prefix-dev/rattler-build/issues/1149

The change in `build.rs` fixes the `--no-test` arg causing the repodata.json to not be regenerated after a package was built.