### PR TITLE
feat: Implement retry logic for directory deletion on Windows

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,9 +5,11 @@ use fs_err as fs;
 use retry_policies::{RetryDecision, RetryPolicy, policies::ExponentialBackoff};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
+#[cfg(windows)]
+use std::time::Duration;
 use std::{
     path::{Component, Path, PathBuf},
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::{SystemTime, UNIX_EPOCH},
 };
 use walkdir::WalkDir;
 


### PR DESCRIPTION
closes #1431

It was extremely hard to reproduce this bug constantly, I could reproduce it 5 times, sixth time it would just vanish. The solution was obviously retrying for a few times after encountering the either OS error 5 or 32, so i just added unit tests that simulates this with a locked file.