### PR TITLE
feat: validate python_version specs in recipe parser

### DIFF
--- a/src/recipe/parser/snapshots/rattler_build__recipe__parser__test__test__python_parsing.snap
+++ b/src/recipe/parser/snapshots/rattler_build__recipe__parser__test__test__python_parsing.snap
@@ -1,16 +1,14 @@
 ---
 source: src/recipe/parser/test.rs
-assertion_line: 505
 expression: yaml_serde
-snapshot_kind: text
 ---
 - python:
     imports:
     - pandas
-    python_version: '3.10'
+    python_version: '>=3.10'
 - python:
     imports:
     - pandas
     python_version:
-    - '3.10'
-    - '3.12'
+    - '>=3.10'
+    - '>=3.12'

--- a/src/recipe/parser/test.rs
+++ b/src/recipe/parser/test.rs
@@ -549,11 +549,11 @@ mod test {
           - python:
               imports:
                 - pandas
-              python_version: "3.10"
+              python_version: ">=3.10"
           - python:
               imports:
                 - pandas
-              python_version: ["3.10", "3.12"]
+              python_version: [">=3.10", ">=3.12"]
         "#;
 
         // parse the YAML
@@ -576,7 +576,7 @@ mod test {
                 assert!(python.pip_check);
                 assert_eq!(
                     python.python_version,
-                    PythonVersion::Single("3.10".to_string())
+                    PythonVersion::Single(">=3.10".to_string())
                 );
             }
             _ => panic!("expected python test"),
@@ -590,7 +590,7 @@ mod test {
                 assert!(python.pip_check);
                 assert_eq!(
                     python.python_version,
-                    PythonVersion::Multiple(vec!["3.10".to_string(), "3.12".to_string()])
+                    PythonVersion::Multiple(vec![">=3.10".to_string(), ">=3.12".to_string()])
                 );
             }
             _ => panic!("expected python test"),

--- a/test-data/recipes/python-version-spec/recipe.yaml
+++ b/test-data/recipes/python-version-spec/recipe.yaml
@@ -1,0 +1,17 @@
+package:
+  name: test
+  version: 0.1.0
+
+build:
+  script:
+    - echo "test" > test.txt
+
+requirements:
+  build:
+    - python
+
+tests:
+  - python:
+      imports:
+        - time
+      python_version: "=.*"

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -1456,8 +1456,6 @@ def test_python_version_spec(
         rattler_build(*args, stderr=STDOUT)
 
     error_output = exc_info.value.output.decode("utf-8")
-    assert "invalid python version specification: =.*" in error_output
     assert (
-        "Use a valid version specification like '3.12', '3.12.*', or '>=3.12'"
-        in error_output
+        "failed to parse match spec: unable to parse version spec: =.*" in error_output
     )


### PR DESCRIPTION
closes #1493

I also change the args of the abi3 test to use --recipe, for some reason it would pick up the recipe file on the root folder without --recipe command. After improving the parser to use matchspec and making it more strict, it would just fail (since it was not using the correct recipe)