### PR TITLE
fix: Fix "the env Jinja functions" example not to ref PKG_HASH

### DIFF
--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -1102,7 +1102,7 @@ This can be used for some light templating, for example:
 
 ```yaml
 build:
-  string: ${{ env.get("GIT_BUILD_STRING") }}_${{ PKG_HASH }}
+  string: ${{ env.get("GIT_BUILD_STRING") }}_${{ hash }}
 ```
 
 #### `match` function


### PR DESCRIPTION
Fix the example in "the env Jinja functions" part of recipe documentation to use `${{ hash }}` rather than `${{ PKG_HASH }}`, as the latter does not work.