### PR TITLE
fix: normalize index name

### DIFF
--- a/src/packaging/metadata.rs
+++ b/src/packaging/metadata.rs
@@ -292,7 +292,7 @@ impl Output {
         };
 
         Ok(IndexJson {
-            name: self.name().clone(),
+            name: self.name().as_normalized().parse().expect("Should always be valid"),
             version: self.version().clone(),
             build: self.build_string().into_owned(),
             build_number: recipe.build().number(),

--- a/src/packaging/metadata.rs
+++ b/src/packaging/metadata.rs
@@ -291,8 +291,21 @@ impl Output {
             *self.recipe.build().noarch()
         };
 
+        if self.name().as_normalized() != self.name().as_source() {
+            tracing::warn!(
+                "The package name {} is not the same as the source name {}. Normalizing to {}.",
+                self.name().as_normalized(),
+                self.name().as_source(),
+                self.name().as_normalized()
+            );
+        }
+
         Ok(IndexJson {
-            name: self.name().as_normalized().parse().expect("Should always be valid"),
+            name: self
+                .name()
+                .as_normalized()
+                .parse()
+                .expect("Should always be valid"),
             version: self.version().clone(),
             build: self.build_string().into_owned(),
             build_number: recipe.build().number(),

--- a/src/recipe/error.rs
+++ b/src/recipe/error.rs
@@ -152,6 +152,10 @@ pub enum ErrorKind {
     #[diagnostic(code(error::package_name_parsing))]
     PackageNameParsing(#[from] rattler_conda_types::InvalidPackageNameError),
 
+    /// Error when parsing a [`PackageName`](rattler_conda_types::PackageName).
+    #[diagnostic(code(error::package_name_normalization))]
+    PackageNameNormalization(String),
+
     /// Error when parsing a [`EntryPoint`](rattler_conda_types::package::EntryPoint).
     #[diagnostic(code(error::entry_point_parsing))]
     EntryPointParsing(String),
@@ -279,6 +283,9 @@ impl fmt::Display for ErrorKind {
             }
             ErrorKind::PackageNameParsing(err) => {
                 write!(f, "failed to parse package name: {}", err)
+            }
+            ErrorKind::PackageNameNormalization(s) => {
+                write!(f, "input package name not normalized: {}", s)
             }
             ErrorKind::EntryPointParsing(err) => {
                 write!(f, "failed to parse entry point: {}", err)

--- a/src/recipe/parser/package.rs
+++ b/src/recipe/parser/package.rs
@@ -167,8 +167,18 @@ impl TryConvertNode<PackageName> for RenderedNode {
 
 impl TryConvertNode<PackageName> for RenderedScalarNode {
     fn try_convert(&self, _name: &str) -> Result<PackageName, Vec<PartialParsingError>> {
-        PackageName::from_str(self.as_str())
-            .map_err(|err| vec![_partialerror!(*self.span(), ErrorKind::from(err),)])
+        let name = PackageName::from_str(self.as_str())
+            .map_err(|err| vec![_partialerror!(*self.span(), ErrorKind::from(err),)])?;
+
+        if name.as_normalized() != name.as_source() {
+            return Err(vec![_partialerror!(
+                *self.span(),
+                ErrorKind::PackageNameNormalization(name.as_source().to_string()),
+                help = "package names are case insensitive, but the name is not normalized"
+            )]);
+        }
+
+        Ok(name)
     }
 }
 


### PR DESCRIPTION
This was failing because the un-normalized name made it into the index.json and then into the `repodata.json`:

```yaml
package:
  name: pyPept
  version: "1.0"

tests:
  - script:
      - exit 0
```