### PR TITLE
fix: properly raise error if macOS `codesign` - ing fails

### DIFF
--- a/src/post_process/relink.rs
+++ b/src/post_process/relink.rs
@@ -23,6 +23,9 @@ pub enum RelinkError {
     #[error("failed to run install_name_tool")]
     InstallNameToolFailed,
 
+    #[error("Codesign failed")]
+    CodesignFailed,
+
     #[error(transparent)]
     SystemToolError(#[from] ToolError),
 

--- a/src/system_tools.rs
+++ b/src/system_tools.rs
@@ -115,7 +115,7 @@ impl SystemTools {
     }
 
     /// Find the tool in the system and return the path to the tool
-    fn find_tool(&self, tool: Tool) -> Result<PathBuf, which::Error> {
+    pub fn find_tool(&self, tool: Tool) -> Result<PathBuf, which::Error> {
         let which = |tool: &str| -> Result<PathBuf, which::Error> {
             if let Some(build_prefix) = &self.build_prefix {
                 let build_prefix_activator =


### PR DESCRIPTION
@zbowling unfortunately, conda-forge ships and uses `sigtool` which advertises itself as `codesign` as well, but does not support these extra options. 

My current idea is to:

- use extra options if `/usr/bin/codesign` is the codesign
- not use extra options if we find codesign somewhere else

Unfortunately neither `sigtool "codesign"` nor `codesign` have a `--version` that we could use easily. 

Their `--help` outputs do look differnet though, so we could also use that as indicator.

Or we could first try with the extra args, and if it fails, fall back ... 

Happy to hear other thoughts. Also pinging @minrk who uncovered all of this.