### PR TITLE
fix: add delay for Windows in test execution

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -552,7 +552,7 @@ pub async fn run_build_from_args(
 
             // let testable = can_test(&test_queue, &all_output_names, &outputs_to_build);
             for (output, archive) in &to_test {
-            // we need a delay here to stop reindexing process undermine the filesystem lock in windows
+                // we need a delay here to stop reindexing process undermine the filesystem lock in windows
                 if cfg!(windows) {
                     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -552,6 +552,7 @@ pub async fn run_build_from_args(
 
             // let testable = can_test(&test_queue, &all_output_names, &outputs_to_build);
             for (output, archive) in &to_test {
+            // we need a delay here to stop reindexing process undermine the filesystem lock in windows
                 if cfg!(windows) {
                     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
                 }


### PR DESCRIPTION
currently after we make conda recognize rattler-build environments, we are dealing with reindexing file lock issues in windows where 13 tests fail due to file permission issues, quite esoteric ones as well with os error 1224. This adds a small delay before reindexing operations, which will solve all of these issues on windows. I also thought and tried to make the reindexing separate for tests but that would cause race condition issues, so i think this is the best solution

p.s: https://github.com/prefix-dev/rattler-build/pull/1613 we also need this for the retry logic on file removal

closes #1628