### PR TITLE
fix: Use tool_configuration.channel_priority in TestConfiguration

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,6 @@ use petgraph::{algo::toposort, graph::DiGraph, visit::DfsPostOrder};
 use rattler_conda_types::{
     package::ArchiveType, Channel, GenericVirtualPackage, MatchSpec, PackageName, Platform,
 };
-use rattler_solve::ChannelPriority;
 use rattler_solve::SolveStrategy;
 use rattler_virtual_packages::{VirtualPackage, VirtualPackageOverrides};
 use recipe::parser::{find_outputs_from_src, Dependency, TestType};
@@ -518,7 +517,7 @@ pub async fn run_build_from_args(
                         )
                         .into_diagnostic()
                         .context("failed to reindex output channel")?,
-                        channel_priority: ChannelPriority::Strict,
+                        channel_priority: tool_configuration.channel_priority,
                         solve_strategy: SolveStrategy::Highest,
                         tool_configuration: tool_configuration.clone(),
                     },


### PR DESCRIPTION
Fix https://github.com/prefix-dev/rattler-build/issues/343

After https://github.com/prefix-dev/rattler-build/pull/1211 was merged some of the code for the build/rendering/testing was refactored and one of the changes used the old `ChannelPriority::Strict` value instead of `tool_config.channel_priority`

https://github.com/prefix-dev/rattler-build/commit/2c7f0e9f513679e8169a2307ef094b9bde9ee71d#diff-be833857e8bbf63e2cbb12410f1e722789c4dce3d8c1dde47a79af89e52c71dcL201

https://github.com/prefix-dev/rattler-build/commit/2c7f0e9f513679e8169a2307ef094b9bde9ee71d#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R521