### PR TITLE
Add the link to build script page from recipe page.

### DIFF
--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -391,7 +391,8 @@ build:
       then:
         - echo "unix"
 ```
-There are many other configurable settings, such as environmental values.
+
+There are many other configurable settings, such as environment variables and secrets.
 Please see [Build script](../build_script.md) for more information.
 
 ### Skipping builds

--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -391,6 +391,8 @@ build:
       then:
         - echo "unix"
 ```
+There are many other configurable settings, such as environmental values.
+Please see [Build script](../build_script.md) for more information.
 
 ### Skipping builds
 


### PR DESCRIPTION
I often can't find the build script environment settings. So, I added the link to build_script.md in the build script section to make it easy to find the build/script configurations.