### PR TITLE
fix: sanitize hyphenated package names in python test imports

### DIFF
--- a/src/recipe_generator/pypi.rs
+++ b/src/recipe_generator/pypi.rs
@@ -430,7 +430,7 @@ pub async fn create_recipe(
 
     recipe.tests.push(Test::Python(PythonTest {
         python: PythonTestInner {
-            imports: vec![metadata.info.name.clone()],
+            imports: vec![metadata.info.name.replace('-', "_")],
             pip_check: true,
         },
     }));
@@ -519,5 +519,33 @@ mod tests {
         let recipe = create_recipe(&opts, &metadata, &client).await.unwrap();
 
         assert_yaml_snapshot!(recipe);
+    }
+
+    #[tokio::test]
+    async fn test_hyphenated_imports_are_sanitized() {
+        let opts = PyPIOpts {
+            package: "file-read-backwards".into(),
+            version: None,
+            write: false,
+            use_mapping: true,
+            tree: false,
+        };
+
+        let client = reqwest::Client::new();
+        let metadata = fetch_pypi_metadata(&opts, &client).await.unwrap();
+        let recipe = create_recipe(&opts, &metadata, &client).await.unwrap();
+
+        let python_test = recipe
+            .tests
+            .iter()
+            .find_map(|t| {
+                if let Test::Python(pt) = t {
+                    Some(pt)
+                } else {
+                    None
+                }
+            })
+            .expect("expected a Python test");
+        assert_eq!(python_test.python.imports, vec!["file_read_backwards"]);
     }
 }

--- a/src/source/patch.rs
+++ b/src/source/patch.rs
@@ -150,6 +150,7 @@ fn write_patch_content(content: &[u8], path: &Path) -> Result<(), SourceError> {
             #[cfg(not(unix))]
             {
                 // Assume this means windows
+                #[allow(clippy::permissions_set_readonly_false)]
                 perms.set_readonly(false);
             }
             fs_err::set_permissions(path, perms).map_err(SourceError::Io)?;


### PR DESCRIPTION
closes https://github.com/prefix-dev/rattler-build/issues/1812

also tested as an example with `cargo run -- generate-recipe pypi file-read-backwards`

as the result:
```
 Generating recipe for file-read-backwards

  tests:
  - python:
     imports:
      - file_read_backwards
```

i assume replacing all `-` with `_` will be fine too.