### PR TITLE
feat: enhance file handling and symlink resolution in file_finder and metadata modules

### DIFF
--- a/src/post_process/relink.rs
+++ b/src/post_process/relink.rs
@@ -152,6 +152,10 @@ pub fn get_relinker(platform: Platform, path: &Path) -> Result<Box<dyn Relinker>
 /// On macOS (Mach-O files), we do the same trick and set the rpath to a relative path with the special
 /// `@loader_path` variable. The change for Mach-O files is applied with the `install_name_tool`.
 pub fn relink(temp_files: &TempFiles, output: &Output) -> Result<(), RelinkError> {
+    // Skip relinking for cache-based builds
+    if output.recipe.cache.is_some() {
+        return Ok(());
+    }
     let dynamic_linking = output.recipe.build().dynamic_linking();
     let target_platform = output.build_configuration.target_platform;
     let relocation_config = dynamic_linking.binary_relocation();

--- a/src/source/copy_dir.rs
+++ b/src/source/copy_dir.rs
@@ -14,6 +14,7 @@ use rayon::iter::{ParallelBridge, ParallelIterator};
 use crate::recipe::parser::{GlobVec, GlobWithSource};
 
 use super::SourceError;
+use pathdiff::diff_paths;
 
 /// The copy options for the copy_dir function.
 pub struct CopyOptions {
@@ -94,7 +95,15 @@ pub(crate) fn copy_file(
 
     // if file is a symlink, copy it as a symlink. Note: it can be a symlink to a file or directory
     if path.is_symlink() {
-        let link_target = fs_err::read_link(path)?;
+        let mut link_target = fs_err::read_link(path)?;
+
+        // If the link target is absolute, try to make it relative to the parent directory
+        if link_target.is_absolute() {
+            if let Some(parent) = dest_path.parent() {
+                // Try to make the link target relative to the parent directory
+                link_target = diff_paths(&link_target, parent).unwrap_or(link_target);
+            }
+        }
 
         if let Some(parent) = dest_path.parent() {
             create_dir_all_cached(parent, paths_created)?;
@@ -297,7 +306,14 @@ impl<'a> CopyDir<'a> {
                     let dest_path = self.to_path.join(stripped_path);
 
                     if path.is_symlink() {
-                        let link_target = fs_err::read_link(path)?;
+                        let mut link_target = fs_err::read_link(path)?;
+                        if link_target.is_absolute() {
+                            if let Some(parent) = dest_path.parent() {
+                                // Make the link target relative to the parent directory
+                                link_target =
+                                    diff_paths(&link_target, parent).unwrap_or(link_target);
+                            }
+                        }
 
                         if let Some(parent) = dest_path.parent() {
                             create_dir_all_cached(parent, paths_created)?;


### PR DESCRIPTION
- We will check for content type for symlinks now and resolve relative paths correctly as well. We will also properly check metadata to differentiate between hard and soft symlinks now thanks to this.
- We will skip relinking for cache builds now as its not needed and will throw errors with proper cache builds (from Bas's PR)
- Updated dependency resolution to filter out ignored run exports based on normalized package names.