### PR TITLE
The section header for menuinst was missing

### DIFF
--- a/docs/system_integration.md
+++ b/docs/system_integration.md
@@ -1,6 +1,6 @@
 # System Integration for Packages
 
-Packages provide software designed for diffent uses.
+Packages provide software designed for different uses.
 Each of these types may be used to satisfy broad use-cases.
 As such each use benefits from specific actions.
 

--- a/docs/system_integration.md
+++ b/docs/system_integration.md
@@ -1,4 +1,21 @@
-# System integration for packages
+# System Integration for Packages
+
+Packages provide software designed for diffent uses.
+Each of these types may be used to satisfy broad use-cases.
+As such each use benefits from specific actions.
+
+* CLI Applications : Shell Completion
+<!-- * Services (daemons) : Service Manager Registration -->
+* GUI Applications : Integration with Window Manager
+<!-- * Application Augmentation : Integration with the Target Framework -->
+* Libraries : Dependencies
+
+## Dependencies
+
+This is the base functionity of the conda package.
+
+
+## Integration with Window Manager
 
 When you are building packages, you might want to integrate with the system to install shortcuts, desktop icons, etc.
 
@@ -17,7 +34,7 @@ build:
 
 To learn more about installing menu items, please take a look at the [`menuinst` documentation](https://conda.github.io/menuinst/).
 
-## Installing shell completion scripts
+## Installation of Shell Completion
 
 Shell completion scripts are scripts that are sourced by the shell to provide tab-completion for commands.
 They are automatically picked up by `pixi` and other tools when they appear in the right location in your package.


### PR DESCRIPTION
Mostly this provides the missing heading for `menuinst`.
```
## Integration with Window Manager
```

It also makes provision for the other package system integration types:
See the following discussions:
* [Support for Services (damons)](https://github.com/prefix-dev/pixi/discussions/3575)
* [Support for Extension Packages](https://github.com/prefix-dev/pixi/discussions/3578)
* [Support for `menuinst`](https://github.com/prefix-dev/pixi/discussions/1894) with [CEP11](https://github.com/conda/ceps/blob/main/cep-0011.md)
