### PR TITLE
ci: pin github actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           submodules: recursive
 
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           # fetch everything so we can checkout the tag
           fetch-depth: 0
@@ -127,7 +127,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           # fetch everything so we can checkout the tag
           fetch-depth: 0

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -36,8 +36,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2
         with:
           workspaces: ". -> target-pixi"
           key: ${{ hashFiles('pixi.lock') }}

--- a/.github/workflows/enforce-sha.yaml
+++ b/.github/workflows/enforce-sha.yaml
@@ -1,4 +1,7 @@
-on: push
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 name: Security
 
@@ -12,4 +15,4 @@ jobs:
         uses: zgosalvez/github-actions-ensure-sha-pinned-actions@25ed13d0628a1601b4b44048e63cc4328ed03633 # v3
         with:
           allowlist: |
-            - prefix-dev/
+            prefix-dev/

--- a/.github/workflows/enforce-sha.yaml
+++ b/.github/workflows/enforce-sha.yaml
@@ -1,0 +1,15 @@
+on: push
+
+name: Security
+
+jobs:
+  ensure-pinned-actions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Ensure SHA pinned actions
+        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@25ed13d0628a1601b4b44048e63cc4328ed03633 # v3
+        with:
+          allowlist: |
+            - prefix-dev/

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,7 +15,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Set up pixi
         uses: prefix-dev/setup-pixi@v0.8.3
         with:

--- a/.github/workflows/python-bindings.yml
+++ b/.github/workflows/python-bindings.yml
@@ -29,7 +29,7 @@ jobs:
     name: Format, Lint and Test Python bindings
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           submodules: recursive
       - uses: prefix-dev/setup-pixi@v0.8.3

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -34,14 +34,14 @@ jobs:
     name: Python Build sdist
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           ref: ${{ inputs.sha }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: "Build sdist"
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@36db84001d74475ad1b8e6613557ae4ee2dc3598 # v1
         with:
           working-directory: py-rattler-build
           command: sdist
@@ -53,7 +53,7 @@ jobs:
     #       pip install dist/${{ env.PACKAGE_NAME }}-*.tar.gz --force-reinstall
     #       python -c "import rattler_build; print(rattler_build.rattler_build_version())"
       - name: "Upload sdist"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         with:
           name: sdist
           path: py-rattler-build/dist
@@ -74,15 +74,15 @@ jobs:
 #          - target: aarch64-pc-windows-msvc
 #            arch: x64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           ref: ${{ inputs.sha }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: ${{ matrix.platform.arch }}
       - name: "Build wheels"
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@36db84001d74475ad1b8e6613557ae4ee2dc3598 # v1
         with:
           working-directory: py-rattler-build
           target: ${{ matrix.platform.target }}
@@ -94,7 +94,7 @@ jobs:
           python -m pip install py-rattler-build/dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
           python -c "import rattler_build; print(rattler_build.rattler_build_version())"
       - name: "Upload wheels"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         with:
           name: windows-wheels-${{ matrix.platform.target }}
           path: py-rattler-build/dist
@@ -109,15 +109,15 @@ jobs:
           - x86_64-unknown-linux-gnu
           - i686-unknown-linux-gnu
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           ref: ${{ inputs.sha }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
       - name: "Build wheels"
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@36db84001d74475ad1b8e6613557ae4ee2dc3598 # v1
         with:
           working-directory: py-rattler-build
           target: ${{ matrix.target }}
@@ -129,7 +129,7 @@ jobs:
           pip install py-rattler-build/dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
           python -c "import rattler_build; print(rattler_build.rattler_build_version())"
       - name: "Upload wheels"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         with:
           name: linux-wheels-${{ matrix.target }}
           path: py-rattler-build/dist
@@ -147,20 +147,20 @@ jobs:
             arch: armv7
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           ref: ${{ inputs.sha }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: "Build wheels"
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@36db84001d74475ad1b8e6613557ae4ee2dc3598 # v1
         with:
           working-directory: py-rattler-build
           target: ${{ matrix.platform.target }}
           manylinux: '2_28'
           args: --release --out dist  --no-default-features --features rustls-tls
-      - uses: uraimo/run-on-arch-action@v3
+      - uses: uraimo/run-on-arch-action@1c358dc49363439f8c563ce8f93005f7fe76b849 # v3
         if: matrix.platform.arch != 'ppc64'
         name: Test wheel
         with:
@@ -175,59 +175,11 @@ jobs:
             pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links py-rattler-build/dist/ --force-reinstall
             python3 -c "import rattler_build; print(rattler_build.rattler_build_version())"
       - name: "Upload wheels"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         with:
           name: linux-wheels-${{ matrix.platform.target }}
           path: py-rattler-build/dist
 
-#   linux-cross-native-tls:
-#     runs-on: ubuntu-latest
-#     name: Python Build ${{ matrix.platform.target }}
-#     strategy:
-#       fail-fast: false
-#       matrix:
-#         platform:
-# #          - target: s390x-unknown-linux-gnu
-# #            arch: s390x
-#           - target: powerpc64le-unknown-linux-gnu
-#             arch: ppc64le
-#           - target: powerpc64-unknown-linux-gnu
-#             arch: ppc64
-
-#     steps:
-#       - uses: actions/checkout@v4
-#         with:
-#           ref: ${{ inputs.sha }}
-#       - uses: actions/setup-python@v5
-#         with:
-#           python-version: ${{ env.PYTHON_VERSION }}
-#       - name: "Build wheels"
-#         uses: PyO3/maturin-action@v1
-#         with:
-#           working-directory: py-rattler-build
-#           target: ${{ matrix.platform.target }}
-#           manylinux: auto
-#           docker-options: ${{ matrix.platform.maturin_docker_options }}
-#           args: --release --out dist --no-default-features --features native-tls,vendored-openssl
-#       - uses: uraimo/run-on-arch-action@v3
-#         if: matrix.platform.arch != 'ppc64'
-#         name: Test wheel
-#         with:
-#           arch: ${{ matrix.platform.arch }}
-#           distro: ubuntu20.04
-#           githubToken: ${{ github.token }}
-#           install: |
-#             apt-get update
-#             apt-get install -y --no-install-recommends python3 python3-pip
-#             pip3 install -U pip
-#           run: |
-#             pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links py-rattler-build/dist/ --force-reinstall
-#             python3 -c "import rattler_build; print(rattler_build.rattler_build_version())"
-#       - name: "Upload wheels"
-#         uses: actions/upload-artifact@v4
-#         with:
-#           name: linux-wheels-${{ matrix.platform.target }}
-#           path: py-rattler-build/dist
 
   musllinux:
     runs-on: ubuntu-latest
@@ -239,16 +191,16 @@ jobs:
           - x86_64-unknown-linux-musl
         #   - i686-unknown-linux-musl
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           ref: ${{ inputs.sha }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
       - name: "Build wheels (rustls-tls)"
         if: matrix.target == 'x86_64-unknown-linux-musl'
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@36db84001d74475ad1b8e6613557ae4ee2dc3598 # v1
         with:
           working-directory: py-rattler-build
           target: ${{ matrix.target }}
@@ -256,7 +208,7 @@ jobs:
           args: --release --out dist --no-default-features --features rustls-tls
       - name: "Build wheels (native-tls)"
         if: matrix.target != 'x86_64-unknown-linux-musl'
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@36db84001d74475ad1b8e6613557ae4ee2dc3598 # v1
         with:
           working-directory: py-rattler-build
           target: ${{ matrix.target }}
@@ -264,7 +216,7 @@ jobs:
           args: --release --out dist --no-default-features --features native-tls,vendored-openssl
       - name: "Test wheel"
         if: matrix.target == 'x86_64-unknown-linux-musl'
-        uses: addnab/docker-run-action@v3
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # v3
         with:
           image: alpine:latest
           options: -v ${{ github.workspace }}:/io -w /io
@@ -273,7 +225,7 @@ jobs:
             pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links /io/py-rattler-build/dist/ --force-reinstall --break-system-packages
             python3 -c "import rattler_build; print(rattler_build.rattler_build_version())"
       - name: "Upload wheels"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         with:
           name: linux-wheels-${{ matrix.target }}
           path: py-rattler-build/dist
@@ -291,20 +243,20 @@ jobs:
             arch: armv7
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           ref: ${{ inputs.sha }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: "Build wheels"
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@36db84001d74475ad1b8e6613557ae4ee2dc3598 # v1
         with:
           working-directory: py-rattler-build
           target: ${{ matrix.platform.target }}
           manylinux: musllinux_1_2
           args: --release --out dist --no-default-features --features rustls-tls
-      - uses: uraimo/run-on-arch-action@v3
+      - uses: uraimo/run-on-arch-action@1c358dc49363439f8c563ce8f93005f7fe76b849 # v3
         name: Test wheel
         with:
           arch: ${{ matrix.platform.arch }}
@@ -316,7 +268,7 @@ jobs:
             pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links py-rattler-build/dist/ --force-reinstall --break-system-packages
             python3 -c "import rattler_build; print(rattler_build.rattler_build_version())"
       - name: "Upload wheels"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         with:
           name: linux-wheels-${{ matrix.platform.target }}
           path: py-rattler-build/dist
@@ -325,15 +277,15 @@ jobs:
     runs-on: macos-13   # x86_64 runner
     name: Python Build x86_64-macos
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           ref: ${{ inputs.sha }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
       - name: "Build wheels - x86_64"
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@36db84001d74475ad1b8e6613557ae4ee2dc3598 # v1
         with:
           working-directory: py-rattler-build
           target: x86_64
@@ -343,7 +295,7 @@ jobs:
           pip install py-rattler-build/dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
           python -c "import rattler_build; print(rattler_build.rattler_build_version())"
       - name: "Upload wheels"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         with:
           name: macos-wheels-x86_64
           path: py-rattler-build/dist
@@ -352,15 +304,15 @@ jobs:
     runs-on: macos-latest
     name: Python Build universal2-apple-macos
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           ref: ${{ inputs.sha }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
       - name: "Build wheels - universal2"
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@36db84001d74475ad1b8e6613557ae4ee2dc3598 # v1
         with:
           args: --release --target universal2-apple-darwin --out dist --no-default-features --features rustls-tls
           working-directory: py-rattler-build
@@ -369,7 +321,7 @@ jobs:
           pip install py-rattler-build/dist/${{ env.PACKAGE_NAME }}-*universal2.whl --force-reinstall
           python -c "import rattler_build; print(rattler_build.rattler_build_version())"
       - name: "Upload wheels"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         with:
           name: macos-wheels-universal2
           path: py-rattler-build/dist
@@ -380,7 +332,7 @@ jobs:
     # If you don't set an input tag, it's a dry run (no uploads).
     if: ${{ inputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           ref: main # We checkout the main branch to check for the commit
       - name: Check main branch
@@ -428,12 +380,12 @@ jobs:
       # For pypi trusted publishing
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
         with:
           merge-multiple: true
           path: wheels
       - name: Publish to PyPi
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # release/v1
         with:
           skip-existing: true
           packages-dir: wheels
@@ -449,7 +401,7 @@ jobs:
       # For git tag
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           ref: ${{ inputs.sha }}
       - name: git tag

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,14 +29,14 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@888c2e1ea69ab0d4330cbf0af1ecc7b68f368cc1 # master
         with:
           toolchain: "1.83.0"
           components: clippy,rustfmt
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2
       - name: Run tests
         run: cargo test --features=tui,recipe-generation --verbose -- --nocapture
 
@@ -91,7 +91,7 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Extract version
         shell: bash
@@ -112,7 +112,7 @@ jobs:
           fi
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@888c2e1ea69ab0d4330cbf0af1ecc7b68f368cc1 # master
         with:
           toolchain: "1.83.0"
           targets: ${{ matrix.target }}
@@ -125,11 +125,11 @@ jobs:
         if: matrix.target == 'powerpc64le-unknown-linux-gnu'
         run: sudo apt install libssl-dev
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2
 
       - name: Install cross
         if: matrix.use-cross
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@d7975a1de23014ff85d5da2d113615774467bcc1 # v2
         with:
           tool: cross
 
@@ -211,13 +211,13 @@ jobs:
           echo "binary-path=binaries/rattler-build-${{ matrix.target }}${{ contains(matrix.target, 'pc-windows') && '.exe' || '' }}" >> $GITHUB_OUTPUT
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         with:
           name: ${{ steps.package.outputs.pkg-name }}
           path: ${{ steps.package.outputs.pkg-path }}
 
       - name: Publish archives and packages
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2
         if: startsWith(github.ref, 'refs/tags/v')
         with:
           draft: true
@@ -229,7 +229,7 @@ jobs:
 
       - name: Create issue on failure
         if: startsWith(github.ref, 'refs/tags/v') && failure()
-        uses: dacbd/create-issue-action@cdb57ab6ff8862aa09fee2be6ba77a59581921c2
+        uses: dacbd/create-issue-action@cdb57ab6ff8862aa09fee2be6ba77a59581921c2 # cdb57ab6ff8862aa09fee2be6ba77a59581921c2
         with:
           token: ${{ github.token }}
           title: GitHub release failed
@@ -242,7 +242,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Set as latest release
         if: startsWith(github.ref, 'refs/tags/v')
         run: |


### PR DESCRIPTION
- pin external actions
- enforce sha also in the future

For motivation see https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised and https://michaelheap.com/pin-your-github-actions/