### PR TITLE
refactor: remove `license_url` from package specification and related structures

### DIFF
--- a/docs/package_spec.md
+++ b/docs/package_spec.md
@@ -198,10 +198,6 @@ in the build recipe:
 
 : The URL of the documentation of the package.
 
-`license_url: url`
-
-: The URL of the license of the package.
-
 `license: string (from about.license)`
 
 : The SPDX license identifier of the package.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -242,6 +242,16 @@ e.g. `tar-bz2:<number>` (from 1 to 9) or `conda:<number>` (from -7 to
 	Enable debug output in build scripts
 
 
+- `--error-prefix-in-binary`
+
+	Error if the host prefix is detected in any binary files
+
+
+- `--allow-symlinks-on-windows`
+
+	Allow symlinks in packages on Windows (defaults to false - symlinks are forbidden on Windows)
+
+
 ###### **Sandbox arguments**
 
 - `--sandbox`

--- a/src/recipe/parser/about.rs
+++ b/src/recipe/parser/about.rs
@@ -42,9 +42,6 @@ pub struct About {
     /// The license file(s) of the package.
     #[serde(default, skip_serializing_if = "GlobVec::is_empty")]
     pub license_file: GlobVec,
-    /// The license URL of the package.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub license_url: Option<Url>,
     /// The summary of the package.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub summary: Option<String>,
@@ -84,7 +81,6 @@ impl TryConvertNode<About> for RenderedMappingNode {
             license,
             license_family,
             license_file,
-            license_url,
             summary,
             description,
             prelink_message

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__recipe_windows.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__recipe_windows.snap
@@ -457,7 +457,6 @@ Recipe {
         license_file: [
             "LICENSE{,/**}",
         ],
-        license_url: None,
         summary: Some(
             "The C++ tensor algebra library",
         ),

--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__unix_recipe.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__unix_recipe.snap
@@ -480,7 +480,6 @@ Recipe {
         license_file: [
             "LICENSE{,/**}",
         ],
-        license_url: None,
         summary: Some(
             "The C++ tensor algebra library",
         ),


### PR DESCRIPTION
closes https://github.com/prefix-dev/rattler-build/issues/1730