### PR TITLE
fix: disable run_exports extraction in render-only solves

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -137,7 +137,7 @@ pub async fn run_build(
     };
 
     let output = output
-        .resolve_dependencies(tool_configuration)
+        .resolve_dependencies(tool_configuration, true)
         .await
         .into_diagnostic()?;
 

--- a/src/build.rs
+++ b/src/build.rs
@@ -9,6 +9,7 @@ use crate::{
     apply_patch_custom,
     metadata::{Output, build_reindexed_channels},
     recipe::parser::TestType,
+    render::resolved_dependencies::RunExportsDownload,
     render::solver::load_repodatas,
     script::InterpreterError,
     tool_configuration,
@@ -137,7 +138,7 @@ pub async fn run_build(
     };
 
     let output = output
-        .resolve_dependencies(tool_configuration, true)
+        .resolve_dependencies(tool_configuration, RunExportsDownload::DownloadMissing)
         .await
         .into_diagnostic()?;
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -18,7 +18,7 @@ use crate::{
         parser::{Dependency, Requirements, Source},
     },
     render::resolved_dependencies::{
-        FinalizedDependencies, install_environments, resolve_dependencies,
+        FinalizedDependencies, RunExportsDownload, install_environments, resolve_dependencies,
     },
     source::{
         copy_dir::{CopyDir, CopyOptions, copy_file},
@@ -225,7 +225,7 @@ impl Output {
                 &self,
                 &channels,
                 tool_configuration,
-                true,
+                RunExportsDownload::DownloadMissing,
             )
             .await
             .unwrap();

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -220,10 +220,15 @@ impl Output {
                 .into_diagnostic()
                 .context("failed to reindex output channel")?;
 
-            let finalized_dependencies =
-                resolve_dependencies(&cache.requirements, &self, &channels, tool_configuration)
-                    .await
-                    .unwrap();
+            let finalized_dependencies = resolve_dependencies(
+                &cache.requirements,
+                &self,
+                &channels,
+                tool_configuration,
+                true,
+            )
+            .await
+            .unwrap();
 
             install_environments(&self, &finalized_dependencies, tool_configuration)
                 .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1052,7 +1052,7 @@ pub async fn build_recipes(
             for output in outputs {
                 updated_outputs.push(
                     output
-                        .resolve_dependencies(&tool_config)
+                        .resolve_dependencies(&tool_config, false)
                         .await
                         .into_diagnostic()?,
                 );
@@ -1161,7 +1161,7 @@ pub async fn debug_recipe(
             .await
             .into_diagnostic()?;
         let output = output
-            .resolve_dependencies(&tool_config)
+            .resolve_dependencies(&tool_config, true)
             .await
             .into_diagnostic()?;
         output

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ mod windows;
 mod package_cache_reporter;
 pub mod source_code;
 
+use crate::render::resolved_dependencies::RunExportsDownload;
 use std::{
     collections::{BTreeMap, HashMap},
     path::{Path, PathBuf},
@@ -1052,7 +1053,7 @@ pub async fn build_recipes(
             for output in outputs {
                 updated_outputs.push(
                     output
-                        .resolve_dependencies(&tool_config, false)
+                        .resolve_dependencies(&tool_config, RunExportsDownload::SkipDownload)
                         .await
                         .into_diagnostic()?,
                 );
@@ -1161,7 +1162,7 @@ pub async fn debug_recipe(
             .await
             .into_diagnostic()?;
         let output = output
-            .resolve_dependencies(&tool_config, true)
+            .resolve_dependencies(&tool_config, RunExportsDownload::DownloadMissing)
             .await
             .into_diagnostic()?;
         output

--- a/src/render/solver.rs
+++ b/src/render/solver.rs
@@ -186,7 +186,7 @@ impl rattler_repodata_gateway::DownloadReporter for GatewayReporter {
             .multi_progress
             .add(ProgressBar::new(1))
             .with_finish(indicatif::ProgressFinish::AndLeave)
-            .with_prefix("Fetching repodata");
+            .with_prefix("Downloading repodata");
 
         // use the configured style
         if let Some(template) = &self.progress_template {

--- a/src/render/solver.rs
+++ b/src/render/solver.rs
@@ -186,7 +186,7 @@ impl rattler_repodata_gateway::DownloadReporter for GatewayReporter {
             .multi_progress
             .add(ProgressBar::new(1))
             .with_finish(indicatif::ProgressFinish::AndLeave)
-            .with_prefix("Downloading");
+            .with_prefix("Fetching repodata");
 
         // use the configured style
         if let Some(template) = &self.progress_template {

--- a/test/end-to-end/helpers.py
+++ b/test/end-to-end/helpers.py
@@ -98,6 +98,7 @@ class RattlerBuild:
         custom_channels: Optional[list[str]] = None,
         extra_args: list[str] = None,
         extra_meta: dict[str, Any] = None,
+        raw: bool = False,
         **kwargs: Any,
     ) -> Any:
         args = self.build_args(
@@ -110,9 +111,19 @@ class RattlerBuild:
         )
         if with_solve:
             args += ["--with-solve"]
-        output = self(*args, "--render-only", **kwargs)
-        print(output)
-        return json.loads(output)
+        if raw:
+            return self(
+                *args,
+                "--render-only",
+                need_result_object=True,
+                text=True,
+                capture_output=True,
+                **kwargs,
+            )
+        else:
+            output = self(*args, "--render-only", **kwargs)
+            print(output)
+            return json.loads(output)
 
 
 def get_package(folder: Path, glob="*.tar.bz2"):

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -140,6 +140,27 @@ def test_python_noarch(rattler_build: RattlerBuild, recipes: Path, tmp_path: Pat
     check_info(pkg, expected=recipes / "toml" / "expected")
 
 
+def test_render_only_with_solve_does_not_download_packages(
+    rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
+):
+    result = rattler_build.render(
+        recipes / "toml",
+        tmp_path,
+        with_solve=True,
+        custom_channels=["conda-forge"],
+        raw=True,
+    )
+
+    assert result.returncode == 0
+    combined = (result.stdout or "") + "\n" + (result.stderr or "")
+
+    # Verify we did not trigger steps that download packages
+    assert "Collecting run exports" not in combined
+    assert "Installing host environment" not in combined
+    assert "Installing build environment" not in combined
+    assert "Resolving host environment" in combined
+
+
 def test_run_exports(
     rattler_build: RattlerBuild, recipes: Path, tmp_path: Path, snapshot_json
 ):

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -158,7 +158,19 @@ def test_render_only_with_solve_does_not_download_packages(
     assert "Collecting run exports" not in combined
     assert "Installing host environment" not in combined
     assert "Installing build environment" not in combined
-    assert "Resolving host environment" in combined
+
+    outputs = json.loads(result.stdout or "[]")
+    assert isinstance(outputs, list) and len(outputs) >= 1
+    deps = outputs[0].get("finalized_dependencies", {})
+    resolved_len = 0
+    host = deps.get("host")
+    if isinstance(host, dict):
+        resolved_len = len(host.get("resolved", []))
+    if resolved_len == 0:
+        build = deps.get("build")
+        if isinstance(build, dict):
+            resolved_len = len(build.get("resolved", []))
+    assert resolved_len >= 1
 
 
 def test_run_exports(


### PR DESCRIPTION
closes https://github.com/prefix-dev/rattler-build/issues/1880

i also think we shouldnt download these packages while running `--render-only --with-solve` as it makes sense and our current behavior would be too confusing. as to provide solvability we dont need to download the packages, we only need the index metadata anyways.

the only change was done to rattler-build build for `--render-only --with-solve` flag.