### PR TITLE
feat: make undefined more strict

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3567,6 +3567,7 @@ dependencies = [
  "sha1",
  "sha2",
  "spdx",
+ "strum",
  "tar",
  "tempfile",
  "terminal_size 0.4.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,7 @@ rattler_solve = { version = "1.2.3", default-features = false, features = ["reso
 rattler_virtual_packages = { version = "1.1.10", default-features = false }
 rattler_package_streaming = { version = "0.22.13", default-features = false }
 lazy_static = "1.5.0"
+strum = "0.26.3"
 
 [dev-dependencies]
 insta = { version = "1.41.1", features = ["yaml"] }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -220,7 +220,7 @@ impl Output {
                 .await
                 .into_diagnostic()?;
 
-            let selector_config = self.build_configuration.selector_config();
+            let selector_config = self.build_configuration.selector_config(self.recipe.build().number());
             let mut jinja = Jinja::new(selector_config.clone());
             for (k, v) in self.recipe.context.iter() {
                 jinja

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,6 +207,7 @@ pub async fn get_build_output(
         target_platform,
         host_platform,
         hash: None,
+        build_number: None,
         build_platform: args.build_platform,
         variant: BTreeMap::new(),
         experimental: args.common.experimental,

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -355,13 +355,14 @@ impl BuildConfiguration {
     }
 
     /// Construct a `SelectorConfig` from the given `BuildConfiguration`
-    pub fn selector_config(&self) -> SelectorConfig {
+    pub fn selector_config(&self, build_number: u64) -> SelectorConfig {
         SelectorConfig {
             target_platform: self.target_platform,
             host_platform: self.host_platform.platform,
             build_platform: self.build_platform.platform,
             variant: self.variant.clone(),
             hash: Some(self.hash.clone()),
+            build_number: Some(build_number),
             experimental: false,
             allow_undefined: false,
         }

--- a/src/package_test/serialize_test.rs
+++ b/src/package_test/serialize_test.rs
@@ -55,7 +55,7 @@ impl CommandsTest {
 }
 
 fn default_jinja_context(output: &Output) -> Jinja {
-    let selector_config = output.build_configuration.selector_config();
+    let selector_config = output.build_configuration.selector_config(output.recipe.build().number());
     let jinja = Jinja::new(selector_config).with_context(&output.recipe.context);
     jinja
 }

--- a/src/recipe/jinja.rs
+++ b/src/recipe/jinja.rs
@@ -399,6 +399,9 @@ fn set_jinja(config: &SelectorConfig) -> minijinja::Environment<'static> {
     } = config.clone();
 
     let mut env = Environment::empty();
+    if !allow_undefined {
+        env.set_undefined_behavior(minijinja::UndefinedBehavior::Strict);
+    }
     default_tests(&mut env);
     default_filters(&mut env);
 

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -374,7 +374,7 @@ impl Output {
         env_vars.extend(env_vars::os_vars(&host_prefix, &target_platform));
         env_vars.extend(self.env_vars_from_variant());
 
-        let selector_config = self.build_configuration.selector_config();
+        let selector_config = self.build_configuration.selector_config(self.recipe.build().number());
         let jinja = Jinja::new(selector_config.clone()).with_context(&self.recipe.context);
 
         self.recipe

--- a/src/selectors.rs
+++ b/src/selectors.rs
@@ -23,6 +23,8 @@ pub struct SelectorConfig {
     pub build_platform: Platform,
     /// The hash, if available
     pub hash: Option<HashInfo>,
+    /// The build number if available
+    pub build_number: Option<u64>,
     /// The variant config
     pub variant: BTreeMap<NormalizedKey, String>,
     /// Enable experimental features
@@ -105,10 +107,13 @@ impl SelectorConfig {
         }
     }
 
-    /// Set allow_undefined for this Jinja context / selector config
-    pub fn with_allow_undefined(self, allow_undefined: bool) -> Self {
+    /// Finish the selector config by adding the hash and build number. 
+    /// After this, all variables are defined and `allow_undefined` is set to false.
+    pub fn finish(self, hash: HashInfo, build_number: u64) -> Self {
         Self {
-            allow_undefined,
+            hash: Some(hash),
+            build_number: Some(build_number),
+            allow_undefined: false,
             ..self
         }
     }
@@ -121,6 +126,7 @@ impl Default for SelectorConfig {
             host_platform: Platform::current(),
             build_platform: Platform::current(),
             hash: None,
+            build_number: None,
             variant: Default::default(),
             experimental: false,
             allow_undefined: false,

--- a/src/variant_render.rs
+++ b/src/variant_render.rs
@@ -384,7 +384,8 @@ pub(crate) fn stage_1_render(
                 let config_with_variant = selector_config
                     .clone()
                     .with_variant(combination.clone(), selector_config.target_platform)
-                    .with_allow_undefined(false);
+                    // TODO finish with the real hash
+                    .finish(HashInfo::from_variant(&Default::default(), &rattler_conda_types::NoArchType::none()), 123);
 
                 let parsed_recipe = Recipe::from_node(output, config_with_variant.clone()).unwrap();
 

--- a/src/variant_render.rs
+++ b/src/variant_render.rs
@@ -88,8 +88,9 @@ pub(crate) fn stage_0_render(
         let mut rendered_outputs = Vec::new();
         // TODO: figure out if we can pre-compute the `noarch` value.
         for output in outputs {
-            let config_with_variant =
-                selector_config.with_variant(combination.clone(), selector_config.target_platform);
+            let config_with_variant = selector_config
+                .clone()
+                .with_variant(combination.clone(), selector_config.target_platform);
 
             let parsed_recipe = Recipe::from_node(output, config_with_variant).map_err(|err| {
                 let errs: ParseErrors = err
@@ -381,7 +382,9 @@ pub(crate) fn stage_1_render(
             for (idx, output) in r.raw_outputs.vec.iter().enumerate() {
                 // use the correct target_platform here?
                 let config_with_variant = selector_config
-                    .with_variant(combination.clone(), selector_config.target_platform);
+                    .clone()
+                    .with_variant(combination.clone(), selector_config.target_platform)
+                    .with_allow_undefined(false);
 
                 let parsed_recipe = Recipe::from_node(output, config_with_variant.clone()).unwrap();
 


### PR DESCRIPTION
This is the start of making parsing undefined Jinja variables more strict. 

I think we should insert some pseudo values for `hash` and `build_number` as those should be the only two values that we allow as undefined.