### PR TITLE
feat: add CarriageReturnToNewline wrapper for async reading

### DIFF
--- a/test-data/recipes/line-breaks/recipe.yaml
+++ b/test-data/recipes/line-breaks/recipe.yaml
@@ -19,4 +19,3 @@ build:
             sleep 0.1
           done
           echo -e "\ndone"
-

--- a/test-data/recipes/line-breaks/recipe.yaml
+++ b/test-data/recipes/line-breaks/recipe.yaml
@@ -1,0 +1,22 @@
+package:
+  name: test-cr
+  version: 0.0.0
+
+build:
+  number: 0
+  script:
+    content:
+      - if: win
+        then: |
+          powershell -Command "$count=1; while($count -le 10) { Write-Host -NoNewline ([char]13); Write-Host -NoNewline ('line ' + $count); Start-Sleep -Milliseconds 100; $count++ }; Write-Host ([char]10 + 'done')"
+      - if: unix
+        then: |
+          #!/usr/bin/env bash
+          set +x
+          set -eu
+          for i in {1..10}; do
+            echo -ne "\rline ${i}"
+            sleep 0.1
+          done
+          echo -e "\ndone"
+

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -1472,3 +1472,27 @@ def test_hatch_vcs_versions(rattler_build: RattlerBuild, recipes: Path, tmp_path
     assert (pkg / "info/index.json").exists()
     index = json.loads((pkg / "info/index.json").read_text())
     assert index["version"] == "0.1.0.dev12+ga47bad07"
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Test requires Windows PowerShell behavior")
+def test_line_breaks(rattler_build: RattlerBuild, recipes: Path, tmp_path: Path):
+    path_to_recipe = recipes / "line-breaks"
+    args = rattler_build.build_args(
+        path_to_recipe,
+        tmp_path,
+    )
+
+    output = check_output(
+        [str(rattler_build.path), *args], stderr=STDOUT, text=True, encoding="utf-8"
+    )
+    output_lines = output.splitlines()
+    found_lines = {i: False for i in range(1, 11)}
+    for line in output_lines:
+        for i in range(1, 11):
+            if f"line {i}" in line:
+                found_lines[i] = True
+
+    for i in range(1, 11):
+        assert found_lines[i], f"Expected to find 'line {i}' in the output"
+
+    assert any("done" in line for line in output_lines)


### PR DESCRIPTION
closes #1525

I needed some time to plan how to approach this. I had two options:

- Use async
- Use sync, spawn threads that wait for every line for output to reach them and return immediately

After some thinking and research specially reading this discussion https://users.rust-lang.org/t/avoid-async-rust-at-all-costs-comments-from-experts/105860/44 I decided to go with async approach since what we are dealing with about script's run returns are a lot close to network operations approach. So I decided to go with async approach. Checked the overall integration test result time, surprisingly it went from 118 seconds to 109 seconds now.

output: 
![image](https://github.com/user-attachments/assets/1720cf33-809d-4006-8e26-847e1da4ad0d)

On the visual changes, the old version would display the script's end line straight in blue line (they would overlap with each other) so that's fixed as well