### PR TITLE
WIP: don't use `build.{sh,bat}` by default in outputs

### DIFF
--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -148,18 +148,9 @@ impl Script {
         extensions: &[&str],
     ) -> Result<ResolvedScriptContents, std::io::Error> {
         let script_content = match self.contents() {
-            // No script was specified, so we try to read the default script. If the file cannot be
-            // found we return an empty string.
+            // No script was specified, which means we return an empty string.
             ScriptContent::Default => {
-                let recipe_file = self.find_file(recipe_dir, extensions, Path::new("build"));
-                if let Some(recipe_file) = recipe_file {
-                    match fs_err::read_to_string(&recipe_file) {
-                        Err(e) => Err(e),
-                        Ok(content) => Ok(ResolvedScriptContents::Path(recipe_file, content)),
-                    }
-                } else {
-                    Ok(ResolvedScriptContents::Missing)
-                }
+                Ok(ResolvedScriptContents::Missing)
             }
 
             // The scripts path was explicitly specified. If the file cannot be found we error out.


### PR DESCRIPTION
This is a PR on invitation by @wolfv [here](https://github.com/conda-forge/torchvision-feedstock/pull/111#discussion_r1921079731). If desired I can open an issue to discuss semantics.

The idea is that outputs _do not_ automatically run `build.{sh,bat}` (causing scriptless outputs to require unintuitive and weird work-arounds), but rather need to explicitly specify their build scripts. This has many advantages (being explicit, no pointless workarounds, recipe becomes more self-explanatory).

About the current behaviour to execute `build.sh` in outputs if present, @wolfv said:
> It's the same behavior as conda build but I'm open to change it.

This is not my experience, but perhaps there are other circumstances I'm not aware of.

In any case, this PR will be deep red, because AFAIU, my change is also changing the default for the main build itself. But before I spend a lot of time figuring out how make this dependent on outputs, I wanted to open this for discussion.