### PR TITLE
[WIP] try fixing missing http version

### DIFF
--- a/src/source/url_source.rs
+++ b/src/source/url_source.rs
@@ -72,7 +72,6 @@ async fn fetch_remote(
     let (mut response, download_size) = {
         let resp = client
             .get(url.as_str())
-            .version(reqwest::Version::HTTP_11)
             .send()
             .await
             .map_err(|e| {

--- a/src/source/url_source.rs
+++ b/src/source/url_source.rs
@@ -11,7 +11,7 @@ use crate::{
     console_utils::LoggingOutputHandler,
     recipe::parser::UrlSource,
     source::extract::{extract_tar, extract_zip},
-    tool_configuration::{self, APP_USER_AGENT},
+    tool_configuration,
 };
 use reqwest_middleware::Error as MiddlewareError;
 use tokio::io::AsyncWriteExt;
@@ -72,7 +72,7 @@ async fn fetch_remote(
     let (mut response, download_size) = {
         let resp = client
             .get(url.as_str())
-            .header(reqwest::header::USER_AGENT, APP_USER_AGENT)
+            .version(reqwest::Version::HTTP_11)
             .send()
             .await
             .map_err(|e| {

--- a/src/tool_configuration.rs
+++ b/src/tool_configuration.rs
@@ -77,6 +77,7 @@ impl BaseClient {
         let common_settings = |builder: reqwest::ClientBuilder| -> reqwest::ClientBuilder {
             builder
                 .no_gzip()
+                .http1_only()
                 .pool_max_idle_per_host(20)
                 .user_agent(APP_USER_AGENT)
                 .read_timeout(std::time::Duration::from_secs(timeout))


### PR DESCRIPTION
for #1608

I can reproduce the problem with the conda-forge builds, but can't when I build it myself, so I can't test this.

This currently tries setting http1_only on the client instead of http version in the request.