### PR TITLE
move tests to `info` directory when packaging

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -129,11 +129,11 @@ Tests are serialized to `info/tests/tests.yaml` in the created package and read 
 When adding extra files to your tests:
 
 1. **During package creation**
-     - Files are copied to `$PREFIX/etc/conda/test-files/{pkg_name}/{idx}`
+     - Files are copied to `$PREFIX/info/conda/test-files/{pkg_name}/{idx}`
      - `{idx}` is a sequential number assigned to each test
      - Files can come from both `source` (work directory) and `recipe` locations
 2. **During test execution**
-     - Files are copied from `$PREFIX/etc/conda/test-files/{pkg_name}/{idx}` to a temporary directory
+     - Files are copied from `$PREFIX/info/conda/test-files/{pkg_name}/{idx}` to a temporary directory
      - Tests run within this temporary directory
      - Use relative paths to access these files in your test commands
 

--- a/src/package_test/serialize_test.rs
+++ b/src/package_test/serialize_test.rs
@@ -77,7 +77,7 @@ pub(crate) fn write_test_files(
     // For each `Command` test, we need to copy the test files to the package
     for (idx, test) in tests.iter_mut().enumerate() {
         if let TestType::Command(command_test) = test {
-            let cwd = PathBuf::from(format!("etc/conda/test-files/{name}/{idx}"));
+            let cwd = PathBuf::from(format!("info/conda/test-files/{name}/{idx}"));
             let folder = tmp_dir_path.join(&cwd);
             let files = command_test.write_to_folder(&folder, output)?;
             if !files.is_empty() {


### PR DESCRIPTION
This PR originates from the request that tests are moved to the `info` directory inside the produced package
in order to let `rattler-build` behavior conform of that of `conda-build`.

The request is documented in [this issue](https://github.com/prefix-dev/rattler-build/issues/1750).