### PR TITLE
add toplevel recipe meta information

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -212,6 +212,35 @@ impl Output {
             let mut env_vars = env_vars::vars(&self, "BUILD");
             env_vars.extend(env_vars::os_vars(self.prefix(), &target_platform));
 
+            // We need to keep the PKG_NAME and PKG_VERSION for the build script consistent
+            // across different cache builds. To this end we use the top level metadata.
+            env_vars.insert(
+                "PKG_NAME".to_string(),
+                Some(
+                    self.recipe
+                        .top_level_recipe_metadata
+                        .as_ref()
+                        .map(|x| x.name.clone())
+                        .unwrap_or("cache".to_string()),
+                ),
+            );
+            env_vars.insert(
+                "PKG_VERSION".to_string(),
+                Some(
+                    self.recipe
+                        .top_level_recipe_metadata
+                        .as_ref()
+                        .map(|x| x.version.clone())
+                        .flatten()
+                        .map(|v| v.to_string())
+                        .unwrap_or("0.0.0".to_string()),
+                ),
+            );
+
+            env_vars.insert("PKG_HASH".to_string(), Some("".to_string()));
+            env_vars.insert("PKG_BUILDNUM".to_string(), Some("0".to_string()));
+            env_vars.insert("PKG_BUILD_STRING".to_string(), Some("".to_string()));
+
             // Reindex the channels
             let channels = build_reindexed_channels(&self.build_configuration, tool_configuration)
                 .await

--- a/src/recipe/parser/build.rs
+++ b/src/recipe/parser/build.rs
@@ -114,6 +114,9 @@ pub struct Build {
     /// Include files in the package
     #[serde(default, skip_serializing_if = "GlobVec::is_empty")]
     pub files: GlobVec,
+    /// Use the cache output for the build or not
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub use_cache: Option<UseCache>,
 }
 
 /// The build string can be either a user specified string, a resolved string or derived from the variant.

--- a/src/recipe/parser/output.rs
+++ b/src/recipe/parser/output.rs
@@ -246,7 +246,9 @@ pub fn find_outputs_from_src<S: SourceCode>(src: S) -> Result<Vec<Node>, Parsing
             }
         }
 
-        output_map.remove("recipe");
+        if let Some(recipe_node) = output_map.remove("recipe") {
+            output_map.insert("__top_level_recipe".into(), recipe_node);
+        }
 
         let recipe = match Node::try_from(output_node) {
             Ok(node) => node,


### PR DESCRIPTION
The idea is to add the top-level metadata (recipe: name / version) to be used as default names for the cache output so that we can workaround the problem of different $PKG_NAME / $PKG_VERSION in the cache output (which would also potentially negatively influence the reproducibility of packages that use the `cache` key).