### PR TITLE
docs: Fix package_contents tests in xtensor example

### DIFF
--- a/docs/tutorials/cpp.md
+++ b/docs/tutorials/cpp.md
@@ -76,8 +76,8 @@ tests:
       include: # (4)!
         - xtensor/xarray.hpp
       files: # (5)!
-        - ${{ "Library" if win }}/share/cmake/xtensor/xtensorConfig.cmake
-        - ${{ "Library" if win }}/share/cmake/xtensor/xtensorConfigVersion.cmake
+        - ${{ "Library/" if win }}share/cmake/xtensor/xtensorConfig.cmake
+        - ${{ "Library/" if win }}share/cmake/xtensor/xtensorConfigVersion.cmake
 
 about:
   homepage: https://github.com/xtensor-stack/xtensor


### PR DESCRIPTION
Without this fix, non-Windows tests fail complaining that `/share/cmake/xtensor/xtensorConfig.cmake` does not exists.