### PR TITLE
feat: support lists in "context" (#1289)

### DIFF
--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -987,6 +987,11 @@ context:
   # later keys can reference previous keys
   # and use jinja functions to compute new values
   major_version: ${{ version.split('.')[0] }}
+  tests_to_skip:
+    # fails for one reason
+    - test_foo
+    # fails for another reason
+    - test_bar
 ```
 
 Later in your `recipe.yaml` you can use these values in string interpolation
@@ -995,6 +1000,10 @@ with Jinja:
 ```yaml
 source:
   url: https://github.com/mamba-org/${{ name }}/v${{ version }}.tar.gz
+
+tests:
+  - script:
+    - pytest -k "not (${{ tests_to_skip | join(" or ")" }})"
 ```
 
 Jinja has built-in support for some common string manipulations.

--- a/src/recipe/error.rs
+++ b/src/recipe/error.rs
@@ -2,6 +2,7 @@
 
 use crate::source_code::SourceCode;
 use miette::{Diagnostic, SourceOffset, SourceSpan};
+use minijinja::value::ValueKind;
 use std::fmt::Debug;
 use std::{borrow::Cow, convert::Infallible, fmt, str::ParseBoolError};
 use thiserror::Error;
@@ -163,6 +164,10 @@ pub enum ErrorKind {
     #[diagnostic(code(error::glob_parsing))]
     RegexParsing(#[from] regex::Error),
 
+    /// Error when a sequence mixes different types.
+    #[diagnostic(code(error::sequence_mixed_types))]
+    SequenceMixedTypes((ValueKind, ValueKind)),
+
     /// Generic unspecified error. If this is returned, the call site should
     /// be annotated with context, if possible.
     #[diagnostic(code(error::other))]
@@ -276,6 +281,10 @@ impl fmt::Display for ErrorKind {
             }
             ErrorKind::GlobParsing(err) => write!(f, "failed to parse glob: {}", err),
             ErrorKind::RegexParsing(err) => write!(f, "failed to parse regex: {}", err),
+            ErrorKind::SequenceMixedTypes((t1, t2)) => write!(
+                f,
+                "mixed types in sequence: subsequent member is `{t1}` in a list of `{t2}`."
+            ),
             ErrorKind::Other => write!(f, "an unspecified error occurred."),
             ErrorKind::ExperimentalOnly(s) => write!(f, "experimental only: `{}`.", s),
         }

--- a/src/recipe/parser.rs
+++ b/src/recipe/parser.rs
@@ -487,7 +487,10 @@ mod tests {
             version: 0.1.0
         "#;
 
-        let recipe = Recipe::from_yaml(raw_recipe, SelectorConfig::default());
+        let recipe = Recipe::from_yaml(raw_recipe, SelectorConfig {
+            experimental: true,
+            ..SelectorConfig::default()
+        });
         let err: ParseErrors<_> = recipe.unwrap_err().into();
         assert_miette_snapshot!(err);
     }

--- a/src/recipe/parser.rs
+++ b/src/recipe/parser.rs
@@ -487,10 +487,13 @@ mod tests {
             version: 0.1.0
         "#;
 
-        let recipe = Recipe::from_yaml(raw_recipe, SelectorConfig {
-            experimental: true,
-            ..SelectorConfig::default()
-        });
+        let recipe = Recipe::from_yaml(
+            raw_recipe,
+            SelectorConfig {
+                experimental: true,
+                ..SelectorConfig::default()
+            },
+        );
         let err: ParseErrors<_> = recipe.unwrap_err().into();
         assert_miette_snapshot!(err);
     }

--- a/src/recipe/parser.rs
+++ b/src/recipe/parser.rs
@@ -201,7 +201,8 @@ impl Recipe {
             for (k, v) in context_map.iter() {
                 let variable = if let Some(sequence) = v.as_sequence() {
                     if experimental {
-                        let mut rendered_sequence: Vec<Variable> = Vec::with_capacity(sequence.len());
+                        let mut rendered_sequence: Vec<Variable> =
+                            Vec::with_capacity(sequence.len());
 
                         for (index, item) in sequence.iter().enumerate() {
                             let rendered_item: Node =
@@ -210,7 +211,8 @@ impl Recipe {
                                 Self::context_scalar_to_var(k, &rendered_item, &jinja)?
                             {
                                 if index != 0
-                                    && variable.as_ref().kind() != rendered_sequence[0].as_ref().kind()
+                                    && variable.as_ref().kind()
+                                        != rendered_sequence[0].as_ref().kind()
                                 {
                                     return Err(vec![_partialerror!(
                                         *item.span(),
@@ -227,7 +229,7 @@ impl Recipe {
                             *k.span(),
                             ErrorKind::ExperimentalOnly("context-list".to_string()),
                             help = "Sequence values in `context` are only allowed in experimental mode (`--experimental`)"
-                        )])
+                        )]);
                     }
                 } else if let Some(variable) = Self::context_scalar_to_var(k, v, &jinja)? {
                     variable

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__context_value_not_scalar.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__context_value_not_scalar.snap
@@ -1,16 +1,18 @@
 ---
 source: src/recipe/parser.rs
+assertion_line: 458
 expression: err
 ---
   × Failed to parse recipe
 
 Error: 
   × expected a scalar value.
-   ╭─[3:16]
- 2 │         context:
- 3 │           key: ["not-scalar"]
-   ·                ───────┬──────
-   ·                       ╰── here
- 4 │ 
+   ╭─[4:16]
+ 3 │               key:
+ 4 │ ╭─▶             foo:
+ 5 │ ├─▶               - [not, scalar]
+   · ╰──── here
+ 6 │     
    ╰────
-  help: `context` values must always be scalars (strings)
+  help: `context` values must always be scalars (booleans, integers or
+        strings) or uniform lists of scalars

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__context_value_not_uniform_list.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__context_value_not_uniform_list.snap
@@ -1,0 +1,17 @@
+---
+source: src/recipe/parser.rs
+expression: err
+---
+  × Failed to parse recipe
+
+Error: 
+  × mixed types in sequence: subsequent member is `number` in a list of
+  │ `string`.
+   ╭─[6:15]
+ 5 │             - bar
+ 6 │             - 3
+   ·               ┬
+   ·               ╰── here
+ 7 │             - 4
+   ╰────
+  help: sequence `context` must have all members of the same scalar type

--- a/src/recipe/variable.rs
+++ b/src/recipe/variable.rs
@@ -50,6 +50,12 @@ impl From<&str> for Variable {
     }
 }
 
+impl From<Vec<Variable>> for Variable {
+    fn from(value: Vec<Variable>) -> Self {
+        Variable(Value::from_serialize(value))
+    }
+}
+
 impl Variable {
     /// Create a variable from a string
     pub fn from_string(value: &str) -> Self {

--- a/test-data/recipes/jinja-types/recipe.yaml
+++ b/test-data/recipes/jinja-types/recipe.yaml
@@ -9,6 +9,11 @@ context:
   cboolean: true
   cquoted_bool: "true"
   cquoted: "5"
+  list:
+    - a
+    - b
+    - c
+  inline_list: [a, b, c]
   is_integer: ${{ xinteger is integer }}
   is_float: ${{ xfloat is float }}
   is_string: ${{ xstring is string }}
@@ -18,13 +23,15 @@ context:
   is_cstring: ${{ cstring is string }}
   is_cboolean: ${{ cboolean is boolean }}
   is_cquoted: ${{ cquoted is string }}
+  is_list: ${{ list is sequence }}
+  is_inline_list: ${{ inline_list is sequence }}
+  is_list_elem: ${{ list[0] is string }}
   computed_int: ${{ "12.3" | replace(".", "") | int }}
   is_computed_int: ${{ computed_int is integer }}
   is_quoted_true: ${{ cquoted_bool is string }}
   # quoted bool is quoted in variants.yaml and thus should be a string
   is_quoted_true_var: ${{ quoted_bool is string }}
   is_quoted_int_var: ${{ quoted_int is string }}
-
 
 package:
   name: testtypes

--- a/test/end-to-end/__snapshots__/test_simple/test_jinja_types.json
+++ b/test/end-to-end/__snapshots__/test_simple/test_jinja_types.json
@@ -8,6 +8,11 @@
   "cquoted_bool": "true",
   "cstring": "blah",
   "float": "1.23",
+  "inline_list": [
+    "a",
+    "b",
+    "c"
+  ],
   "integer": 5,
   "is_boolean": true,
   "is_cboolean": true,
@@ -17,10 +22,18 @@
   "is_cquoted": true,
   "is_cstring": true,
   "is_float": false,
+  "is_inline_list": true,
   "is_integer": true,
+  "is_list": true,
+  "is_list_elem": true,
   "is_quoted_int_var": true,
   "is_quoted_true": true,
   "is_quoted_true_var": true,
   "is_string": true,
+  "list": [
+    "a",
+    "b",
+    "c"
+  ],
   "string": "blah"
 }

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -1369,8 +1369,9 @@ def test_jinja_types(
     rattler_build: RattlerBuild, recipes: Path, tmp_path: Path, snapshot_json
 ):
     # render only and snapshot json
-    rendered = rattler_build.render(recipes / "jinja-types", tmp_path,
-                                    extra_args=["--experimental"])
+    rendered = rattler_build.render(
+        recipes / "jinja-types", tmp_path, extra_args=["--experimental"]
+    )
     print(rendered)
     # load as json
     assert snapshot_json == rendered[0]["recipe"]["context"]

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -1369,7 +1369,8 @@ def test_jinja_types(
     rattler_build: RattlerBuild, recipes: Path, tmp_path: Path, snapshot_json
 ):
     # render only and snapshot json
-    rendered = rattler_build.render(recipes / "jinja-types", tmp_path)
+    rendered = rattler_build.render(recipes / "jinja-types", tmp_path,
+                                    extra_args=["--experimental"])
     print(rendered)
     # load as json
     assert snapshot_json == rendered[0]["recipe"]["context"]


### PR DESCRIPTION
Add support for specifying lists in addition to scalars in `context`. They are converted to Jinja sequences.

This is literally the first Rust code I have written, so it's probably horrible. I consider it a miracle that it works. I appreciate any hints to make it cleaner. I also need to add error handling, and tests.

rattler_build_conda_compat needs updating too.