### PR TITLE
docs: Fix s3 docs for force-path-style

### DIFF
--- a/docs/authentication_and_upload.md
+++ b/docs/authentication_and_upload.md
@@ -169,5 +169,5 @@ rattler-build upload s3 \
   --channel s3://my-bucket/my-channel \
   --region auto \
   --endpoint-url https://xyz.r2.cloudflarestorage.com \
-  --force-path-style true
+  --force-path-style
 ```

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -50,6 +50,11 @@ This document contains the help content for the `rattler-build` command-line pro
 	- Possible values: `true`, `false`
 
 
+- `--config-file <CONFIG_FILE>`
+
+	The rattler-build configuration file to use
+
+
 - `--color <COLOR>`
 
 	Enable or disable colored output from rattler-build. Also honors the `CLICOLOR` and `CLICOLOR_FORCE` environment variable


### PR DESCRIPTION
# Motivation

Fixes #1595.

# Changes

* Update docs
* Add clearer error message if user uses endpoint URL with IPv4 address and doesn't use `--force-path-style`