### PR TITLE
feat: add log messages for patches applied

### DIFF
--- a/src/source/patch.rs
+++ b/src/source/patch.rs
@@ -55,6 +55,8 @@ pub(crate) fn apply_patches(
     for patch in patches {
         let patch = recipe_dir.join(patch);
 
+        tracing::info!("Applying patch: {}", patch.to_string_lossy());
+
         if !patch.exists() {
             return Err(SourceError::PatchNotFound(patch));
         }


### PR DESCRIPTION
This was suggested by @wolfv and @anjos on the conda-forge Zulip channel.

Add log messages for every patch applied to the build. So that package maintainers can verify that all patches are being correctly applied to the build when debugging build issues.

rattler-build does not output any log messages when it applies a patch. The only place the patches are listed is in the "Files in package:" section, but that is at the end of the build and is not shown if the build fails.

conda-build does log patches. Below is the patch info displayed when building conda-forge/dtc-package-feedstock.

```
Applying patch: /home/conda/recipe_root/patches/0001-tests-sw_tree1.c-fix-unitialized-saveptr.patch
Applying patch: /home/conda/recipe_root/patches/0001-tests-sw_tree1.c-fix-unitialized-saveptr.patch with args:
['-Np1', '-i', '/tmp/tmpi51vhcgx/0001-tests-sw_tree1.c-fix-unitialized-saveptr.patch.native', '--binary']
checking file tests/sw_tree1.c
patching file tests/sw_tree1.c
Applying patch: /home/conda/recipe_root/patches/0002-pylibfdt-libfdt.i-fix-backwards-compatibility-of-ret.patch
Applying patch: /home/conda/recipe_root/patches/0002-pylibfdt-libfdt.i-fix-backwards-compatibility-of-ret.patch with args:
['-Np1', '-i', '/tmp/tmph4twsx0e/0002-pylibfdt-libfdt.i-fix-backwards-compatibility-of-ret.patch.native', '--binary']
checking file pylibfdt/libfdt.i
patching file pylibfdt/libfdt.i
Patch analysis gives:
[[ RA-MD1LOVE ]] - [[             patches/0001-tests-sw_tree1.c-fix-unitialized-saveptr.patch ]]
[[ RA-MD1LOVE ]] - [[ patches/0002-pylibfdt-libfdt.i-fix-backwards-compatibility-of-ret.patch ]]

Key:

R :: Reversible                       A :: Applicable
Y :: Build-prefix patch in use        M :: Minimal, non-amalgamated
D :: Dry-runnable                     N :: Patch level (1 is preferred)
L :: Patch level not-ambiguous        O :: Patch applies without offsets
V :: Patch applies without fuzz       E :: Patch applies without emitting to stderr
```