### PR TITLE
fix(parser): enhance package name extraction logic in TryConvertNode

### DIFF
--- a/src/recipe/parser/package.rs
+++ b/src/recipe/parser/package.rs
@@ -167,7 +167,22 @@ impl TryConvertNode<PackageName> for RenderedNode {
 
 impl TryConvertNode<PackageName> for RenderedScalarNode {
     fn try_convert(&self, _name: &str) -> Result<PackageName, Vec<PartialParsingError>> {
-        PackageName::from_str(self.as_str())
+        let input = self.as_str();
+
+        let package_name_str = input
+            .split_once(' ')
+            .and_then(|(name, version)| {
+                if name.contains('_')
+                    && (version.starts_with('=') || version.chars().any(|c| c.is_ascii_digit()))
+                {
+                    Some(name)
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(input);
+
+        PackageName::from_str(package_name_str)
             .map_err(|err| vec![_partialerror!(*self.span(), ErrorKind::from(err),)])
     }
 }

--- a/src/recipe/parser/package.rs
+++ b/src/recipe/parser/package.rs
@@ -1,4 +1,6 @@
-use rattler_conda_types::{MatchSpec, PackageName, ParseStrictness, VersionWithSource};
+use std::str::FromStr;
+
+use rattler_conda_types::{PackageName, VersionWithSource};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -165,11 +167,8 @@ impl TryConvertNode<PackageName> for RenderedNode {
 
 impl TryConvertNode<PackageName> for RenderedScalarNode {
     fn try_convert(&self, _name: &str) -> Result<PackageName, Vec<PartialParsingError>> {
-        let input = self.as_str();
-        match MatchSpec::from_str(input, ParseStrictness::Strict) {
-            Ok(match_spec) => Ok(match_spec.name.expect("MatchSpec must have a name")),
-            Err(err) => Err(vec![_partialerror!(*self.span(), ErrorKind::from(err),)]),
-        }
+        PackageName::from_str(self.as_str())
+            .map_err(|err| vec![_partialerror!(*self.span(), ErrorKind::from(err),)])
     }
 }
 

--- a/src/recipe/parser/package.rs
+++ b/src/recipe/parser/package.rs
@@ -1,6 +1,4 @@
-use std::str::FromStr;
-
-use rattler_conda_types::{PackageName, VersionWithSource};
+use rattler_conda_types::{MatchSpec, PackageName, ParseStrictness, VersionWithSource};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -168,22 +166,10 @@ impl TryConvertNode<PackageName> for RenderedNode {
 impl TryConvertNode<PackageName> for RenderedScalarNode {
     fn try_convert(&self, _name: &str) -> Result<PackageName, Vec<PartialParsingError>> {
         let input = self.as_str();
-
-        let package_name_str = input
-            .split_once(' ')
-            .and_then(|(name, version)| {
-                if name.contains('_')
-                    && (version.starts_with('=') || version.chars().any(|c| c.is_ascii_digit()))
-                {
-                    Some(name)
-                } else {
-                    None
-                }
-            })
-            .unwrap_or(input);
-
-        PackageName::from_str(package_name_str)
-            .map_err(|err| vec![_partialerror!(*self.span(), ErrorKind::from(err),)])
+        match MatchSpec::from_str(input, ParseStrictness::Strict) {
+            Ok(match_spec) => Ok(match_spec.name.expect("MatchSpec must have a name")),
+            Err(err) => Err(vec![_partialerror!(*self.span(), ErrorKind::from(err),)]),
+        }
     }
 }
 

--- a/src/recipe/parser/requirements.rs
+++ b/src/recipe/parser/requirements.rs
@@ -569,6 +569,22 @@ impl TryConvertNode<IgnoreRunExports> for RenderedMappingNode {
 
         crate::validate_keys!(ignore_run_exports, self.iter(), by_name, from_package);
 
+        if let Some(by_name_node) = self.get("by_name") {
+            let specs: Vec<MatchSpec> = by_name_node.try_convert("by_name")?;
+            ignore_run_exports.by_name = specs
+                .into_iter()
+                .map(|ms| ms.name.expect("MatchSpec must have a name"))
+                .collect();
+        }
+
+        if let Some(from_package_node) = self.get("from_package") {
+            let specs: Vec<MatchSpec> = from_package_node.try_convert("from_package")?;
+            ignore_run_exports.from_package = specs
+                .into_iter()
+                .map(|ms| ms.name.expect("MatchSpec must have a name"))
+                .collect();
+        }
+
         Ok(ignore_run_exports)
     }
 }

--- a/test-data/recipes/test-parsing/recipe_ignore_run_exports.yaml
+++ b/test-data/recipes/test-parsing/recipe_ignore_run_exports.yaml
@@ -1,0 +1,14 @@
+package:
+  name: mypkg
+  version: '0.1.0'
+
+build:
+  number: 0
+
+requirements:
+  ignore_run_exports:
+    from_package:
+    - ${{ compiler('cxx') }}
+  build:
+    - ${{ compiler('c') }}
+    - ${{ compiler('cxx') }}

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -1418,7 +1418,7 @@ def test_ignore_run_exports(rattler_build: RattlerBuild, recipes: Path, tmp_path
     elif current_subdir.startswith("osx"):
         expected_compiler = f"clangxx_{current_subdir}"
     elif current_subdir.startswith("win"):
-        expected_compiler = f"vs2019_{current_subdir}"
+        expected_compiler = f"vs2017_{current_subdir}"
     else:
         pytest.fail(f"Unsupported platform for compiler check: {current_subdir}")
 

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -1425,5 +1425,10 @@ def test_ignore_run_exports(rattler_build: RattlerBuild, recipes: Path, tmp_path
     # verify ignore_run_exports is rendered correctly using the multiple-os expectation
     assert "requirements" in rendered_recipe["recipe"]
     assert "ignore_run_exports" in rendered_recipe["recipe"]["requirements"]
-    assert "from_package" in rendered_recipe["recipe"]["requirements"]["ignore_run_exports"]
-    assert rendered_recipe["recipe"]["requirements"]["ignore_run_exports"]["from_package"] == [expected_compiler]
+    assert (
+        "from_package"
+        in rendered_recipe["recipe"]["requirements"]["ignore_run_exports"]
+    )
+    assert rendered_recipe["recipe"]["requirements"]["ignore_run_exports"][
+        "from_package"
+    ] == [expected_compiler]


### PR DESCRIPTION
Fixes https://github.com/prefix-dev/rattler-build/issues/1445

```
package:
  name: mypkg
  version: '0.1.0'

build:
  number: 0

requirements:
  ignore_run_exports:
    from_package:
    - ${{ compiler('cxx') }}
  build:
    - ${{ stdlib('c') }}
    - ${{ compiler('c') }}
    - ${{ compiler('cxx') }}
```

```
c_compiler:
- clang
c_compiler_version:
- '16'
c_stdlib:
- macosx_deployment_target
c_stdlib_version:
- '11.0'
cxx_compiler:
- clangxx
cxx_compiler_version:
- '16'
```

Results in (i am on windows btw, just wanted to exactly reproduce the issue so used the same macos deps)

```
 ╭─ Finding outputs from recipe
 │ Loading variant config file: "recipe/issue_variant.yml"
 │ Found 1 variants
 │
 │ Build variant: mypkg-0.1.0-h3ee991f_0
 │
 │ ╭──────────────────────┬────────────────────────────╮
 │ │ Variant              ┆ Version                    │
 │ ╞══════════════════════╪════════════════════════════╡
 │ │ c_compiler           ┆ "clang"                    │
 │ │ c_compiler_version   ┆ "16"                       │
 │ │ c_stdlib             ┆ "macosx_deployment_target" │
 │ │ c_stdlib_version     ┆ "11.0"                     │
 │ │ cxx_compiler         ┆ "clangxx"                  │
 │ │ cxx_compiler_version ┆ "16"                       │
 │ │ target_platform      ┆ "win-64"                   │
 │ ╰──────────────────────┴────────────────────────────╯
 │
 ╰─────────────────── (took 0 seconds)

 ╭─ Running build for recipe: mypkg-0.1.0-h3ee991f_0
 │
 │ ╭─ Fetching source code
 │ │ No sources to fetch
 │ │
 │ ╰─────────────────── (took 0 seconds)
 │
 │ ╭─ Resolving environments
 │ │
 │ │ Resolving build environment:
 │ │   Platform: win-64 [__win=10.0.26100=0, __cuda=12.8=0, __archspec=1=skylake]
 │ │   Channels:
 │ │    - file:///C:/Users/deniz/rattler-build/output/
 │ │    - conda-forge
 │ │   Specs:
 │ │    - macosx_deployment_target_win-64 11.0.*
 │ │    - clang_win-64 16.*
 │ │    - clangxx_win-64 16.*
 │ │                                                                                                                      
 │ ╰─────────────────── (took 1 second)
 │
 ╰─────────────────── (took 1 second)
Error:   × Failed to resolve dependencies: Cannot solve the request because of: No candidates were found for
  │ macosx_deployment_target_win-64 11.0.*.
  │
  ╰─▶ Cannot solve the request because of: No candidates were found for macosx_deployment_target_win-64 11.0.*.
```
