### PR TITLE
fix: use `fs_err` for invalid source path

### DIFF
--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -202,7 +202,9 @@ pub(crate) async fn fetch_source(
             rendered_sources.push(Source::Url(src.clone()));
         }
         Source::Path(src) => {
-            let src_path = recipe_dir.join(src.path()).canonicalize()?;
+            let rel_src_path = src.path();
+            tracing::debug!("Processing source path '{}'", rel_src_path.display());
+            let src_path = fs::canonicalize(recipe_dir.join(rel_src_path))?;
             tracing::info!("Fetching source from path: {}", src_path.display());
 
             let dest_dir = if let Some(target_directory) = src.target_directory() {


### PR DESCRIPTION
before: closes gh-1739

after:

```console
❯ rattler-build build     

 ╭─ Finding outputs from recipe
 │ Found 1 variants
 │ 
 │ Build variant: foo-0.1.0-h60d57d3_0
 │ 
 │ ╭─────────────────┬─────────────╮
 │ │ Variant         ┆ Version     │
 │ ╞═════════════════╪═════════════╡
 │ │ target_platform ┆ "osx-arm64" │
 │ ╰─────────────────┴─────────────╯
 │
 ╰─────────────────── (took 0 seconds)
Error:   × IO Error: failed to canonicalize path `/Users/lucascolley/programming/pixi-sandbox/temp3/bar`: No such file or directory (os error 2)
  ╰─▶ failed to canonicalize path `/Users/lucascolley/programming/pixi-sandbox/temp3/bar`: No such file or directory (os error 2)

❯ rattler-build build -v  
2025-06-24T16:21:00.237982Z DEBUG rattler_build::opt: Using mirrors: {}
2025-06-24T16:21:00.507120Z DEBUG rattler_build: Platforms: build: osx-arm64, host: osx-arm64, target: osx-arm64
Found 1 variants


Build variant: foo-0.1.0-h60d57d3_0

╭─────────────────┬─────────────╮
│ Variant         ┆ Version     │
╞═════════════════╪═════════════╡
│ target_platform ┆ "osx-arm64" │
╰─────────────────┴─────────────╯

2025-06-24T16:21:00.507623Z DEBUG rattler_build: Ordered output: "foo"
2025-06-24T16:21:00.507786Z DEBUG Running build for{recipe="foo-0.1.0-h60d57d3_0"}:Fetching source code: rattler_build::source: Processing source path 'bar'
Error:   × IO Error: failed to canonicalize path `/Users/lucascolley/programming/pixi-sandbox/temp3/bar`: No such file or directory (os error 2)
  ╰─▶ failed to canonicalize path `/Users/lucascolley/programming/pixi-sandbox/temp3/bar`: No such file or directory (os error 2)
```
