### PR TITLE
fix: allow relinking on read-only files

### DIFF
--- a/src/linux/link.rs
+++ b/src/linux/link.rs
@@ -15,6 +15,7 @@ use std::path::{Path, PathBuf};
 use crate::post_process::relink::{RelinkError, Relinker};
 use crate::recipe::parser::GlobVec;
 use crate::system_tools::{SystemTools, Tool};
+use crate::unix::permission_guard::PermissionGuard;
 use crate::utils::to_lexical_absolute;
 
 /// A linux shared object (ELF)
@@ -213,6 +214,8 @@ impl Relinker for SharedObject {
 
         // keep only first unique item
         final_rpaths = final_rpaths.into_iter().unique().collect();
+
+        let _permission_guard = PermissionGuard::new(&self.path, 0o200)?;
 
         // run builtin relink. if it fails, try patchelf
         if builtin_relink(&self.path, &final_rpaths).is_err() {

--- a/src/linux/link.rs
+++ b/src/linux/link.rs
@@ -15,7 +15,7 @@ use std::path::{Path, PathBuf};
 use crate::post_process::relink::{RelinkError, Relinker};
 use crate::recipe::parser::GlobVec;
 use crate::system_tools::{SystemTools, Tool};
-use crate::unix::permission_guard::PermissionGuard;
+use crate::unix::permission_guard::{PermissionGuard, READ_WRITE};
 use crate::utils::to_lexical_absolute;
 
 /// A linux shared object (ELF)
@@ -215,7 +215,7 @@ impl Relinker for SharedObject {
         // keep only first unique item
         final_rpaths = final_rpaths.into_iter().unique().collect();
 
-        let _permission_guard = PermissionGuard::new(&self.path, 0o200)?;
+        let _permission_guard = PermissionGuard::new(&self.path, READ_WRITE)?;
 
         // run builtin relink. if it fails, try patchelf
         if builtin_relink(&self.path, &final_rpaths).is_err() {

--- a/src/macos/link.rs
+++ b/src/macos/link.rs
@@ -259,14 +259,11 @@ impl Relinker for Dylib {
 
         if modified {
             let _permission_guard = PermissionGuard::new(&self.path, READ_WRITE)?;
-            // run builtin relink. if it fails, try install_name_tool
-            match relink(&self.path, &changes) {
-                Err(e) => {
-                    assert!(self.path.exists());
-                    tracing::warn!("Builtin relink failed {:?}, trying install_name_tool", e);
-                    install_name_tool(&self.path, &changes, system_tools)?;
-                }
-                Ok(_) => {}
+            // run builtin relink. If it fails, try install_name_tool
+            if let Err(e) = relink(&self.path, &changes) {
+                assert!(self.path.exists());
+                tracing::warn!("Builtin relink failed {:?}, trying install_name_tool", e);
+                install_name_tool(&self.path, &changes, system_tools)?;
             }
             codesign(&self.path, system_tools)?;
         }

--- a/src/macos/link.rs
+++ b/src/macos/link.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 use crate::post_process::relink::{RelinkError, Relinker};
 use crate::recipe::parser::GlobVec;
 use crate::system_tools::{SystemTools, Tool};
-use crate::unix::permission_guard::PermissionGuard;
+use crate::unix::permission_guard::{PermissionGuard, READ_WRITE};
 use crate::utils::to_lexical_absolute;
 
 /// A macOS dylib (Mach-O)
@@ -258,7 +258,7 @@ impl Relinker for Dylib {
         }
 
         if modified {
-            let _permission_guard = PermissionGuard::new(&self.path, 0o200)?;
+            let _permission_guard = PermissionGuard::new(&self.path, READ_WRITE)?;
             // run builtin relink. if it fails, try install_name_tool
             match relink(&self.path, &changes) {
                 Err(e) => {

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -1,1 +1,2 @@
 pub mod env;
+pub mod permission_guard;

--- a/src/unix/permission_guard.rs
+++ b/src/unix/permission_guard.rs
@@ -92,6 +92,9 @@ mod unix {
 
 #[cfg(windows)]
 mod windows {
+    use std::io;
+    use std::path::Path;
+
     pub struct PermissionGuard;
 
     impl PermissionGuard {

--- a/src/unix/permission_guard.rs
+++ b/src/unix/permission_guard.rs
@@ -1,81 +1,109 @@
-//! Unix-specific implementation of the `PermissionGuard` struct.
-use std::fs::Permissions;
-use std::io;
-use std::os::unix::fs::PermissionsExt;
-use std::path::{Path, PathBuf};
+//! Implementation of the `PermissionGuard` struct.
 
-pub struct PermissionGuard {
-    path: PathBuf,
-    original_permissions: Permissions,
-}
+/// User read/write permissions (0o600).
+pub const READ_WRITE: u32 = 0o600;
 
-pub const READ_WRITE: u32 = 0o600; // User read/write
+#[cfg(unix)]
+mod unix {
+    use std::fs::Permissions;
+    use std::io;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::{Path, PathBuf};
 
-impl PermissionGuard {
-    pub fn new<P: AsRef<Path>>(path: P, permissions: u32) -> io::Result<Self> {
-        let path = path.as_ref().to_path_buf();
-        let metadata = std::fs::metadata(&path)?;
-        let original_permissions = metadata.permissions();
-
-        let new_permissions = Permissions::from_mode(original_permissions.mode() | permissions);
-
-        // Set new permissions
-        std::fs::set_permissions(&path, new_permissions)?;
-
-        Ok(Self {
-            path,
-            original_permissions,
-        })
+    /// A guard that modifies the permissions of a file and restores them when dropped.
+    pub struct PermissionGuard {
+        /// The path to the file.
+        path: PathBuf,
+        /// The original permissions of the file.
+        original_permissions: Permissions,
     }
-}
 
-impl Drop for PermissionGuard {
-    fn drop(&mut self) {
-        if self.path.exists() {
-            if let Err(e) = std::fs::set_permissions(&self.path, self.original_permissions.clone())
-            {
-                eprintln!("Failed to restore file permissions: {}", e);
+    impl PermissionGuard {
+        /// Create a new `PermissionGuard` for the given path with the given permissions.
+        pub fn new<P: AsRef<Path>>(path: P, permissions: u32) -> io::Result<Self> {
+            let path = path.as_ref().to_path_buf();
+            let metadata = std::fs::metadata(&path)?;
+            let original_permissions = metadata.permissions();
+
+            let new_permissions = Permissions::from_mode(original_permissions.mode() | permissions);
+
+            // Set new permissions
+            std::fs::set_permissions(&path, new_permissions)?;
+
+            Ok(Self {
+                path,
+                original_permissions,
+            })
+        }
+    }
+
+    impl Drop for PermissionGuard {
+        fn drop(&mut self) {
+            if self.path.exists() {
+                if let Err(e) =
+                    std::fs::set_permissions(&self.path, self.original_permissions.clone())
+                {
+                    eprintln!("Failed to restore file permissions: {}", e);
+                }
             }
         }
     }
-}
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::fs::{self, File};
-    use tempfile::tempdir;
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use std::fs::{self, File};
+        use tempfile::tempdir;
 
-    #[test]
-    fn test_permission_guard_modifies_and_restores() -> io::Result<()> {
-        let dir = tempdir()?;
-        let test_file = dir.path().join("test-restore.txt");
-        File::create(&test_file)?;
+        #[test]
+        fn test_permission_guard_modifies_and_restores() -> io::Result<()> {
+            let dir = tempdir()?;
+            let test_file = dir.path().join("test-restore.txt");
+            File::create(&test_file)?;
 
-        // Set initial permissions to 0o002 so we can check if the guard modifies them
-        fs::set_permissions(&test_file, Permissions::from_mode(0o002))?;
-        let initial_mode = fs::metadata(&test_file)?.permissions().mode();
+            // Set initial permissions to 0o002 so we can check if the guard modifies them
+            fs::set_permissions(&test_file, Permissions::from_mode(0o002))?;
+            let initial_mode = fs::metadata(&test_file)?.permissions().mode();
 
-        // Create scope for PermissionGuard
-        {
-            let _guard = PermissionGuard::new(&test_file, 0o200)?; // Write permission
+            // Create scope for PermissionGuard
+            {
+                let _guard = PermissionGuard::new(&test_file, 0o200)?; // Write permission
 
-            // Check permissions were modified
-            let modified_mode = fs::metadata(&test_file)?.permissions().mode();
-            assert_ne!(initial_mode, modified_mode);
-            assert_eq!(modified_mode & 0o200, 0o200);
+                // Check permissions were modified
+                let modified_mode = fs::metadata(&test_file)?.permissions().mode();
+                assert_ne!(initial_mode, modified_mode);
+                assert_eq!(modified_mode & 0o200, 0o200);
+            }
+
+            // Check permissions were restored after guard dropped
+            let final_mode = fs::metadata(&test_file)?.permissions().mode();
+            assert_eq!(initial_mode, final_mode);
+
+            Ok(())
         }
 
-        // Check permissions were restored after guard dropped
-        let final_mode = fs::metadata(&test_file)?.permissions().mode();
-        assert_eq!(initial_mode, final_mode);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_permission_guard_nonexistent_file() {
-        let result = PermissionGuard::new("nonexistent_file", 0o777);
-        assert!(result.is_err());
+        #[test]
+        fn test_permission_guard_nonexistent_file() {
+            let result = PermissionGuard::new("nonexistent_file", 0o777);
+            assert!(result.is_err());
+        }
     }
 }
+
+#[cfg(windows)]
+mod windows {
+    pub struct PermissionGuard;
+
+    impl PermissionGuard {
+        /// Create a new `PermissionGuard` for the given path with the given permissions. Does nothing on Windows.
+        pub fn new<P: AsRef<Path>>(_path: P, _permissions: u32) -> io::Result<Self> {
+            Ok(Self)
+        }
+    }
+}
+
+#[cfg(unix)]
+pub use self::unix::PermissionGuard;
+
+#[cfg(windows)]
+pub use self::windows::PermissionGuard;

--- a/src/unix/permission_guard.rs
+++ b/src/unix/permission_guard.rs
@@ -1,0 +1,81 @@
+//! Unix-specific implementation of the `PermissionGuard` struct.
+use std::fs::Permissions;
+use std::io;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+pub struct PermissionGuard {
+    path: PathBuf,
+    original_permissions: Permissions,
+}
+
+pub const READ_WRITE: u32 = 0o600; // User read/write
+
+impl PermissionGuard {
+    pub fn new<P: AsRef<Path>>(path: P, permissions: u32) -> io::Result<Self> {
+        let path = path.as_ref().to_path_buf();
+        let metadata = std::fs::metadata(&path)?;
+        let original_permissions = metadata.permissions();
+
+        let new_permissions = Permissions::from_mode(original_permissions.mode() | permissions);
+
+        // Set new permissions
+        std::fs::set_permissions(&path, new_permissions)?;
+
+        Ok(Self {
+            path,
+            original_permissions,
+        })
+    }
+}
+
+impl Drop for PermissionGuard {
+    fn drop(&mut self) {
+        if self.path.exists() {
+            if let Err(e) = std::fs::set_permissions(&self.path, self.original_permissions.clone())
+            {
+                eprintln!("Failed to restore file permissions: {}", e);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::{self, File};
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_permission_guard_modifies_and_restores() -> io::Result<()> {
+        let dir = tempdir()?;
+        let test_file = dir.path().join("test-restore.txt");
+        File::create(&test_file)?;
+
+        // Set initial permissions to 0o002 so we can check if the guard modifies them
+        fs::set_permissions(&test_file, Permissions::from_mode(0o002))?;
+        let initial_mode = fs::metadata(&test_file)?.permissions().mode();
+
+        // Create scope for PermissionGuard
+        {
+            let _guard = PermissionGuard::new(&test_file, 0o200)?; // Write permission
+
+            // Check permissions were modified
+            let modified_mode = fs::metadata(&test_file)?.permissions().mode();
+            assert_ne!(initial_mode, modified_mode);
+            assert_eq!(modified_mode & 0o200, 0o200);
+        }
+
+        // Check permissions were restored after guard dropped
+        let final_mode = fs::metadata(&test_file)?.permissions().mode();
+        assert_eq!(initial_mode, final_mode);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_permission_guard_nonexistent_file() {
+        let result = PermissionGuard::new("nonexistent_file", 0o777);
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
There was an issue on macOS where relinking did not work, because the file was `read-only`.

This fixes it, but I also need to check wether the same problem occurs on Linux.