### PR TITLE
docs: remove schema link

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,6 @@ There is also a [terminal user interface (TUI)](https://prefix-dev.github.io/rat
 A simple example recipe for the `xtensor` header-only C++ library:
 
 ```yaml
-# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
-
 context:
   name: xtensor
   version: 0.24.6

--- a/docs/automatic_linting.md
+++ b/docs/automatic_linting.md
@@ -3,11 +3,3 @@
 Our new recipe format adheres to a strict JSON schema, which you can access [here](https://github.com/prefix-dev/recipe-format).
 
 This schema is implemented using `pydantic` and can be rendered into a JSON schema file. The [YAML language server extension in VSCode](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) is capable of recognizing this schema, providing useful hints during the editing process.
-
-To enable automatic linting with the YAML language server, you need to add the following line at the beginning of your recipe file:
-
-```yaml
-# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
-```
-
-**Alternatively**, if you prefer not to add this line to your file, you can install the [JSON Schema Store Catalog extension](https://marketplace.visualstudio.com/items?itemName=remcohaszing.schemastore). This extension will also enable automatic linting for your recipe files.

--- a/docs/index.md
+++ b/docs/index.md
@@ -147,7 +147,7 @@ There is a GitHub Action for `rattler-build`. It can be used to install `rattler
 A simple example recipe for the `xtensor` header-only C++ library:
 
 ```yaml
-# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+
 
 context:
   name: xtensor

--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -66,19 +66,6 @@ validation).<br/>
 The schema (and `pydantic` source file) can be found in this repository:
 [`recipe-format`](https://github.com/prefix-dev/recipe-format)
 
-???+ info "To use with VSCode(yaml-plugin) and other IDEs:"
-    Either start the document with the following line:
-    ```html
-    # yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
-    ```
-    Or, using `yaml.schemas`,
-    ```yaml
-    yaml.schemas: {
-      "https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json": "**/recipe.yaml",
-    }
-    ```
-    Read more about this [here](https://github.com/redhat-developer/yaml-language-server).
-
 
 See more in the [automatic linting](../automatic_linting.md) chapter.
 

--- a/examples/cargo-edit/recipe.yaml
+++ b/examples/cargo-edit/recipe.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+
 
 context:
   version: "0.11.9"

--- a/examples/curl/recipe.yaml
+++ b/examples/curl/recipe.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+
 
 context:
   version: "8.0.1"

--- a/examples/mamba/recipe.yaml
+++ b/examples/mamba/recipe.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+
 
 context:
   name: mamba

--- a/examples/rich/recipe.yaml
+++ b/examples/rich/recipe.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+
 
 context:
   version: "13.4.2"

--- a/examples/ros-humble-turtlebot4-msgs/recipe.yaml
+++ b/examples/ros-humble-turtlebot4-msgs/recipe.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+
 
 package:
   name: ros-humble-turtlebot4-msgs

--- a/test-data/recipes/allow_missing_dso/recipe.yaml
+++ b/test-data/recipes/allow_missing_dso/recipe.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+
 
 context:
   version: "0.1.0"

--- a/test-data/recipes/correct-sha/recipe.yaml
+++ b/test-data/recipes/correct-sha/recipe.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+
 context:
   version: '0.0.1'
 

--- a/test-data/recipes/empty_folder/recipe.yaml
+++ b/test-data/recipes/empty_folder/recipe.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+
 
 package:
   name: empty_folder

--- a/test-data/recipes/git_source/recipe.yaml
+++ b/test-data/recipes/git_source/recipe.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+
 
 package:
   name: "git_source"

--- a/test-data/recipes/globtest/recipe.yaml
+++ b/test-data/recipes/globtest/recipe.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+
 
 context:
   name: globtest

--- a/test-data/recipes/llamacpp/recipe.yaml
+++ b/test-data/recipes/llamacpp/recipe.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+
 
 context:
   name: llama.cpp

--- a/test-data/recipes/overdepending/recipe.yaml
+++ b/test-data/recipes/overdepending/recipe.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+
 
 context:
   version: "0.1.0"

--- a/test-data/recipes/overlinking/recipe.yaml
+++ b/test-data/recipes/overlinking/recipe.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+
 
 context:
   version: "0.1.0"

--- a/test-data/recipes/pkg_hash/recipe.yaml
+++ b/test-data/recipes/pkg_hash/recipe.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+
 
 package:
   name: pkg_hash

--- a/test-data/recipes/polarify/recipe.yaml
+++ b/test-data/recipes/polarify/recipe.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+
 
 context:
   name: polarify

--- a/test-data/recipes/private-repository/recipe.yaml
+++ b/test-data/recipes/private-repository/recipe.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+
 
 package:
   name: "_testpackage_requiring_private_repo"

--- a/test-data/recipes/read_only_build_files/recipe.yaml
+++ b/test-data/recipes/read_only_build_files/recipe.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+
 package:
   name: read-only-build-files
   version: 0.1.0

--- a/test-data/recipes/rich/recipe.yaml
+++ b/test-data/recipes/rich/recipe.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+
 
 context:
   version: "13.4.2"

--- a/test-data/recipes/rpath/recipe.yaml
+++ b/test-data/recipes/rpath/recipe.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+
 
 context:
   name: mssql-tools

--- a/test-data/recipes/run_exports_from/recipe.yaml
+++ b/test-data/recipes/run_exports_from/recipe.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+
 
 package:
   name: run_exports_test

--- a/test-data/recipes/toml/recipe.yaml
+++ b/test-data/recipes/toml/recipe.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+
 
 context:
   name: toml

--- a/test-data/recipes/zip-source/recipe.yaml
+++ b/test-data/recipes/zip-source/recipe.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+
 package:
   name: zip-source
   version: 0.1.0


### PR DESCRIPTION
This is not necessary anymore. Naming the recipe `recipe.yaml` is good enough.