### PR TITLE
feat: make undefined values in jinja an error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,9 +631,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.27"
+version = "4.5.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
+checksum = "a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -651,9 +651,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.27"
+version = "4.5.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+checksum = "96b01801b5fc6a0a232407abc821660c9c6d25a1cafc0d4f85f29fb8d9afc121"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1260,9 +1260,9 @@ dependencies = [
 
 [[package]]
 name = "fs-err"
-version = "3.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f89bda4c2a21204059a977ed3bfe746677dfd137b83c339e702b0ac91d482aa"
+checksum = "8bb60e7409f34ef959985bc9d9c5ee8f5db24ee46ed9775850548021710f807f"
 dependencies = [
  "autocfg",
  "tokio",
@@ -1527,7 +1527,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.7.1",
+ "indexmap 2.7.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1989,9 +1989,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -2068,9 +2068,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
 name = "is_ci"
@@ -2423,9 +2423,8 @@ dependencies = [
 
 [[package]]
 name = "minijinja"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212b4cab3aad057bc6e611814472905546c533295723b9e26a31c7feb19a8e65"
+version = "2.7.0"
+source = "git+https://github.com/mitsuhiko/minijinja?branch=feature/mostly-undefined#384262513d25424a1a3cd0b72ca6b3006e2822db"
 dependencies = [
  "aho-corasick",
  "serde",
@@ -2672,9 +2671,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
@@ -2850,7 +2849,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.7.1",
+ "indexmap 2.7.0",
 ]
 
 [[package]]
@@ -2959,7 +2958,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42cf17e9a1800f5f396bc67d193dc9411b59012a5876445ef450d449881e1016"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.7.1",
+ "indexmap 2.7.0",
  "quick-xml",
  "serde",
  "time",
@@ -3188,7 +3187,7 @@ dependencies = [
  "fs-err",
  "futures",
  "humantime",
- "indexmap 2.7.1",
+ "indexmap 2.7.0",
  "indicatif",
  "itertools 0.14.0",
  "memchr",
@@ -3243,7 +3242,7 @@ dependencies = [
  "goblin",
  "hex",
  "ignore",
- "indexmap 2.7.1",
+ "indexmap 2.7.0",
  "indicatif",
  "insta",
  "itertools 0.14.0",
@@ -3355,7 +3354,7 @@ dependencies = [
  "fxhash",
  "glob",
  "hex",
- "indexmap 2.7.1",
+ "indexmap 2.7.0",
  "itertools 0.14.0",
  "lazy-regex",
  "nom",
@@ -3566,7 +3565,7 @@ checksum = "8c490f65decb6fa347c74da3fa5b102b92c996bb2ae7b22312d7af76ea1549f9"
 dependencies = [
  "enum_dispatch",
  "fs-err",
- "indexmap 2.7.1",
+ "indexmap 2.7.0",
  "itertools 0.14.0",
  "rattler_conda_types",
  "serde_json",
@@ -3685,12 +3684,11 @@ dependencies = [
 
 [[package]]
 name = "reflink-copy"
-version = "0.1.23"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbd3533fd4222b8337470456ea84d80436b4c91c53db51c372461d5f7e6eb0b4"
+checksum = "0a7aea22fc8204e0f291719120cbcdae4f25f0807d7b00f5b6b27d95a8f1a2ad"
 dependencies = [
  "cfg-if",
- "libc",
  "rustix",
  "windows 0.59.0",
 ]
@@ -3846,7 +3844,7 @@ dependencies = [
  "elsa",
  "event-listener",
  "futures",
- "indexmap 2.7.1",
+ "indexmap 2.7.0",
  "itertools 0.14.0",
  "petgraph",
  "tracing",
@@ -3962,9 +3960,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
+version = "0.38.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
 dependencies = [
  "bitflags 2.8.0",
  "errno",
@@ -4165,9 +4163,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.25"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
+checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
 
 [[package]]
 name = "serde"
@@ -4202,11 +4200,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.137"
+version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
+checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap 2.7.0",
  "itoa",
  "memchr",
  "ryu",
@@ -4255,7 +4253,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.7.1",
+ "indexmap 2.7.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -4281,7 +4279,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap 2.7.0",
  "itoa",
  "ryu",
  "serde",
@@ -4429,9 +4427,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
-version = "2.7.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
 
 [[package]]
 name = "simple_asn1"
@@ -4902,7 +4900,7 @@ version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap 2.7.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -4970,9 +4968,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-indicatif"
-version = "0.3.9"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8201ca430e0cd893ef978226fd3516c06d9c494181c8bf4e5b32e30ed4b40aa1"
+checksum = "74ba258e9de86447f75edf6455fded8e5242704c6fccffe7bf8d7fb6daef1180"
 dependencies = [
  "indicatif",
  "tracing",
@@ -5096,9 +5094,9 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.15"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11cd88e12b17c6494200a9c1b683a04fcac9573ed74cd1b62aeb2727c5592243"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "unicode-linebreak"
@@ -5185,9 +5183,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.12.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
+checksum = "744018581f9a3454a9e15beb8a33b017183f1e7c0cd170232a2d1453b23a51c4"
 dependencies = [
  "getrandom",
  "rand",
@@ -6068,7 +6066,7 @@ dependencies = [
  "crossbeam-utils",
  "displaydoc",
  "flate2",
- "indexmap 2.7.1",
+ "indexmap 2.7.0",
  "memchr",
  "thiserror 2.0.11",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ serde_with = "3.12.0"
 url = "2.5.4"
 tracing = "0.1.41"
 clap = { version = "4.5.26", features = ["derive", "env", "cargo"] }
-minijinja = { version = "2.6.0", features = [
+minijinja = { version = "2.7.0", git = "https://github.com/mitsuhiko/minijinja", branch = "feature/mostly-undefined", features = [
   "unstable_machinery",
   "custom_syntax",
 ] }

--- a/src/recipe/jinja.rs
+++ b/src/recipe/jinja.rs
@@ -9,7 +9,9 @@ use std::{collections::BTreeMap, str::FromStr};
 
 use minijinja::value::{from_args, Kwargs, Object};
 use minijinja::{Environment, Value};
-use rattler_conda_types::{Arch, PackageName, ParseStrictness, Platform, Version, VersionSpec};
+use rattler_conda_types::{
+    Arch, NamelessMatchSpec, PackageName, ParseStrictness, Platform, Version, VersionSpec,
+};
 
 use crate::normalized_key::NormalizedKey;
 use crate::render::pin::PinArgs;
@@ -396,7 +398,7 @@ fn set_jinja(config: &SelectorConfig) -> minijinja::Environment<'static> {
     } = config.clone();
 
     let mut env = Environment::empty();
-    // env.set_undefined_behavior(minijinja::UndefinedBehavior::Strict);
+    env.set_undefined_behavior(minijinja::UndefinedBehavior::MostlyStrict);
     default_tests(&mut env);
     default_filters(&mut env);
 
@@ -419,8 +421,22 @@ fn set_jinja(config: &SelectorConfig) -> minijinja::Environment<'static> {
     env.add_function("match", |a: &Value, spec: &str| {
         if let Some(variant) = a.as_str() {
             // check if version matches spec
-            let (version, _) = variant.split_once(' ').unwrap_or((variant, ""));
+            let nameless_matchspec = NamelessMatchSpec::from_str(variant, ParseStrictness::Lenient)
+                .map_err(|e| {
+                    minijinja::Error::new(
+                        minijinja::ErrorKind::SyntaxError,
+                        format!("Bad syntax for `variant`: {}", e),
+                    )
+                })?;
+
+            let Some(version) = nameless_matchspec.version else {
+                return Err(minijinja::Error::new(
+                    minijinja::ErrorKind::InvalidOperation,
+                    "Failed to parse version from variant",
+                ));
+            };
             // remove trailing .* or *
+            let version = version.to_string();
             let version = version.trim_end_matches(".*").trim_end_matches('*');
 
             let version = Version::from_str(version).map_err(|e| {


### PR DESCRIPTION
This makes use of a new feature in minijinja for "semi-strict" undefined.

Things like `${{ "foo" if unix }}` still works with these changes in minijinja.