### PR TITLE
refactor: change PackageInfo fields to use Option types for optional binaries and pkgdocs

### DIFF
--- a/src/recipe_generator/cran.rs
+++ b/src/recipe_generator/cran.rs
@@ -42,11 +42,11 @@ pub struct PackageInfo {
     pub _distro: String,
     pub _host: String,
     pub _status: String,
-    pub _pkgdocs: String,
+    pub _pkgdocs: Option<String>,
     pub _srconly: Option<String>,
-    pub _winbinary: String,
-    pub _macbinary: String,
-    pub _wasmbinary: String,
+    pub _winbinary: Option<String>,
+    pub _macbinary: Option<String>,
+    pub _wasmbinary: Option<String>,
     pub _buildurl: String,
     pub _registered: bool,
     pub _dependencies: Vec<Dependency>,
@@ -303,8 +303,10 @@ pub async fn generate_r_recipe(opts: &CranOpts) -> miette::Result<()> {
     recipe.about.description = Some(package_info.Description.clone());
     (recipe.about.license, recipe.about.license_file) = map_license(&package_info.License);
     recipe.about.repository = Some(package_info._upstream.clone());
-    if url::Url::parse(&package_info._pkgdocs).is_ok() {
-        recipe.about.documentation = Some(package_info._pkgdocs.clone());
+    if let Some(pkgdocs) = &package_info._pkgdocs {
+        if url::Url::parse(pkgdocs).is_ok() {
+            recipe.about.documentation = Some(pkgdocs.clone());
+        }
     }
 
     recipe.tests.push(Test::Script(ScriptTest {


### PR DESCRIPTION
closes #1624

turns out we didn't need pkgdocs as a required field, as a lot of R packages have only a readme as documentation and they dont always provide precompiled binaries for all platforms as well. So I choose to use option types, we will still get them if they exist but i don't think we should make them required 