### PR TITLE
doc: fix experimental env

### DIFF
--- a/docs/experimental_features.md
+++ b/docs/experimental_features.md
@@ -7,7 +7,7 @@
 Currently only the `build` and `rebuild` commands support the following experimental features.
 
 To enable them, use the `--experimental` flag with the command.
-Or, use the environment variable, `RATTLER_BUILD_EXPERIMENTAL=1`.
+Or, use the environment variable, `RATTLER_BUILD_EXPERIMENTAL=true`.
 
 ## Jinja functions
 


### PR DESCRIPTION
'1' is not a valid value for boolean env, apparently:

```
> RATTLER_BUILD_EXPERIMENTAL=1 rattler-build build
error: invalid value '1' for '--experimental'
  [possible values: true, false]
```

(arguably, it would be more expected for the documented `EXPERIMENTAL=1` to actually work, since it's a far more common pattern than string true/false in env).