### PR TITLE
docs: Update to reference `host_platform` instead of `target_platform`

### DIFF
--- a/docs/build_script.md
+++ b/docs/build_script.md
@@ -390,7 +390,7 @@ macOS.
 | Variable                   | Description                                                                                                              |
 | -------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
 | `MACOSX_DEPLOYMENT_TARGET` | Same as the Anaconda Python macOS deployment target. Currently `10.9` for intel 32- and 64bit macOS, and 11.0 for arm64. |
-| `OSX_ARCH`                 | `i386` or `x86_64` or `arm64`, depending on the target platform                                                          |
+| `OSX_ARCH`                 | `i386` or `x86_64` or `arm64`, depending on the host platform                                                            |
 
 #### Linux
 

--- a/docs/compilers.md
+++ b/docs/compilers.md
@@ -3,7 +3,7 @@
 To use a compiler in your project, it's best to use the `${{ compiler('lang')
 }}` template function. The compiler function works by taking a language,
 determining the configured compiler for that language, and adding some
-information about the target platform to the selected compiler. To configure a
+information about the host platform to the selected compiler. To configure a
 compiler for a specific language, the `variants.yaml` file can be used.
 
 For example, in a recipe that uses a C-compiler, you can use the following code:
@@ -35,7 +35,7 @@ variant config.
 
 Cross-compilation is supported by Rattler-Build and the compiler template
 function is part of what makes it possible. When you want to cross-compile from
-`linux-64` to `linux-aarch64` (i.e. intel to ARM), you can pass `--target-platform
+`linux-64` to `linux-aarch64` (i.e. intel to ARM), you can pass `--host-platform
 linux-aarch64` to the `rattler-build` command. This will cause the compiler
 template function to select a compiler that is configured for `linux-aarch64`.
 The above example would resolve to `gcc_linux-aarch64 9.3.0`. Provided that the
@@ -57,7 +57,7 @@ build:
   - cmake
   - ${{ compiler('c') }}
 # packages that we want to link against in the architecture we are
-# cross-compiling to the target_platform
+# cross-compiling to the host_platform
 host:
   - libcurl
   - openssl

--- a/docs/conda_forge.md
+++ b/docs/conda_forge.md
@@ -83,7 +83,7 @@ Ensure your recipe includes all required metadata:
 The PR template includes a checklist. Key items:
 
 - [ ] License file is included in the package
-- [ ] Recipe builds on all target platforms
+- [ ] Recipe builds on all host platforms
 - [ ] Tests are included and pass
 - [ ] Recipe follows conda-forge guidelines
 - [ ] You've added yourself as a maintainer

--- a/docs/index.md
+++ b/docs/index.md
@@ -154,7 +154,7 @@ For the `curl` library recipe, two additional script files (`build.sh` and `buil
 # Get an updated config.sub and config.guess
 cp $BUILD_PREFIX/share/libtool/build-aux/config.* .
 
-if [[ $target_platform =~ linux.* ]]; then
+if [[ $host_platform =~ linux.* ]]; then
     USESSL="--with-openssl=${PREFIX}"
 else
     USESSL="--with-secure-transport"

--- a/docs/reference/jinja.md
+++ b/docs/reference/jinja.md
@@ -8,11 +8,11 @@ functions and filters that can be used in the recipe.
 ### The compiler function
 
 The compiler function can be used to put together a compiler that works for the
-current platform and the compilation "`target_platform`". The syntax looks like:
+current platform and the compilation "`host_platform`". The syntax looks like:
 `${{ compiler('c') }}` where `'c'` signifies the programming language that is
 used.
 
-This function evaluates to `<compiler>_<target_platform> <compiler_version>`.
+This function evaluates to `<compiler>_<host_platform> <compiler_version>`.
 For example, when compiling _on_ `linux` and _to_ `linux-64`, this function
 evaluates to `gcc_linux-64`.
 
@@ -38,9 +38,9 @@ c_compiler_version:
 ```
 
 The variables shown above would select the `clang` compiler in version `9.0`.
-Note that the final output will still contain the `target_platform`, so that the
+Note that the final output will still contain the `host_platform`, so that the
 full compiler will read `clang_linux-64 9.0` when compiling with
-`--target-platform linux-64`.
+`--host-platform linux-64`.
 
 Rattler-Build defines some default compilers for the following languages
 (inherited from `conda-build`):
@@ -54,11 +54,11 @@ Rattler-Build defines some default compilers for the following languages
 
 The `stdlib` function closely mirrors the compiler function. It can be used to
 put together a standard library that works for the current platform and the
-compilation "`target_platform`".
+compilation "`host_platform`".
 
 Usage: `${{ stdlib('c') }}`
 
-Results in `<stdlib>_<target_platform> <stdlib_version>`. And uses the variant
+Results in `<stdlib>_<host_platform> <stdlib_version>`. And uses the variant
 variables `<lang>_stdlib` and `<lang>_stdlib_version` to influence the output.
 
 #### Usage in a recipe:

--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -642,11 +642,11 @@ requirements:
 
 ### Host
 
-Represents packages that need to be specific to the target platform when the
-target platform is not necessarily the same as the native build platform. For
+Represents packages that need to be specific to the host platform when the
+host platform is not necessarily the same as the native build platform. For
 example, in order for a recipe to be "cross-capable", shared libraries
 requirements must be listed in the `host` section, rather than the `build` section,
-so that the shared libraries that get linked are ones for the target platform,
+so that the shared libraries that get linked are ones for the host platform,
 rather than the native build platform. You should also include the base
 interpreter for packages that need one. In other words, a Python package would
 list `python` here and an R package would list `mro-base` or `r-base`.
@@ -665,8 +665,8 @@ requirements:
 !!! note
     When both "`build`" and "`host`" sections are defined, the `build` section can
     be thought of as "build tools" - things that run on the native platform, but
-    output results for the target platform (e.g. a cross-compiler that runs on
-    `linux-64`, but targets `linux-armv7`).
+    output results for the host platform (e.g. a cross-compiler that runs on
+    `linux-64`, but builds for `linux-armv7`).
 
 
 The `PREFIX` environment variable points to the host prefix. With respect to
@@ -1374,7 +1374,7 @@ available during the Rattler-Build process: `pin_compatible`, `pin_subpackage`,
 `compiler` and `stdlib`.
 
 The `compiler` function takes `c`, `cxx`, `fortran` and other values as argument
-and automatically selects the right (cross-)compiler for the target platform.
+and automatically selects the right (cross-)compiler for the host platform.
 Similarly, `stdlib` function selects the right standard library dependencies.
 
 ```

--- a/docs/selectors.md
+++ b/docs/selectors.md
@@ -54,7 +54,7 @@ host:
 Other examples often found in the wild:
 
 ```yaml
-if: build_platform != target_platform ... # true if cross-platform build
+if: build_platform != host_platform ... # true if cross-platform build
 if: osx and arm64 ... # true for apple silicon (osx-arm64)
 if: linux and (aarch64 or ppc64le)) ... # true for linux ppc64le or linux-aarch64
 ```
@@ -65,14 +65,14 @@ The following variables are available during rendering of the recipe:
 
 | Variable             | Description                                                            |
 |----------------------|------------------------------------------------------------------------|
-| `target_platform`    | the configured `target_platform` for the build                         |
 | `build_platform`     | the configured `build_platform` for the build                          |
 | `host_platform`      | the configured `host_platform` for the build                           |
+| `target_platform`    | the configured `target_platform` for the build                         |
 | `linux`              | "true" if `host_platform` is Linux                                     |
 | `osx`                | "true" if `host_platform` is OSX / macOS                               |
 | `win`                | "true" if `host_platform` is Windows                                   |
 | `unix`               | "true" if `host_platform` is a Unix (macOS or Linux)                   |
-| `x86`, `x86_64`      | x86 32/64-bit Architecture (based on `host_platform`)                  |
+| `x86`, `x86_64`      | x86 32/64-bit Architecture                                             |
 | `aarch64`            | 64-bit Arm (if `host_platform` is `linux-aarch64`)                     |
 | `arm64`              | 64-bit Arm (if `host_platform` is `osx-arm64` or `win-arm64`)          |
 | `armV6l`, `armV7l`   | 32-bit Arm                                                             |

--- a/docs/snippets/recipes/linkerd.yaml
+++ b/docs/snippets/recipes/linkerd.yaml
@@ -3,12 +3,12 @@ package:
   version: 25.5.2
 
 source:
-  - if: target_platform == "linux-64"
+  - if: host_platform == "linux-64"
     then:
       url: https://github.com/linkerd/linkerd2/releases/download/edge-25.5.2/linkerd2-cli-edge-25.5.2-linux-amd64
       sha256: 55e7721ab0eb48217f239628b55517b7d663a962df18cdab180e5d42e45f83cb
       file_name: linkerd
-  - if: target_platform == "osx-arm64"
+  - if: host_platform == "osx-arm64"
     then:
       url: https://github.com/linkerd/linkerd2/releases/download/edge-25.5.2/linkerd2-cli-edge-25.5.2-darwin-arm64
       sha256: 405ddf3af0089bfece93d811c9bfb9f63e3a000e3f423163fc56690ef4d427cf

--- a/docs/tutorials/repackaging.md
+++ b/docs/tutorials/repackaging.md
@@ -15,10 +15,10 @@ This example shows how to repackage the `linkerd` binary. The `linkerd` binary i
 
 !!! note
 
-    To repackage the `linkerd` package on `osx-arm64` for `linux-64`, you can pass the `--target-platform` argument to `rattler-build`:
+    To repackage the `linkerd` package on `osx-arm64` for `linux-64`, you can pass the `--host-platform` argument to `rattler-build`:
 
     ```bash
-    rattler-build build --target-platform linux-64 linkerd
+    rattler-build build --host-platform linux-64 linkerd
     ```
 
 ## Adding system requirements

--- a/docs/tutorials/rust.md
+++ b/docs/tutorials/rust.md
@@ -9,8 +9,8 @@ This utility manages Cargo dependencies from the command line.
 
 !!! note
     The `${{ compiler(...) }}` functions are very useful in the context of cross-compilation.
-    When the function is evaluated it will insert the correct compiler (as selected with the variant config) as well the `target_platform`.
-    The "rendered" compiler will look like `rust_linux-64` when you are targeting the `linux-64` platform.
+    When the function is evaluated it will insert the correct compiler (as selected with the variant config) as well the `host_platform`.
+    The "rendered" compiler will look like `rust_linux-64` when you are building for the `linux-64` platform.
 
     You can read more about this in the [cross-compilation](../compilers.md) section.
 


### PR DESCRIPTION
Update the documentation throughout to replace the references to `target_platform` with `host_platform` where appropriate.  That said, unless I've missed some fine point, this means pretty much everywhere.