### PR TITLE
feat: add enhanced file listing with path checks and warnings

### DIFF
--- a/src/packaging.rs
+++ b/src/packaging.rs
@@ -8,11 +8,12 @@ use std::{
 
 use fs_err as fs;
 use fs_err::File;
+use indicatif::HumanBytes;
 use metadata::clean_url;
 use rattler_conda_types::{
     ChannelUrl, Platform,
     compression_level::CompressionLevel,
-    package::{ArchiveType, PackageFile, PathsJson},
+    package::{ArchiveType, PackageFile, PathType, PathsJson},
 };
 use rattler_package_streaming::write::{write_conda_package, write_tar_bz2_package};
 use unicode_normalization::UnicodeNormalization;
@@ -377,6 +378,219 @@ where
     result
 }
 
+/// Print enhanced file listing with sizes, symlink targets, and warnings.
+fn print_enhanced_file_listing(
+    files: &[&Path],
+    tmp: &TempFiles,
+    output: &Output,
+) -> Result<(), PackagingError> {
+    use crate::post_process::path_checks::perform_path_checks;
+
+    let normalize_path = |p: &Path| -> String { p.display().to_string().replace('\\', "/") };
+
+    // Get all path entries for path checks
+    let path_entries: Vec<rattler_conda_types::package::PathsEntry> = files
+        .iter()
+        .map(|f| {
+            let full_path = tmp.temp_dir.path().join(f);
+            let metadata = fs::metadata(&full_path).unwrap_or_else(|_| {
+                // Create a dummy metadata for directories or if file doesn't exist
+                fs::metadata(".").unwrap()
+            });
+
+            let path_type = if full_path.is_symlink() {
+                PathType::SoftLink
+            } else if full_path.is_dir() {
+                PathType::Directory
+            } else {
+                PathType::HardLink
+            };
+
+            rattler_conda_types::package::PathsEntry {
+                relative_path: f.to_path_buf(),
+                path_type,
+                sha256: None,
+                prefix_placeholder: None,
+                no_link: false,
+                // Don't include size for directories or symlinks
+                size_in_bytes: if path_type == PathType::Directory
+                    || path_type == PathType::SoftLink
+                {
+                    None
+                } else {
+                    Some(metadata.len())
+                },
+            }
+        })
+        .collect();
+
+    // Run comprehensive path checks and record warnings to output
+    perform_path_checks(output, &path_entries);
+
+    // Collect per-file warnings for display purposes
+    let mut path_warnings: HashMap<PathBuf, Vec<String>> = HashMap::new();
+    for entry in &path_entries {
+        let mut warnings = Vec::new();
+        let path = &entry.relative_path;
+
+        if let Some(path_str) = path.to_str() {
+            if !path_str.is_ascii() {
+                warnings.push("Contains non-ASCII characters".to_string());
+            }
+            if path_str.contains(' ') {
+                warnings.push("Contains spaces".to_string());
+            }
+            if path_str.len() > 200 {
+                warnings.push(format!("Path too long ({} > 200)", path_str.len()));
+            }
+        }
+
+        if !warnings.is_empty() {
+            path_warnings.insert(path.clone(), warnings);
+        }
+    }
+
+    // Helper to check if a file is executable
+    #[cfg(unix)]
+    fn is_executable(path: &Path) -> bool {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(metadata) = fs::metadata(path) {
+            metadata.permissions().mode() & 0o111 != 0
+        } else {
+            false
+        }
+    }
+
+    #[cfg(not(unix))]
+    fn is_executable(path: &Path) -> bool {
+        // On Windows, check for common executable file extensions
+        const EXECUTABLE_EXTENSIONS: &[&str] = &["exe", "bat", "cmd", "com", "ps1"];
+        path.extension()
+            .and_then(|ext| ext.to_str())
+            .is_some_and(|ext| EXECUTABLE_EXTENSIONS.contains(&ext.to_lowercase().as_str()))
+    }
+
+    // Print each file with enhanced information
+    for (index, file) in files.iter().enumerate() {
+        let full_path = tmp.temp_dir.path().join(file);
+        let is_info = file.components().next() == Some(Component::Normal("info".as_ref()));
+        let normalized_path = normalize_path(file);
+        let is_last = index == files.len() - 1;
+        let is_symlink = full_path.is_symlink();
+        let is_exec = !is_symlink && is_executable(&full_path);
+
+        // Get file size (don't show for symlinks)
+        let size_info = if is_symlink {
+            String::new()
+        } else if let Ok(metadata) = fs::metadata(&full_path) {
+            if full_path.is_dir() {
+                " (dir)".to_string()
+            } else {
+                format!(" ({})", HumanBytes(metadata.len()))
+            }
+        } else {
+            String::new()
+        };
+
+        // Check if it's a symlink and get target
+        let symlink_info = if is_symlink {
+            match fs::read_link(&full_path) {
+                Ok(target) => {
+                    let target_str = target.display().to_string();
+                    format!(" -> {}", console::style(target_str).cyan())
+                }
+                Err(_) => " -> <invalid symlink>".to_string(),
+            }
+        } else {
+            String::new()
+        };
+
+        // Choose the appropriate tree character
+        let tree_char = if is_last { "└─" } else { "├─" };
+
+        // Format the main file entry with appropriate styling
+        let file_entry = if is_info {
+            format!(
+                "  {} {}{}{}",
+                tree_char,
+                console::style(&normalized_path).dim(),
+                console::style(&size_info).dim(),
+                symlink_info
+            )
+        } else if is_symlink {
+            format!(
+                "  {} {}{}",
+                tree_char,
+                console::style(&normalized_path).magenta(),
+                symlink_info
+            )
+        } else if is_exec {
+            format!(
+                "  {} {}{}",
+                tree_char,
+                console::style(&normalized_path).green(),
+                console::style(&size_info).dim(),
+            )
+        } else {
+            format!(
+                "  {} {}{}{}",
+                tree_char,
+                normalized_path,
+                console::style(&size_info).dim(),
+                symlink_info
+            )
+        };
+
+        tracing::info!("{}", file_entry);
+
+        // Print warnings for this file
+        if let Some(warnings) = path_warnings.get(&file.to_path_buf()) {
+            for warning in warnings {
+                tracing::warn!("       └─ {}", console::style(warning).yellow());
+            }
+        }
+    }
+
+    // Print package statistics
+    let total_size: u64 = path_entries.iter().filter_map(|e| e.size_in_bytes).sum();
+    let file_count = path_entries.len();
+    let non_info_count = files
+        .iter()
+        .filter(|f| f.components().next() != Some(Component::Normal("info".as_ref())))
+        .count();
+
+    tracing::info!("");
+    tracing::info!(
+        "Package statistics: {} files ({} content, {} metadata), total size: {}",
+        file_count,
+        non_info_count,
+        file_count - non_info_count,
+        HumanBytes(total_size)
+    );
+
+    // Show largest files (top 5)
+    let mut files_with_sizes: Vec<_> = path_entries
+        .iter()
+        .filter(|e| e.size_in_bytes.is_some() && e.size_in_bytes.unwrap() > 0)
+        .collect();
+    files_with_sizes.sort_by(|a, b| b.size_in_bytes.cmp(&a.size_in_bytes));
+
+    if !files_with_sizes.is_empty() {
+        tracing::info!("Largest files:");
+        for entry in files_with_sizes.iter().take(5) {
+            let size = entry.size_in_bytes.unwrap_or(0);
+            let path_str = entry.relative_path.display().to_string().replace('\\', "/");
+            tracing::info!(
+                "  {} - {}",
+                console::style(HumanBytes(size)).cyan(),
+                path_str
+            );
+        }
+    }
+
+    Ok(())
+}
+
 /// Given an output and a set of new files, create a conda package.
 /// This function will copy all the files to a temporary directory and then
 /// create a conda package from that. Note that the output needs to have its
@@ -469,15 +683,7 @@ pub fn package_conda(
         output.record_warning(&warn_str);
     }
 
-    let normalize_path = |p: &Path| -> String { p.display().to_string().replace('\\', "/") };
-
-    files.iter().for_each(|f| {
-        if f.components().next() == Some(Component::Normal("info".as_ref())) {
-            tracing::info!("  - {}", console::style(normalize_path(f)).dim())
-        } else {
-            tracing::info!("  - {}", normalize_path(f))
-        }
-    });
+    print_enhanced_file_listing(&files, &tmp, output)?;
 
     let output_folder =
         local_channel_dir.join(output.build_configuration.target_platform.to_string());

--- a/src/post_process/mod.rs
+++ b/src/post_process/mod.rs
@@ -1,6 +1,7 @@
 pub mod checks;
 pub mod menuinst;
 pub mod package_nature;
+pub mod path_checks;
 pub mod python;
 pub mod regex_replacements;
 pub mod relink;

--- a/src/post_process/path_checks.rs
+++ b/src/post_process/path_checks.rs
@@ -1,0 +1,298 @@
+//! Path validation checks for conda packages.
+//!
+//! This module provides functionality to check paths in packages for common issues:
+//! - Non-ASCII characters
+//! - Spaces in paths
+//! - Path length exceeding limits
+//! - Case-insensitive collisions
+//! - Mixed file extensions for the same file type
+
+// Allow unused code since these functions provide a reusable API for path validation
+// that may be used in future features or by external consumers.
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use rattler_conda_types::package::PathsEntry;
+
+/// Trait for types that can record warnings during package building.
+pub trait WarningRecorder {
+    /// Record a warning message.
+    fn record_warning(&self, warning: &str);
+}
+
+const FILE_EXTENSION_GROUPS: &[&[&str]] = &[
+    &[".cc", ".CC", ".cpp", ".CPP"],
+    &[".htm", ".HTM", ".html", ".HTML"],
+    &[".jpg", ".JPG", ".jpeg", ".JPEG"],
+    &[".jsonl", ".JSONL", ".ndjson", ".NDJSON"],
+    &[".txt", ".TXT", ".text", ".TEXT"],
+    &[".yaml", ".YAML", ".yml", ".YML"],
+];
+
+/// Perform path validation checks on the given paths and emit warnings.
+///
+/// This function checks for:
+/// - Non-ASCII characters in paths
+/// - Spaces in paths
+/// - Paths exceeding 200 characters
+/// - Case-insensitive collisions
+/// - Mixed file extensions for the same file type
+pub fn perform_path_checks(output: &dyn WarningRecorder, paths_entries: &[PathsEntry]) {
+    // Convert PathsEntry to paths for easier processing
+    let all_paths: Vec<&Path> = paths_entries
+        .iter()
+        .map(|entry| entry.relative_path.as_path())
+        .collect();
+
+    // Check for non-ASCII characters
+    check_non_ascii_characters(&all_paths, output);
+
+    // Check for spaces in paths
+    check_spaces_in_paths(&all_paths, output);
+
+    // Check path length (default limit: 200 characters)
+    check_path_length(&all_paths, 200, output);
+
+    // Check for case-insensitive collisions
+    check_case_collisions(&all_paths, output);
+
+    // Check for mixed file extensions
+    check_mixed_file_extensions(&all_paths, output);
+}
+
+fn check_non_ascii_characters(paths: &[&Path], output: &dyn WarningRecorder) {
+    for path in paths {
+        if let Some(path_str) = path.to_str()
+            && !path_str.is_ascii()
+        {
+            output.record_warning(&format!(
+                "Path contains non-ASCII characters: '{}'",
+                path_str
+            ));
+        }
+    }
+}
+
+fn check_spaces_in_paths(paths: &[&Path], output: &dyn WarningRecorder) {
+    for path in paths {
+        if let Some(path_str) = path.to_str()
+            && path_str.contains(' ')
+        {
+            output.record_warning(&format!("Path contains spaces: '{}'", path_str));
+        }
+    }
+}
+
+fn check_path_length(paths: &[&Path], max_length: usize, output: &dyn WarningRecorder) {
+    for path in paths {
+        if let Some(path_str) = path.to_str() {
+            let length = path_str.len();
+            if length > max_length {
+                output.record_warning(&format!(
+                    "Path is very long ({} > {}): '{}'",
+                    length, max_length, path_str
+                ));
+            }
+        }
+    }
+}
+
+fn check_case_collisions(paths: &[&Path], output: &dyn WarningRecorder) {
+    let mut path_lower_to_original: HashMap<String, Vec<String>> = HashMap::new();
+
+    for path in paths {
+        if let Some(path_str) = path.to_str() {
+            let lower = path_str.to_lowercase();
+            path_lower_to_original
+                .entry(lower)
+                .or_default()
+                .push(path_str.to_string());
+        }
+    }
+
+    for (_, originals) in path_lower_to_original {
+        if originals.len() > 1 {
+            let files_str = originals.join(", ");
+            output.record_warning(&format!(
+                "Found files which differ only by case: {}",
+                files_str
+            ));
+        }
+    }
+}
+
+fn check_mixed_file_extensions(paths: &[&Path], output: &dyn WarningRecorder) {
+    let mut extension_counts: HashMap<String, usize> = HashMap::new();
+
+    // Count occurrences of each extension
+    for path in paths {
+        if let Some(ext) = path.extension()
+            && let Some(ext_str) = ext.to_str()
+        {
+            let ext_with_dot = format!(".{}", ext_str);
+            *extension_counts.entry(ext_with_dot).or_insert(0) += 1;
+        }
+    }
+
+    // Check each group of related extensions
+    for group in FILE_EXTENSION_GROUPS {
+        let mut found_extensions = Vec::new();
+        for ext in *group {
+            if extension_counts.contains_key(*ext) {
+                found_extensions.push(*ext);
+            }
+        }
+
+        if found_extensions.len() >= 2 {
+            let extensions_str = found_extensions
+                .iter()
+                .map(|ext| format!("{} ({})", ext, extension_counts.get(*ext).unwrap_or(&0)))
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            output.record_warning(&format!(
+                "Found a mix of file extensions for the same file type: {}",
+                extensions_str
+            ));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rattler_conda_types::package::{PathType, PathsEntry};
+    use std::path::PathBuf;
+    use std::sync::{Arc, Mutex};
+
+    // Mock struct to capture warnings
+    #[derive(Default)]
+    struct MockOutput {
+        warnings: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl MockOutput {
+        fn new() -> Self {
+            Self::default()
+        }
+
+        fn warnings(&self) -> Vec<String> {
+            self.warnings.lock().unwrap().clone()
+        }
+    }
+
+    impl WarningRecorder for MockOutput {
+        fn record_warning(&self, warning: &str) {
+            self.warnings.lock().unwrap().push(warning.to_string());
+        }
+    }
+
+    fn create_test_entry(path: &str, path_type: PathType) -> PathsEntry {
+        PathsEntry {
+            relative_path: PathBuf::from(path),
+            path_type,
+            sha256: None,
+            prefix_placeholder: None,
+            no_link: false,
+            size_in_bytes: None,
+        }
+    }
+
+    #[test]
+    fn test_non_ascii_characters() {
+        let entries = vec![
+            create_test_entry("normal/file.txt", PathType::HardLink),
+            create_test_entry("café/file.txt", PathType::HardLink),
+            create_test_entry("文件/test.py", PathType::HardLink),
+        ];
+
+        let output = MockOutput::new();
+        perform_path_checks(&output, &entries);
+
+        let warnings = output.warnings();
+        assert!(warnings.iter().any(|w| w.contains("café")));
+        assert!(warnings.iter().any(|w| w.contains("文件")));
+    }
+
+    #[test]
+    fn test_spaces_in_paths() {
+        let entries = vec![
+            create_test_entry("normal/file.txt", PathType::HardLink),
+            create_test_entry("has space/file.txt", PathType::HardLink),
+            create_test_entry("another file.txt", PathType::HardLink),
+        ];
+
+        let output = MockOutput::new();
+        perform_path_checks(&output, &entries);
+
+        let warnings = output.warnings();
+        assert_eq!(warnings.iter().filter(|w| w.contains("spaces")).count(), 2);
+    }
+
+    #[test]
+    fn test_path_too_long() {
+        let long_path = "a".repeat(250);
+        let entries = vec![
+            create_test_entry("normal/file.txt", PathType::HardLink),
+            create_test_entry(&long_path, PathType::HardLink),
+        ];
+
+        let output = MockOutput::new();
+        perform_path_checks(&output, &entries);
+
+        let warnings = output.warnings();
+        assert_eq!(
+            warnings.iter().filter(|w| w.contains("very long")).count(),
+            1
+        );
+        assert!(warnings.iter().any(|w| w.contains("250 > 200")));
+    }
+
+    #[test]
+    fn test_case_collisions() {
+        let entries = vec![
+            create_test_entry("file.txt", PathType::HardLink),
+            create_test_entry("File.txt", PathType::HardLink),
+            create_test_entry("FILE.TXT", PathType::HardLink),
+            create_test_entry("other.py", PathType::HardLink),
+        ];
+
+        let output = MockOutput::new();
+        perform_path_checks(&output, &entries);
+
+        let warnings = output.warnings();
+        assert_eq!(
+            warnings
+                .iter()
+                .filter(|w| w.contains("differ only by case"))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn test_mixed_extensions() {
+        let entries = vec![
+            create_test_entry("file.txt", PathType::HardLink),
+            create_test_entry("file.TXT", PathType::HardLink),
+            create_test_entry("file.text", PathType::HardLink),
+            create_test_entry("doc.yaml", PathType::HardLink),
+            create_test_entry("doc.yml", PathType::HardLink),
+        ];
+
+        let output = MockOutput::new();
+        perform_path_checks(&output, &entries);
+
+        let warnings = output.warnings();
+        // txt/TXT/text and yaml/yml groups
+        assert!(
+            warnings
+                .iter()
+                .filter(|w| w.contains("mix of file extensions"))
+                .count()
+                >= 2
+        );
+    }
+}

--- a/src/types/build_output.rs
+++ b/src/types/build_output.rs
@@ -340,3 +340,9 @@ impl Display for BuildOutput {
         self.format_table_with_option(f, comfy_table::presets::UTF8_FULL, false)
     }
 }
+
+impl crate::post_process::path_checks::WarningRecorder for BuildOutput {
+    fn record_warning(&self, warning: &str) {
+        self.record_warning(warning);
+    }
+}


### PR DESCRIPTION
This PR adds enhanced file listing during package creation with improved output, warnings, and statistics.

## Features

### Enhanced File Listing
- File sizes displayed using HumanBytes for better readability
- Symlink targets shown with colored output
- Tree-style file listing with visual indicators (├─ and └─)
- Info files displayed with dim styling for visual distinction

### Package Statistics
- Total package size (uncompressed)
- File counts (content vs metadata files)
- **Top 5 largest files** for quick size analysis

### Path Warnings
Per-file warnings are shown for:
- Non-ASCII characters in paths
- Spaces in filenames  
- Paths exceeding 200 characters
- Case-insensitive collisions (detected separately)
- Mixed file extensions for the same file type (e.g., .yaml and .yml)

### Reusable Path Checks Module
Added `src/post_process/path_checks.rs` with:
- `WarningRecorder` trait for recording warnings during builds
- Comprehensive `perform_path_checks()` function used by the file listing
- Full test coverage for all path validation scenarios

## TODO:

- Restore the proper package stats as before (got lost in the merging)
- Fix up logging of relinking / codesigning on macOS, currently:

```
 │ ╭─ Packaging new files
 │ │ Copying done!
 │ │ builtin relink for "libcurl.4.dylib":
 │ │  - changing absolute rpath from "$PREFIX/lib" to "@loader_path/"
 │ │  - change dylib id to "@rpath/libcurl.4.dylib"
 │ │  - change dylib from "/Users/wolfv/Programs/rattler-build/output/bld/rattler-build_curl_1764195552/host_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_p
 │ │ lacehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib/libcurl.4.dylib" to "@rpath/libcurl.4.dylib"
 │ │ builtin relink for "curl":
 │ │  - changing absolute rpath from "$PREFIX/lib" to "@loader_path/../lib"
 │ │  - change dylib from "/Users/wolfv/Programs/rattler-build/output/bld/rattler-build_curl_1764195552/host_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_p
 │ │ lacehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib/libcurl.4.dylib" to "@rpath/libcurl.4.dylib"
 │ │ Running codesign: "/Users/wolfv/Programs/rattler-build/output/bld/rattler-build_curl_1764195552/build_env/bin/codesign" "-f" "-s" "-" "/var/folders/ls/nd2_c1qn1tz8c8sccxmg83m00000
 │ │ gn/T/curl9XTIfi/lib/libcurl.4.dylib"
 │ │ Running codesign: "/Users/wolfv/Programs/rattler-build/output/bld/rattler-build_curl_1764195552/build_env/bin/codesign" "-f" "-s" "-" "/var/folders/ls/nd2_c1qn1tz8c8sccxmg83m00000
 │ │ gn/T/curl9XTIfi/bin/curl"
 │ │ 
 ```

## Screenshots

<img width="1606" height="139" alt="Screenshot 2025-07-16 at 17 43 18" src="https://github.com/user-attachments/assets/d035940b-c07f-4c6b-8635-5944ebc47955" />

<img width="877" height="512" alt="Screenshot 2025-07-16 at 17 49 06" src="https://github.com/user-attachments/assets/c52ef41f-1161-4ac0-9346-87b3a371dc40" />