### PR TITLE
feat: use index map for env

### DIFF
--- a/src/packaging.rs
+++ b/src/packaging.rs
@@ -125,7 +125,7 @@ fn copy_license_files(
         // if a file was copied from the recipe dir, and the work dir, we should
         // issue a warning
         for file in copied_files_recipe_dir {
-            if copied_files_work_dir.contains(&file) {
+            if copied_files_work_dir.contains(file) {
                 let warn_str = format!("License file from source directory was overwritten by license file from recipe folder ({})", file.display());
                 tracing::warn!(warn_str);
                 output.record_warning(&warn_str);

--- a/src/recipe/custom_yaml.rs
+++ b/src/recipe/custom_yaml.rs
@@ -1251,6 +1251,26 @@ where
     }
 }
 
+impl<K, V> TryConvertNode<IndexMap<K, V>> for RenderedNode
+where
+    K: Ord + Display + Hash,
+    RenderedScalarNode: TryConvertNode<K>,
+    RenderedNode: TryConvertNode<V>,
+{
+    fn try_convert(&self, name: &str) -> Result<IndexMap<K, V>, Vec<PartialParsingError>> {
+        self.as_mapping()
+            .ok_or_else(|| {
+                _partialerror!(
+                    *self.span(),
+                    ErrorKind::ExpectedMapping,
+                    help = format!("expected a mapping for `{name}`")
+                )
+            })
+            .map_err(|e| vec![e])
+            .and_then(|m| m.try_convert(name))
+    }
+}
+
 impl<K, V> TryConvertNode<IndexMap<K, V>> for RenderedMappingNode
 where
     K: Ord + Display + Hash,

--- a/src/recipe/parser/script.rs
+++ b/src/recipe/parser/script.rs
@@ -6,8 +6,9 @@ use crate::{
     },
     recipe::error::{ErrorKind, PartialParsingError},
 };
+use indexmap::IndexMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::{borrow::Cow, collections::BTreeMap, path::PathBuf};
+use std::{borrow::Cow, path::PathBuf};
 
 /// Defines the script to run to build the package.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -15,7 +16,7 @@ pub struct Script {
     /// The interpreter to use for the script.
     pub interpreter: Option<String>,
     /// Environment variables to set in the build environment.
-    pub env: BTreeMap<String, String>,
+    pub env: IndexMap<String, String>,
     /// Environment variables to leak into the build environment from the host system that
     /// contain sensitive information. Use with care because this might make recipes no
     /// longer reproducible on other machines.
@@ -48,8 +49,8 @@ impl Serialize for Script {
             Object {
                 #[serde(skip_serializing_if = "Option::is_none")]
                 interpreter: Option<&'a String>,
-                #[serde(skip_serializing_if = "BTreeMap::is_empty")]
-                env: &'a BTreeMap<String, String>,
+                #[serde(skip_serializing_if = "IndexMap::is_empty")]
+                env: &'a IndexMap<String, String>,
                 #[serde(skip_serializing_if = "Vec::is_empty")]
                 secrets: &'a Vec<String>,
                 #[serde(skip_serializing_if = "Option::is_none", flatten)]
@@ -114,7 +115,7 @@ impl<'de> Deserialize<'de> for Script {
                 #[serde(default)]
                 interpreter: Option<String>,
                 #[serde(default)]
-                env: BTreeMap<String, String>,
+                env: IndexMap<String, String>,
                 #[serde(default)]
                 secrets: Vec<String>,
                 #[serde(default, flatten)]
@@ -164,7 +165,7 @@ impl Script {
     }
 
     /// Get the environment variables to set in the build environment.
-    pub fn env(&self) -> &BTreeMap<String, String> {
+    pub fn env(&self) -> &IndexMap<String, String> {
         &self.env
     }
 

--- a/src/recipe/parser/snapshots/rattler_build__recipe__parser__test__test__script_parsing.snap
+++ b/src/recipe/parser/snapshots/rattler_build__recipe__parser__test__test__script_parsing.snap
@@ -15,8 +15,8 @@ expression: yaml_serde
 - script:
     interpreter: bash
     env:
-      BAZ: QUX
       FOO: BAR
+      BAZ: QUX
     secrets:
     - ABC
     - DEF

--- a/src/variant_render.rs
+++ b/src/variant_render.rs
@@ -276,6 +276,7 @@ impl Stage1Render {
         Ok(sorted_indices)
     }
 
+    #[allow(clippy::type_complexity)]
     pub fn into_sorted_outputs(
         self,
     ) -> Result<Vec<((Node, Recipe), BTreeMap<NormalizedKey, String>)>, VariantError> {


### PR DESCRIPTION
I think I prefer to keep the original order of env vars. In the future, we might allow "rendering" the env vars etc.