### PR TITLE
fix: pixi build warnings

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -5,10 +5,6 @@ channels = ["conda-forge"]
 platforms = ["linux-64", "win-64", "osx-64", "osx-arm64"]
 preview = ['pixi-build']
 
-[package]
-name = "rattler-build"
-version = "0.0.0dev"   # NOTE: how to set this automatically?
-
 [tasks]
 build-release = "cargo build --release"
 install = "cargo install --path . --locked"
@@ -121,11 +117,11 @@ default = { features = [
 docs = { features = ["docs"], no-default-feature = true }
 lint = { features = ["lint"], solve-group = "default" }
 
-# pixi build
+[package]
+name = "rattler-build"
+version = "0.0.0dev"   # NOTE: how to set this automatically?
 
-[package.build]
-backend = { name = "pixi-build-rust", version = "0.1.*" }
-channels = [
-  "https://prefix.dev/pixi-build-backends",
-  "https://prefix.dev/conda-forge",
-]
+# pixi build
+[package.build.backend]
+name = "pixi-build-rust"
+version = "*"


### PR DESCRIPTION
`package.build.channels` was moved to `package.build.backend.channels`