### PR TITLE
feat: serialize `extra_meta` when it is not none so that can rebuild perfectly

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -467,7 +467,7 @@ pub struct Output {
     /// Some extra metadata that should be recorded additionally in about.json
     /// Usually it is used during the CI build to record link to the CI job
     /// that created this artifact
-    #[serde(skip)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub extra_meta: Option<BTreeMap<String, Value>>,
 }
 


### PR DESCRIPTION
conda-forge packages use this to add some extra metadata to the `about.json` file. 

We did not serialize this data, and so it got lost when re-building. This should fix that.