### PR TITLE
feat: disable .ignore files in source copying

### DIFF
--- a/src/source/copy_dir.rs
+++ b/src/source/copy_dir.rs
@@ -209,6 +209,8 @@ impl<'a> CopyDir<'a> {
             // ignore any .gitignore files from parent directories
             .parents(false)
             .git_ignore(self.use_gitignore)
+            // Always disable .ignore files - they should not affect source copying
+            .ignore(false)
             .hidden(self.hidden)
             .build()
             .filter_map(|entry| {

--- a/test-data/recipes/url-source-with-ignore/recipe.yaml
+++ b/test-data/recipes/url-source-with-ignore/recipe.yaml
@@ -1,0 +1,20 @@
+package:
+  name: test-url-source-ignore
+  version: 1.0.0
+
+source:
+  url: https://github.com/zed-industries/zed/archive/6f918ed99bfa107d496f7e6a7101a956494f3153.tar.gz
+  sha256: 8d9598aa5a7da38661f3968eaf8094a93cd7ae019b2750181c8da14ba13e7c07
+
+build:
+  script:
+    - if: unix
+      then:
+        - test -f tooling/workspace-hack/Cargo.toml || (echo "FAIL: Cargo.toml was ignored!" && exit 1)
+        - echo "SUCCESS: Cargo.toml was not ignored"
+      else:
+        - if not exist tooling\workspace-hack\Cargo.toml (echo FAIL: Cargo.toml was ignored! && exit 1)
+        - echo SUCCESS: Cargo.toml was not ignored
+
+about:
+  summary: Test that .ignore files don't affect URL sources

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -1937,3 +1937,20 @@ def test_extracted_timestamps(
         recipes / "timestamps/recipe.yaml",
         tmp_path,
     )
+
+
+def test_url_source_ignore_files(rattler_build: RattlerBuild, tmp_path: Path):
+    """Test that .ignore files don't affect URL sources."""
+    recipe_path = Path("test-data/recipes/url-source-with-ignore/recipe.yaml")
+
+    # This should succeed since we don't respect .ignore files anymore
+    rattler_build.build(
+        recipe_path,
+        tmp_path,
+    )
+
+    pkg = get_extracted_package(tmp_path, "test-url-source-ignore")
+    assert (pkg / "info/index.json").exists()
+    index_json = json.loads((pkg / "info/index.json").read_text())
+    assert index_json["name"] == "test-url-source-ignore"
+    assert index_json["version"] == "1.0.0"


### PR DESCRIPTION
closes #1693

it was relatively easy to fix actually, what we did before was:

- `.git_ignore(self.use_gitignore)` was not respecting .gitignore files, not even respecting buut, this for some reason respected `.ignore` files on `WalkBuilder`
- Added a false flag on `WalkBuilder` to not to respect `.ignore` files, also added a test and buildscript to check the `cargo.toml` specially. I tried to use a local zip file so that we don't download zed archieve, but i think we lack the relative path approach for urls there. Which might be a good idea to add in another pr.