### PR TITLE
Strict parsing

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -3,7 +3,7 @@
 use std::{path::PathBuf, vec};
 
 use miette::{Context, IntoDiagnostic};
-use rattler_conda_types::{Channel, MatchSpec, ParseStrictness};
+use rattler_conda_types::{Channel, MatchSpec};
 
 use crate::{
     metadata::{build_reindexed_channels, Output},
@@ -39,10 +39,8 @@ pub async fn skip_existing(
 
     let match_specs = outputs
         .iter()
-        .map(|o| {
-            MatchSpec::from_str(o.name().as_normalized(), ParseStrictness::Strict).into_diagnostic()
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+        .map(|o| o.name().clone().into())
+        .collect::<Vec<MatchSpec>>();
 
     let channels = if only_local {
         vec![

--- a/src/package_test/run_test.rs
+++ b/src/package_test/run_test.rs
@@ -510,9 +510,9 @@ impl PythonTest {
 
         // Add `pip` if pip_check is set to true
         if self.pip_check {
-            dependencies_map.iter_mut().for_each(|(_, v)| {
-                v.push("pip".parse().unwrap())
-            });
+            dependencies_map
+                .iter_mut()
+                .for_each(|(_, v)| v.push("pip".parse().unwrap()));
         }
 
         // Run tests for each python version
@@ -613,10 +613,7 @@ impl PerlTest {
             ParseStrictness::Lenient,
         )?;
 
-        let dependencies = vec![
-            "perl".parse().unwrap(),
-            match_spec,
-        ];
+        let dependencies = vec!["perl".parse().unwrap(), match_spec];
 
         create_environment(
             "test",

--- a/src/package_test/run_test.rs
+++ b/src/package_test/run_test.rs
@@ -511,7 +511,7 @@ impl PythonTest {
         // Add `pip` if pip_check is set to true
         if self.pip_check {
             dependencies_map.iter_mut().for_each(|(_, v)| {
-                v.push(MatchSpec::from_str("pip", ParseStrictness::Strict).unwrap())
+                v.push("pip".parse().unwrap())
             });
         }
 
@@ -614,7 +614,7 @@ impl PerlTest {
         )?;
 
         let dependencies = vec![
-            MatchSpec::from_str("perl", ParseStrictness::Strict).unwrap(),
+            "perl".parse().unwrap(),
             match_spec,
         ];
 

--- a/src/recipe/parser/requirements.rs
+++ b/src/recipe/parser/requirements.rs
@@ -366,7 +366,7 @@ impl TryConvertNode<MatchSpec> for RenderedNode {
 
 impl TryConvertNode<MatchSpec> for RenderedScalarNode {
     fn try_convert(&self, _name: &str) -> Result<MatchSpec, Vec<PartialParsingError>> {
-        MatchSpec::from_str(self.as_str(), ParseStrictness::Strict).map_err(|err| {
+        MatchSpec::from_str(self.as_str(), ParseStrictness::Lenient).map_err(|err| {
             let str = self.as_str();
             vec![_partialerror!(
                 *self.span(),

--- a/src/recipe/parser/requirements.rs
+++ b/src/recipe/parser/requirements.rs
@@ -366,7 +366,34 @@ impl TryConvertNode<MatchSpec> for RenderedNode {
 
 impl TryConvertNode<MatchSpec> for RenderedScalarNode {
     fn try_convert(&self, _name: &str) -> Result<MatchSpec, Vec<PartialParsingError>> {
-        MatchSpec::from_str(self.as_str(), ParseStrictness::Lenient).map_err(|err| {
+        let string = self.as_str();
+
+        // if we have a matchspec that is only numbers, and ., we complain and ask the user to add a
+        // `.*` or `==` in front of it.
+        let splitted = string.split_whitespace().collect::<Vec<_>>();
+        if splitted.len() >= 2 {
+            if splitted[1].chars().all(|c| c.is_numeric() || c == '.') {
+                let name = splitted[0];
+                let version = splitted[1];
+                let rest = splitted[2..].join(" ");
+                let rest = if rest.is_empty() {
+                    "".to_string()
+                } else {
+                    format!(" {}", rest)
+                };
+
+                return Err(vec![_partialerror!(
+                    *self.span(),
+                    ErrorKind::Other,
+                    label = format!(
+                        "This match spec is ambiguous. Do you mean `{name} =={version}{rest}` or `{name} {version}.*{rest}`?"
+                    )
+                )]);
+            }
+        }
+
+
+        MatchSpec::from_str(self.as_str(), ParseStrictness::Strict).map_err(|err| {
             let str = self.as_str();
             vec![_partialerror!(
                 *self.span(),

--- a/src/render/resolved_dependencies.rs
+++ b/src/render/resolved_dependencies.rs
@@ -467,11 +467,23 @@ pub fn apply_variant(
                     if m.version.is_none() && m.build.is_none() {
                         if let Some(name) = &m.name {
                             if let Some(version) = variant.get(&name.into()) {
+                                // if the variant starts with an alphanumeric character,
+                                // we have to add a '=' to the version spec
+                                let mut spec = version.clone();
+
+                                // check if all characters are alphanumeric or ., in that case add
+                                // a '=' to get "startswith" behavior
+                                if spec.chars().all(|c| c.is_alphanumeric() || c == '.') {
+                                    spec = format!("={}", version);
+                                } else {
+                                    spec = version.clone();
+                                }
+
                                 // we split at whitespace to separate into version and build
-                                let mut splitter = version.split_whitespace();
+                                let mut splitter = spec.split_whitespace();
                                 let version_spec = splitter
                                     .next()
-                                    .map(|v| VersionSpec::from_str(v, ParseStrictness::Lenient))
+                                    .map(|v| VersionSpec::from_str(v, ParseStrictness::Strict))
                                     .transpose()?;
                                 let build_spec =
                                     splitter.next().map(StringMatcher::from_str).transpose()?;

--- a/src/render/resolved_dependencies.rs
+++ b/src/render/resolved_dependencies.rs
@@ -467,23 +467,11 @@ pub fn apply_variant(
                     if m.version.is_none() && m.build.is_none() {
                         if let Some(name) = &m.name {
                             if let Some(version) = variant.get(&name.into()) {
-                                // if the variant starts with an alphanumeric character,
-                                // we have to add a '=' to the version spec
-                                let mut spec = version.clone();
-
-                                // check if all characters are alphanumeric or ., in that case add
-                                // a '=' to get "startswith" behavior
-                                if spec.chars().all(|c| c.is_alphanumeric() || c == '.') {
-                                    spec = format!("={}", version);
-                                } else {
-                                    spec = version.clone();
-                                }
-
                                 // we split at whitespace to separate into version and build
-                                let mut splitter = spec.split_whitespace();
+                                let mut splitter = version.split_whitespace();
                                 let version_spec = splitter
                                     .next()
-                                    .map(|v| VersionSpec::from_str(v, ParseStrictness::Strict))
+                                    .map(|v| VersionSpec::from_str(v, ParseStrictness::Lenient))
                                     .transpose()?;
                                 let build_spec =
                                     splitter.next().map(StringMatcher::from_str).transpose()?;


### PR DESCRIPTION
We currently parse `python 3` as `python ==3` which is a deviation from conda-build (which has some complicated logic to add stars sometimes).

We propose to simplify the logic and ask the user to provide operators, suhc as `>=3`, `3.*`, `==3` etc.