### PR TITLE
fix: properly link check on Windows

### DIFF
--- a/examples/linking/recipe.yaml
+++ b/examples/linking/recipe.yaml
@@ -10,9 +10,14 @@ source:
 
 build:
   script:
-    - cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release ${CMAKE_ARGS}
+    - if: win
+      then:
+        - cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release %CMAKE_ARGS%
+    - if: unix
+      then:
+        - cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release ${CMAKE_ARGS}
     - cmake --build build --config Release
-    - cmake --install build --prefix ${PREFIX}
+    - cmake --install build
 
 requirements:
   build:

--- a/src/post_process/package_nature.rs
+++ b/src/post_process/package_nature.rs
@@ -146,9 +146,9 @@ impl Hash for CaseInsensitivePathBuf {
     }
 }
 
-impl Into<CaseInsensitivePathBuf> for PathBuf {
-    fn into(self) -> CaseInsensitivePathBuf {
-        CaseInsensitivePathBuf { path: self }
+impl From<PathBuf> for CaseInsensitivePathBuf {
+    fn from(path: PathBuf) -> Self {
+        CaseInsensitivePathBuf { path }
     }
 }
 

--- a/src/post_process/package_nature.rs
+++ b/src/post_process/package_nature.rs
@@ -15,6 +15,7 @@
 use rattler_conda_types::{PackageName, PrefixRecord};
 use std::{
     collections::{HashMap, HashSet},
+    hash::Hash,
     ops::Sub,
     path::{Path, PathBuf},
 };
@@ -126,10 +127,43 @@ impl PackageNature {
     }
 }
 
+pub struct CaseInsensitivePathBuf {
+    path: PathBuf,
+}
+
+impl CaseInsensitivePathBuf {
+    fn normalize_path(&self) -> String {
+        self.path
+            .to_string_lossy()
+            .to_lowercase()
+            .replace('\\', "/")
+    }
+}
+
+impl Hash for CaseInsensitivePathBuf {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.normalize_path().hash(state);
+    }
+}
+
+impl Into<CaseInsensitivePathBuf> for PathBuf {
+    fn into(self) -> CaseInsensitivePathBuf {
+        CaseInsensitivePathBuf { path: self }
+    }
+}
+
+impl PartialEq for CaseInsensitivePathBuf {
+    fn eq(&self, other: &Self) -> bool {
+        self.normalize_path() == other.normalize_path()
+    }
+}
+
+impl Eq for CaseInsensitivePathBuf {}
+
 #[derive(Default)]
 pub(crate) struct PrefixInfo {
     pub package_to_nature: HashMap<PackageName, PackageNature>,
-    pub path_to_package: HashMap<PathBuf, PackageName>,
+    pub path_to_package: HashMap<CaseInsensitivePathBuf, PackageName>,
 }
 
 impl PrefixInfo {
@@ -149,10 +183,12 @@ impl PrefixInfo {
                         record.repodata_record.package_record.name.clone(),
                         package_nature,
                     );
+
                     for file in record.files {
-                        prefix_info
-                            .path_to_package
-                            .insert(file, record.repodata_record.package_record.name.clone());
+                        prefix_info.path_to_package.insert(
+                            file.into(),
+                            record.repodata_record.package_record.name.clone(),
+                        );
                     }
                 }
             }

--- a/src/windows/link.rs
+++ b/src/windows/link.rs
@@ -103,7 +103,10 @@ impl Relinker for Dll {
             let dll_name = lib.file_name().unwrap_or_default();
 
             // 1. Check in the same directory as the original DLL
-            let path_in_prefix = self.path.strip_prefix(prefix).unwrap();
+            let path_in_prefix = self
+                .path
+                .strip_prefix(prefix)
+                .expect("DLL path should be in prefix");
             let path = encoded_prefix.join(path_in_prefix);
             let same_dir = path.parent().map(|p| p.join(dll_name));
 


### PR DESCRIPTION
We were collecting the libraries that a specific library / executable is linking against, but we were not yet matching it up against the libraries installed by other packages or the system.

This is fixed now and we get output that looks like this:

<img width="533" alt="Screenshot 2025-04-29 at 14 50 45" src="https://github.com/user-attachments/assets/83b80de2-2df9-493f-8509-0c276497b6b5" />

This should also give more meaningful overlinking and overdependening analysis results.