### PR TITLE
fix: update lock file of python bindings

### DIFF
--- a/.github/workflows/python-bindings.yml
+++ b/.github/workflows/python-bindings.yml
@@ -39,6 +39,10 @@ jobs:
         working-directory: py-rattler-build
         run: |
           pixi run -e test fmt-check
+      - name: Check Cargo.lock
+        working-directory: py-rattler-build
+        run: |
+          pixi run -e test check-cargo-lock
       - name: Lint
         working-directory: py-rattler-build
         run: |

--- a/py-rattler-build/Cargo.lock
+++ b/py-rattler-build/Cargo.lock
@@ -2255,9 +2255,9 @@ dependencies = [
 
 [[package]]
 name = "miette"
-version = "7.4.0"
+version = "7.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317f146e2eb7021892722af37cf1b971f0a70c8406f487e24952667616192c64"
+checksum = "1a955165f87b37fd1862df2a59547ac542c77ef6d17c666f619d1ad22dd89484"
 dependencies = [
  "backtrace",
  "backtrace-ext",
@@ -2275,9 +2275,9 @@ dependencies = [
 
 [[package]]
 name = "miette-derive"
-version = "7.4.0"
+version = "7.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23c9b935fbe1d6cbd1dac857b54a688145e2d93f48db36010514d0f612d0ad67"
+checksum = "bf45bf44ab49be92fd1227a3be6fc6f617f1a337c06af54981048574d8783147"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3100,9 +3100,9 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8ae420dece97e74ee63147f32e0313a15ec6291b39cfa4084b729564f3867e"
+checksum = "0e2b15d6db3042d80b4c11129de8ad77508ba4e27a3446e84491a4e11abcc852"
 dependencies = [
  "anyhow",
  "clap",
@@ -3228,9 +3228,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbbaf9b271d64032f993fd79089e2a50fc892ba3b6c302fd36291f0c255ad603"
+checksum = "9d93206d9c03b33671c3491ac09aed4db2f2a0d42ac31ebbd31da3467055c547"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -3258,9 +3258,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.30.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8bbea6227e4049dc1c22573e8ff76e66cf97e8bec24106b3a58f068c5353239"
+checksum = "4ffa0a5858fe4cd68964ae7ea77564fe5224b72969d10aeb035d145dc69aa15c"
 dependencies = [
  "chrono",
  "dirs",
@@ -3313,9 +3313,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.20.8"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda7a1755e85fd35367520403bff356f45138667355d26d7677088058e51fab"
+checksum = "8a36e9b4756a5deec88905d72c061475a6b8b38488b3249eadbe768b232fa4ce"
 dependencies = [
  "fs-err",
  "rattler_conda_types",
@@ -3339,9 +3339,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f51e99049404b7af6ec4939467471600d220dc047e2ce111607d95664134605"
+checksum = "7a59eabad5042aeaab596487f5d5442a2df8c4491440f6851e3be3f47c9f6254"
 dependencies = [
  "anyhow",
  "async-fd-lock",
@@ -3367,9 +3367,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.22.24"
+version = "0.22.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66612512b57c80841d99771030c61ae45ad02eb2272289fb12303bf02aeb587"
+checksum = "4e334f61be7beb81b38d54dcfd195736173ea0eff6e66775a95c824eeaf0fbd3"
 dependencies = [
  "bzip2 0.5.0",
  "chrono",
@@ -3407,9 +3407,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.21.33"
+version = "0.21.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6faef71b30bdfcd4c9a29d04e4d2750e8c6347430758f81676d345d3834d0837"
+checksum = "dd0bd6f2a9c8456bd206651b0db440201d075d205e330c7e340d603e45ae65f9"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -3475,9 +3475,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.22.16"
+version = "0.22.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20aa508a9086854d414c356a03b3f240699b220f5300f0798592e2398b6cc61b"
+checksum = "6c64e3c32e0351113ec7a5f7434ffa9a93ef646c5befca3c05d31c9eeff87b1a"
 dependencies = [
  "enum_dispatch",
  "fs-err",
@@ -3494,9 +3494,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "1.3.5"
+version = "1.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4376133643a36e92e94e647e920ac4a253b31b94858c79619ae4b3b289535f8"
+checksum = "e2367b5f1cf3467de01757b8a0b97bfd9c277d538839ca5dc77216b9854866af"
 dependencies = [
  "chrono",
  "futures",
@@ -3514,9 +3514,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0e5bc2c87f5bb27e42e06be3c3d5f0c0f3d7d9ef1dc276881fb8cf81846b91"
+checksum = "062e9c8e12a50ade1e4ea0cd2408ee59b4bc8214427642518cb7e0f3dbff3c0d"
 dependencies = [
  "archspec",
  "libloading",

--- a/py-rattler-build/pixi.toml
+++ b/py-rattler-build/pixi.toml
@@ -38,13 +38,14 @@ typer = "*"
 types-networkx = "*"
 
 [feature.test.tasks]
-test = { cmd = "pytest --doctest-modules", depends-on = ["build"] }
+check-cargo-lock = "cargo check --locked"
+fmt = { depends-on = ["fmt-python", "fmt-rust"] }
 fmt-python = "ruff format rattler_build examples tests"
 fmt-rust = "cargo fmt --all"
-lint-python = "ruff check ."
-lint-rust = "cargo clippy --all"
-fmt = { depends-on = ["fmt-python", "fmt-rust"] }
 lint = { depends-on = ["type-check", "lint-python", "lint-rust"] }
+lint-python = "ruff check ."
+lint-rust = "cargo clippy --all-targets --workspace -- -D warnings"
+test = { cmd = "pytest --doctest-modules", depends-on = ["build"] }
 type-check = { cmd = "mypy", depends-on = ["build"] }
 
 # checks for the CI

--- a/py-rattler-build/src/lib.rs
+++ b/py-rattler-build/src/lib.rs
@@ -24,6 +24,7 @@ fn get_rattler_build_version_py() -> PyResult<String> {
 
 #[pyfunction]
 #[pyo3(signature = (recipes, up_to, build_platform, target_platform, host_platform, channel, variant_config, ignore_recipe_variants, render_only, with_solve, keep_build, no_build_id, package_format, compression_threads, no_include_recipe, test, output_dir, auth_file, channel_priority, skip_existing, noarch_build_platform))]
+#[allow(clippy::too_many_arguments)]
 fn build_recipes_py(
     recipes: Vec<PathBuf>,
     up_to: Option<String>,
@@ -247,6 +248,7 @@ fn upload_package_to_anaconda_py(
 
 #[pyfunction]
 #[pyo3(signature = (package_files, staging_token, feedstock, feedstock_token, staging_channel, anaconda_url, validation_endpoint, provider, dry_run))]
+#[allow(clippy::too_many_arguments)]
 fn upload_packages_to_conda_forge_py(
     package_files: Vec<PathBuf>,
     staging_token: String,
@@ -261,19 +263,12 @@ fn upload_packages_to_conda_forge_py(
     let anaconda_url = anaconda_url
         .map(|u| Url::parse(&u))
         .transpose()
-        .map_err(|e| {
-            PyRuntimeError::new_err(format!("Error parsing anaconda_url: {}", e.to_string()))
-        })?;
+        .map_err(|e| PyRuntimeError::new_err(format!("Error parsing anaconda_url: {e}")))?;
 
     let validation_endpoint = validation_endpoint
         .map(|u| Url::parse(&u))
         .transpose()
-        .map_err(|e| {
-            PyRuntimeError::new_err(format!(
-                "Error parsing validation_endpoint: {}",
-                e.to_string()
-            ))
-        })?;
+        .map_err(|e| PyRuntimeError::new_err(format!("Error parsing validation_endpoint: {e}",)))?;
 
     let conda_forge_data = CondaForgeData::new(
         staging_token,


### PR DESCRIPTION
- Update lock file to make it compile again
- Ensure on CI that lock file is up-to-date
- Ensure that warnings fail on CI
- Fix clippy lints