### PR TITLE
feat: add tracing logs for generating recipe file backup and write operations

### DIFF
--- a/src/recipe_generator/serialize.rs
+++ b/src/recipe_generator/serialize.rs
@@ -3,6 +3,7 @@ use std::{fmt, path::PathBuf};
 use indexmap::IndexMap;
 use serde::Serialize;
 use serde_with::{OneOrMany, formats::PreferOne, serde_as};
+use tracing;
 
 #[derive(Debug, Serialize)]
 #[serde(untagged)]
@@ -158,10 +159,14 @@ pub fn write_recipe(package_name: &str, recipe: &str) -> std::io::Result<()> {
     if path.exists() {
         // move to backup
         let backup_path = path.with_extension("yaml.bak");
+        tracing::warn!(
+            "Existing recipe file will be backed up to {}",
+            backup_path.display()
+        );
         fs_err::rename(&path, backup_path)?;
     }
 
-    println!("Writing recipe to {}", path.display());
+    tracing::info!("Writing recipe to {}", path.display());
 
     fs_err::write(path, recipe)
 }


### PR DESCRIPTION
we were not showing any info about creating a backup (which i think is not good, we shouldn't hide it from user), also changed the printin to use tracing instead

<img width="1000" height="620" alt="Screenshot_20250914_211731" src="https://github.com/user-attachments/assets/034ef9f4-55aa-4702-9bd2-80ef06267f21" />
