### PR TITLE
feat: auto detect license files from prefix directory as well

### DIFF
--- a/src/packaging.rs
+++ b/src/packaging.rs
@@ -116,7 +116,7 @@ fn copy_license_files(
         ),
         (
             &output.build_configuration.directories.work_dir,
-            "work directory",
+            "source directory",
             true,
         ),
         (
@@ -159,7 +159,7 @@ fn copy_license_files(
                 if files_j.contains(file) {
                     let warn_str = format!(
                         "License file '{}' from {} was overwritten by license file from {}",
-                        file.display(),
+                        file.file_name().unwrap_or_default().to_string_lossy(),
                         source_i_name,
                         source_j_name
                     );

--- a/test-data/recipes/double_license/recipe.yaml
+++ b/test-data/recipes/double_license/recipe.yaml
@@ -8,6 +8,20 @@ source:
 
 build:
   number: 0
+  script:
+    - if: unix
+      then:
+        - mkdir -p $PREFIX/license-folder/
+        - echo "prefix-license" > $PREFIX/license-folder/prefix-license.txt
+        - echo "source-license" > $SRC_DIR/source-license.txt
+      else:
+        - mkdir -p %PREFIX%\license-folder\
+        - echo "prefix-license" > %PREFIX%\license-folder\prefix-license.txt
+        - echo "source-license" > %SRC_DIR%\source-license.txt
 
 about:
-  license_file: license.txt
+  license_file:
+    - license.txt
+    - recipe_license.txt
+    - license-folder/prefix-license.txt
+    - source-license.txt

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -852,7 +852,7 @@ def test_double_license(rattler_build: RattlerBuild, recipes: Path, tmp_path: Pa
     path_to_recipe = recipes / "double_license"
     args = rattler_build.build_args(path_to_recipe, tmp_path)
     output = rattler_build(*args, stderr=STDOUT)
-    assert "warning License file from source directory was overwritten" in output
+    assert "warning License file 'license.txt' from work directory was overwritten by license file from recipe directory" in output
 
 
 @pytest.mark.skipif(

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -854,6 +854,12 @@ def test_double_license(rattler_build: RattlerBuild, recipes: Path, tmp_path: Pa
     output = rattler_build(*args, stderr=STDOUT)
     assert "warning License file 'license.txt' from work directory was overwritten by license file from recipe directory" in output
 
+    pkg = get_extracted_package(tmp_path, "double_license")
+    assert (pkg / "info/licenses/license.txt").exists()
+    assert (pkg / "info/licenses/recipe_license.txt").exists()
+    assert (pkg / "info/licenses/prefix-license.txt").exists()
+    assert (pkg / "info/licenses/source-license.txt").exists()
+
 
 @pytest.mark.skipif(
     os.name == "nt", reason="recipe does not support execution on windows"


### PR DESCRIPTION
This adds auto-detection from the `$PREFIX` as well.

@mfansler do you think this is acceptable? It would fix the Rust case. I would have to think a bit longer to find a good solution for `${{ PREFIX }}/foobar` case because the way we render the recipe, these variables are not available.