### PR TITLE
fix: add more unit tests and simplify normalize path logic

### DIFF
--- a/src/packaging.rs
+++ b/src/packaging.rs
@@ -582,13 +582,14 @@ impl Output {
 #[cfg(test)]
 mod packaging_tests {
     use super::*;
-    use std::ffi::OsStr;
     use std::path::Path;
 
     #[cfg(unix)]
+    use std::ffi::OsStr;
+    #[cfg(unix)]
     use std::os::unix::ffi::OsStrExt;
     #[cfg(windows)]
-    use std::os::windows::ffi::OsStrExt;
+    use std::os::windows::ffi::OsStringExt;
 
     #[test]
     fn test_find_case_insensitive_collisions_detects() {
@@ -770,7 +771,8 @@ mod packaging_tests {
     fn test_normalize_path_for_comparison_invalid_unicode_windows() {
         // Invalid UTF-16 sequence
         let invalid_utf16: &[u16] = &[0x0043, 0x003A, 0xD800, 0x005C];
-        let path = Path::new(OsStr::from_wide(invalid_utf16));
+        let os_string = std::ffi::OsString::from_wide(invalid_utf16);
+        let path = Path::new(&os_string);
 
         let result = normalize_path_for_comparison(path, false);
         assert!(matches!(

--- a/src/packaging.rs
+++ b/src/packaging.rs
@@ -3,7 +3,7 @@
 use std::{
     collections::{HashMap, HashSet},
     io::Write,
-    path::{Component, MAIN_SEPARATOR, Path, PathBuf},
+    path::{Component, Path, PathBuf},
 };
 
 use fs_err as fs;
@@ -296,15 +296,17 @@ fn normalize_path_for_comparison(
     let estimated_capacity = path.as_os_str().len() * 6 / 5 + path.components().count();
     let mut normalized = String::with_capacity(estimated_capacity);
 
+    let separator = '/';
+
     for c in path.components() {
         match c {
             Component::CurDir => continue,
             Component::RootDir => {
-                normalized.push(MAIN_SEPARATOR);
+                normalized.push(separator);
             }
             Component::Prefix(_) | Component::ParentDir | Component::Normal(_) => {
-                if !normalized.is_empty() && !normalized.ends_with(MAIN_SEPARATOR) {
-                    normalized.push(MAIN_SEPARATOR);
+                if !normalized.is_empty() && !normalized.ends_with(separator) {
+                    normalized.push(separator);
                 }
 
                 let os_str = match c {

--- a/src/packaging.rs
+++ b/src/packaging.rs
@@ -809,7 +809,7 @@ mod packaging_tests {
     #[cfg(windows)]
     #[test]
     fn test_normalize_path_for_comparison_mixed_separators() {
-        let path = Path::new(r"foo/baraz");
+        let path = Path::new(r"foo/bar\baz");
         let normalized = normalize_path_for_comparison(path, false).unwrap();
         assert_eq!(normalized, "foo/bar/baz");
     }


### PR DESCRIPTION
This code should not warn anymore about: `foo/test.py` == `footest.py`