### PR TITLE
fix: use relative path for binary relocation glob match

### DIFF
--- a/src/post_process/relink.rs
+++ b/src/post_process/relink.rs
@@ -185,7 +185,8 @@ pub fn relink(temp_files: &TempFiles, output: &Output) -> Result<(), RelinkError
             continue;
         }
 
-        if !relocation_config.is_match(p) {
+        let rel_path = p.strip_prefix(tmp_prefix)?;
+        if !relocation_config.is_match(rel_path) {
             continue;
         }
 


### PR DESCRIPTION
The current implementation([1](https://github.com/prefix-dev/rattler-build/blob/a40d91cacce345a40c8fa4ab6eddb99ecce77995/src/post_process/relink.rs#L188), [2](https://github.com/prefix-dev/rattler-build/blob/a40d91cacce345a40c8fa4ab6eddb99ecce77995/src/packaging/file_mapper.rs#L108)) uses paths prefixed with `tmp_dir` like `/tmp/riscv-toolsrhLUlq/riscv-tools/bin/riscv64-unknown-elf-c++`.

This causes a mismatch with the configured glob patterns in `dynamic_linking.binary_relocation`, which expect paths relative to the prefix:
```
build:
  dynamic_linking:
    binary_relocation:
      - riscv-tools/bin/**
      - riscv-tools/include/**
      - riscv-tools/lib/**
      - riscv-tools/libexec/**
      - riscv-tools/riscv64-unknown-elf/**
      - riscv-tools/riscv64-unknown-linux-gnu/**
      - riscv-tools/share/**
```
As a result, entries under the prefix are not properly matched and relocated. The proposed change ensures paths are made relative to the prefix before glob matching.
