### PR TITLE
fix: search for forward slash path on Windows, even for noarch packages

### DIFF
--- a/src/packaging.rs
+++ b/src/packaging.rs
@@ -54,6 +54,9 @@ pub enum PackagingError {
     #[error("Could not strip a prefix from a Path")]
     StripPrefixError(#[from] std::path::StripPrefixError),
 
+    #[error("Found mixed Prefix placeholders in file (forward- vs backslashes)")]
+    MixedPrefixPlaceholders(PathBuf),
+
     #[error("Could not serialize JSON: {0}")]
     SerializationError(#[from] serde_json::Error),
 


### PR DESCRIPTION
This fixes https://github.com/prefix-dev/rattler-build/issues/1788

We were checking for forward slash prefix in text files on Windows, but only when the `target_platform.is_windows()` was true. I think the saner default is to use `cfg!(windows)` as the path format is dependent on the build platform.