### PR TITLE
feat: support `channel_sources` from variant configs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,7 +302,7 @@ pub async fn get_build_output(
             recipe.package().name().as_normalized().to_string()
         };
 
-        let variant_channels = if let Some(channel_sources) = discovered_output
+        let channel_names = if let Some(channel_sources) = discovered_output
             .used_vars
             .get(&NormalizedKey("channel_sources".to_string()))
         {
@@ -312,13 +312,12 @@ pub async fn get_build_output(
                 .map(str::to_string)
                 .collect::<Vec<_>>()
         } else {
-            Vec::new()
+            build_data.channels.clone()
         };
 
         // Add the channels from the args and by default always conda-forge
-        let channels = variant_channels
+        let channels = channel_names
             .into_iter()
-            .chain(build_data.channels.clone())
             .map(|c| Channel::from_str(c, &tool_config.channel_config).map(|c| c.base_url))
             .collect::<Result<Vec<_>, _>>()
             .into_diagnostic()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,11 +302,23 @@ pub async fn get_build_output(
             recipe.package().name().as_normalized().to_string()
         };
 
+        let variant_channels = if let Some(channel_sources) = discovered_output
+            .used_vars
+            .get(&NormalizedKey("channel_sources".to_string()))
+        {
+            channel_sources
+                .to_string()
+                .split(",")
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        } else {
+            Vec::new()
+        };
+
         // Add the channels from the args and by default always conda-forge
-        let channels = build_data
-            .channels
-            .clone()
+        let channels = variant_channels
             .into_iter()
+            .chain(build_data.channels.clone())
             .map(|c| Channel::from_str(c, &tool_config.channel_config).map(|c| c.base_url))
             .collect::<Result<Vec<_>, _>>()
             .into_diagnostic()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -309,7 +309,7 @@ pub async fn get_build_output(
             channel_sources
                 .to_string()
                 .split(",")
-                .map(str::to_string)
+                .map(|x| x.trim().to_string())
                 .collect::<Vec<_>>()
         } else {
             build_data.channels.clone()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,7 +302,9 @@ pub async fn get_build_output(
             recipe.package().name().as_normalized().to_string()
         };
 
-        let channel_names = if let Some(channel_sources) = discovered_output
+        let channel_names = if let Some(cli_channels) = &build_data.channels {
+            cli_channels.clone()
+        } else if let Some(channel_sources) = discovered_output
             .used_vars
             .get(&NormalizedKey("channel_sources".to_string()))
         {
@@ -312,7 +314,7 @@ pub async fn get_build_output(
                 .map(|x| x.trim().to_string())
                 .collect::<Vec<_>>()
         } else {
-            build_data.channels.clone()
+            vec!["conda-forge".to_string()]
         };
 
         // Add the channels from the args and by default always conda-forge

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -505,7 +505,7 @@ impl BuildData {
             host_platform: host_platform
                 .or(target_platform)
                 .unwrap_or(Platform::current()),
-            channels: channels,
+            channels,
             variant_config: variant_config.unwrap_or_default(),
             ignore_recipe_variants,
             render_only,

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -450,7 +450,7 @@ pub struct BuildData {
     pub build_platform: Platform,
     pub target_platform: Platform,
     pub host_platform: Platform,
-    pub channels: Vec<String>,
+    pub channels: Option<Vec<String>>,
     pub variant_config: Vec<PathBuf>,
     pub ignore_recipe_variants: bool,
     pub render_only: bool,
@@ -505,7 +505,7 @@ impl BuildData {
             host_platform: host_platform
                 .or(target_platform)
                 .unwrap_or(Platform::current()),
-            channels: channels.unwrap_or(vec!["conda-forge".to_string()]),
+            channels: channels,
             variant_config: variant_config.unwrap_or_default(),
             ignore_recipe_variants,
             render_only,

--- a/src/variant_render.rs
+++ b/src/variant_render.rs
@@ -372,8 +372,9 @@ pub(crate) fn stage_1_render<S: SourceCode>(
                 additional_variables.insert("CONDA_BUILD_SYSROOT".into());
             }
 
-            // also always add `target_platform` and `channel_targets`
+            // also always add `target_platform`, `channel_sources` and `channel_targets`
             additional_variables.insert("target_platform".into());
+            additional_variables.insert("channel_sources".into());
             additional_variables.insert("channel_targets".into());
 
             // Environment variables can be overwritten by the variant configuration


### PR DESCRIPTION
Besides the code being ugly, what I get now is:

```
 │ │   Channels: 
 │ │    - file:///var/tmp/conda-bld/
 │ │    - conda-forge/label/llvm_rc
 │ │    - conda-forge
 │ │    - conda-forge
```

I wonder if we should remove the `conda-forge` default when we're now reading channels from the variant configs.

Fixes conda-forge/conda-smithy#2226