### PR TITLE
refactor: make source generic

### DIFF
--- a/src/conda_build_config.rs
+++ b/src/conda_build_config.rs
@@ -1,12 +1,9 @@
 //! Module to load deprecated `conda_build_config.yaml` files and apply the selector_config to it
+use minijinja::{Environment, Value};
+use std::path::PathBuf;
 use std::{collections::BTreeMap, path::Path};
 
-use minijinja::{Environment, Value};
-
-use crate::{
-    selectors::SelectorConfig,
-    variant_config::{VariantConfig, VariantConfigError},
-};
+use crate::{selectors::SelectorConfig, variant_config::VariantConfig};
 
 #[derive(Debug)]
 struct ParsedLine<'a> {
@@ -48,17 +45,28 @@ fn evaluate_condition(
     template.render(context).unwrap() == "true"
 }
 
+/// An error that can occur when parsing a `conda_build_config.yaml` file
+#[derive(Debug, thiserror::Error)]
+pub enum ParseConfigBuildConfigError {
+    /// An IO error occurred while trying to read the file
+    #[error("Could not open file ({0}): {1}")]
+    IOError(PathBuf, std::io::Error),
+
+    /// An error occurred while parsing the file
+    #[error("Could not parse variant config file ({0}): {1}")]
+    ParseError(PathBuf, serde_yaml::Error),
+}
+
 /// Load an old-school conda_build_config.yaml file, and apply the selector_config to it
 /// The parser supports only a small subset of (potential) conda_build_config.yaml features.
 /// Especially, only `os.environ.get(...)` is supported.
 pub fn load_conda_build_config(
     path: &Path,
     selector_config: &SelectorConfig,
-) -> Result<VariantConfig, VariantConfigError> {
+) -> Result<VariantConfig, ParseConfigBuildConfigError> {
     // load the text, parse it and load as VariantConfig using serde_yaml
-
     let mut input = fs_err::read_to_string(path)
-        .map_err(|e| VariantConfigError::IOError(path.to_path_buf(), e))?;
+        .map_err(|e| ParseConfigBuildConfigError::IOError(path.to_path_buf(), e))?;
 
     let mut context = selector_config.clone().into_context();
 
@@ -109,7 +117,7 @@ pub fn load_conda_build_config(
 
     // We need to filter "unit keys" from the YAML because our config expects a list (not None)
     let value: serde_yaml::Value = serde_yaml::from_str(&out).map_err(|e| {
-        VariantConfigError::IOError(
+        ParseConfigBuildConfigError::IOError(
             path.to_path_buf(),
             std::io::Error::new(std::io::ErrorKind::InvalidData, e),
         )
@@ -123,7 +131,7 @@ pub fn load_conda_build_config(
     let value = value
         .as_mapping()
         .ok_or_else(|| {
-            VariantConfigError::IOError(
+            ParseConfigBuildConfigError::IOError(
                 path.to_path_buf(),
                 std::io::Error::new(
                     std::io::ErrorKind::InvalidData,
@@ -138,7 +146,7 @@ pub fn load_conda_build_config(
 
     let config: VariantConfig =
         serde_yaml::from_value(serde_yaml::Value::Mapping(value)).map_err(|e| {
-            VariantConfigError::IOError(
+            ParseConfigBuildConfigError::IOError(
                 path.to_path_buf(),
                 std::io::Error::new(std::io::ErrorKind::InvalidData, e),
             )

--- a/src/recipe/custom_yaml/rendered.rs
+++ b/src/recipe/custom_yaml/rendered.rs
@@ -15,6 +15,7 @@ use crate::{
         jinja::Jinja,
         Render,
     },
+    source_code::SourceCode,
 };
 
 use super::{
@@ -85,8 +86,11 @@ impl RenderedNode {
     /// type here is the generic Node enumeration to make it potentially easier
     /// for callers to use.  Regardless, it's always possible to treat the
     /// returned node as a mapping node without risk of panic.
-    pub fn parse_yaml(init_span_index: usize, src: &str) -> Result<Self, ParsingError> {
-        let yaml = parse_yaml(init_span_index, src)?;
+    pub fn parse_yaml<S: SourceCode>(
+        init_span_index: usize,
+        src: S,
+    ) -> Result<Self, ParsingError<S>> {
+        let yaml = parse_yaml(init_span_index, src.clone())?;
         Self::try_from(yaml).map_err(|err| ParsingError::from_partial(src, err))
     }
 

--- a/src/recipe/parser/about.rs
+++ b/src/recipe/parser/about.rs
@@ -161,7 +161,7 @@ mod test {
             homepage: license_urla.asda:://sdskd
         "#;
 
-        let err: ParseErrors = Recipe::from_yaml(recipe, SelectorConfig::default())
+        let err: ParseErrors<_> = Recipe::from_yaml(recipe, SelectorConfig::default())
             .unwrap_err()
             .into();
 
@@ -179,7 +179,7 @@ mod test {
             license: MIT/X derivate
         "#;
 
-        let err: ParseErrors = Recipe::from_yaml(recipe, SelectorConfig::default())
+        let err: ParseErrors<_> = Recipe::from_yaml(recipe, SelectorConfig::default())
             .unwrap_err()
             .into();
 

--- a/src/recipe/parser/output.rs
+++ b/src/recipe/parser/output.rs
@@ -10,9 +10,10 @@ use crate::{
     _partialerror,
     recipe::{
         custom_yaml::{parse_yaml, Node},
-        error::ErrorKind,
+        error::{ErrorKind, PartialParsingError},
         ParsingError,
     },
+    source_code::SourceCode,
 };
 
 static DEEP_MERGE_KEYS: [&str; 4] = ["package", "about", "extra", "build"];
@@ -28,19 +29,17 @@ static ALLOWED_KEYS_MULTI_OUTPUTS: [&str; 9] = [
     "schema_version",
 ];
 
-// Check if the `cache` top-level key is present. If it does not contain a source, but there is a
-// top-level `source` key, then we should warn the user because this key was moved to the `cache`
-fn check_src_cache(root: &MarkedMappingNode) -> Result<(), ParsingError> {
+// Check if the `cache` top-level key is present. If it does not contain a
+// source, but there is a top-level `source` key, then we should warn the user
+// because this key was moved to the `cache`
+fn check_src_cache(root: &MarkedMappingNode) -> Result<(), PartialParsingError> {
     if let Some(cache) = root.get("cache") {
         let has_top_level_source = root.contains_key("source");
         let cache_map = cache.as_mapping().ok_or_else(|| {
-            ParsingError::from_partial(
-                "",
-                _partialerror!(
-                    *cache.span(),
-                    ErrorKind::ExpectedMapping,
-                    help = "`cache` must always be a mapping"
-                ),
+            _partialerror!(
+                *cache.span(),
+                ErrorKind::ExpectedMapping,
+                help = "`cache` must always be a mapping"
             )
         })?;
 
@@ -53,11 +52,11 @@ fn check_src_cache(root: &MarkedMappingNode) -> Result<(), ParsingError> {
 }
 
 /// Retrieve all outputs from the recipe source (YAML)
-pub fn find_outputs_from_src(src: &str) -> Result<Vec<Node>, ParsingError> {
-    let root_node = parse_yaml(0, src)?;
+pub fn find_outputs_from_src<S: SourceCode>(src: S) -> Result<Vec<Node>, ParsingError<S>> {
+    let root_node = parse_yaml(0, src.clone())?;
     let root_map = root_node.as_mapping().ok_or_else(|| {
         ParsingError::from_partial(
-            src,
+            src.clone(),
             _partialerror!(
                 *root_node.span(),
                 ErrorKind::ExpectedMapping,
@@ -66,7 +65,9 @@ pub fn find_outputs_from_src(src: &str) -> Result<Vec<Node>, ParsingError> {
         )
     })?;
 
-    check_src_cache(root_map)?;
+    if let Err(err) = check_src_cache(root_map) {
+        return Err(ParsingError::from_partial(src, err));
+    };
 
     if root_map.contains_key("outputs") {
         if root_map.contains_key("package") {
@@ -75,7 +76,7 @@ pub fn find_outputs_from_src(src: &str) -> Result<Vec<Node>, ParsingError> {
                 .find(|k| k.as_str() == "package")
                 .expect("unreachable we preemptively check for if contains");
             return Err(ParsingError::from_partial(
-                src,
+                src.clone(),
                 _partialerror!(
                     *key.span(),
                     ErrorKind::InvalidField("package".to_string().into()),
@@ -145,44 +146,45 @@ pub fn find_outputs_from_src(src: &str) -> Result<Vec<Node>, ParsingError> {
         }
     }
 
-    let outputs = outputs.as_sequence().ok_or_else(|| {
-        ParsingError::from_partial(
+    let Some(outputs) = outputs.as_sequence() else {
+        return Err(ParsingError::from_partial(
             src,
             _partialerror!(
                 *outputs.span(),
                 ErrorKind::ExpectedSequence,
                 help = "`outputs` must always be a sequence"
             ),
-        )
-    })?;
+        ));
+    };
 
     let mut res = Vec::with_capacity(outputs.len());
 
-    // the schema says that `outputs` can be either an output, a if-selector or a sequence
-    // of outputs and if-selectors. We need to handle all of these cases but for now, lets
-    // handle only sequence of outputs
+    // the schema says that `outputs` can be either an output, a if-selector or a
+    // sequence of outputs and if-selectors. We need to handle all of these
+    // cases but for now, lets handle only sequence of outputs
     for output in outputs.iter() {
         // 1. clone the root node
         // 2. remove the `outputs` key
         // 3. substitute repeated value (make sure to preserve the spans)
         // 4. merge skip values (make sure to preserve the spans)
         // Note: Make sure to preserve the spans of the original root span so the error
-        // messages remain accurate and point the correct part of the original recipe src
+        // messages remain accurate and point the correct part of the original recipe
+        // src
         let mut root = root_map.clone();
         root.remove("outputs");
 
         let mut output_node = output.clone();
 
-        let output_map = output_node.as_mapping_mut().ok_or_else(|| {
-            ParsingError::from_partial(
+        let Some(output_map) = output_node.as_mapping_mut() else {
+            return Err(ParsingError::from_partial(
                 src,
                 _partialerror!(
                     *output.span(),
                     ErrorKind::ExpectedMapping,
                     help = "individual `output` must always be a mapping"
                 ),
-            )
-        })?;
+            ));
+        };
 
         for (key, value) in root.iter() {
             if !output_map.contains_key(key) {
@@ -191,30 +193,30 @@ pub fn find_outputs_from_src(src: &str) -> Result<Vec<Node>, ParsingError> {
                 // deep merge
                 if DEEP_MERGE_KEYS.contains(&key.as_str()) {
                     let output_map_span = *output_map.span();
-                    let output_value = output_map.get_mut(key).ok_or_else(|| {
-                        ParsingError::from_partial(
+                    let Some(output_value) = output_map.get_mut(key) else {
+                        return Err(ParsingError::from_partial(
                             src,
                             _partialerror!(
                                 output_map_span,
                                 ErrorKind::MissingField(key.as_str().to_owned().into()),
                             ),
-                        )
-                    })?;
+                        ));
+                    };
                     let output_value_span = *output_value.span();
-                    let output_value_map = output_value.as_mapping_mut().ok_or_else(|| {
-                        ParsingError::from_partial(
+                    let Some(output_value_map) = output_value.as_mapping_mut() else {
+                        return Err(ParsingError::from_partial(
                             src,
                             _partialerror!(output_value_span, ErrorKind::ExpectedMapping,),
-                        )
-                    })?;
+                        ));
+                    };
 
                     let mut root_value = value.clone();
-                    let root_value_map = root_value.as_mapping_mut().ok_or_else(|| {
-                        ParsingError::from_partial(
+                    let Some(root_value_map) = root_value.as_mapping_mut() else {
+                        return Err(ParsingError::from_partial(
                             src,
                             _partialerror!(*value.span(), ErrorKind::ExpectedMapping,),
-                        )
-                    })?;
+                        ));
+                    };
 
                     for (key, value) in root_value_map.iter() {
                         if !output_value_map.contains_key(key) {
@@ -246,8 +248,10 @@ pub fn find_outputs_from_src(src: &str) -> Result<Vec<Node>, ParsingError> {
 
         output_map.remove("recipe");
 
-        let recipe =
-            Node::try_from(output_node).map_err(|err| ParsingError::from_partial(src, err))?;
+        let recipe = match Node::try_from(output_node) {
+            Ok(node) => node,
+            Err(err) => return Err(ParsingError::from_partial(src, err)),
+        };
         res.push(recipe);
     }
     Ok(res)
@@ -257,40 +261,39 @@ pub fn find_outputs_from_src(src: &str) -> Result<Vec<Node>, ParsingError> {
 mod tests {
     use insta::assert_debug_snapshot;
 
+    use super::*;
     use crate::{
         assert_miette_snapshot,
         recipe::{jinja::SelectorConfig, Recipe},
     };
-
-    use super::*;
 
     #[test]
     fn recipe_schema_error() {
         let test_data_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("test-data");
         let yaml_file = test_data_dir.join("recipes/test-parsing/recipe_outputs_and_package.yaml");
         let src = std::fs::read_to_string(yaml_file).unwrap();
-        assert_miette_snapshot!(find_outputs_from_src(&src).unwrap_err());
+        assert_miette_snapshot!(find_outputs_from_src(src.as_str()).unwrap_err());
 
         let yaml_file =
             test_data_dir.join("recipes/test-parsing/recipe_outputs_and_requirements.yaml");
         let src = std::fs::read_to_string(yaml_file).unwrap();
-        assert_miette_snapshot!(find_outputs_from_src(&src).unwrap_err());
+        assert_miette_snapshot!(find_outputs_from_src(src.as_str()).unwrap_err());
 
         let yaml_file = test_data_dir.join("recipes/test-parsing/recipe_missing_version.yaml");
         let src = std::fs::read_to_string(yaml_file).unwrap();
-        let nodes = find_outputs_from_src(&src).unwrap();
+        let nodes = find_outputs_from_src(src.as_str()).unwrap();
         let parsed_recipe =
             Recipe::from_node(&nodes[0], SelectorConfig::default()).map_err(|err| {
                 err.into_iter()
-                    .map(|err| ParsingError::from_partial(&src, err))
+                    .map(|err| ParsingError::from_partial(src.as_str(), err))
                     .collect::<Vec<_>>()
             });
-        let err: crate::variant_config::ParseErrors = parsed_recipe.unwrap_err().into();
+        let err: crate::variant_config::ParseErrors<_> = parsed_recipe.unwrap_err().into();
         assert_miette_snapshot!(err);
 
         let yaml_file = test_data_dir.join("recipes/test-parsing/recipe_outputs_extra_keys.yaml");
         let src = std::fs::read_to_string(yaml_file).unwrap();
-        assert_miette_snapshot!(find_outputs_from_src(&src).unwrap_err());
+        assert_miette_snapshot!(find_outputs_from_src(src.as_str()).unwrap_err());
     }
 
     #[test]
@@ -298,6 +301,6 @@ mod tests {
         let test_data_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("test-data");
         let yaml_file = test_data_dir.join("recipes/test-parsing/recipe_outputs_merging.yaml");
         let src = std::fs::read_to_string(yaml_file).unwrap();
-        assert_debug_snapshot!(find_outputs_from_src(&src).unwrap());
+        assert_debug_snapshot!(find_outputs_from_src(src.as_str()).unwrap());
     }
 }

--- a/src/recipe/parser/package.rs
+++ b/src/recipe/parser/package.rs
@@ -188,7 +188,7 @@ mod tests {
         "#;
 
         let recipe = Recipe::from_yaml(raw_recipe, SelectorConfig::default());
-        let err: ParseErrors = recipe.unwrap_err().into();
+        let err: ParseErrors<_> = recipe.unwrap_err().into();
         assert_miette_snapshot!(err);
     }
 
@@ -202,7 +202,7 @@ mod tests {
         "#;
 
         let recipe = Recipe::from_yaml(raw_recipe, SelectorConfig::default());
-        let err: ParseErrors = recipe.unwrap_err().into();
+        let err: ParseErrors<_> = recipe.unwrap_err().into();
         assert_miette_snapshot!(err);
     }
 }

--- a/src/recipe/parser/snapshots/rattler_build__recipe__parser__about__test__invalid_license.snap
+++ b/src/recipe/parser/snapshots/rattler_build__recipe__parser__about__test__invalid_license.snap
@@ -5,7 +5,7 @@ expression: err
   × Failed to parse recipe
 
 Error: 
-  × Parsing: failed to parse SPDX license: invalid character(s)
+  × failed to parse SPDX license: invalid character(s)
   │ See <https://spdx.org/licenses> for the list of valid licenses.
   │ Use 'LicenseRef-<MyLicense>' if you are using a custom license.
    ╭─[7:22]

--- a/src/recipe/parser/snapshots/rattler_build__recipe__parser__about__test__invalid_url.snap
+++ b/src/recipe/parser/snapshots/rattler_build__recipe__parser__about__test__invalid_url.snap
@@ -5,7 +5,7 @@ expression: err
   × Failed to parse recipe
 
 Error: 
-  × Parsing: failed to parse URL: relative URL without a base
+  × failed to parse URL: relative URL without a base
    ╭─[7:23]
  6 │         about:
  7 │             homepage: license_urla.asda:://sdskd

--- a/src/recipe/parser/snapshots/rattler_build__recipe__parser__glob_vec__tests__parsing_globvec_fail.snap
+++ b/src/recipe/parser/snapshots/rattler_build__recipe__parser__glob_vec__tests__parsing_globvec_fail.snap
@@ -2,8 +2,8 @@
 source: src/recipe/parser/glob_vec.rs
 expression: err
 ---
-  × Parsing: failed to parse glob: error parsing glob 'foo/{bla': unclosed
-  │ alternate group; missing '}' (maybe escape '{' with '[{]'?)
+  × failed to parse glob: error parsing glob 'foo/{bla': unclosed alternate
+  │ group; missing '}' (maybe escape '{' with '[{]'?)
    ╭─[2:11]
  1 │ globs:
  2 │         - foo/{bla
@@ -11,4 +11,3 @@ expression: err
    ·               ╰── here
  3 │         
    ╰────
-

--- a/src/recipe/parser/snapshots/rattler_build__recipe__parser__output__tests__recipe_schema_error-2.snap
+++ b/src/recipe/parser/snapshots/rattler_build__recipe__parser__output__tests__recipe_schema_error-2.snap
@@ -1,8 +1,8 @@
 ---
 source: src/recipe/parser/output.rs
-expression: find_outputs_from_src(&src).unwrap_err()
+expression: find_outputs_from_src(src.as_str()).unwrap_err()
 ---
-  × Parsing: invalid field `requirements`.
+  × invalid field `requirements`.
    ╭─[5:1]
  4 │ 
  5 │ requirements:

--- a/src/recipe/parser/snapshots/rattler_build__recipe__parser__output__tests__recipe_schema_error-3.snap
+++ b/src/recipe/parser/snapshots/rattler_build__recipe__parser__output__tests__recipe_schema_error-3.snap
@@ -5,7 +5,7 @@ expression: err
   × Failed to parse recipe
 
 Error: 
-  × Parsing: missing field `version`
+  × missing field `version`
    ╭─[6:11]
  5 │       - package:
  6 │ ╭─▶       name: bla

--- a/src/recipe/parser/snapshots/rattler_build__recipe__parser__output__tests__recipe_schema_error-4.snap
+++ b/src/recipe/parser/snapshots/rattler_build__recipe__parser__output__tests__recipe_schema_error-4.snap
@@ -1,8 +1,8 @@
 ---
 source: src/recipe/parser/output.rs
-expression: find_outputs_from_src(&src).unwrap_err()
+expression: find_outputs_from_src(src.as_str()).unwrap_err()
 ---
-  × Parsing: invalid field `randomkey`.
+  × invalid field `randomkey`.
     ╭─[11:1]
  10 │ 
  11 │ randomkey:

--- a/src/recipe/parser/snapshots/rattler_build__recipe__parser__output__tests__recipe_schema_error.snap
+++ b/src/recipe/parser/snapshots/rattler_build__recipe__parser__output__tests__recipe_schema_error.snap
@@ -1,8 +1,8 @@
 ---
 source: src/recipe/parser/output.rs
-expression: find_outputs_from_src(&src).unwrap_err()
+expression: find_outputs_from_src(src.as_str()).unwrap_err()
 ---
-  × Parsing: invalid field `package`.
+  × invalid field `package`.
    ╭─[3:1]
  2 │ 
  3 │ package:
@@ -12,4 +12,3 @@ expression: find_outputs_from_src(&src).unwrap_err()
    ╰────
   help: recipe cannot have both `outputs` and `package` fields. Rename
         `package` to `recipe` or remove `outputs`
-

--- a/src/recipe/parser/snapshots/rattler_build__recipe__parser__package__tests__invalid_fields.snap
+++ b/src/recipe/parser/snapshots/rattler_build__recipe__parser__package__tests__invalid_fields.snap
@@ -5,7 +5,7 @@ expression: err
   × Failed to parse recipe
 
 Error: 
-  × Parsing: invalid field `invalid`.
+  × invalid field `invalid`.
    ╭─[5:13]
  4 │             version: 0.1.0
  5 │             invalid: "field"

--- a/src/recipe/parser/snapshots/rattler_build__recipe__parser__package__tests__missing_fields.snap
+++ b/src/recipe/parser/snapshots/rattler_build__recipe__parser__package__tests__missing_fields.snap
@@ -5,7 +5,7 @@ expression: err
   × Failed to parse recipe
 
 Error: 
-  × Parsing: missing field `version`
+  × missing field `version`
    ╭─[3:17]
  2 │         package:
  3 │             name: test

--- a/src/recipe/parser/test.rs
+++ b/src/recipe/parser/test.rs
@@ -492,7 +492,7 @@ mod test {
             .unwrap();
 
         // parse the YAML
-        let yaml_root = RenderedNode::parse_yaml(0, &text)
+        let yaml_root = RenderedNode::parse_yaml(0, text.as_str())
             .map_err(|err| vec![err])
             .unwrap();
 

--- a/src/recipe/snapshots/rattler_build__recipe__error__tests__miette_output.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__error__tests__miette_output.snap
@@ -5,7 +5,7 @@ expression: err
   × Failed to parse recipe
 
 Error: 
-  × Parsing: expected a mapping.
+  × expected a mapping.
    ╭─[3:17]
  2 │                 context:
  3 │ ╭─▶                 - a

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__bad_skip_multi_output.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__bad_skip_multi_output.snap
@@ -5,8 +5,8 @@ expression: err
   × Failed to parse recipe
 
 Error: 
-  × Parsing: failed to render Jinja expression: syntax error: unexpected
-  │ character (in <expression>:1)
+  × failed to render Jinja expression: syntax error: unexpected character (in
+  │ <expression>:1)
     ╭─[12:11]
  11 │       skip:
  12 │         - asd;asd;123

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__bad_skip_single_output.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__bad_skip_single_output.snap
@@ -5,8 +5,8 @@ expression: err
   × Failed to parse recipe
 
 Error: 
-  × Parsing: failed to render Jinja expression: syntax error: unexpected
-  │ character (in <expression>:1)
+  × failed to render Jinja expression: syntax error: unexpected character (in
+  │ <expression>:1)
    ╭─[7:7]
  6 │   skip:
  7 │     - asd;asd;123

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__context_not_mapping.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__context_not_mapping.snap
@@ -5,7 +5,7 @@ expression: err
   × Failed to parse recipe
 
 Error: 
-  × Parsing: expected a mapping.
+  × expected a mapping.
    ╭─[2:18]
  1 │ 
  2 │         context: "not-mapping"

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__context_value_not_scalar.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__context_value_not_scalar.snap
@@ -5,7 +5,7 @@ expression: err
   × Failed to parse recipe
 
 Error: 
-  × Parsing: expected a scalar value.
+  × expected a scalar value.
    ╭─[3:16]
  2 │         context:
  3 │           key: ["not-scalar"]

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__duplicate_keys_error.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__duplicate_keys_error.snap
@@ -5,7 +5,7 @@ expression: err
   × Failed to parse recipe
 
 Error: 
-  × Parsing: failed to parse YAML: duplicate key.
+  × failed to parse YAML: duplicate key.
    ╭─[8:1]
  7 │ 
  8 │ build:

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__jinja_error.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__jinja_error.snap
@@ -5,8 +5,8 @@ expression: err
   × Failed to parse recipe
 
 Error: 
-  × Parsing: failed to render Jinja expression: unknown function: zcompiler is
-  │ unknown (in <string>:1)
+  × failed to render Jinja expression: unknown function: zcompiler is unknown
+  │ (in <string>:1)
    ╭─[7:7]
  6 │   host:
  7 │     - ${{ zcompiler('c') }}

--- a/src/source_code.rs
+++ b/src/source_code.rs
@@ -1,0 +1,11 @@
+//! Provides a trait for source code that can be used for error reporting. See
+//! [`SourceCode`].
+
+use std::fmt::Debug;
+
+/// A helper trait that provides source code for rattler-build.
+///
+/// This trait is useful for error reporting to provide information about the
+/// source code for diagnostics.
+pub trait SourceCode: Debug + Clone + AsRef<str> + miette::SourceCode {}
+impl<T: Debug + Clone + AsRef<str> + miette::SourceCode> SourceCode for T {}

--- a/src/variant_render.rs
+++ b/src/variant_render.rs
@@ -16,8 +16,11 @@ use crate::{
         Jinja, ParsingError, Recipe,
     },
     selectors::SelectorConfig,
+    source_code::SourceCode,
     used_variables::used_vars_from_expressions,
-    variant_config::{ParseErrors, VariantConfig, VariantError},
+    variant_config::{
+        ParseErrors, VariantConfig, VariantConfigError, VariantError, VariantExpandError,
+    },
 };
 
 /// All the raw outputs of a single recipe.yaml
@@ -28,57 +31,55 @@ pub struct RawOutputVec {
 
     /// The used variables in each of the nodes
     pub used_vars_jinja: Vec<HashSet<NormalizedKey>>,
-
-    /// The recipe string
-    #[allow(unused)]
-    pub recipe: String,
 }
 
 /// Stage 0 render of a single recipe.yaml
 #[derive(Clone, Debug)]
-pub struct Stage0Render {
+pub struct Stage0Render<S: SourceCode> {
     /// The used variables with their values
     pub variables: BTreeMap<NormalizedKey, String>,
 
     /// The raw outputs of the recipe
     pub raw_outputs: RawOutputVec,
 
-    // Pre-rendered recipe nodes
+    /// Pre-rendered recipe nodes
     pub rendered_outputs: Vec<Recipe>,
+
+    /// The source code of the recipe
+    pub source: S,
 }
 
-pub(crate) fn stage_0_render(
+pub(crate) fn stage_0_render<S: SourceCode>(
     outputs: &[Node],
-    recipe: &str,
+    source: S,
     selector_config: &SelectorConfig,
     variant_config: &VariantConfig,
-) -> Result<Vec<Stage0Render>, VariantError> {
+) -> Result<Vec<Stage0Render<S>>, VariantError<S>> {
     let used_vars = outputs
         .iter()
         .map(|output| {
-            used_vars_from_expressions(output, recipe)
+            used_vars_from_expressions(output, source.clone())
                 .map(|x| x.into_iter().map(Into::into).collect())
         })
-        .collect::<Result<Vec<HashSet<NormalizedKey>>, Vec<ParsingError>>>()
+        .collect::<Result<_, _>>()
         .map_err(|errs| {
-            let errs: ParseErrors = errs.into();
-            VariantError::RecipeParseErrors(errs)
+            let errs: ParseErrors<S> = errs.into();
+            VariantConfigError::RecipeParseErrors(errs)
         })?;
 
     let raw_output_vec = RawOutputVec {
         vec: outputs.to_vec(),
         used_vars_jinja: used_vars,
-        recipe: recipe.to_string(),
     };
 
     // find all the jinja variables from all the expressions
     let mut used_vars = HashSet::<NormalizedKey>::new();
     for output in outputs {
         used_vars.extend(
-            used_vars_from_expressions(output, recipe)
+            used_vars_from_expressions(output, source.clone())
                 .map_err(|errs| {
-                    let errs: ParseErrors = errs.into();
-                    VariantError::RecipeParseErrors(errs)
+                    let errs: ParseErrors<_> = errs.into();
+                    VariantConfigError::RecipeParseErrors(errs)
                 })?
                 .into_iter()
                 .map(Into::into),
@@ -96,14 +97,16 @@ pub(crate) fn stage_0_render(
             let config_with_variant =
                 selector_config.with_variant(combination.clone(), selector_config.target_platform);
 
-            let parsed_recipe = Recipe::from_node(output, config_with_variant).map_err(|err| {
-                let errs: ParseErrors = err
-                    .into_iter()
-                    .map(|err| ParsingError::from_partial(recipe, err))
-                    .collect::<Vec<ParsingError>>()
-                    .into();
-                errs
-            })?;
+            let parsed_recipe = Recipe::from_node(output, config_with_variant)
+                .map_err(|err| {
+                    let errs: ParseErrors<_> = err
+                        .into_iter()
+                        .map(|err| ParsingError::from_partial(source.clone(), err))
+                        .collect::<Vec<ParsingError<_>>>()
+                        .into();
+                    errs
+                })
+                .map_err(VariantConfigError::from)?;
 
             rendered_outputs.push(parsed_recipe);
         }
@@ -112,6 +115,7 @@ pub(crate) fn stage_0_render(
             variables: combination,
             raw_outputs: raw_output_vec.clone(),
             rendered_outputs,
+            source: source.clone(),
         });
     }
 
@@ -128,15 +132,15 @@ pub struct Stage1Inner {
 
 /// Stage 1 render of a single recipe.yaml
 #[derive(Debug)]
-pub struct Stage1Render {
+pub struct Stage1Render<S: SourceCode> {
     pub(crate) variables: BTreeMap<NormalizedKey, String>,
 
     pub(crate) inner: Vec<Stage1Inner>,
 
-    pub(crate) stage_0_render: Stage0Render,
+    pub(crate) stage_0_render: Stage0Render<S>,
 }
 
-impl Stage1Render {
+impl<S: SourceCode> Stage1Render<S> {
     pub fn index_from_name(&self, package_name: &PackageName) -> Option<usize> {
         self.inner
             .iter()
@@ -146,7 +150,7 @@ impl Stage1Render {
     pub fn variant_for_output(
         &self,
         idx: usize,
-    ) -> Result<BTreeMap<NormalizedKey, String>, VariantError> {
+    ) -> Result<BTreeMap<NormalizedKey, String>, VariantExpandError> {
         let inner = &self.inner[idx];
         // combine jinja variables and the variables from the dependencies
         let self_name = self.stage_0_render.rendered_outputs[idx].package().name();
@@ -181,7 +185,9 @@ impl Stage1Render {
                 continue;
             }
             let Some(other_idx) = self.index_from_name(pin) else {
-                return Err(VariantError::MissingOutput(pin.as_source().to_string()));
+                return Err(VariantExpandError::MissingOutput(
+                    pin.as_source().to_string(),
+                ));
             };
             // find the referenced output
             let build_string = self.build_string_for_output(other_idx)?;
@@ -200,7 +206,7 @@ impl Stage1Render {
         Ok(variant)
     }
 
-    pub fn build_string_for_output(&self, idx: usize) -> Result<String, VariantError> {
+    pub fn build_string_for_output(&self, idx: usize) -> Result<String, VariantExpandError> {
         let variant = self.variant_for_output(idx)?;
         let recipe = &self.stage_0_render.rendered_outputs[idx];
         let hash = HashInfo::from_variant(&variant, recipe.build().noarch());
@@ -218,7 +224,7 @@ impl Stage1Render {
     }
 
     /// sort the outputs topologically
-    pub fn sorted_indices(&self) -> Result<Vec<usize>, VariantError> {
+    pub fn sorted_indices(&self) -> Result<Vec<usize>, VariantExpandError> {
         // Create an empty directed graph
         let mut graph = DiGraph::<_, ()>::new();
         let mut node_indices = Vec::new();
@@ -261,7 +267,7 @@ impl Stage1Render {
             Err(cycle) => {
                 let cycle = cycle.node_id();
                 let cycle_name = graph[cycle].package().name();
-                return Err(VariantError::CycleInRecipeOutputs(
+                return Err(VariantExpandError::CycleInRecipeOutputs(
                     cycle_name.as_source().to_string(),
                 ));
             }
@@ -279,7 +285,7 @@ impl Stage1Render {
     #[allow(clippy::type_complexity)]
     pub fn into_sorted_outputs(
         self,
-    ) -> Result<Vec<((Node, Recipe), BTreeMap<NormalizedKey, String>)>, VariantError> {
+    ) -> Result<Vec<((Node, Recipe), BTreeMap<NormalizedKey, String>)>, VariantExpandError> {
         // zip node from stage0 and final render output
         let sorted_indices = self.sorted_indices()?;
 
@@ -302,11 +308,11 @@ impl Stage1Render {
 }
 
 /// Render the stage 1 of the recipe by adding in variants from the dependencies
-pub(crate) fn stage_1_render(
-    stage0_renders: Vec<Stage0Render>,
+pub(crate) fn stage_1_render<S: SourceCode>(
+    stage0_renders: Vec<Stage0Render<S>>,
     selector_config: &SelectorConfig,
     variant_config: &VariantConfig,
-) -> Result<Vec<Stage1Render>, VariantError> {
+) -> Result<Vec<Stage1Render<S>>, VariantError<S>> {
     let mut stage_1_renders = Vec::new();
 
     // TODO we need to add variables from the cache output here!
@@ -329,8 +335,8 @@ pub(crate) fn stage_1_render(
                 }
             }
 
-            // We want to add something to packages that are requiring a subpackage _exactly_ because
-            // that creates additional variants
+            // We want to add something to packages that are requiring a subpackage
+            // _exactly_ because that creates additional variants
             for pin in output.requirements.all_pin_subpackage() {
                 if pin.args.exact {
                     let name = pin.name.clone().as_normalized().to_string();
@@ -351,7 +357,8 @@ pub(crate) fn stage_1_render(
 
             additional_variables.extend(extra_use_keys);
 
-            // If the recipe is `noarch: python` we can remove an empty python key that comes from the dependencies
+            // If the recipe is `noarch: python` we can remove an empty python key that
+            // comes from the dependencies
             if output.build().is_python_version_independent() {
                 additional_variables.remove(&"python".into());
             }
@@ -387,7 +394,8 @@ pub(crate) fn stage_1_render(
             exact_pins_per_output.push(exact_pins);
         }
 
-        // Create the additional combinations and attach the whole variant x outputs to the stage 1 render
+        // Create the additional combinations and attach the whole variant x outputs to
+        // the stage 1 render
         let mut all_vars = extra_vars_per_output
             .iter()
             .fold(HashSet::new(), |acc, x| acc.union(x).cloned().collect());
@@ -405,13 +413,14 @@ pub(crate) fn stage_1_render(
 
                 let parsed_recipe = Recipe::from_node(output, config_with_variant.clone())
                     .map_err(|err| {
-                        let errs: ParseErrors = err
+                        let errs: ParseErrors<_> = err
                             .into_iter()
-                            .map(|err| ParsingError::from_partial(&r.raw_outputs.recipe, err))
-                            .collect::<Vec<ParsingError>>()
+                            .map(|err| ParsingError::from_partial(r.source.clone(), err))
+                            .collect::<Vec<_>>()
                             .into();
                         errs
-                    })?;
+                    })
+                    .map_err(VariantConfigError::from)?;
 
                 inner.push(Stage1Inner {
                     used_vars_from_dependencies: extra_vars_per_output[idx].clone(),


### PR DESCRIPTION
This refactors parsing code slightly to accept a generic `SourceCode`. This allows for the propagation of source code information from the input to errors and diagnostics. Miette provides source code information in the errors. However, the input for any parsing function is always `&str` which doesn't provide any information about the input file. This refactor changes that type to `SourceCode`.

This is especially useful in pixi-build where we can use that information to provide more contextual errors. It should not change anything for the rattler-build CLI besides that the error will indicate the filename (`recipe.yaml`). 