### PR TITLE
chore: remove outdated URL from SSL test recipe

### DIFF
--- a/test-data/recipes/ssl_test/recipe.yaml
+++ b/test-data/recipes/ssl_test/recipe.yaml
@@ -3,8 +3,6 @@ package:
   version: 1.1.0
 
 source:
-  - url: http://www.inf.puc-rio.br/~roberto/lpeg/lpeg-1.1.0.tar.gz
-    sha256: 4b155d67d2246c1ffa7ad7bc466c1ea899bbc40fef0257cc9c03cecbaed4352a
   - url: https://untrusted-root.badssl.com/style.css
     sha256: 0e755b89c8859e52f62869c84913efb0d11c48734437c93c506c210be2157e6b
   - url: https://self-signed.badssl.com/icons/favicon-red.ico


### PR DESCRIPTION
@wolfv seems like their host is down so github runners are struggling, we are using badssl anyways so i removed them from recipe