### PR TITLE
right align size in solve table

### DIFF
--- a/src/render/solver.rs
+++ b/src/render/solver.rs
@@ -26,6 +26,8 @@ fn print_as_table(packages: &[RepoDataRecord]) {
         "Package", "Version", "Build", "Channel", "Size",
         // "License",
     ]);
+    let column = table.column_mut(4).expect("This should be column five");
+    column.set_cell_alignment(comfy_table::CellAlignment::Right);
 
     for package in packages
         .iter()


### PR DESCRIPTION
Thanks for `rattler-build`!

As I watch more builds, I noticed that the logged solve table doesn't 
right-align package sizes, making it rather hard to do any kind of visual comparison. 

```
 │ │ ╭──────────────────┬────────────┬────────────────────┬─────────────┬────────────╮
 │ │ │ Package          ┆ Version    ┆ Build              ┆ Channel     ┆ Size       │
 │ │ ╞══════════════════╪════════════╪════════════════════╪═════════════╪════════════╡
 │ │ │ _libgcc_mutex    ┆ 0.1        ┆ conda_forge        ┆ conda-forge ┆ 2.50 KiB   │
 │ │ │ _openmp_mutex    ┆ 4.5        ┆ 2_gnu              ┆ conda-forge ┆ 23.07 KiB  │
 │ │ │ bzip2            ┆ 1.0.8      ┆ h4bc722e_7         ┆ conda-forge ┆ 246.86 KiB │
 │ │ │ ca-certificates  ┆ 2024.12.14 ┆ hbcca054_0         ┆ conda-forge ┆ 153.41 KiB │
 │ │ │ ld_impl_linux-64 ┆ 2.43       ┆ h712a8e2_2         ┆ conda-forge ┆ 653.53 KiB │
 │ │ │ libffi           ┆ 3.4.2      ┆ h7f98852_5         ┆ conda-forge ┆ 56.93 KiB  │
 │ │ │ libgcc           ┆ 14.2.0     ┆ h77fa898_1         ┆ conda-forge ┆ 828.85 KiB │
 │ │ │ libgcc-ng        ┆ 14.2.0     ┆ h69a702a_1         ┆ conda-forge ┆ 52.87 KiB  │
 │ │ │ libgomp          ┆ 14.2.0     ┆ h77fa898_1         ┆ conda-forge ┆ 450.19 KiB │
 │ │ │ liblzma          ┆ 5.6.3      ┆ hb9d3cd8_1         ┆ conda-forge ┆ 108.53 KiB │
 │ │ │ libnsl           ┆ 2.0.1      ┆ hd590300_0         ┆ conda-forge ┆ 32.62 KiB  │
 │ │ │ libsqlite        ┆ 3.48.0     ┆ hee588c1_1         ┆ conda-forge ┆ 857.64 KiB │
 │ │ │ libuuid          ┆ 2.38.1     ┆ h0b41bf4_0         ┆ conda-forge ┆ 32.81 KiB  │
 │ │ │ libxcrypt        ┆ 4.4.36     ┆ hd590300_1         ┆ conda-forge ┆ 98.04 KiB  │
 │ │ │ libzlib          ┆ 1.3.1      ┆ hb9d3cd8_2         ┆ conda-forge ┆ 59.53 KiB  │
 │ │ │ ncurses          ┆ 6.5        ┆ h2d0b736_2         ┆ conda-forge ┆ 873.49 KiB │
 │ │ │ openssl          ┆ 3.4.0      ┆ h7b32b05_1         ┆ conda-forge ┆ 2.80 MiB   │
 │ │ │ pip              ┆ 25.0       ┆ pyh8b19718_0       ┆ conda-forge ┆ 1.20 MiB   │
 │ │ │ python           ┆ 3.9.21     ┆ h9c0c6dc_1_cpython ┆ conda-forge ┆ 22.53 MiB  │
 │ │ │ readline         ┆ 8.2        ┆ h8228510_1         ┆ conda-forge ┆ 274.86 KiB │
 │ │ │ setuptools       ┆ 75.8.0     ┆ pyhff2d567_0       ┆ conda-forge ┆ 757.42 KiB │
 │ │ │ tk               ┆ 8.6.13     ┆ noxft_h4845f30_101 ┆ conda-forge ┆ 3.17 MiB   │
 │ │ │ tzdata           ┆ 2025a      ┆ h78e105d_0         ┆ conda-forge ┆ 120.04 KiB │
 │ │ │ wheel            ┆ 0.45.1     ┆ pyhd8ed1ab_1       ┆ conda-forge ┆ 61.46 KiB  │
 │ │ ╰──────────────────┴────────────┴────────────────────┴─────────────┴────────────╯
```

_Hopefully_ (as in, i copy and pasted from `resolved_dependencies.rs`), this PR will at least get it to:

```
 │ │ ╭──────────────────┬────────────┬────────────────────┬─────────────┬────────────╮
 │ │ │ Package          ┆ Version    ┆ Build              ┆ Channel     ┆       Size │
 │ │ ╞══════════════════╪════════════╪════════════════════╪═════════════╪════════════╡
 │ │ │ _libgcc_mutex    ┆ 0.1        ┆ conda_forge        ┆ conda-forge ┆   2.50 KiB │
 │ │ │ _openmp_mutex    ┆ 4.5        ┆ 2_gnu              ┆ conda-forge ┆  23.07 KiB │
 │ │ │ bzip2            ┆ 1.0.8      ┆ h4bc722e_7         ┆ conda-forge ┆ 246.86 KiB │
 │ │ │ ca-certificates  ┆ 2024.12.14 ┆ hbcca054_0         ┆ conda-forge ┆ 153.41 KiB │
 │ │ │ ld_impl_linux-64 ┆ 2.43       ┆ h712a8e2_2         ┆ conda-forge ┆ 653.53 KiB │
 │ │ │ libffi           ┆ 3.4.2      ┆ h7f98852_5         ┆ conda-forge ┆  56.93 KiB │
 │ │ │ libgcc           ┆ 14.2.0     ┆ h77fa898_1         ┆ conda-forge ┆ 828.85 KiB │
 │ │ │ libgcc-ng        ┆ 14.2.0     ┆ h69a702a_1         ┆ conda-forge ┆  52.87 KiB │
 │ │ │ libgomp          ┆ 14.2.0     ┆ h77fa898_1         ┆ conda-forge ┆ 450.19 KiB │
 │ │ │ liblzma          ┆ 5.6.3      ┆ hb9d3cd8_1         ┆ conda-forge ┆ 108.53 KiB │
 │ │ │ libnsl           ┆ 2.0.1      ┆ hd590300_0         ┆ conda-forge ┆  32.62 KiB │
 │ │ │ libsqlite        ┆ 3.48.0     ┆ hee588c1_1         ┆ conda-forge ┆ 857.64 KiB │
 │ │ │ libuuid          ┆ 2.38.1     ┆ h0b41bf4_0         ┆ conda-forge ┆  32.81 KiB │
 │ │ │ libxcrypt        ┆ 4.4.36     ┆ hd590300_1         ┆ conda-forge ┆  98.04 KiB │
 │ │ │ libzlib          ┆ 1.3.1      ┆ hb9d3cd8_2         ┆ conda-forge ┆  59.53 KiB │
 │ │ │ ncurses          ┆ 6.5        ┆ h2d0b736_2         ┆ conda-forge ┆ 873.49 KiB │
 │ │ │ openssl          ┆ 3.4.0      ┆ h7b32b05_1         ┆ conda-forge ┆   2.80 MiB │
 │ │ │ pip              ┆ 25.0       ┆ pyh8b19718_0       ┆ conda-forge ┆   1.20 MiB │
 │ │ │ python           ┆ 3.9.21     ┆ h9c0c6dc_1_cpython ┆ conda-forge ┆  22.53 MiB │
 │ │ │ readline         ┆ 8.2        ┆ h8228510_1         ┆ conda-forge ┆ 274.86 KiB │
 │ │ │ setuptools       ┆ 75.8.0     ┆ pyhff2d567_0       ┆ conda-forge ┆ 757.42 KiB │
 │ │ │ tk               ┆ 8.6.13     ┆ noxft_h4845f30_101 ┆ conda-forge ┆   3.17 MiB │
 │ │ │ tzdata           ┆ 2025a      ┆ h78e105d_0         ┆ conda-forge ┆ 120.04 KiB │
 │ │ │ wheel            ┆ 0.45.1     ┆ pyhd8ed1ab_1       ┆ conda-forge ┆  61.46 KiB │
 │ │ ╰──────────────────┴────────────┴────────────────────┴─────────────┴────────────╯
```


<details>

<summary>
Aside: As a quick scan, which of the above packages is the biggest? The smallest?
</summary>

Yes, it's:
```
       python   22.53 MiB 
_libgcc_mutex    2.50 KiB
```

I (with relatively poor eyes) had difficulty doing it quickly, and actually 
likely _cheated_ and fell back on some prior knowledge.

It would be interesting to see if there are some non-tricky, portable ways
to better help identify outliers.

</details>

