### PR TITLE
feat: add vswhere recipe and ensure environment variable directories exist

### DIFF
--- a/src/render/solver.rs
+++ b/src/render/solver.rs
@@ -313,6 +313,16 @@ pub async fn install_packages(
             )
         })?;
 
+    // Ensure required environment variable directories exist
+    let env_vars = crate::env_vars::os_vars(target_prefix, &target_platform);
+
+    // Create directories for path variables
+    for dir in env_vars.values().flatten() {
+        if dir.contains('/') || dir.contains('\\') {
+            let _ = tokio::fs::create_dir_all(dir).await;
+        }
+    }
+
     let installed_packages = PrefixRecord::collect_from_prefix(target_prefix)?;
 
     if !installed_packages.is_empty() && name.starts_with("host") {

--- a/test-data/recipes/package-content-tests/recipe-test-succeed.yaml
+++ b/test-data/recipes/package-content-tests/recipe-test-succeed.yaml
@@ -5,8 +5,13 @@ package:
 build:
   number: 0
   script:
-    - echo "Hello World" > %PREFIX%/test-execution.txt
-    - echo "Hello World" > %PREFIX%/Library/bin/rust.exe
+    - if: unix
+      then:
+        - echo "Hello World" > $PREFIX/test-execution.txt
+        - echo "Hello World" > $PREFIX/bin/rust
+      else:
+        - echo "Hello World" > %PREFIX%\test-execution.txt
+        - echo "Hello World" > %PREFIX%\Library\bin\rust.exe
 
 tests:
   - package_contents:

--- a/test-data/recipes/package-content-tests/recipe-test-succeed.yaml
+++ b/test-data/recipes/package-content-tests/recipe-test-succeed.yaml
@@ -3,14 +3,10 @@ package:
   version: 0.1.0
 
 build:
+  number: 0
   script:
-    - if: unix
-      then:
-        - echo "Hello World" > $PREFIX/test-execution.txt
-        - mkdir $PREFIX/bin && echo "Hello World" > $PREFIX/bin/rust
-      else:
-        - echo "Hello World" > %PREFIX%\test-execution.txt
-        - mkdir %PREFIX%\Library\bin && echo "Hello World" > %PREFIX%\Library\bin\rust.exe
+    - echo "Hello World" > %PREFIX%/test-execution.txt
+    - echo "Hello World" > %PREFIX%/Library/bin/rust.exe
 
 tests:
   - package_contents:

--- a/test-data/recipes/package-content-tests/recipe-test-succeed.yaml
+++ b/test-data/recipes/package-content-tests/recipe-test-succeed.yaml
@@ -8,7 +8,7 @@ build:
     - if: unix
       then:
         - echo "Hello World" > $PREFIX/test-execution.txt
-        - echo "Hello World" > $PREFIX/bin/rust
+        - mkdir $PREFIX/bin && echo "Hello World" > $PREFIX/bin/rust
       else:
         - echo "Hello World" > %PREFIX%\test-execution.txt
         - echo "Hello World" > %PREFIX%\Library\bin\rust.exe

--- a/test-data/recipes/vswhere/recipe.yaml
+++ b/test-data/recipes/vswhere/recipe.yaml
@@ -1,0 +1,36 @@
+context:
+  version: "3.1.7"
+
+package:
+  name: vswhere
+  version: ${{ version }}
+
+source:
+  - url: https://github.com/microsoft/vswhere/releases/download/${{ version }}/vswhere.exe
+    sha256: c54f3b7c9164ea9a0db8641e81ecdda80c2664ef5a47c4191406f848cc07c662
+    file_name: vswhere.exe
+  - url: https://raw.githubusercontent.com/microsoft/vswhere/master/LICENSE.txt
+    sha256: a1e41a01dd80dbe3f8ad5edebfd746e64ccff9c2aae3d8f47922746cf83204ef
+
+build:
+  number: 0
+  script: MOVE vswhere.exe %LIBRARY_BIN%\vswhere.exe
+  skip: not win
+
+tests:
+  - script:
+      - vswhere
+
+about:
+  homepage: https://github.com/microsoft/vswhere
+  license: MIT
+  license_file: LICENSE.txt
+  summary: CLI tool to locate Visual Studio 2017 and newer installations
+  description: |
+    vswhere is designed to be a redistributable, single-file executable that
+    can be used in build or deployment scripts to find where Visual Studio
+    - or other products in the Visual Studio family - is located.
+
+extra:
+  recipe-maintainers:
+    - wolfv

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -1496,3 +1496,10 @@ def test_line_breaks(rattler_build: RattlerBuild, recipes: Path, tmp_path: Path)
         assert found_lines[i], f"Expected to find 'line {i}' in the output"
 
     assert any("done" in line for line in output_lines)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="vswhere recipe only supports Windows")
+def test_vswhere(rattler_build: RattlerBuild, recipes: Path, tmp_path: Path):
+    rattler_build.build(recipes / "vswhere", tmp_path)
+    pkg = get_extracted_package(tmp_path, "vswhere")
+    assert (pkg / "Library/bin/vswhere.exe").exists()


### PR DESCRIPTION
closes #1576

while manually debugging i noticed and mentioned to @wolfv mkdir fixes the recipe, so checked further on why path envs were not being created as a folder even though they are being SET in the build script, turns out none of them were being created. I filter out the basic system information that is being SET in build script while trying to create the default PREFIX path folders here