### PR TITLE
feat: add cmake/pkg-config tests

### DIFF
--- a/examples/xtensor/recipe.yaml
+++ b/examples/xtensor/recipe.yaml
@@ -15,7 +15,7 @@ build:
 requirements:
   build:
     - ${{ compiler('cxx') }}
-    - cmake
+    - cmake <4
     - ninja
     - nushell
   host:
@@ -32,6 +32,10 @@ tests:
       files:
         - ${{ "Library/" if win }}share/cmake/xtensor/xtensorConfig.cmake
         - ${{ "Library/" if win }}share/cmake/xtensor/xtensorConfigVersion.cmake
+  - cmake:
+      find_package: [xtensor]
+  - pkg_config:
+      pkg_config: [xtensor]
 about:
   homepage: https://github.com/xtensor-stack/xtensor
   license: BSD-3-Clause

--- a/src/recipe/parser.rs
+++ b/src/recipe/parser.rs
@@ -48,8 +48,8 @@ pub use self::{
     script::{Script, ScriptContent},
     source::{GitRev, GitSource, GitUrl, PathSource, Source, UrlSource},
     test::{
-        CommandsTest, CommandsTestFiles, CommandsTestRequirements, DownstreamTest,
-        PackageContentsTest, PerlTest, PythonTest, PythonVersion, RTest, TestType,
+        CMakeTest, CommandsTest, CommandsTestFiles, CommandsTestRequirements, DownstreamTest,
+        PackageContentsTest, PerlTest, PkgConfigTest, PythonTest, PythonVersion, RTest, TestType,
     },
 };
 


### PR DESCRIPTION
Ideating some additional checks:

- test if cmake can execute `find_package` successfully
- test if pkg-config finds the package successfully

The `cmake` test unfortunately _requires_ compilers to be installed as CMake is going to search for them. 

For `pkg-config` I am not sure what to call the second key.

Tests look like:

```
  - cmake:
      find_package: [xtensor]
  - pkg_config:
      pkg_config: [xtensor]
```