### PR TITLE
fix: ignore python more for abi3 recipes

### DIFF
--- a/src/variant_config.rs
+++ b/src/variant_config.rs
@@ -536,6 +536,11 @@ impl VariantConfig {
                         .ignore_run_exports
                         .from_package
                         .insert("python".parse().unwrap());
+                    recipe
+                        .requirements
+                        .ignore_run_exports
+                        .by_name
+                        .insert("python".parse().unwrap());
                 }
 
                 recipes.insert(DiscoveredOutput {

--- a/test-data/recipes/abi3/recipe.yaml
+++ b/test-data/recipes/abi3/recipe.yaml
@@ -15,6 +15,8 @@ build:
 requirements:
   build:
     - ${{ compiler('c') }}
+    - if: host_platform != build_platform
+      then: cross-python_${{ host_platform }}
   host:
     - python-abi3
     - python


### PR DESCRIPTION
This fixes #1592 cc @isuruf
