### PR TITLE
chore: add original license to error

### DIFF
--- a/src/recipe/error.rs
+++ b/src/recipe/error.rs
@@ -268,7 +268,7 @@ impl fmt::Display for ErrorKind {
             ErrorKind::UrlParsing(err) => write!(f, "failed to parse URL: {}", err),
             ErrorKind::IntegerParsing(err) => write!(f, "failed to parse integer: {}", err),
             ErrorKind::SpdxParsing(err) => {
-                writeln!(f, "failed to parse SPDX license: {}", err.reason)?;
+                writeln!(f, "failed to parse SPDX license: {} with: {}", err.original, err.reason)?;
                 writeln!(
                     f,
                     "See <https://spdx.org/licenses> for the list of valid licenses."

--- a/src/recipe/error.rs
+++ b/src/recipe/error.rs
@@ -268,7 +268,11 @@ impl fmt::Display for ErrorKind {
             ErrorKind::UrlParsing(err) => write!(f, "failed to parse URL: {}", err),
             ErrorKind::IntegerParsing(err) => write!(f, "failed to parse integer: {}", err),
             ErrorKind::SpdxParsing(err) => {
-                writeln!(f, "failed to parse SPDX license: {} with: {}", err.original, err.reason)?;
+                writeln!(
+                    f,
+                    "failed to parse SPDX license: {} with: {}",
+                    err.original, err.reason
+                )?;
                 writeln!(
                     f,
                     "See <https://spdx.org/licenses> for the list of valid licenses."


### PR DESCRIPTION
Old:
```
Error:   × failed to solve requirements of environment 'default' for platform 'linux-64'
  ├─▶   × failed to extract metadata for package 'ros-jazzy-action-tutorials-py'
  │   
  ╰─▶   × Failed to parse recipe
      
      Error:
        × failed to parse SPDX license: unknown term
        │ See <https://spdx.org/licenses> for the list of valid licenses.
        │ Use 'LicenseRef-<MyLicense>' if you are using a custom license.
        [Failed to read contents for label `here` (offset: 1828, length: 18): OutOfBounds]
```

New:
```
Error:   × failed to solve requirements of environment 'default' for platform 'osx-arm64'
  ├─▶   × failed to extract metadata for package 'ros-jazzy-action-tutorials-py'
  │   
  ╰─▶   × Failed to parse recipe
      
      Error:
        × failed to parse SPDX license: Apache License 2.0 with: unknown term
        │ See <https://spdx.org/licenses> for the list of valid licenses.
        │ Use 'LicenseRef-<MyLicense>' if you are using a custom license.
        [Failed to read contents for label `here` (offset: 1837, length: 18): OutOfBounds]

```

More improvements possible, but I need this now.