### PR TITLE
fix: allow preserving the working directory

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -14,6 +14,15 @@ use crate::{
     tool_configuration,
 };
 
+/// Behavior for handling the working directory during the build process
+#[derive(Debug, Clone, Copy)]
+pub enum WorkingDirectoryBehavior {
+    /// Preserve the working directory (don't clean up)
+    Preserve,
+    /// Clean up the working directory after build
+    Cleanup,
+}
+
 /// Check if the build should be skipped because it already exists in any of the
 /// channels
 pub async fn skip_existing(
@@ -100,12 +109,16 @@ pub async fn skip_existing(
 pub async fn run_build(
     output: Output,
     tool_configuration: &tool_configuration::Configuration,
-    preserve_working_directory: bool,
+    working_directory_behavior: WorkingDirectoryBehavior,
 ) -> miette::Result<(Output, PathBuf)> {
+    let cleanup = matches!(
+        working_directory_behavior,
+        WorkingDirectoryBehavior::Cleanup
+    );
     output
         .build_configuration
         .directories
-        .create_build_dir(!preserve_working_directory)
+        .create_build_dir(cleanup)
         .into_diagnostic()?;
 
     let span = tracing::info_span!("Running build for", recipe = output.identifier());

--- a/src/build.rs
+++ b/src/build.rs
@@ -100,11 +100,12 @@ pub async fn skip_existing(
 pub async fn run_build(
     output: Output,
     tool_configuration: &tool_configuration::Configuration,
+    preserve_working_directory: bool,
 ) -> miette::Result<(Output, PathBuf)> {
     output
         .build_configuration
         .directories
-        .create_build_dir(true)
+        .create_build_dir(!preserve_working_directory)
         .into_diagnostic()?;
 
     let span = tracing::info_span!("Running build for", recipe = output.identifier());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -483,6 +483,7 @@ pub async fn run_build_from_args(
 ) -> miette::Result<()> {
     let mut outputs = Vec::new();
     let mut test_queue = Vec::new();
+    let preserve_working_directory = false;
 
     let outputs_to_build = skip_existing(build_output, &tool_configuration).await?;
 
@@ -492,9 +493,13 @@ pub async fn run_build_from_args(
         .collect::<Vec<_>>();
 
     for (index, output) in outputs_to_build.iter().enumerate() {
-        let (output, archive) = match run_build(output.clone(), &tool_configuration)
-            .boxed_local()
-            .await
+        let (output, archive) = match run_build(
+            output.clone(),
+            &tool_configuration,
+            preserve_working_directory,
+        )
+        .boxed_local()
+        .await
         {
             Ok((output, archive)) => {
                 output.record_build_end();
@@ -796,7 +801,8 @@ pub async fn rebuild(
         .recreate_directories()
         .into_diagnostic()?;
 
-    run_build(output, &tool_config).await?;
+    let preserve_working_directory = false;
+    run_build(output, &tool_config, preserve_working_directory).await?;
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use build::{run_build, skip_existing};
+use build::{WorkingDirectoryBehavior, run_build, skip_existing};
 use console_utils::LoggingOutputHandler;
 use dunce::canonicalize;
 use fs_err as fs;
@@ -483,8 +483,6 @@ pub async fn run_build_from_args(
 ) -> miette::Result<()> {
     let mut outputs = Vec::new();
     let mut test_queue = Vec::new();
-    let preserve_working_directory = false;
-
     let outputs_to_build = skip_existing(build_output, &tool_configuration).await?;
 
     let all_output_names = outputs_to_build
@@ -496,7 +494,7 @@ pub async fn run_build_from_args(
         let (output, archive) = match run_build(
             output.clone(),
             &tool_configuration,
-            preserve_working_directory,
+            WorkingDirectoryBehavior::Cleanup,
         )
         .boxed_local()
         .await
@@ -801,8 +799,7 @@ pub async fn rebuild(
         .recreate_directories()
         .into_diagnostic()?;
 
-    let preserve_working_directory = false;
-    run_build(output, &tool_config, preserve_working_directory).await?;
+    run_build(output, &tool_config, WorkingDirectoryBehavior::Cleanup).await?;
 
     Ok(())
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -20,7 +20,7 @@ use std::io::{self, Stderr};
 use std::panic;
 use std::path::PathBuf;
 
-use crate::build::run_build;
+use crate::build::{WorkingDirectoryBehavior, run_build};
 use crate::console_utils::LoggingOutputHandler;
 use crate::{BuildData, get_build_output, sort_build_outputs_topologically};
 
@@ -249,8 +249,13 @@ pub async fn run<B: Backend>(
                             log_sender
                                 .send(Event::SetBuildState(i, BuildProgress::Building))
                                 .unwrap();
-                            let preserve_working_directory = false;
-                            match run_build(package.output, &package.tool_config, preserve_working_directory).await {
+                            match run_build(
+                                package.output,
+                                &package.tool_config,
+                                WorkingDirectoryBehavior::Cleanup,
+                            )
+                            .await
+                            {
                                 Ok((output, _archive)) => {
                                     output.record_build_end();
                                     let span = tracing::info_span!("Build summary");

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -249,7 +249,8 @@ pub async fn run<B: Backend>(
                             log_sender
                                 .send(Event::SetBuildState(i, BuildProgress::Building))
                                 .unwrap();
-                            match run_build(package.output, &package.tool_config).await {
+                            let preserve_working_directory = false;
+                            match run_build(package.output, &package.tool_config, preserve_working_directory).await {
                                 Ok((output, _archive)) => {
                                     output.record_build_end();
                                     let span = tracing::info_span!("Build summary");


### PR DESCRIPTION
I noticed that by default rattler-build always deletes the working directory. However, in pixi-build we want to retain it. This PR allows overwriting the default behavior. I think this aligns more with the [future work comment from the PR that introduced this feature](https://github.com/prefix-dev/rattler-build/pull/1119#issuecomment-2410474855).