### PR TITLE
Add support  for `pixi build`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ site
 # pixi environments
 .pixi
 target-pixi
+*.conda

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -242,6 +242,16 @@ e.g. `tar-bz2:<number>` (from 1 to 9) or `conda:<number>` (from -7 to
 	Enable debug output in build scripts
 
 
+- `--error-prefix-in-binary`
+
+	Error if the host prefix is detected in any binary files
+
+
+- `--allow-symlinks-on-windows`
+
+	Allow symlinks in packages on Windows (defaults to false - symlinks are forbidden on Windows)
+
+
 ###### **Sandbox arguments**
 
 - `--sandbox`

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,9 +1,13 @@
-[project]
+[workspace]
 name = "rattler-build"
 description = "Conda package builder, using the rattler rust backend"
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 channels = ["conda-forge"]
 platforms = ["linux-64", "win-64", "osx-64", "osx-arm64"]
+preview = ['pixi-build']
+
+[package]
+version = "0.0.0dev"
 
 [tasks]
 build-release = "cargo build --release"
@@ -107,3 +111,12 @@ default = { features = [
 ], solve-group = "default" } # Using same solve group to keep the environment consistent in versions used and improving cache hits
 docs = { features = ["docs"], no-default-feature = true }
 lint = { features = ["lint"], solve-group = "default" }
+
+# pixi build
+
+[package.build]
+backend = { name = "pixi-build-rattler-build", version = "0.1.*" }
+channels = [
+  "https://prefix.dev/pixi-build-backends",
+  "https://prefix.dev/conda-forge",
+]

--- a/pixi.toml
+++ b/pixi.toml
@@ -7,7 +7,7 @@ platforms = ["linux-64", "win-64", "osx-64", "osx-arm64"]
 preview = ['pixi-build']
 
 [package]
-version = "0.0.0dev"
+version = "0.0.0dev" # NOTE: how to set this automatically?
 
 [tasks]
 build-release = "cargo build --release"

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -1,0 +1,39 @@
+package:
+  name: rattler-build
+  # version: "${{ env.get('PIXI_BUILD_RUST_VERSION', default='0.1.0dev') }}"
+  version: "0.0.0dev"
+
+source:
+  path: .
+
+requirements:
+  build:
+    - ${{ compiler('rust') }}
+    - ${{ compiler('c') }}
+  host:
+    - ${{ "openssl" if linux }}
+  run:
+    - ${{ "patchelf" if linux }}
+
+build:
+  script:
+    - if: osx and x86_64
+      then:
+        - if [[ "${MACOSX_SDK_VERSION}" != "11.0" ]]; then exit 1; fi
+        # use the default linker for macOS as we are hitting a bug with the conda-forge linker
+        - unset CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER
+    - if: unix
+      then:
+        # Unix recipe
+        - export OPENSSL_DIR="$PREFIX"
+        - cargo install --locked --bin rattler-build --root ${PREFIX} --path . --no-track
+      else:
+        # Win recipe
+        # hack: path too long for pixi_config subpackage, https://github.com/prefix-dev/pixi/issues/3691
+        - set CARGO_HOME=C:\.cargo
+        - md %CARGO_HOME%
+        - cargo install --locked --bins --root %PREFIX% --path . --no-track
+        - if errorlevel 1 exit 1
+
+tests:
+  - script: rattler-build --help

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -1,7 +1,7 @@
 package:
   name: rattler-build
   # version: "${{ env.get('PIXI_BUILD_RUST_VERSION', default='0.1.0dev') }}"
-  version: "0.0.0dev"
+  version: "0.0.0dev" # NOTE: how to set this automatically?
 
 source:
   path: .


### PR DESCRIPTION
This is a simple POC adding support for `pixi build`. The motivation is to be able to simply and quickly test a custom `rattler-build` binary within a conda-forge feedstock. 

With this PR you can now tweak the `pixi.toml` of any feedstock that way:

```diff
@@ -3,20 +3,22 @@
 # -*- mode: toml -*-
 
 #                             VVVVVV  minimum `pixi` version
-"$schema" = "https://pixi.sh/v0.36.0/schema/manifest/schema.json"
+# "$schema" = "https://pixi.sh/v0.36.0/schema/manifest/schema.json"
 
-[project]
+[workspace]
 name = "katago-feedstock"
 version = "3.50.0"  # conda-smithy version used to generate this file
 description = "Pixi configuration for conda-forge/katago-feedstock"
 authors = ["@conda-forge/katago"]
 channels = ["conda-forge"]
-platforms = ["linux-64", "osx-64", "win-64"]
+platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+preview = ["pixi-build"]
 
 [dependencies]
 conda-build = ">=24.1"
 conda-forge-ci-setup = "4.*"
-rattler-build = "*"
+# rattler-build = "*"
+rattler-build = { git = "https://github.com/hadim/rattler-build.git", branch = "pixi_build" }
 
 [tasks]
 [tasks.inspect-all]
```

Simply set the location of `rattler-build` repo or URL you want to test with `rattler-build = { git = "https://github.com/hadim/rattler-build.git", branch = "pixi_build" }` and then the c-f feedstock will build it and use it during the c-f builds on the c-f CIs.

---

This POC is leveraging the `pixi-build-rattler-build` backend but moving forward it might make sense to use `pixi-build-rust` instead.