### PR TITLE
feat: add error handling for hypen in context variables

### DIFF
--- a/src/recipe/error.rs
+++ b/src/recipe/error.rs
@@ -168,6 +168,10 @@ pub enum ErrorKind {
     #[diagnostic(code(error::sequence_mixed_types))]
     SequenceMixedTypes((ValueKind, ValueKind)),
 
+    /// Error when a context variable name contains a hyphen.
+    #[diagnostic(code(error::invalid_context_variable_name))]
+    InvalidContextVariableName,
+
     /// Generic unspecified error. If this is returned, the call site should
     /// be annotated with context, if possible.
     #[diagnostic(code(error::other))]
@@ -287,6 +291,7 @@ impl fmt::Display for ErrorKind {
             ),
             ErrorKind::Other => write!(f, "an unspecified error occurred."),
             ErrorKind::ExperimentalOnly(s) => write!(f, "experimental only: `{}`.", s),
+            ErrorKind::InvalidContextVariableName => write!(f, "invalid context variable name."),
         }
     }
 }

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__context_variable_with_hyphen.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__context_variable_with_hyphen.snap
@@ -1,0 +1,17 @@
+---
+source: src/recipe/parser.rs
+expression: err
+---
+  × Failed to parse recipe
+
+Error: 
+  × invalid context variable name.
+   ╭─[3:11]
+ 2 │         context:
+ 3 │           foo-bar: baz
+   ·           ───┬───
+   ·              ╰── here
+ 4 │ 
+   ╰────
+  help: `context` variable names cannot contain hyphens (-) as they are not
+        valid in jinja expressions


### PR DESCRIPTION
closes #995

the issue was only mentioned the hyphen, i though dots would have a problem with jinja as well but i saw we already use `(jinja, &format!("context.{}", k.as_str()))?;` so i didn't continue with adding dots