### PR TITLE
fix: add `PWD` to env vars to fix some weird issues with conda-bash

### DIFF
--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -601,6 +601,9 @@ async fn run_process_with_replacements(
 
     command
         .current_dir(cwd)
+        // when using `pixi global install bash` the current work dir 
+        // causes some strange issues that are fixed when setting the `PWD`
+        .env("PWD", cwd)
         .args(&args[1..])
         .stdin(Stdio::null())
         .stdout(Stdio::piped())

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -601,7 +601,7 @@ async fn run_process_with_replacements(
 
     command
         .current_dir(cwd)
-        // when using `pixi global install bash` the current work dir 
+        // when using `pixi global install bash` the current work dir
         // causes some strange issues that are fixed when setting the `PWD`
         .env("PWD", cwd)
         .args(&args[1..])


### PR DESCRIPTION
I think this is quite harmless and makes pixi global installed `bash` work much nicer on macOS.