### PR TITLE
fix: preserve macOS entitlements and requirements in codesign

### DIFF
--- a/src/macos/link.rs
+++ b/src/macos/link.rs
@@ -277,6 +277,7 @@ fn codesign(path: &Path, system_tools: &SystemTools) -> Result<(), RelinkError> 
         .arg("-f")
         .arg("-s")
         .arg("-")
+        .arg("--preserve-metadata=entitlements,requirements")
         .arg(path)
         .output()
         .map(|_| ())


### PR DESCRIPTION
During recodesign after dynamic relocation, we drop entitlements and requirements stored on the binary. These are important to keep, especially for debuggers like lldb, which need certain entitlements like com.apple.security.get-task-allow which ad-hoc signed apps don't have default so they can attach to other processes. 

Long term, we should expose more options to set signing identities, explicit signing requirements, and other options. This is especially important if we want to allow GUI apps to be in conda-forge that can be directly launched without first launching a signed terminal process.