### PR TITLE
mac: relink 'libfoo.dylib' as '@rpath/libfoo.dylib'

### DIFF
--- a/src/macos/link.rs
+++ b/src/macos/link.rs
@@ -182,7 +182,7 @@ impl Relinker for Dylib {
                     final_rpaths.push(rpath.clone());
                 }
                 tracing::info!(
-                    "Rpath not in prefix or allow-listed: {} – removing it",
+                    "Rpath not in prefix or allow-listed: {} - removing it",
                     rpath.display()
                 );
             } else if let Ok(rel) = rpath.strip_prefix(encoded_prefix) {
@@ -206,7 +206,7 @@ impl Relinker for Dylib {
                 final_rpaths.push(rpath.clone());
             } else {
                 tracing::info!(
-                    "Rpath not in prefix or allow-listed: {} – removing it",
+                    "Rpath not in prefix or allow-listed: {} - removing it",
                     rpath.display()
                 );
             }
@@ -232,25 +232,26 @@ impl Relinker for Dylib {
             modified = true;
         }
 
+        // find the first rpath that looks like `lib/` and extends the prefix
+        // by default, the first element of custom_rpaths is `lib/`
+        let base_rpath = custom_rpaths
+            .iter()
+            .find(|r| !r.contains("@") && !r.starts_with('/') && !r.starts_with('.'));
+
         let exchange_dylib = |path: &Path| {
-            let mut _path = path;
-            let path_str = path.to_string_lossy();
-            let encoded_prefix_lib = encoded_prefix.join("lib");
-            let resolved_path = encoded_prefix_lib.join(path);
             // treat 'libfoo.dylib' the same as $PREFIX/lib/libfoo.dylib
             // if that's where it is installed
-            if path.parent() == Some(Path::new(""))
-                && !path_str.starts_with("@")
-                && prefix.join("lib").join(path).is_file()
-            {
-                _path = resolved_path.as_path();
-                tracing::debug!(
-                    "Treating relative {} as {}",
-                    path.display(),
-                    _path.display(),
-                );
-            }
-            if let Ok(relpath) = _path.strip_prefix(encoded_prefix_lib) {
+            let encoded_prefix_lib = encoded_prefix.join(base_rpath.cloned().unwrap_or_default());
+            let resolved_path = encoded_prefix_lib.join(path);
+
+            let path = if path.components().count() == 1 && resolved_path.exists() {
+                tracing::debug!("Treating relative {:?} as {:?}", path, resolved_path);
+                resolved_path
+            } else {
+                path.to_path_buf()
+            };
+
+            if let Ok(relpath) = path.strip_prefix(encoded_prefix_lib) {
                 // absolute $PREFIX/lib/...
                 let new_path = PathBuf::from(format!("@rpath/{}", relpath.to_string_lossy()));
                 Some(new_path)

--- a/test-data/recipes/test-relink/absolute.c
+++ b/test-data/recipes/test-relink/absolute.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+
+void absolute() {
+  printf("hello from absolute\n");
+}

--- a/test-data/recipes/test-relink/build.sh
+++ b/test-data/recipes/test-relink/build.sh
@@ -1,0 +1,13 @@
+$CC $CFLAGS $LDFLAGS -shared -Wl,-install_name,$PREFIX/lib/libabsolute.dylib ${RECIPE_DIR}/absolute.c -o libabsolute.dylib
+$CC $CFLAGS $LDFLAGS -shared ${RECIPE_DIR}/relative.c -o librelative.dylib
+
+$CC $CFLAGS $LDFLAGS ${RECIPE_DIR}/test_link.c -L. -labsolute -lrelative -o test_link
+
+# install
+mkdir -p $PREFIX/bin
+mkdir -p $PREFIX/lib
+cp -v *${SHLIB_EXT} $PREFIX/lib/
+cp -v test_link $PREFIX/bin/test_link
+
+# check for before/after comparison
+otool -L $PREFIX/lib/libabsolute.dylib $PREFIX/lib/librelative.dylib $PREFIX/bin/test_link

--- a/test-data/recipes/test-relink/recipe.yaml
+++ b/test-data/recipes/test-relink/recipe.yaml
@@ -1,0 +1,23 @@
+context:
+  c_compiler: clang
+  c_compiler_version: "19"
+
+package:
+  name: test-relink
+  version: 0.0.0
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+tests:
+  - script:
+      - otool -L $PREFIX/lib/libabsolute.dylib $PREFIX/lib/librelative.dylib $PREFIX/bin/test_link
+      # verify that links are rewritten with @rpath
+      - otool -L $PREFIX/lib/libabsolute.dylib | grep @rpath/libabsolute.dylib
+      - otool -L $PREFIX/lib/librelative.dylib | grep @rpath/librelative.dylib
+      - otool -L $PREFIX/bin/test_link | grep @rpath/libabsolute.dylib
+      - otool -L $PREFIX/bin/test_link | grep @rpath/librelative.dylib
+      - test_link

--- a/test-data/recipes/test-relink/relative.c
+++ b/test-data/recipes/test-relink/relative.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+
+void relative() {
+  printf("hello from relative\n");
+}

--- a/test-data/recipes/test-relink/test_link.c
+++ b/test-data/recipes/test-relink/test_link.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+
+void absolute();
+void relative();
+
+int main() {
+  printf("hello from test_link\n");
+  absolute();
+  relative();
+}

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -1393,3 +1393,8 @@ def test_jinja_types(
     # remove target_platform from the variant
     variant.pop("target_platform")
     assert snapshot_json == variant
+
+
+@pytest.mark.skipif(platform.system() != "Darwin", reason="macos-only")
+def test_relink_rpath(rattler_build: RattlerBuild, recipes: Path, tmp_path: Path):
+    rattler_build.build(recipes / "test-relink", tmp_path)


### PR DESCRIPTION
_similar_ to conda-build, but not the same. conda-build [searches a lot more](https://github.com/conda/conda-build/blob/61e9bb24588d8b353321c11de5452d57aa2f85ca/conda_build/post.py#L386-L412), and sets the link to find any matching file anywhere in the package, whereas this only handles the case where it's in $PREFIX/lib.

This also fixes an erroneous check for absolute path install_name for dylibs in $prefix/lib. The check was `strip_prefix(prefix)` whereas it should have been `strip_prefix(encoded_prefix.join("lib"))` if it were to match the path of absolute install_names.

I'm not sure how to add a test for this in this repo, but [this sample recipe](https://github.com/minrk/test-recipe/tree/relink) is fixed by it.

closes #1476

(feel free to ignore my code and rewrite with your own fix, I don't know how to rust).