### PR TITLE
fix: return proper error instead of unwrapping

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -228,7 +228,7 @@ impl Output {
                 RunExportsDownload::DownloadMissing,
             )
             .await
-            .unwrap();
+            .into_diagnostic()?;
 
             install_environments(&self, &finalized_dependencies, tool_configuration)
                 .await


### PR DESCRIPTION
Should fix https://github.com/prefix-dev/rattler-build/issues/1902