### PR TITLE
feat: upgrade middleware and rip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,14 +363,14 @@ dependencies = [
 
 [[package]]
 name = "async_http_range_reader"
-version = "0.7.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8561e6613f8361df8bed11c0eef05b98384643bc81f6b753eec7c1d91f097509"
+checksum = "2b537c00269e3f943e06f5d7cabf8ccd281b800fd0c7f111dd82f77154334197"
 dependencies = [
  "bisection",
  "futures",
  "http-content-range",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "memmap2 0.9.5",
  "reqwest",
  "reqwest-middleware",
@@ -1292,8 +1292,7 @@ checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
 [[package]]
 name = "file_url"
 version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff487eda48708def359958613c6c9762d9c4f8396db240e37083758ccb01c79"
+source = "git+https://github.com/conda/rattler?branch=main#104a5216e50facf88c2b81405f66309ed1a134f5"
 dependencies = [
  "itertools 0.13.0",
  "percent-encoding",
@@ -1859,9 +1858,9 @@ dependencies = [
 
 [[package]]
 name = "http-content-range"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa7929c876417cd3ece616950474c7dff5b0150a2b53bd7e7fda55afa086c22b"
+checksum = "91314cc9d86f625097a3365cab4e4b6f190eac231650f8f41c1edd8080cea1d0"
 
 [[package]]
 name = "http-serde"
@@ -3461,8 +3460,7 @@ dependencies = [
 [[package]]
 name = "rattler"
 version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df153e466ba59551f1967e46b312bc9743cec6f424691f20c45c99553d97b0d"
+source = "git+https://github.com/conda/rattler?branch=main#104a5216e50facf88c2b81405f66309ed1a134f5"
 dependencies = [
  "anyhow",
  "clap",
@@ -3594,8 +3592,7 @@ dependencies = [
 [[package]]
 name = "rattler_cache"
 version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465972d151a672bc000b64c19a67c4c3b4ffeb11bd433eaf4dfe4c9aa04d748a"
+source = "git+https://github.com/conda/rattler?branch=main#104a5216e50facf88c2b81405f66309ed1a134f5"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -3622,8 +3619,7 @@ dependencies = [
 [[package]]
 name = "rattler_conda_types"
 version = "0.29.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157b9dca7f9ed5bf7f04202fdd9fda5d8a76f76e937a3b6fd94ed8b2d55565bc"
+source = "git+https://github.com/conda/rattler?branch=main#104a5216e50facf88c2b81405f66309ed1a134f5"
 dependencies = [
  "chrono",
  "dirs",
@@ -3674,8 +3670,7 @@ dependencies = [
 [[package]]
 name = "rattler_digest"
 version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a97526971dd357657ea4c88f6d39b31b2875c87dfe9fd12aac305fec6c0f60"
+source = "git+https://github.com/conda/rattler?branch=main#104a5216e50facf88c2b81405f66309ed1a134f5"
 dependencies = [
  "blake2",
  "digest",
@@ -3691,8 +3686,7 @@ dependencies = [
 [[package]]
 name = "rattler_index"
 version = "0.19.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a805fc30cc208c5a45a722b3818a83175e1de2e3a6e3f4e0b8454a4f9183651"
+source = "git+https://github.com/conda/rattler?branch=main#104a5216e50facf88c2b81405f66309ed1a134f5"
 dependencies = [
  "fs-err 3.0.0",
  "rattler_conda_types",
@@ -3705,9 +3699,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_installs_packages"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66608389964a21838becccf55b04ed14bfbbb3dc88527a48671c2c749e236dff"
+checksum = "e3750b5054cd7a77efcf27760ea0283959b6390569ca89990670c4b2f84d74de"
 dependencies = [
  "async-once-cell",
  "async-recursion",
@@ -3767,8 +3761,7 @@ dependencies = [
 [[package]]
 name = "rattler_macros"
 version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19eadf6fea87bd67d9d4c372caa3c2bed33cd91cdc235ce86210d7bc513ae0a4"
+source = "git+https://github.com/conda/rattler?branch=main#104a5216e50facf88c2b81405f66309ed1a134f5"
 dependencies = [
  "quote",
  "syn",
@@ -3777,8 +3770,7 @@ dependencies = [
 [[package]]
 name = "rattler_networking"
 version = "0.21.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b547cd28190f62c7f580493e41b7f6c9abc6bbef755e8703e8faea890ca2397f"
+source = "git+https://github.com/conda/rattler?branch=main#104a5216e50facf88c2b81405f66309ed1a134f5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3805,8 +3797,7 @@ dependencies = [
 [[package]]
 name = "rattler_package_streaming"
 version = "0.22.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef13aafa7b14262517b9b2ccce8a96f821c27e52489e2e9c67e57dbbfb932031"
+source = "git+https://github.com/conda/rattler?branch=main#104a5216e50facf88c2b81405f66309ed1a134f5"
 dependencies = [
  "bzip2",
  "chrono",
@@ -3833,8 +3824,7 @@ dependencies = [
 [[package]]
 name = "rattler_redaction"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa822f7a897914ff30e372814234047d556c98f3813fad616c93147b38dab7e7"
+source = "git+https://github.com/conda/rattler?branch=main#104a5216e50facf88c2b81405f66309ed1a134f5"
 dependencies = [
  "reqwest",
  "reqwest-middleware",
@@ -3844,8 +3834,7 @@ dependencies = [
 [[package]]
 name = "rattler_repodata_gateway"
 version = "0.21.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7999914f20afeeca1019c61956a27707f6258020e343975f979e25b172e6252f"
+source = "git+https://github.com/conda/rattler?branch=main#104a5216e50facf88c2b81405f66309ed1a134f5"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -3899,8 +3888,7 @@ dependencies = [
 [[package]]
 name = "rattler_shell"
 version = "0.22.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47fbaf13fcf46e10c72c266f975f9d979e13bfe4ff159e4778b2357cf0ac2530"
+source = "git+https://github.com/conda/rattler?branch=main#104a5216e50facf88c2b81405f66309ed1a134f5"
 dependencies = [
  "enum_dispatch",
  "fs-err 3.0.0",
@@ -3918,8 +3906,7 @@ dependencies = [
 [[package]]
 name = "rattler_solve"
 version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "102a559fb323891fb8e6438174c808d2a7e10d757d19c7a0b00fe240d8493ea2"
+source = "git+https://github.com/conda/rattler?branch=main#104a5216e50facf88c2b81405f66309ed1a134f5"
 dependencies = [
  "chrono",
  "futures",
@@ -3937,8 +3924,7 @@ dependencies = [
 [[package]]
 name = "rattler_virtual_packages"
 version = "1.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fef9adbeaf928423267ebd93d260b11dbc97999fcdf688e8c03a6d23c871a9e"
+source = "git+https://github.com/conda/rattler?branch=main#104a5216e50facf88c2b81405f66309ed1a134f5"
 dependencies = [
  "archspec",
  "libloading",
@@ -4127,9 +4113,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest-middleware"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562ceb5a604d3f7c885a792d42c199fd8af239d0a51b2fa6a78aafa092452b04"
+checksum = "d1ccd3b55e711f91a9885a2fa6fbbb2e39db1776420b062efc058c6410f7e5e3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4722,8 +4708,7 @@ dependencies = [
 [[package]]
 name = "simple_spawn_blocking"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b31ed96d1593e129cc76cb7aca364fb5c173558bfda922c15aac4e2f2f5844e"
+source = "git+https://github.com/conda/rattler?branch=main#104a5216e50facf88c2b81405f66309ed1a134f5"
 dependencies = [
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,8 +113,8 @@ xz2 = "0.1.7"
 zstd = "0.13.2"
 toml = "0.8.19"
 memmap2 = "0.9.5"
-reqwest-middleware = "0.3.3"
-rattler_installs_packages = { version = "0.9.0", default-features = false, optional = true }
+reqwest-middleware = "0.4.0"
+rattler_installs_packages = { version = "0.10.0", default-features = false, optional = true }
 async-once-cell = "0.5.4"
 terminal_size = "0.4.0"
 memchr = "2.7.4"
@@ -169,17 +169,18 @@ pre-build = [
 # this fork contains fixes for slow zip reading and large file writing
 zip = { git = "https://github.com/wolfv/zip2", branch = "patched"}
 
-# rattler = { git = "https://github.com/nichmor/rattler", branch = "feat/add-extra-field-on-about-json" }
-# rattler_conda_types = { git = "https://github.com/nichmor/rattler", branch = "feat/add-extra-field-on-about-json" }
-# rattler_digest = { git = "https://github.com/nichmor/rattler", branch = "feat/add-extra-field-on-about-json" }
-# rattler_index = { git = "https://github.com/nichmor/rattler", branch = "feat/add-extra-field-on-about-json" }
-# rattler_networking = { git = "https://github.com/nichmor/rattler", branch = "feat/add-extra-field-on-about-json" }
-# rattler_repodata_gateway = { git = "https://github.com/nichmor/rattler", branch = "feat/add-extra-field-on-about-json" }
-# rattler_redaction = { git = "https://github.com/nichmor/rattler", branch = "feat/add-extra-field-on-about-json" }
-# rattler_shell = { git = "https://github.com/nichmor/rattler", branch = "feat/add-extra-field-on-about-json" }
-# rattler_solve = { git = "https://github.com/nichmor/rattler", branch = "feat/add-extra-field-on-about-json" }
-# rattler_virtual_packages = { git = "https://github.com/nichmor/rattler", branch = "feat/add-extra-field-on-about-json" }
-# rattler_package_streaming = { git = "https://github.com/nichmor/rattler", branch = "feat/add-extra-field-on-about-json" }
+rattler = { git = "https://github.com/conda/rattler", branch = "main" }
+rattler_cache = { git = "https://github.com/conda/rattler", branch = "main" }
+rattler_conda_types = { git = "https://github.com/conda/rattler", branch = "main" }
+rattler_digest = { git = "https://github.com/conda/rattler", branch = "main" }
+rattler_index = { git = "https://github.com/conda/rattler", branch = "main" }
+rattler_networking = { git = "https://github.com/conda/rattler", branch = "main" }
+rattler_repodata_gateway = { git = "https://github.com/conda/rattler", branch = "main" }
+rattler_redaction = { git = "https://github.com/conda/rattler", branch = "main" }
+rattler_shell = { git = "https://github.com/conda/rattler", branch = "main" }
+rattler_solve = { git = "https://github.com/conda/rattler", branch = "main" }
+rattler_virtual_packages = { git = "https://github.com/conda/rattler", branch = "main" }
+rattler_package_streaming = { git = "https://github.com/conda/rattler", branch = "main" }
 
 # rattler = { path = "../rattler/crates/rattler" }
 # rattler_cache = { path = "../rattler/crates/rattler_cache" }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -827,7 +827,7 @@ mod test {
                 file_name: "test-1.2.3-h123.tar.bz2".into(),
                 url: Url::from_str("https://test.com/test/linux-64/test-1.2.3-h123.tar.bz2")
                     .unwrap(),
-                channel: "test".into(),
+                channel: Some("test".into()),
             }],
         };
 

--- a/src/recipe_generator/pypi.rs
+++ b/src/recipe_generator/pypi.rs
@@ -1,6 +1,7 @@
 use async_once_cell::OnceCell;
 use clap::Parser;
 use miette::{IntoDiagnostic, WrapErr};
+use rattler_installs_packages::index::CheckAvailablePackages;
 use rattler_installs_packages::python_env::Pep508EnvMakers;
 use rattler_installs_packages::resolve::solve_options::ResolveOptions;
 use rattler_installs_packages::types::{ArtifactFromSource, Requirement, VersionOrUrl};
@@ -118,6 +119,7 @@ pub async fn generate_pypi_recipe(opts: &PyPIOpts) -> miette::Result<()> {
         package_sources,
         client_with_middlewares,
         &tempdir_path.join("pkg-db"),
+        CheckAvailablePackages::Always,
     )?);
     let artifacts = package_db.available_artifacts(artifact_request).await?;
 

--- a/src/render/resolved_dependencies.rs
+++ b/src/render/resolved_dependencies.rs
@@ -249,7 +249,8 @@ pub struct ResolvedDependencies {
     pub resolved: Vec<RepoDataRecord>,
 }
 
-fn short_channel(channel: &str) -> String {
+fn short_channel(channel: Option<&str>) -> String {
+    let channel = channel.unwrap_or_default();
     if channel.contains('/') {
         channel
             .rsplit('/')
@@ -301,7 +302,7 @@ impl ResolvedDependencies {
                     .render(long),
                 record.package_record.version.to_string(),
                 record.package_record.build.to_string(),
-                short_channel(&record.channel),
+                short_channel(record.channel.as_deref()),
                 record
                     .package_record
                     .size
@@ -315,7 +316,7 @@ impl ResolvedDependencies {
                 "".to_string(),
                 record.package_record.version.to_string(),
                 record.package_record.build.to_string(),
-                short_channel(&record.channel),
+                short_channel(record.channel.as_deref()),
                 record
                     .package_record
                     .size

--- a/src/render/solver.rs
+++ b/src/render/solver.rs
@@ -31,15 +31,16 @@ fn print_as_table(packages: &[RepoDataRecord]) {
         .iter()
         .sorted_by_key(|p| p.package_record.name.as_normalized())
     {
-        let channel_short = if package.channel.contains('/') {
+        let channel_short = if package.channel.as_deref().unwrap_or_default().contains('/') {
             package
                 .channel
-                .rsplit('/')
-                .find(|s| !s.is_empty())
-                .expect("yep will crash if ")
+                .as_ref()
+                .map(|s| s.rsplit('/').find(|s| !s.is_empty()))
+                .flatten()
+                .expect("expected channel to be defined and contain '/'")
                 .to_string()
         } else {
-            package.channel.to_string()
+            package.channel.as_deref().unwrap_or_default().to_string()
         };
 
         table.add_row(vec![


### PR DESCRIPTION
## Description

Updates the middleware and RIP. So that we can use these in the pixi build backends and is compatible with the lattest rattler main branch (which is unreleased).