### PR TITLE
fix: use read timeout, not global timeout

### DIFF
--- a/src/tool_configuration.rs
+++ b/src/tool_configuration.rs
@@ -118,7 +118,7 @@ pub fn reqwest_client_from_auth_storage(
             .no_gzip()
             .pool_max_idle_per_host(20)
             .user_agent(APP_USER_AGENT)
-            .timeout(std::time::Duration::from_secs(timeout))
+            .read_timeout(std::time::Duration::from_secs(timeout))
             .build()
             .expect("failed to create client"),
     )


### PR DESCRIPTION
This should fix users with slower internet connection. Currently, a package can download only for 5 minutes - which is definitely not appropriate for some larger ones.

With the `read_timeout` this value is reset at every read so only really stalled connections will time out.

similar change in pixi: https://github.com/prefix-dev/pixi/pull/1329