### PR TITLE
fix: fix up error message

### DIFF
--- a/src/script/interpreter/bash.rs
+++ b/src/script/interpreter/bash.rs
@@ -11,7 +11,13 @@ pub(crate) struct BashInterpreter;
 
 fn print_debug_info(args: &ExecutionArgs) -> String {
     let mut output = String::new();
-    output.push_str("\nDebug mode enabled - not executing the script.\n\n");
+
+    if args.debug.is_enabled() {
+        output.push_str("\nDebug mode enabled - not executing the script.\n\n");
+    } else {
+        output.push_str("\nScript execution failed.\n\n");
+    }
+
     output.push_str(&format!("  Work directory: {}\n", args.work_dir.display()));
     output.push_str(&format!("  Prefix: {}\n", args.run_prefix.display()));
 

--- a/src/script/interpreter/cmd_exe.rs
+++ b/src/script/interpreter/cmd_exe.rs
@@ -9,7 +9,12 @@ use super::{CMDEXE_PREAMBLE, Interpreter, InterpreterError, find_interpreter};
 
 fn print_debug_info(args: &ExecutionArgs) -> String {
     let mut output = String::new();
-    output.push_str("Debug mode enabled - not executing the script. \n\nRun the script with the following arguments:\n");
+    if args.debug.is_enabled() {
+        output.push_str("\nDebug mode enabled - not executing the script.\n\n");
+    } else {
+        output.push_str("\nScript execution failed.\n\n")
+    }
+
     output.push_str(&format!("  Work directory: {}\n", args.work_dir.display()));
     output.push_str(&format!("  Prefix: {}\n", args.run_prefix.display()));
 


### PR DESCRIPTION
We always printed the `debug` message, but that is a little misleading when the script actually errored.