### PR TITLE
fix: Use UrlWithTrailingSlash for upload, use bearer auth for Artifactory upload

### DIFF
--- a/src/opt.rs
+++ b/src/opt.rs
@@ -537,12 +537,16 @@ pub struct ArtifactoryOpts {
     pub channel: String,
 
     /// Your Artifactory username
-    #[arg(short = 'r', long, env = "ARTIFACTORY_USERNAME")]
+    #[arg(long, env = "ARTIFACTORY_USERNAME", hide = true)]
     pub username: Option<String>,
 
     /// Your Artifactory password
-    #[arg(short, long, env = "ARTIFACTORY_PASSWORD")]
+    #[arg(long, env = "ARTIFACTORY_PASSWORD", hide = true)]
     pub password: Option<String>,
+
+    /// Your Artifactory token
+    #[arg(short, long, env = "ARTIFACTORY_TOKEN")]
+    pub token: Option<String>,
 }
 
 /// Options for uploading to a prefix.dev server.

--- a/src/upload/anaconda.rs
+++ b/src/upload/anaconda.rs
@@ -12,12 +12,14 @@ use tracing::debug;
 use tracing::info;
 use url::Url;
 
+use crate::url_with_trailing_slash::UrlWithTrailingSlash;
+
 use super::package::ExtractedPackage;
 use super::VERSION;
 
 pub struct Anaconda {
     client: Client,
-    url: Url,
+    url: UrlWithTrailingSlash,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -45,7 +47,7 @@ struct FileStageResponse {
 }
 
 impl Anaconda {
-    pub fn new(token: String, url: Url) -> Self {
+    pub fn new(token: String, url: UrlWithTrailingSlash) -> Self {
         let mut default_headers = reqwest::header::HeaderMap::new();
 
         default_headers.append(

--- a/src/upload/conda_forge.rs
+++ b/src/upload/conda_forge.rs
@@ -48,7 +48,7 @@ pub async fn upload_packages_to_conda_forge(
     opts: CondaForgeOpts,
     package_files: &Vec<PathBuf>,
 ) -> miette::Result<()> {
-    let anaconda = anaconda::Anaconda::new(opts.staging_token, opts.anaconda_url);
+    let anaconda = anaconda::Anaconda::new(opts.staging_token, opts.anaconda_url.into());
 
     let mut channels: HashMap<String, HashMap<_, _>> = HashMap::new();
 

--- a/src/url_with_trailing_slash.rs
+++ b/src/url_with_trailing_slash.rs
@@ -1,0 +1,82 @@
+// copied from rattler-conda-types::utils::url_with_trailing_slash
+// TODO: move to separate crate
+
+use std::{
+    fmt::{Display, Formatter},
+    ops::Deref,
+    str::FromStr,
+};
+
+use rattler_redaction::Redact;
+use serde::{Deserialize, Deserializer, Serialize};
+use url::Url;
+
+/// A URL that always has a trailing slash. A trailing slash in a URL has
+/// significance but users often forget to add it. This type is used to
+/// normalize the use of the URL.
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize)]
+#[serde(transparent)]
+pub struct UrlWithTrailingSlash(Url);
+
+impl Deref for UrlWithTrailingSlash {
+    type Target = Url;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl AsRef<Url> for UrlWithTrailingSlash {
+    fn as_ref(&self) -> &Url {
+        &self.0
+    }
+}
+
+impl From<Url> for UrlWithTrailingSlash {
+    fn from(url: Url) -> Self {
+        let path = url.path();
+        if path.ends_with('/') {
+            Self(url)
+        } else {
+            let mut url = url.clone();
+            url.set_path(&format!("{path}/"));
+            Self(url)
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for UrlWithTrailingSlash {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let url = Url::deserialize(deserializer)?;
+        Ok(url.into())
+    }
+}
+
+impl FromStr for UrlWithTrailingSlash {
+    type Err = url::ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Url::parse(s)?.into())
+    }
+}
+
+impl From<UrlWithTrailingSlash> for Url {
+    fn from(value: UrlWithTrailingSlash) -> Self {
+        value.0
+    }
+}
+
+impl Display for UrlWithTrailingSlash {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", &self.0)
+    }
+}
+
+impl Redact for UrlWithTrailingSlash {
+    fn redact(self) -> Self {
+        UrlWithTrailingSlash(self.0.redact())
+    }
+}


### PR DESCRIPTION
closes #1254

tested out locally with my artifactory instance, seems to work flawlessly