### PR TITLE
fix: ensure package name is defined in the pixi.toml

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -1,5 +1,4 @@
 [workspace]
-name = "rattler-build"
 description = "Conda package builder, using the rattler rust backend"
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 channels = ["conda-forge"]


### PR DESCRIPTION
I have no idea when did this got broken, assuming its because of the new pixi update