### PR TITLE
fix: skip uninterpretable PE files during relinking

### DIFF
--- a/src/windows/link.rs
+++ b/src/windows/link.rs
@@ -78,6 +78,11 @@ impl Dll {
                         tracing::warn!("[relink/windows] Skipping malformed PE file {path:?}: {e}");
                         Ok(None)
                     }
+                    goblin::error::Error::Scroll(_) => {
+                        // A valid PE file but goblin can not reading and interpreting bytes
+                        tracing::warn!("[relink/windows] Skipping uninterpretable PE file {path:?}: {e}");
+                        Ok(None)
+                    }
                     _ => {
                         // IO, buffer, scroll errors should bubble up as real system errors
                         Err(RelinkError::ParseError(e))


### PR DESCRIPTION
fix #1905 