### PR TITLE
chore: Update dependencies of rattler-build and py-rattler-build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ dependencies = [
  "getrandom 0.2.15",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -583,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.11"
+version = "1.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4730490333d58093109dc02c23174c3f4d490998c3fed3cc8e82d57afedb9cf"
+checksum = "755717a7de9ec452bf7f3f1a3099085deabd7f2962b861dae91ecd7a365903d2"
 dependencies = [
  "jobserver",
  "libc",
@@ -631,9 +631,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.27"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
+checksum = "3e77c3243bd94243c03672cb5154667347c457ca271254724f9f393aee1c05ff"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -682,9 +682,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.24"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
+checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -706,13 +706,12 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "comfy-table"
-version = "7.1.3"
+version = "7.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f165e7b643266ea80cb858aed492ad9280e3e05ce24d4a99d7d7b889b6a4d9"
+checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
 dependencies = [
  "crossterm",
- "strum",
- "strum_macros",
+ "unicode-segmentation",
  "unicode-width 0.2.0",
 ]
 
@@ -940,7 +939,7 @@ dependencies = [
  "hkdf",
  "num",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "sha2",
 ]
 
@@ -1499,9 +1498,9 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-metadata"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f945a208886a13d07636f38fb978da371d0abc3e34bad338124b9f8c135a8f"
+checksum = "d901aeb453fd80e51d64df4ee005014f6cf39f2d736dd64f7239c132d9d39a6a"
 dependencies = [
  "reqwest",
  "thiserror 1.0.69",
@@ -2163,11 +2162,11 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.3.0"
+version = "9.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "js-sys",
  "pem",
  "ring",
@@ -2643,9 +2642,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "openssl"
@@ -2873,7 +2872,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -3001,7 +3000,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -3085,7 +3084,7 @@ checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
 dependencies = [
  "bytes",
  "getrandom 0.2.15",
- "rand",
+ "rand 0.8.5",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3133,8 +3132,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.0",
+ "zerocopy 0.8.17",
 ]
 
 [[package]]
@@ -3144,7 +3154,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.0",
 ]
 
 [[package]]
@@ -3154,6 +3174,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
+dependencies = [
+ "getrandom 0.3.1",
+ "zerocopy 0.8.17",
 ]
 
 [[package]]
@@ -3179,9 +3209,9 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.30.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e2b15d6db3042d80b4c11129de8ad77508ba4e27a3446e84491a4e11abcc852"
+checksum = "be2cb261862e1e5652f9865235ad6ab986b87c76835425f66c13ebd9d3f8f8cf"
 dependencies = [
  "anyhow",
  "clap",
@@ -3317,9 +3347,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d93206d9c03b33671c3491ac09aed4db2f2a0d42ac31ebbd31da3467055c547"
+checksum = "eac34a341a866092543233e4819b82a589bfc9e06253ab970b87afaebff63ae4"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -3347,9 +3377,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.30.1"
+version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffa0a5858fe4cd68964ae7ea77564fe5224b72969d10aeb035d145dc69aa15c"
+checksum = "d93ef8309ef8f8fa25adbd9ee08831ce942015c73c317b5c1e26f41878c99cf3"
 dependencies = [
  "chrono",
  "dirs",
@@ -3402,9 +3432,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.20.9"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a36e9b4756a5deec88905d72c061475a6b8b38488b3249eadbe768b232fa4ce"
+checksum = "a496064e4c3f643d6be55b78e59a989951b9939a98e816240ae4460a772f2a1f"
 dependencies = [
  "fs-err",
  "rattler_conda_types",
@@ -3428,16 +3458,15 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.22.1"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a59eabad5042aeaab596487f5d5442a2df8c4491440f6851e3be3f47c9f6254"
+checksum = "84dd2b0aacfa246c12f98b752c53aa7f05e623290b740903dc11addc7b1ee8d9"
 dependencies = [
  "anyhow",
- "async-fd-lock",
  "async-trait",
  "base64 0.22.1",
- "chrono",
  "dirs",
+ "fs-err",
  "getrandom 0.2.15",
  "google-cloud-auth",
  "http",
@@ -3449,6 +3478,7 @@ dependencies = [
  "retry-policies",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.11",
  "tracing",
  "url",
@@ -3456,9 +3486,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.22.25"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e334f61be7beb81b38d54dcfd195736173ea0eff6e66775a95c824eeaf0fbd3"
+checksum = "898834d08153789abcc81984725467d1587cc29e83e44395dccf2b6e157b8025"
 dependencies = [
  "bzip2 0.5.0",
  "chrono",
@@ -3496,9 +3526,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.21.34"
+version = "0.21.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0bd6f2a9c8456bd206651b0db440201d075d205e330c7e340d603e45ae65f9"
+checksum = "cafaf8b1eab127254b42cebee1632dd40f74669171189de22e5974a91737a607"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -3564,9 +3594,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.22.17"
+version = "0.22.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c64e3c32e0351113ec7a5f7434ffa9a93ef646c5befca3c05d31c9eeff87b1a"
+checksum = "33c828aeaeed411b272af08775fe3b1888cfb8e6a886d58752587d4aa88595b3"
 dependencies = [
  "enum_dispatch",
  "fs-err",
@@ -3583,9 +3613,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "1.3.6"
+version = "1.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2367b5f1cf3467de01757b8a0b97bfd9c277d538839ca5dc77216b9854866af"
+checksum = "690ce36134019de400f8a2cfff13e754e8c8c72a9533505888e8ce87ed9ee5d2"
 dependencies = [
  "chrono",
  "futures",
@@ -3603,9 +3633,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062e9c8e12a50ade1e4ea0cd2408ee59b4bc8214427642518cb7e0f3dbff3c0d"
+checksum = "c69d889314e4e25f8da7596102d378d11a380e5cf49cbe74de30a73d7835d283"
 dependencies = [
  "archspec",
  "libloading",
@@ -3864,7 +3894,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5875471e6cab2871bc150ecb8c727db5113c9338cc3354dc5ee3425b6aa40a1c"
 dependencies = [
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -3953,9 +3983,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -4127,7 +4157,7 @@ dependencies = [
  "hkdf",
  "num",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "serde",
  "sha2",
  "zbus",
@@ -4759,7 +4789,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d36b5738d666a2b4c91b7c24998a8588db724b3107258343ebf8824bf55b06d"
 dependencies = [
- "rand",
+ "rand 0.8.5",
  "ratatui",
 ]
 
@@ -4883,9 +4913,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -5191,12 +5221,12 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.12.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
+checksum = "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
 dependencies = [
- "getrandom 0.2.15",
- "rand",
+ "getrandom 0.3.1",
+ "rand 0.9.0",
 ]
 
 [[package]]
@@ -5426,9 +5456,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "7.0.1"
+version = "7.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb4a9e33648339dc1642b0e36e21b3385e6148e289226f657c809dee59df5028"
+checksum = "2774c861e1f072b3aadc02f8ba886c26ad6321567ecc294c935434cad06f1283"
 dependencies = [
  "either",
  "env_home",
@@ -5845,9 +5875,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e49d2d35d3fad69b39b94139037ecfb4f359f08958b9c11e7315ce770462419"
+checksum = "86e376c75f4f43f44db463cf729e0d3acbf954d13e22c51e26e4c264b4ab545f"
 dependencies = [
  "memchr",
 ]
@@ -5992,7 +6022,7 @@ dependencies = [
  "hex",
  "nix",
  "ordered-stream",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_repr",
  "sha1",
@@ -6037,7 +6067,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa91407dacce3a68c56de03abe2760159582b846c6a4acd2f456618087f12713"
+dependencies = [
+ "zerocopy-derive 0.8.17",
 ]
 
 [[package]]
@@ -6045,6 +6084,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06718a168365cad3d5ff0bb133aad346959a2074bd4a85c121255a11304a8626"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ content_inspector = "0.2.4"
 serde_with = "3.12.0"
 url = "2.5.4"
 tracing = "0.1.41"
-clap = { version = "4.5.27", features = ["derive", "env", "cargo"] }
+clap = { version = "4.5.28", features = ["derive", "env", "cargo"] }
 minijinja = { version = "2.7.0", features = [
   "unstable_machinery",
   "custom_syntax",
@@ -78,7 +78,7 @@ num_cpus = "1.16.0"
 goblin = "0.9.3"
 scroll = "0.12.0"
 pathdiff = "0.2.3"
-comfy-table = "7.1.3"
+comfy-table = "7.1.4"
 futures = "0.3.31"
 indicatif = "0.17.11"
 console = { version = "0.15.10", features = ["windows-console-colors"] }
@@ -95,7 +95,7 @@ petgraph = "0.7.1"
 indexmap = "2.7.1"
 dunce = "1.0.5"
 fs-err = "3.1.0"
-which = "7.0.1"
+which = "7.0.2"
 clap_complete = "4.5.44"
 clap_complete_nushell = "4.5.5"
 tokio-util = "0.7.13"
@@ -110,7 +110,7 @@ base64 = "0.22.1"
 flate2 = "1.0.35"
 xz2 = "0.1.7"
 zstd = "0.13.2"
-toml = "0.8.19"
+toml = "0.8.20"
 memmap2 = "0.9.5"
 reqwest-middleware = { version = "0.4.0", features = ["json"] }
 async-once-cell = "0.5.4"
@@ -128,35 +128,35 @@ regex = "1.11.1"
 async-recursion = "1.1.1"
 
 # Rattler crates
-rattler = { version = "0.30.0", default-features = false, features = [
+rattler = { version = "0.31.1", default-features = false, features = [
   "cli-tools",
   "indicatif",
 ] }
-rattler_cache = { version = "0.3.6", default-features = false }
-rattler_conda_types = { version = "0.30.1", default-features = false, features = [
+rattler_cache = { version = "0.3.8", default-features = false }
+rattler_conda_types = { version = "0.30.2", default-features = false, features = [
   "rayon",
 ] }
 rattler_digest = { version = "1.0.5", default-features = false, features = [
   "serde",
 ] }
-rattler_index = { version = "0.20.9", default-features = false }
-rattler_networking = { version = "0.22.1", default-features = false }
+rattler_index = { version = "0.20.11", default-features = false }
+rattler_networking = { version = "0.22.3", default-features = false }
 rattler_redaction = { version = "0.1.6" }
-rattler_repodata_gateway = { version = "0.21.34", default-features = false, features = [
+rattler_repodata_gateway = { version = "0.21.36", default-features = false, features = [
   "gateway",
 ] }
 rattler_sandbox = { version = "0.1.2", default-features = false, features = [
   "tokio",
 ] }
-rattler_shell = { version = "0.22.17", default-features = false, features = [
+rattler_shell = { version = "0.22.18", default-features = false, features = [
   "sysinfo",
 ] }
-rattler_solve = { version = "1.3.6", default-features = false, features = [
+rattler_solve = { version = "1.3.7", default-features = false, features = [
   "resolvo",
   "serde",
 ] }
-rattler_virtual_packages = { version = "2.0.1", default-features = false }
-rattler_package_streaming = { version = "0.22.25", default-features = false }
+rattler_virtual_packages = { version = "2.0.2", default-features = false }
+rattler_package_streaming = { version = "0.22.27", default-features = false }
 lazy_static = "1.5.0"
 reqwest-retry = "0.7.0"
 retry-policies = "0.4.0"

--- a/py-rattler-build/Cargo.lock
+++ b/py-rattler-build/Cargo.lock
@@ -333,9 +333,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.85"
+version = "0.1.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
+checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -497,9 +497,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 
 [[package]]
 name = "bzip2"
@@ -549,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.10"
+version = "1.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
+checksum = "755717a7de9ec452bf7f3f1a3099085deabd7f2962b861dae91ecd7a365903d2"
 dependencies = [
  "jobserver",
  "libc",
@@ -597,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.27"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
+checksum = "3e77c3243bd94243c03672cb5154667347c457ca271254724f9f393aee1c05ff"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -648,9 +648,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.24"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
+checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -672,13 +672,12 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "comfy-table"
-version = "7.1.3"
+version = "7.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f165e7b643266ea80cb858aed492ad9280e3e05ce24d4a99d7d7b889b6a4d9"
+checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
 dependencies = [
  "crossterm",
- "strum",
- "strum_macros",
+ "unicode-segmentation",
  "unicode-width 0.2.0",
 ]
 
@@ -2518,15 +2517,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "openssl"
-version = "0.10.69"
+version = "0.10.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e534d133a060a3c19daec1eb3e98ec6f4685978834f2dbadfe2ec215bab64e"
+checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
 dependencies = [
  "bitflags 2.8.0",
  "cfg-if",
@@ -2556,9 +2555,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.104"
+version = "0.9.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
 dependencies = [
  "cc",
  "libc",
@@ -3100,9 +3099,9 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.30.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e2b15d6db3042d80b4c11129de8ad77508ba4e27a3446e84491a4e11abcc852"
+checksum = "be2cb261862e1e5652f9865235ad6ab986b87c76835425f66c13ebd9d3f8f8cf"
 dependencies = [
  "anyhow",
  "clap",
@@ -3228,9 +3227,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d93206d9c03b33671c3491ac09aed4db2f2a0d42ac31ebbd31da3467055c547"
+checksum = "eac34a341a866092543233e4819b82a589bfc9e06253ab970b87afaebff63ae4"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -3258,9 +3257,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.30.1"
+version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffa0a5858fe4cd68964ae7ea77564fe5224b72969d10aeb035d145dc69aa15c"
+checksum = "d93ef8309ef8f8fa25adbd9ee08831ce942015c73c317b5c1e26f41878c99cf3"
 dependencies = [
  "chrono",
  "dirs",
@@ -3313,9 +3312,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.20.9"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a36e9b4756a5deec88905d72c061475a6b8b38488b3249eadbe768b232fa4ce"
+checksum = "a496064e4c3f643d6be55b78e59a989951b9939a98e816240ae4460a772f2a1f"
 dependencies = [
  "fs-err",
  "rattler_conda_types",
@@ -3339,16 +3338,15 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.22.1"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a59eabad5042aeaab596487f5d5442a2df8c4491440f6851e3be3f47c9f6254"
+checksum = "84dd2b0aacfa246c12f98b752c53aa7f05e623290b740903dc11addc7b1ee8d9"
 dependencies = [
  "anyhow",
- "async-fd-lock",
  "async-trait",
  "base64 0.22.1",
- "chrono",
  "dirs",
+ "fs-err",
  "getrandom 0.2.15",
  "google-cloud-auth",
  "http",
@@ -3360,6 +3358,7 @@ dependencies = [
  "retry-policies",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.11",
  "tracing",
  "url",
@@ -3367,9 +3366,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.22.25"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e334f61be7beb81b38d54dcfd195736173ea0eff6e66775a95c824eeaf0fbd3"
+checksum = "898834d08153789abcc81984725467d1587cc29e83e44395dccf2b6e157b8025"
 dependencies = [
  "bzip2 0.5.0",
  "chrono",
@@ -3407,9 +3406,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.21.34"
+version = "0.21.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0bd6f2a9c8456bd206651b0db440201d075d205e330c7e340d603e45ae65f9"
+checksum = "cafaf8b1eab127254b42cebee1632dd40f74669171189de22e5974a91737a607"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -3475,9 +3474,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.22.17"
+version = "0.22.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c64e3c32e0351113ec7a5f7434ffa9a93ef646c5befca3c05d31c9eeff87b1a"
+checksum = "33c828aeaeed411b272af08775fe3b1888cfb8e6a886d58752587d4aa88595b3"
 dependencies = [
  "enum_dispatch",
  "fs-err",
@@ -3494,9 +3493,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "1.3.6"
+version = "1.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2367b5f1cf3467de01757b8a0b97bfd9c277d538839ca5dc77216b9854866af"
+checksum = "690ce36134019de400f8a2cfff13e754e8c8c72a9533505888e8ce87ed9ee5d2"
 dependencies = [
  "chrono",
  "futures",
@@ -3514,9 +3513,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062e9c8e12a50ade1e4ea0cd2408ee59b4bc8214427642518cb7e0f3dbff3c0d"
+checksum = "c69d889314e4e25f8da7596102d378d11a380e5cf49cbe74de30a73d7835d283"
 dependencies = [
  "archspec",
  "libloading",
@@ -3817,9 +3816,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
@@ -3836,9 +3835,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.21"
+version = "0.23.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
+checksum = "9fb9263ab4eb695e42321db096e3b8fbd715a59b154d5c88d82db2175b681ba7"
 dependencies = [
  "once_cell",
  "ring",
@@ -4367,9 +4366,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4651,9 +4650,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -4672,9 +4671,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "02a8b472d1a3d7c18e2d61a489aee3453fd9031c33e4f55bd533f4a7adca1bee"
 dependencies = [
  "indexmap 2.7.1",
  "serde",
@@ -4836,6 +4835,12 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
@@ -5098,18 +5103,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.7"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
+checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "which"
-version = "7.0.1"
+version = "7.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb4a9e33648339dc1642b0e36e21b3385e6148e289226f657c809dee59df5028"
+checksum = "2774c861e1f072b3aadc02f8ba886c26ad6321567ecc294c935434cad06f1283"
 dependencies = [
  "either",
  "env_home",
@@ -5526,9 +5531,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.6.25"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad699df48212c6cc6eb4435f35500ac6fd3b9913324f938aea302022ce19d310"
+checksum = "86e376c75f4f43f44db463cf729e0d3acbf954d13e22c51e26e4c264b4ab545f"
 dependencies = [
  "memchr",
 ]

--- a/py-rattler-build/Cargo.toml
+++ b/py-rattler-build/Cargo.toml
@@ -27,11 +27,9 @@ tokio = { version = "1.43.0", features = [
   "rt-multi-thread",
   "process",
 ] }
-rattler_conda_types = "0.30.0"
-clap = "4.5.27"
+rattler_conda_types = "0.30.2"
+clap = "4.5.28"
 url = "2.5.4"
-
-# pyo3-async-runtimes = { version = "0.23.0", features = ["tokio-runtime"] }
 
 [build-dependencies]
 pyo3-build-config = "0.23.4"

--- a/rust-tests/Cargo.toml
+++ b/rust-tests/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 glob = "0.3.2"
-rattler_package_streaming = { version = "0.22.25", default-features = false }
+rattler_package_streaming = { version = "0.22.27", default-features = false }
 serde_json = "1.0.138"
 sha1 = "0.10.6"
 duct = "0.13.7"

--- a/src/tool_configuration.rs
+++ b/src/tool_configuration.rs
@@ -7,7 +7,7 @@ use clap::ValueEnum;
 use rattler::package_cache::PackageCache;
 use rattler_conda_types::{ChannelConfig, Platform};
 use rattler_networking::{
-    authentication_storage::{self, backends::file::FileStorageError},
+    authentication_storage::{self, AuthenticationStorageError},
     AuthenticationMiddleware, AuthenticationStorage,
 };
 use rattler_repodata_gateway::Gateway;
@@ -94,7 +94,7 @@ pub struct Configuration {
 /// Get the authentication storage from the given file
 pub fn get_auth_store(
     auth_file: Option<PathBuf>,
-) -> Result<AuthenticationStorage, FileStorageError> {
+) -> Result<AuthenticationStorage, AuthenticationStorageError> {
     match auth_file {
         Some(auth_file) => {
             let mut store = AuthenticationStorage::empty();
@@ -103,14 +103,14 @@ pub fn get_auth_store(
             ));
             Ok(store)
         }
-        None => Ok(rattler_networking::AuthenticationStorage::from_env_and_defaults()?),
+        None => rattler_networking::AuthenticationStorage::from_env_and_defaults(),
     }
 }
 
 /// Create a reqwest client with the authentication middleware
 pub fn reqwest_client_from_auth_storage(
     auth_file: Option<PathBuf>,
-) -> Result<ClientWithMiddleware, FileStorageError> {
+) -> Result<ClientWithMiddleware, AuthenticationStorageError> {
     let auth_storage = get_auth_store(auth_file)?;
 
     let timeout = 5 * 60;


### PR DESCRIPTION
Installing https://github.com/killercup/cargo-edit and running `cargo upgrade --incompatible=allow` does the trick