### PR TITLE
fix: `git apply` inside a subdirectory of a git repository

### DIFF
--- a/src/source/patch.rs
+++ b/src/source/patch.rs
@@ -150,7 +150,7 @@ pub(crate) fn apply_patches(
             .arg("--verbose")
             .arg("--ignore-space-change")
             .arg("--ignore-whitespace")
-            .arg("--inaccurate-eof")
+            .arg("--recount")
             .arg(patch_file_path.as_os_str())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());

--- a/src/source/patch.rs
+++ b/src/source/patch.rs
@@ -150,6 +150,7 @@ pub(crate) fn apply_patches(
             .arg("--verbose")
             .arg("--ignore-space-change")
             .arg("--ignore-whitespace")
+            .arg("--inaccurate-eof")
             .arg(patch_file_path.as_os_str())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());


### PR DESCRIPTION
This PR should fix #1670 .

### Description

The problem seemed to be that (apparently) some versions of `git` use the root directory of the repository as the root of the files described in the patch. If the working directory is a subdirectory of some git repository, running `git apply` will silently fail with `Skipping patch <path in patch>` (if run with `--verbose`).

I could obverse this behavior by running rattler-build with some patches. Wait for failure because the patches arent applied and then.

1) manually try applying the patch and observing git ignoring it.
2) initialize a git repository inside the working directory with `git init`.
3) retry applying the patch, this time it works as expected.

I could only observe this behavior on ubuntu using:

```
> git --version
git version 2.34.1
```

I did not see this behavior on Windows.

### Implementation

I did not find a combination of flags for `git apply` that could fix this issue, so instead I implemented a silly workaround: simply initialize a temporary git repository in the working directory. My implementation doesn't actually invoke `git init` but adds just the files and directories needed for `git` to think it is a git repository.

### Tests

I added a unit test that initializes a git repository in a temporary directory and then tries to apply a patch inside a sub directory. As expected, this fails with the code on `main`. With the changes from this PR, this succeeds.

I also tested this on the real-world example of libmodplug. With this PR the patches are successfully applied where previously they were silently ignored.

### Extras

The code now reads the output of the `git apply` run, regardless of whether the program returned a non-zero exit code. If it finds a line with `Skipped patch`, it raises an error and outputs the result. Patches are _explicitly_ added in the recipe, I do not think we should be silently skipping them even if it's for a good reason!

I changed the behavior of `--recount` slightly. The patches in `libmodplug` require it to be gone while the patch in this repository require it to be there. I opted to just try to run `git apply` with a combination of flags until we find one that works. `git apply` is atomic, so if it fails, no changes were made.

I also improved the error messages generated by the patch function in general:

```
Error:   × Failed to apply patch: 0001-fix-non-const-stack-alloc.patch
  │ `git apply` failed. The output of the command is:
  │
  │     Checking patch src/load_abc.cpp...
  │     error: while searching for:
  │                             }
  │                             *p = '\0';
  │                             abc_substitute(h, t, s);
  │                     }
  │             }
  │             else
  │     -
  │
  │     error: patch failed: src/load_abc.cpp:2272
  │     error: src/load_abc.cpp: patch does not apply
  │
  │ The command was invoked with:
  │
  │     /usr/bin/git apply -p1 --verbose --ignore-space-change --ignore-whitespace --recount /home/zalms/Developer/
  │ libmodplug-feedstock/recipe/0001-fix-non-const-stack-alloc.patch
```

### See also

https://stackoverflow.com/a/27283285