### PR TITLE
Enhanced zip_keys parsing to detect flat lists

### DIFF
--- a/docs/build_options.md
+++ b/docs/build_options.md
@@ -153,7 +153,7 @@ options.
 
 A variant package has the same version number, but different "hash" and
 potentially different dependencies or build options. Variant keys are extracted
-from the `variant_config.yaml` file and usually any used Jinja variables or
+from the `variants.yaml` file and usually any used Jinja variables or
 dependencies without version specifier are used as variant keys.
 
 Variant keys can also be forcibly set or ignored with the `use_keys` and

--- a/docs/build_script.md
+++ b/docs/build_script.md
@@ -231,7 +231,7 @@ noted, no variables are inherited from the shell environment in which you invoke
 `PY_VER`
 
 : Specifies the Python version against which the build is occurring.
-  This can be modified with a `variant_config.yaml` file.
+  This can be modified with a `variants.yaml` file.
 
 `PATH`
 

--- a/docs/compilers.md
+++ b/docs/compilers.md
@@ -4,7 +4,7 @@ To use a compiler in your project, it's best to use the `${{ compiler('lang')
 }}` template function. The compiler function works by taking a language,
 determining the configured compiler for that language, and adding some
 information about the target platform to the selected compiler. To configure a
-compiler for a specific language, the `variant_config.yaml` file can be used.
+compiler for a specific language, the `variants.yaml` file can be used.
 
 For example, in a recipe that uses a C-compiler, you can use the following code:
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -847,7 +847,7 @@ Store authentication information for a given host
 
 - `<HOST>`
 
-	The host to authenticate with (e.g. repo.prefix.dev)
+	The host to authenticate with (e.g. prefix.dev)
 
 
 

--- a/docs/tutorials/python.md
+++ b/docs/tutorials/python.md
@@ -88,7 +88,7 @@ rattler-build build --recipe ./ipywidgets
 We will build a package for `numpy` – which contains compiled code.
 Since compiled code is `python` version-specific, we will need to specify the `python` version explicitly.
 
-The best way to do this is with a "variant_config.yaml" file.
+The best way to do this is with a "variants.yaml" file.
 The variant config file allows us to easily compile the package against multiple Python versions.
 
 ```yaml title="variants.yaml"

--- a/docs/variants.md
+++ b/docs/variants.md
@@ -145,7 +145,7 @@ numpy: ["1.12", "1.14"]
 However, if we use the `zip_keys` and specify:
 
 ```yaml
-zip_keys: ["python", "numpy"]
+zip_keys: [["python", "numpy"]]
 python: ["3.8", "3.9"]
 numpy: ["1.12", "1.14"]
 ```


### PR DESCRIPTION
Fixes #1868 by throwing an error if the user accidentally passes a flat list instead of a nested list for `zip_keys`.

Also updates docs since it references variants_config.yaml but looks like rattler-build has now standardized on `variants.yaml` as the auto-detected filename for variants.