### PR TITLE
fix: add a default constructor for the baseclient

### DIFF
--- a/src/tool_configuration.rs
+++ b/src/tool_configuration.rs
@@ -48,7 +48,7 @@ pub enum TestStrategy {
 }
 
 /// A client that can handle both secure and insecure connections
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct BaseClient {
     /// The standard client with SSL verification enabled
     client: ClientWithMiddleware,
@@ -407,12 +407,20 @@ impl ConfigurationBuilder {
         }
     }
 
+    /// Set the base client to use for network requests.
+    pub fn with_base_client(self, base_client: BaseClient) -> Self {
+        Self {
+            client: Some(base_client),
+            ..self
+        }
+    }
+
     /// Construct a [`Configuration`] from the builder.
     pub fn finish(self) -> Configuration {
         let cache_dir = self.cache_dir.unwrap_or_else(|| {
             rattler_cache::default_cache_dir().expect("failed to determine default cache directory")
         });
-        let client = self.client.expect("client not initialized");
+        let client = self.client.unwrap_or_default();
         let package_cache = PackageCache::new(cache_dir.join(rattler_cache::PACKAGE_CACHE_DIR));
         let channel_config = self.channel_config.unwrap_or_else(|| {
             ChannelConfig::default_with_root_dir(

--- a/src/tool_configuration.rs
+++ b/src/tool_configuration.rs
@@ -407,14 +407,6 @@ impl ConfigurationBuilder {
         }
     }
 
-    /// Set the base client to use for network requests.
-    pub fn with_base_client(self, base_client: BaseClient) -> Self {
-        Self {
-            client: Some(base_client),
-            ..self
-        }
-    }
-
     /// Construct a [`Configuration`] from the builder.
     pub fn finish(self) -> Configuration {
         let cache_dir = self.cache_dir.unwrap_or_else(|| {


### PR DESCRIPTION
## Overview

it would be nice to have a default constructor for the base client, and not panic on expect