### PR TITLE
fix: license from recipe folder instead of erroring if both are found

### DIFF
--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -943,6 +943,9 @@ to directories with license information. Directory entries must end with a `/`
 suffix (this is to lessen unintentional inclusion of non-license files; all the
 directory's contents will be unconditionally and recursively added).
 
+If a license file is found in both the source and recipe directories, the file from
+the recipe directory is used (you should see a warning about this in the build log).
+
 ```yaml
 about:
   license_file:

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -699,13 +699,9 @@ def test_filter_files(
 
 def test_double_license(rattler_build: RattlerBuild, recipes: Path, tmp_path: Path):
     path_to_recipe = recipes / "double_license"
-    args = rattler_build.build_args(
-        path_to_recipe,
-        tmp_path,
-    )
-    # make sure that two license files in $SRC_DIR and $RECIPE_DIR raise an exception
-    with pytest.raises(CalledProcessError):
-        rattler_build(*args)
+    args = rattler_build.build_args(path_to_recipe, tmp_path)
+    output = rattler_build(*args, stderr=STDOUT)
+    assert "warning License file from source directory was overwritten" in output
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
So far we were erroring if the same license file was added from both the source directory and the recipe directory. Now we are issueing a warning and prefer the license from the recipe directory.

In practice, it would be much better to remedy this by using different license names or removing the license from the recipe folder.

fixes https://github.com/prefix-dev/rattler-build/issues/1173