### PR TITLE
feat: cache sources too

### DIFF
--- a/py-rattler-build/rattler_build/__init__.py
+++ b/py-rattler-build/rattler_build/__init__.py
@@ -1,5 +1,4 @@
-from .rattler_build import \
-    get_rattler_build_version_py as _get_rattler_build_version_py
+from .rattler_build import get_rattler_build_version_py as _get_rattler_build_version_py
 
 
 def rattler_build_version() -> str:

--- a/py-rattler-build/rattler_build/__init__.py
+++ b/py-rattler-build/rattler_build/__init__.py
@@ -1,4 +1,5 @@
-from .rattler_build import get_rattler_build_version_py as _get_rattler_build_version_py
+from .rattler_build import \
+    get_rattler_build_version_py as _get_rattler_build_version_py
 
 
 def rattler_build_version() -> str:

--- a/src/build.rs
+++ b/src/build.rs
@@ -118,7 +118,7 @@ pub async fn run_build(
         output.build_or_fetch_cache(tool_configuration).await?
     } else {
         output
-            .fetch_sources(tool_configuration)
+            .fetch_sources(None, tool_configuration)
             .await
             .into_diagnostic()?
     };

--- a/src/build.rs
+++ b/src/build.rs
@@ -118,7 +118,7 @@ pub async fn run_build(
         output.build_or_fetch_cache(tool_configuration).await?
     } else {
         output
-            .fetch_sources(None, tool_configuration)
+            .fetch_sources(tool_configuration)
             .await
             .into_diagnostic()?
     };

--- a/src/build.rs
+++ b/src/build.rs
@@ -114,12 +114,14 @@ pub async fn run_build(
 
     let directories = output.build_configuration.directories.clone();
 
-    let output = output
-        .fetch_sources(tool_configuration)
-        .await
-        .into_diagnostic()?;
-
-    let output = output.build_or_fetch_cache(tool_configuration).await?;
+    let output = if output.recipe.cache.is_some() {
+        output.build_or_fetch_cache(tool_configuration).await?
+    } else {
+        output
+            .fetch_sources(tool_configuration)
+            .await
+            .into_diagnostic()?
+    };
 
     let output = output
         .resolve_dependencies(tool_configuration)

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -204,9 +204,10 @@ impl Output {
             }
 
             // fetch the sources for the `cache` section
-            // TODO store them as finalized?!
-            fetch_sources(
-                &cache.source,
+            let rendered_sources = fetch_sources(
+                self.finalized_cache_sources
+                    .as_ref()
+                    .unwrap_or(&cache.source),
                 &self.build_configuration.directories,
                 &self.system_tools,
                 tool_configuration,
@@ -312,6 +313,7 @@ impl Output {
 
             Ok(Output {
                 finalized_cache_dependencies: Some(finalized_dependencies),
+                finalized_cache_sources: Some(rendered_sources),
                 ..self
             })
         } else {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -52,9 +52,6 @@ pub struct Cache {
     /// The prefix that was used at build time (needs to be replaced when
     /// restoring the files)
     pub prefix: PathBuf,
-
-    /// The sources that were already present in the `work_dir`
-    pub sources: Vec<Source>,
 }
 
 impl Output {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -143,9 +143,14 @@ impl Output {
 
         // restore the work dir files
         let cache_dir_work = cache_dir.join("work_dir");
-        CopyDir::new(&cache_dir_work, &self.build_configuration.directories.work_dir)
-            .run()
-            .into_diagnostic()?;
+        let result = CopyDir::new(
+            &cache_dir_work,
+            &self.build_configuration.directories.work_dir,
+        )
+        .run()
+        .into_diagnostic()?;
+
+        tracing::info!("Restored source files from cache");
 
         Ok(Output {
             finalized_cache_dependencies: Some(cache.finalized_dependencies.clone()),
@@ -265,7 +270,9 @@ impl Output {
             let work_dir_files = CopyDir::new(
                 &self.build_configuration.directories.work_dir.clone(),
                 &cache_dir.join("work_dir"),
-            ).run().into_diagnostic()?;
+            )
+            .run()
+            .into_diagnostic()?;
 
             // save the cache
             let cache = Cache {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -373,8 +373,9 @@ pub async fn get_build_output(
                 force_colors: args.color_build_log && console::colors_enabled(),
             },
             finalized_dependencies: None,
-            finalized_cache_dependencies: None,
             finalized_sources: None,
+            finalized_cache_dependencies: None,
+            finalized_cache_sources: None,
             system_tools: SystemTools::new(),
             build_summary: Arc::new(Mutex::new(BuildSummary::default())),
             extra_meta: Some(

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -404,12 +404,17 @@ pub struct Output {
     /// dependencies have not been resolved yet. During the `run_build`
     /// functions, the dependencies are resolved and this field is filled.
     pub finalized_dependencies: Option<FinalizedDependencies>,
-    /// The finalized dependencies from the cache (if there is a cache
-    /// instruction)
-    pub finalized_cache_dependencies: Option<FinalizedDependencies>,
     /// The finalized sources for this output. Contain the exact git hashes for
     /// the sources that are used to build this output.
     pub finalized_sources: Option<Vec<Source>>,
+
+    /// The finalized dependencies from the cache (if there is a cache
+    /// instruction)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub finalized_cache_dependencies: Option<FinalizedDependencies>,
+    /// The finalized sources from the cache (if there is a cache instruction)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub finalized_cache_sources: Option<Vec<Source>>,
 
     /// Summary of the build
     #[serde(skip)]

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -114,7 +114,7 @@ pub fn get_rattler_build_version() -> &'static str {
     env!("CARGO_PKG_VERSION")
 }
 
-#[allow(missing_docs)]
+/// The main application.
 #[derive(Parser)]
 #[clap(version = crate_version!())]
 pub struct App {
@@ -494,20 +494,24 @@ pub struct UploadOpts {
     pub common: CommonOpts,
 }
 
-/// Server type.
+/// The server type to upload to.
 #[derive(Clone, Debug, PartialEq, Parser)]
-#[allow(missing_docs)]
 pub enum ServerType {
+    /// A Quetz server
     Quetz(QuetzOpts),
+    /// An Artifactory server
     Artifactory(ArtifactoryOpts),
+    /// A prefix.dev server
     Prefix(PrefixOpts),
+    /// An anaconda.org server
     Anaconda(AnacondaOpts),
+    /// A conda-forge server
     #[clap(hide = true)]
     CondaForge(CondaForgeOpts),
 }
 
 #[derive(Clone, Debug, PartialEq, Parser)]
-/// Upload to aQuetz server.
+/// Upload to a Quetz server.
 /// Authentication is used from the keychain / auth-file.
 pub struct QuetzOpts {
     /// The URL to your Quetz server

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -114,7 +114,7 @@ pub fn get_rattler_build_version() -> &'static str {
     env!("CARGO_PKG_VERSION")
 }
 
-/// The main application.
+#[allow(missing_docs)]
 #[derive(Parser)]
 #[clap(version = crate_version!())]
 pub struct App {
@@ -494,25 +494,21 @@ pub struct UploadOpts {
     pub common: CommonOpts,
 }
 
-/// The server type to upload to.
+/// Server type.
 #[derive(Clone, Debug, PartialEq, Parser)]
+#[allow(missing_docs)]
 pub enum ServerType {
-    /// A Quetz server
     Quetz(QuetzOpts),
-    /// An Artifactory server
     Artifactory(ArtifactoryOpts),
-    /// A prefix.dev server
     Prefix(PrefixOpts),
-    /// An anaconda.org server
     Anaconda(AnacondaOpts),
-    /// A conda-forge server
     #[clap(hide = true)]
     CondaForge(CondaForgeOpts),
 }
 
-#[derive(Clone, Debug, PartialEq, Parser)]
 /// Upload to a Quetz server.
 /// Authentication is used from the keychain / auth-file.
+#[derive(Clone, Debug, PartialEq, Parser)]
 pub struct QuetzOpts {
     /// The URL to your Quetz server
     #[arg(short, long, env = "QUETZ_SERVER_URL")]

--- a/src/recipe/parser/cache.rs
+++ b/src/recipe/parser/cache.rs
@@ -9,11 +9,14 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 
-use super::{Build, Requirements};
+use super::{Build, Requirements, Source};
 
 /// A cache build that can be used to split up a build into multiple outputs
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct Cache {
+    /// Sources that are used in the cache build and subsequent output builds
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub source: Vec<Source>,
     /// The build configuration for the cache
     pub build: Build,
     /// The requirements for building the cache
@@ -35,6 +38,7 @@ impl TryConvertNode<Cache> for RenderedMappingNode {
         validate_keys! {
             cache,
             self.iter(),
+            source,
             build,
             requirements
         };

--- a/src/recipe/parser/source.rs
+++ b/src/recipe/parser/source.rs
@@ -20,7 +20,7 @@ use crate::{
 use super::FlattenErrors;
 
 /// Source information.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Source {
     /// Git source pointing to a Git repository to retrieve the source from
@@ -167,7 +167,7 @@ where
 }
 
 /// Git source information.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GitSource {
     /// Url to the git repository
     #[serde(rename = "git")]
@@ -358,7 +358,7 @@ impl TryConvertNode<GitSource> for RenderedMappingNode {
 }
 
 /// A Git repository URL or a local path to a Git repository
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum GitUrl {
     /// A remote Git repository URL
@@ -382,7 +382,7 @@ impl fmt::Display for GitUrl {
 /// A url source (usually a tar.gz or tar.bz2 archive). A compressed file
 /// will be extracted to the `work` (or `work/<folder>` directory).
 #[serde_as]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct UrlSource {
     /// Url to the source code (usually a tar.gz or tar.bz2 etc. file)
     #[serde_as(as = "OneOrMany<_, PreferOne>")]
@@ -509,7 +509,7 @@ impl TryConvertNode<UrlSource> for RenderedMappingNode {
 /// A local path source. The source code will be copied to the `work`
 /// (or `work/<folder>` directory).
 #[serde_as]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PathSource {
     /// Path to the local source code
     pub path: PathBuf,
@@ -531,8 +531,12 @@ pub struct PathSource {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub file_name: Option<PathBuf>,
     /// Whether to use the `.gitignore` file in the source directory. Defaults to `true`.
-    #[serde(skip_serializing_if = "should_not_serialize_use_gitignore")]
+    #[serde(default = "default_gitignore", skip_serializing_if = "should_not_serialize_use_gitignore")]
     pub use_gitignore: bool,
+}
+
+fn default_gitignore() -> bool {
+    true
 }
 
 /// Helper method to skip serializing the use_gitignore flag if it is true.
@@ -677,4 +681,22 @@ mod tests {
 
         assert_eq!(parsed_git.url, git.url);
     }
+
+    // test serde json round trip for path source "../"
+    #[test]
+    fn test_path_source_round_trip() {
+        let path_source = PathSource {
+            path: "../".into(),
+            sha256: None,
+            md5: None,
+            patches: Vec::new(),
+            target_directory: None,
+            file_name: None,
+            use_gitignore: true,
+        };
+
+        let json = serde_json::to_string(&path_source).unwrap();
+        serde_json::from_str::<PathSource>(&json).unwrap();
+    }
+    
 }

--- a/src/recipe/parser/source.rs
+++ b/src/recipe/parser/source.rs
@@ -531,7 +531,10 @@ pub struct PathSource {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub file_name: Option<PathBuf>,
     /// Whether to use the `.gitignore` file in the source directory. Defaults to `true`.
-    #[serde(default = "default_gitignore", skip_serializing_if = "should_not_serialize_use_gitignore")]
+    #[serde(
+        default = "default_gitignore",
+        skip_serializing_if = "should_not_serialize_use_gitignore"
+    )]
     pub use_gitignore: bool,
 }
 
@@ -698,5 +701,4 @@ mod tests {
         let json = serde_json::to_string(&path_source).unwrap();
         serde_json::from_str::<PathSource>(&json).unwrap();
     }
-    
 }

--- a/src/snapshots/rattler_build__metadata__test__curl_recipe.yaml.snap
+++ b/src/snapshots/rattler_build__metadata__test__curl_recipe.yaml.snap
@@ -640,7 +640,6 @@ finalized_dependencies:
   run:
     depends: []
     constraints: []
-finalized_cache_dependencies: ~
 finalized_sources: ~
 system_tools:
   rattler-build: 0.12.1

--- a/src/snapshots/rattler_build__metadata__test__read_recipe_with_sources.snap
+++ b/src/snapshots/rattler_build__metadata__test__read_recipe_with_sources.snap
@@ -62,7 +62,6 @@ finalized_dependencies:
   run:
     depends: []
     constraints: []
-finalized_cache_dependencies: ~
 finalized_sources:
   - git: "https://github.com/prefix-dev/rattler-build"
     rev: 4ae7bd207b437c3a5955788e6516339a84358e1c

--- a/src/snapshots/rattler_build__metadata__test__rich_recipe.yaml.snap
+++ b/src/snapshots/rattler_build__metadata__test__rich_recipe.yaml.snap
@@ -383,7 +383,6 @@ finalized_dependencies:
         from: host
         run_export: python
     constraints: []
-finalized_cache_dependencies: ~
 finalized_sources: ~
 system_tools:
   rattler-build: 0.12.1

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -283,7 +283,6 @@ impl Output {
     /// Fetches the sources for the given output and returns a new output with the finalized sources attached
     pub async fn fetch_sources(
         self,
-        already_fetched: Option<Vec<Source>>,
         tool_configuration: &tool_configuration::Configuration,
     ) -> Result<Self, SourceError> {
         let span = tracing::info_span!("Fetching source code");
@@ -300,19 +299,8 @@ impl Output {
 
             Ok(self)
         } else {
-            let sources_to_fetch = if let Some(already_fetched) = already_fetched {
-                self.recipe
-                    .sources()
-                    .iter()
-                    .filter(|&s| !already_fetched.iter().any(|fetched| fetched == s))
-                    .cloned()
-                    .collect()
-            } else {
-                self.recipe.sources().to_vec()
-            };
-
             let rendered_sources = fetch_sources(
-                &sources_to_fetch,
+                &self.recipe.sources(),
                 &self.build_configuration.directories,
                 &self.system_tools,
                 tool_configuration,

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -304,8 +304,8 @@ impl Output {
                 self.recipe
                     .sources()
                     .iter()
+                    .filter(|&s| !already_fetched.iter().any(|fetched| fetched == s))
                     .cloned()
-                    .filter(|s| !already_fetched.iter().any(|fetched| fetched == s))
                     .collect()
             } else {
                 self.recipe.sources().to_vec()

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -288,29 +288,19 @@ impl Output {
         let span = tracing::info_span!("Fetching source code");
         let _enter = span.enter();
 
-        if let Some(finalized_sources) = &self.finalized_sources {
-            fetch_sources(
-                finalized_sources,
-                &self.build_configuration.directories,
-                &self.system_tools,
-                tool_configuration,
-            )
-            .await?;
+        let rendered_sources = fetch_sources(
+            self.finalized_sources
+                .as_deref()
+                .unwrap_or(self.recipe.sources()),
+            &self.build_configuration.directories,
+            &self.system_tools,
+            tool_configuration,
+        )
+        .await?;
 
-            Ok(self)
-        } else {
-            let rendered_sources = fetch_sources(
-                &self.recipe.sources(),
-                &self.build_configuration.directories,
-                &self.system_tools,
-                tool_configuration,
-            )
-            .await?;
-
-            Ok(Output {
-                finalized_sources: Some(rendered_sources),
-                ..self
-            })
-        }
+        Ok(Output {
+            finalized_sources: Some(rendered_sources),
+            ..self
+        })
     }
 }

--- a/src/system_tools.rs
+++ b/src/system_tools.rs
@@ -11,9 +11,10 @@ use std::{
 };
 use thiserror::Error;
 
+/// Errors that can occur when working with system tools
 #[derive(Error, Debug)]
-#[allow(missing_docs)]
 pub enum ToolError {
+    /// The tool was not found on the system
     #[error("failed to find `{0}` ({1})")]
     ToolNotFound(Tool, which::Error),
 }

--- a/test-data/recipes/cache/recipe-symlinks.yaml
+++ b/test-data/recipes/cache/recipe-symlinks.yaml
@@ -14,6 +14,7 @@ cache:
       ln -s $PREFIX/foo.txt $PREFIX/absolute-symlink.txt
       ln -s $PREFIX/non-existent-file $PREFIX/broken-symlink.txt
       ln -s ./foo.txt $PREFIX/relative-symlink.txt
+      echo ${{ PREFIX }} > $PREFIX/prefix.txt
 
 outputs:
   - package:

--- a/test/end-to-end/__snapshots__/test_symlinks/test_symlink_cache.json
+++ b/test/end-to-end/__snapshots__/test_symlinks/test_symlink_cache.json
@@ -25,6 +25,13 @@
       "size_in_bytes": 0
     },
     {
+      "_path": "prefix.txt",
+      "file_mode": "text",
+      "path_type": "hardlink",
+      "sha256": "1f7c780c5a35eeab2ffd8a7d38f9db34974e84ca569db0ff99af21159b5d02d6",
+      "size_in_bytes": 256
+    },
+    {
       "_path": "relative-symlink.txt",
       "path_type": "softlink",
       "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",

--- a/test/end-to-end/__snapshots__/test_symlinks/test_symlink_cache.json
+++ b/test/end-to-end/__snapshots__/test_symlinks/test_symlink_cache.json
@@ -28,7 +28,6 @@
       "_path": "prefix.txt",
       "file_mode": "text",
       "path_type": "hardlink",
-      "sha256": "1f7c780c5a35eeab2ffd8a7d38f9db34974e84ca569db0ff99af21159b5d02d6",
       "size_in_bytes": 256
     },
     {

--- a/test/end-to-end/test_symlinks.py
+++ b/test/end-to-end/test_symlinks.py
@@ -36,7 +36,12 @@ def test_symlink_cache(
     paths_json = pkg / "info/paths.json"
     j = json.loads(paths_json.read_text())
     # prefix placeholder always changes, and we test it later
-    assert snapshot_json(exclude=filter_paths("paths.4.prefix_placeholder", "paths.4.sha256")) == j
+    assert (
+        snapshot_json(
+            exclude=filter_paths("paths.4.prefix_placeholder", "paths.4.sha256")
+        )
+        == j
+    )
 
     paths = j["paths"]
     assert len(paths) == 6

--- a/test/end-to-end/test_symlinks.py
+++ b/test/end-to-end/test_symlinks.py
@@ -36,7 +36,7 @@ def test_symlink_cache(
     paths_json = pkg / "info/paths.json"
     j = json.loads(paths_json.read_text())
     # prefix placeholder always changes, and we test it later
-    assert snapshot_json(exclude=filter_paths("paths.4.prefix_placeholder")) == j
+    assert snapshot_json(exclude=filter_paths("paths.4.prefix_placeholder", "paths.4.sha256")) == j
 
     paths = j["paths"]
     assert len(paths) == 6
@@ -67,7 +67,7 @@ def test_symlink_cache(
     prefix_txt = pkg / "prefix.txt"
     assert prefix_txt.exists()
     contents = prefix_txt.read_text()
-    assert contents.len() > 0
+    assert len(contents) > 0
     # find the path in paths.json for the prefix.txt
     for p in paths:
         if p["_path"] == "prefix.txt":


### PR DESCRIPTION
This PR enables the caching of the source folder, too. 

This meant we had to change the behavior a bit:

- cache has to be restored to the _exact_ same prefix. That means every output will build in the same directory (should also fix the Windows bug!). For this, we currently use the name of the first output (we don't have the `recipe.name` available, but that could be fixed).
- ~~When the cache is involved, we don't fetch sources for the outputs. We should, however, change this to fetch the "diff" of the sources. Sources that were already fetched for the cache should not be re-fetched, but additional sources should be added on top (user has to make sure that there is no clobbering.~~ Cache has its own source section now.

These changes made the example at https://github.com/wolfv/rattler-build-cache-test work :)

- [x] fix finalized sources in output (not correct right now I think)
