### PR TITLE
delimit case-insensitive file matches with newline-space-hyphen instead of comma-space

### DIFF
--- a/src/packaging.rs
+++ b/src/packaging.rs
@@ -477,9 +477,9 @@ pub fn package_conda(
             .iter()
             .map(|p| p.display().to_string())
             .collect::<Vec<_>>()
-            .join(", ");
+            .join("\n  - ");
         let warn_str = format!(
-            "Mixed-case filenames detected, case-insensitive filesystems may break: {}",
+            "Mixed-case filenames detected, case-insensitive filesystems may break:  - {}",
             list
         );
         tracing::error!(warn_str);

--- a/src/packaging.rs
+++ b/src/packaging.rs
@@ -479,7 +479,7 @@ pub fn package_conda(
             .collect::<Vec<_>>()
             .join("\n  - ");
         let warn_str = format!(
-            "Mixed-case filenames detected, case-insensitive filesystems may break:  - {}",
+            "Mixed-case filenames detected, case-insensitive filesystems may break:\n  - {}",
             list
         );
         tracing::error!(warn_str);

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -1576,8 +1576,8 @@ about:
         r"\n  - case_test/case-file.txt"
     )
 
-    assert (
-        re.search(collision_warning_pattern, output, flags=re.IGNORECASE)
+    assert re.search(
+        collision_warning_pattern, output, flags=re.IGNORECASE
     ), f"Case collision warning not found in build output. Output contains:\n{output}"
 
 

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -2,6 +2,7 @@ import hashlib
 import json
 import os
 import platform
+import re
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -1569,11 +1570,14 @@ about:
         "regular-file.txt" in extracted_files_list
     ), "regular-file.txt not found in package"
 
-    collision_warning_pattern1 = "Mixed-case filenames detected, case-insensitive filesystems may break: case_test/CASE-FILE.txt, case_test/case-file.txt"
-    collision_warning_pattern2 = "Mixed-case filenames detected, case-insensitive filesystems may break: case_test/case-file.txt, case_test/CASE-FILE.txt"
+    collision_warning_pattern = (
+        r"Mixed-case filenames detected, case-insensitive filesystems may break:"
+        r"\n  - case_test/CASE-FILE.txt"
+        r"\n  - case_test/case-file.txt"
+    )
 
     assert (
-        collision_warning_pattern1 in output or collision_warning_pattern2 in output
+        re.search(collision_warning_pattern, output, flags=re.IGNORECASE)
     ), f"Case collision warning not found in build output. Output contains:\n{output}"
 
 


### PR DESCRIPTION
## references
- for #1756

## changes
- [x] replace `, ` delimiter with `\n  -` for mixed case file name warning