### PR TITLE
feat: add strict mode for package content tests to enforce file matching

### DIFF
--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -890,6 +890,10 @@ tests:
       bin:
         - mamba
 
+      # enable strict mode: error if any file in the package is not matched by one of the globs
+      # (default: false)
+      strict: true
+
       # searches for `$PREFIX/lib/libmamba.so` or `$PREFIX/lib/libmamba.dylib` on Linux or macOS,
       # on Windows for %PREFIX%\Library\lib\mamba.dll & %PREFIX%\Library\bin\mamba.bin
       lib:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -63,6 +63,15 @@ tests:
   - package_contents:
       files:
         - share/package/*.txt
+
+  # test with strict mode: fails if there are any files not matched by the globs
+  - package_contents:
+      strict: true
+      files:
+        - share/package/*.txt
+        - bin/myapp
+      lib:
+        - mylib
 ```
 
 ### Testing package contents
@@ -78,6 +87,7 @@ It has multiple sub-keys that help when building cross-platform packages:
 - **`include`**: matches files under the `include` directory in the package. You can specify the file name like `foo.h`.
 - **`bin`**: matches files under the `bin` directory in the package. You can specify executable names like `foo` which will match `foo.exe` on Windows and `foo` on Linux and macOS.
 - **`site_packages`**: matches files under the `site-packages` directory in the package. You can specify the import path like `foobar.api` which will match `foobar/api.py` and `foobar/api/__init__.py`.
+- **`strict`**: when set to `true`, enables strict mode. In strict mode, the test will fail if there are any files in the package that don't match any of the specified globs. (default: `false`).
 
 ## Testing existing packages
 

--- a/src/recipe/parser/snapshots/rattler_build__recipe__parser__test__test__script_parsing.snap
+++ b/src/recipe/parser/snapshots/rattler_build__recipe__parser__test__test__script_parsing.snap
@@ -32,9 +32,11 @@ expression: yaml_serde
     files:
     - foo
     - bar
+    strict: false
 - package_contents:
     lib:
     - libfoo.so
     - libbar.so
     include:
     - xtensor/xarray.hpp
+    strict: false

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__complete_recipe.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__complete_recipe.snap
@@ -169,6 +169,7 @@ tests:
     include:
     - test.h
     - test.h*
+    strict: false
 - python:
     imports:
     - numpy

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__recipe_windows.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__recipe_windows.snap
@@ -366,6 +366,7 @@ Recipe {
                 include: [
                     "xtensor/xarray.hpp{,/**}",
                 ],
+                strict: false,
             },
         },
         Command(

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__unix_recipe.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__unix_recipe.snap
@@ -388,6 +388,7 @@ Recipe {
                 include: [
                     "xtensor/xarray.hpp{,/**}",
                 ],
+                strict: false,
             },
         },
         Command(


### PR DESCRIPTION
closes https://github.com/prefix-dev/rattler-build/issues/1258

i kept the boolean approach since i don't think we need an enum for it, but would like to hear wolf's thoughts about it too