### PR TITLE
fix: expose `NormalizedKey`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,8 @@ use variant_config::VariantConfig;
 
 use crate::metadata::PlatformWithVirtualPackages;
 
+pub use normalized_key::NormalizedKey;
+
 /// Returns the recipe path.
 pub fn get_recipe_path(path: &Path) -> miette::Result<PathBuf> {
     let recipe_path = canonicalize(path);

--- a/src/normalized_key.rs
+++ b/src/normalized_key.rs
@@ -2,10 +2,12 @@ use rattler_conda_types::PackageName;
 use serde::{Deserialize, Serialize};
 use std::hash::Hash;
 
+/// A key in a variant configuration.
 #[derive(Debug, Clone, Deserialize)]
 pub struct NormalizedKey(pub String);
 
 impl NormalizedKey {
+    /// Returns the normalized form of the key.
     pub fn normalize(&self) -> String {
         self.0
             .chars()


### PR DESCRIPTION
`NormalizedKey` is used in the `VariantConfig` but it is not publicly exposed.