### PR TITLE
chore: switch to `pixi-build-rust`

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -117,7 +117,7 @@ lint = { features = ["lint"], solve-group = "default" }
 # pixi build
 
 [package.build]
-backend = { name = "pixi-build-rattler-build", version = "0.1.*" }
+backend = { name = "pixi-build-rust", version = "0.1.*" }
 channels = [
   "https://prefix.dev/pixi-build-backends",
   "https://prefix.dev/conda-forge",


### PR DESCRIPTION
https://github.com/prefix-dev/rattler-build/pull/1716#issuecomment-3018982570
