### PR TITLE
feat: allow prefixes to be created outside of rattler-build

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -127,7 +127,7 @@ pub async fn run_build(
         .await
         .into_diagnostic()?;
 
-    output
+    let output = output
         .install_environments(tool_configuration)
         .await
         .into_diagnostic()?;

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -222,9 +222,20 @@ impl Output {
                 .await
                 .into_diagnostic()
                 .context("failed to reindex output channel")?;
+            // Merge output-specific ignore_run_exports into cache requirements for cache build stage
+            let mut cache_requirements = cache.requirements.clone();
+            let output_ignore = self.recipe.requirements.ignore_run_exports(None);
+            cache_requirements
+                .ignore_run_exports
+                .by_name
+                .extend(output_ignore.by_name.iter().cloned());
+            cache_requirements
+                .ignore_run_exports
+                .from_package
+                .extend(output_ignore.from_package.iter().cloned());
 
             let finalized_dependencies =
-                resolve_dependencies(&cache.requirements, &self, &channels, tool_configuration)
+                resolve_dependencies(&cache_requirements, &self, &channels, tool_configuration)
                     .await
                     .unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -399,6 +399,8 @@ pub async fn get_build_output(
             finalized_sources: None,
             finalized_cache_dependencies: None,
             finalized_cache_sources: None,
+            finalized_host_prefix: None,
+            finalized_build_prefix: None,
             system_tools: SystemTools::new(),
             build_summary: Arc::new(Mutex::new(BuildSummary::default())),
             extra_meta: Some(
@@ -1079,7 +1081,7 @@ pub async fn debug_recipe(
             .resolve_dependencies(&tool_config)
             .await
             .into_diagnostic()?;
-        output
+        let output = output
             .install_environments(&tool_config)
             .await
             .into_diagnostic()?;

--- a/src/package_test/run_test.rs
+++ b/src/package_test/run_test.rs
@@ -858,7 +858,7 @@ impl CommandsTest {
                 &test_dir,
                 path,
                 &run_prefix,
-                build_prefix.as_ref(),
+                build_prefix.as_deref(),
                 None,
                 None,
                 config.debug,

--- a/src/packaging.rs
+++ b/src/packaging.rs
@@ -92,8 +92,9 @@ pub enum PackagingError {
 }
 
 /// This function copies the license files to the info/licenses folder.
-/// License files are selected from the recipe directory and the source (work) folder.
-/// If the same file is found in both locations, the file from the recipe directory is used.
+/// License files are selected from the recipe directory and the source (work)
+/// folder. If the same file is found in both locations, the file from the
+/// recipe directory is used.
 fn copy_license_files(
     output: &Output,
     tmp_dir_path: &Path,
@@ -270,8 +271,9 @@ pub enum PathNormalizationError {
 
 /// Normalizes a component string for comparison.
 ///
-/// This helper function applies Unicode normalization (NFKC) and optional case folding to a path component.
-/// When case folding is applied, it's done in a way that properly handles special Unicode cases.
+/// This helper function applies Unicode normalization (NFKC) and optional case
+/// folding to a path component. When case folding is applied, it's done in a
+/// way that properly handles special Unicode cases.
 fn normalize_component(component_str: &str, to_lowercase: bool) -> String {
     if to_lowercase {
         let normalized = component_str.nfkc().collect::<String>();
@@ -570,7 +572,9 @@ impl Output {
         let span = tracing::info_span!("Packaging new files");
         let _enter = span.enter();
         let files_after = Files::from_prefix(
-            &self.build_configuration.directories.host_prefix,
+            self.prefix()
+                .expect("the prefix must have been set at this point")
+                .path(),
             self.recipe.build().always_include_files(),
             self.recipe.build().files(),
         )?;
@@ -581,15 +585,15 @@ impl Output {
 
 #[cfg(test)]
 mod packaging_tests {
-    use super::*;
-    use std::path::Path;
-
     #[cfg(unix)]
     use std::ffi::OsStr;
     #[cfg(unix)]
     use std::os::unix::ffi::OsStrExt;
     #[cfg(windows)]
     use std::os::windows::ffi::OsStringExt;
+    use std::path::Path;
+
+    use super::*;
 
     #[test]
     fn test_find_case_insensitive_collisions_detects() {
@@ -738,7 +742,8 @@ mod packaging_tests {
         let normalized_case_sensitive = normalize_path_for_comparison(path, false).unwrap();
         let normalized_case_insensitive = normalize_path_for_comparison(path, true).unwrap();
 
-        // Current dir components (.) are skipped, but parent dir (..) and other components are preserved
+        // Current dir components (.) are skipped, but parent dir (..) and other
+        // components are preserved
         assert_eq!(normalized_case_sensitive, "Foo/../Bar/Baz.TXT");
         assert_eq!(normalized_case_insensitive, "foo/../bar/baz.txt");
     }

--- a/src/packaging/file_finder.rs
+++ b/src/packaging/file_finder.rs
@@ -240,6 +240,12 @@ impl Files {
 }
 
 impl TempFiles {
+    /// Clear all files and content type information
+    pub fn clear(&mut self) {
+        self.files.clear();
+        self.content_type_map.clear();
+    }
+
     /// Add files to the TempFiles struct
     pub fn add_files<I>(&mut self, files: I)
     where

--- a/src/render/solver.rs
+++ b/src/render/solver.rs
@@ -11,6 +11,7 @@ use futures::FutureExt;
 use indicatif::{HumanBytes, ProgressBar, ProgressStyle};
 use itertools::Itertools;
 use rattler::install::{DefaultProgressFormatter, IndicatifReporter, Installer};
+use rattler_conda_types::prefix::Prefix;
 use rattler_conda_types::{Channel, ChannelUrl, MatchSpec, Platform, PrefixRecord, RepoDataRecord};
 use rattler_solve::{ChannelPriority, SolveStrategy, SolverImpl, SolverTask, resolvo::Solver};
 use url::Url;
@@ -306,7 +307,7 @@ pub async fn install_packages(
     target_platform: Platform,
     target_prefix: &Path,
     tool_configuration: &tool_configuration::Configuration,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<Prefix> {
     // Make sure the target prefix exists, regardless of whether we'll actually
     // install anything in there.
     let prefix = rattler_conda_types::prefix::Prefix::create(target_prefix).with_context(|| {
@@ -371,5 +372,5 @@ pub async fn install_packages(
         console::style(console::Emoji("✔", "")).green(),
     );
 
-    Ok(())
+    Ok(prefix)
 }

--- a/src/source/patch.rs
+++ b/src/source/patch.rs
@@ -150,6 +150,7 @@ fn write_patch_content(content: &[u8], path: &Path) -> Result<(), SourceError> {
             #[cfg(not(unix))]
             {
                 // Assume this means windows
+                #[allow(clippy::permissions_set_readonly_false)]
                 perms.set_readonly(false);
             }
             fs_err::set_permissions(path, perms).map_err(SourceError::Io)?;


### PR DESCRIPTION
## Summary

This PR adds `finalized_host_prefix` and `finalized_build_prefix` fields to the `Output` struct, enabling external management of prefix creation outside of rattler-build. This allows external tooling to control when and how build environments are created.

## Technical Details

Key changes across 13 files:
- Added `finalized_host_prefix` and `finalized_build_prefix` as `Option<Prefix>` fields to `Output`
- Refactored `install_environments` method to consume `self` and return `Output` with finalized prefixes
- Updated `prefix()` method to return `Option<&Prefix>` instead of `&Path`
- Modified environment variable handling to use finalized prefixes when available

## Breaking Changes

- `install_environments` method signature changed from `&self` to `self`, returns `Output`
- `prefix()` method now returns `Option<&Prefix>` instead of `&Path`

## Use Cases

This enables external build systems to:
- Control prefix creation timing and location
- Implement custom caching strategies
- Better manage resource cleanup
- Inject prefixes for testing

The finalized prefixes provide clear separation between configuration (where prefixes should be) and reality (where they actually are).