### PR TITLE
fix: run clippy with all features

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -374,7 +374,7 @@ Rebuild a package from a package file instead of a recipe
 
 - `-p`, `--package-file <PACKAGE_FILE>`
 
-	The package file to rebuild
+	The package file to rebuild (can be a local path or URL)
 
 
 - `--compression-threads <COMPRESSION_THREADS>`

--- a/pixi.toml
+++ b/pixi.toml
@@ -55,7 +55,7 @@ dprint = ">=0.50.0,<0.51"
 
 [feature.lint.tasks]
 actionlint = { cmd = "actionlint", env = { SHELLCHECK_OPTS = "-e SC2086" } }
-cargo-clippy = "cargo clippy --all-targets --workspace -- -D warnings -Dclippy::dbg_macro"
+cargo-clippy = "cargo clippy --all-targets --all-features --workspace -- -D warnings -Dclippy::dbg_macro"
 cargo-fmt = "cargo fmt"
 dprint-check = { cmd = "dprint check --log-level=silent", description = "Check formatting with dprint" }
 dprint-fmt = { cmd = "dprint fmt --incremental=false", description = "Format with dprint" }


### PR DESCRIPTION
Otherwise, we might get problems with CI like the one in #1866, where a lint error occurs in a seemingly unrelated place. 