### PR TITLE
feat: add support for Git and path dependencies in recipe parsing and variant resolution

### DIFF
--- a/src/recipe/parser.rs
+++ b/src/recipe/parser.rs
@@ -42,8 +42,8 @@ pub use self::{
     package::{OutputPackage, Package},
     regex::SerializableRegex,
     requirements::{
-        Dependency, IgnoreRunExports, Language, PinCompatible, PinSubpackage, Requirements,
-        RunExports,
+        Dependency, GitDependency, IgnoreRunExports, Language, PathDependency, PinCompatible,
+        PinSubpackage, Requirements, RunExports,
     },
     script::{Script, ScriptContent},
     source::{GitRev, GitSource, GitUrl, PathSource, Source, UrlSource},


### PR DESCRIPTION
closes https://github.com/prefix-dev/rattler-build/issues/1722

i also used async for git deps resolution in requirements as that was my only idea that i could think of. 