### PR TITLE
fix: use python key, and improve skip output

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,11 +256,18 @@ pub async fn get_build_output(
 
     tracing::info!("Found {} variants\n", outputs_and_variants.len());
     for discovered_output in &outputs_and_variants {
+        let skipped = if discovered_output.recipe.build().skip() {
+            console::style(" (skipped)").red().to_string()
+        } else {
+            "".to_string()
+        };
+
         tracing::info!(
-            "Build variant: {}-{}-{}",
+            "\nBuild variant: {}-{}-{}{}",
             discovered_output.name,
             discovered_output.version,
-            discovered_output.build_string
+            discovered_output.build_string,
+            skipped
         );
 
         let mut table = comfy_table::Table::new();
@@ -287,10 +294,6 @@ pub async fn get_build_output(
         let recipe = &discovered_output.recipe;
 
         if recipe.build().skip() {
-            tracing::info!(
-                "Skipping build for variant: {:#?}",
-                discovered_output.used_vars
-            );
             continue;
         }
 

--- a/src/variant_render.rs
+++ b/src/variant_render.rs
@@ -359,7 +359,7 @@ pub(crate) fn stage_1_render<S: SourceCode>(
 
             // If the recipe is `noarch: python` we can remove an empty python key that
             // comes from the dependencies
-            if output.build().is_python_version_independent() {
+            if output.build().noarch().is_python() {
                 additional_variables.remove(&"python".into());
             }
 


### PR DESCRIPTION
Fixing a problem with the new ABI3 / CEP20 implementation as discussed with @isuruf: https://github.com/conda-forge/atomic-counter-feedstock/pull/8

<img width="608" alt="Screenshot 2025-01-20 at 19 44 40" src="https://github.com/user-attachments/assets/c1e78e71-5966-4300-8db7-9fcbae42a052" />
