### PR TITLE
chore: use rattler-sandbox as an external tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,9 +365,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-config"
-version = "1.8.7"
+version = "1.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04b37ddf8d2e9744a0b9c19ce0b78efe4795339a90b66b7bae77987092cd2e69"
+checksum = "37cf2b6af2a95a20e266782b4f76f1a5e12bf412a9db2de9c1e9123b9d8c0ad8"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -395,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.7"
+version = "1.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799a1290207254984cb7c05245111bc77958b92a3c9bb449598044b36341cce6"
+checksum = "faf26925f4a5b59eb76722b63c2892b1d70d06fa053c72e4a100ec308c1d47bc"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -407,9 +407,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.5.11"
+version = "1.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e1ed337dabcf765ad5f2fb426f13af22d576328aaf09eac8f70953530798ec0"
+checksum = "bfa006bb32360ed90ac51203feafb9d02e3d21046e1fd3a450a404b90ea73e5d"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -432,9 +432,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.107.0"
+version = "1.108.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9118b3454ba89b30df55931a1fa7605260fc648e070b5aab402c24b375b1f"
+checksum = "200be4aed61e3c0669f7268bacb768f283f1c32a7014ce57225e1160be2f6ccb"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -466,9 +466,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.85.0"
+version = "1.86.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f2c741e2e439f07b5d1b33155e246742353d82167c785a2ff547275b7e32483"
+checksum = "4a0abbfab841446cce6e87af853a3ba2cc1bc9afcd3f3550dd556c43d434c86d"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -488,9 +488,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.87.0"
+version = "1.88.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6428ae5686b18c0ee99f6f3c39d94ae3f8b42894cdc35c35d8fb2470e9db2d4c"
+checksum = "9a68d675582afea0e94d38b6ca9c5aaae4ca14f1d36faa6edb19b42e687e70d7"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -510,9 +510,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.87.0"
+version = "1.88.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5871bec9a79a3e8d928c7788d654f135dde0e71d2dd98089388bab36b37ef607"
+checksum = "d30990923f4f675523c51eb1c0dec9b752fb267b36a61e83cbc219c9d86da715"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -533,9 +533,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.3.4"
+version = "1.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084c34162187d39e3740cb635acd73c4e3a551a36146ad6fe8883c929c9f876c"
+checksum = "bffc03068fbb9c8dd5ce1c6fb240678a5cffb86fb2b7b1985c999c4b83c8df68"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -751,9 +751,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.8"
+version = "1.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b069d19bf01e46298eaedd7c6f283fe565a59263e53eebec945f3e6398f42390"
+checksum = "e2fd329bf0e901ff3f60425691410c69094dc2a1f34b331f37bfc4e9ac1565a1"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -3120,9 +3120,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lzma-rust2"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d3176655c152883186e161a1031192759660878ac04b2f776290b4f4e770a9"
+checksum = "e5999f9ccfee85f09b54a2205c5851f884c83e4e7ef056843ff68d7f2006cd82"
 
 [[package]]
 name = "lzma-sys"
@@ -6858,9 +6858,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
+checksum = "32b130c0d2d49f8b6889abc456e795e82525204f27c42cf767cf0d7734e089b8"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,19 +827,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
-name = "birdcage"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "848df95320021558dd6bb4c26de3fe66724cdcbdbbf3fa720150b52b086ae568"
-dependencies = [
- "bitflags 2.9.4",
- "libc",
- "log",
- "rustix 0.38.44",
- "seccompiler",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4256,7 +4243,6 @@ dependencies = [
  "rattler_package_streaming",
  "rattler_redaction",
  "rattler_repodata_gateway",
- "rattler_sandbox",
  "rattler_shell",
  "rattler_solve",
  "rattler_upload",
@@ -4680,18 +4666,6 @@ dependencies = [
  "thiserror 2.0.17",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "rattler_sandbox"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68292c668ef45d693895d7d6c17db5dde1ae84ff8b108cc51fda4610f44834ed"
-dependencies = [
- "birdcage",
- "clap",
- "fs-err",
- "tokio",
 ]
 
 [[package]]
@@ -5382,15 +5356,6 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "seccompiler"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f6575e3c2b3a0fe2ef3e53855b6a8dead7c29f783da5e123d378c8c6a89017e"
-dependencies = [
- "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,9 +196,6 @@ rattler_redaction = { version = "0.1.12" }
 rattler_repodata_gateway = { version = "0.24.7", default-features = false, features = [
   "gateway",
 ] }
-rattler_sandbox = { version = "0.1.11", default-features = false, features = [
-  "tokio",
-] }
 rattler_shell = { version = "0.25.2", default-features = false, features = [
   "sysinfo",
 ] }

--- a/py-rattler-build/Cargo.lock
+++ b/py-rattler-build/Cargo.lock
@@ -346,9 +346,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-config"
-version = "1.8.7"
+version = "1.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04b37ddf8d2e9744a0b9c19ce0b78efe4795339a90b66b7bae77987092cd2e69"
+checksum = "37cf2b6af2a95a20e266782b4f76f1a5e12bf412a9db2de9c1e9123b9d8c0ad8"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -376,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.7"
+version = "1.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799a1290207254984cb7c05245111bc77958b92a3c9bb449598044b36341cce6"
+checksum = "faf26925f4a5b59eb76722b63c2892b1d70d06fa053c72e4a100ec308c1d47bc"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -388,9 +388,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.5.11"
+version = "1.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e1ed337dabcf765ad5f2fb426f13af22d576328aaf09eac8f70953530798ec0"
+checksum = "bfa006bb32360ed90ac51203feafb9d02e3d21046e1fd3a450a404b90ea73e5d"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -413,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.107.0"
+version = "1.108.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9118b3454ba89b30df55931a1fa7605260fc648e070b5aab402c24b375b1f"
+checksum = "200be4aed61e3c0669f7268bacb768f283f1c32a7014ce57225e1160be2f6ccb"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -447,9 +447,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.85.0"
+version = "1.86.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f2c741e2e439f07b5d1b33155e246742353d82167c785a2ff547275b7e32483"
+checksum = "4a0abbfab841446cce6e87af853a3ba2cc1bc9afcd3f3550dd556c43d434c86d"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -469,9 +469,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.87.0"
+version = "1.88.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6428ae5686b18c0ee99f6f3c39d94ae3f8b42894cdc35c35d8fb2470e9db2d4c"
+checksum = "9a68d675582afea0e94d38b6ca9c5aaae4ca14f1d36faa6edb19b42e687e70d7"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -491,9 +491,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.87.0"
+version = "1.88.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5871bec9a79a3e8d928c7788d654f135dde0e71d2dd98089388bab36b37ef607"
+checksum = "d30990923f4f675523c51eb1c0dec9b752fb267b36a61e83cbc219c9d86da715"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -514,9 +514,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.3.4"
+version = "1.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084c34162187d39e3740cb635acd73c4e3a551a36146ad6fe8883c929c9f876c"
+checksum = "bffc03068fbb9c8dd5ce1c6fb240678a5cffb86fb2b7b1985c999c4b83c8df68"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -732,9 +732,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.8"
+version = "1.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b069d19bf01e46298eaedd7c6f283fe565a59263e53eebec945f3e6398f42390"
+checksum = "e2fd329bf0e901ff3f60425691410c69094dc2a1f34b331f37bfc4e9ac1565a1"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -806,19 +806,6 @@ name = "base64ct"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
-
-[[package]]
-name = "birdcage"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "848df95320021558dd6bb4c26de3fe66724cdcbdbbf3fa720150b52b086ae568"
-dependencies = [
- "bitflags 2.9.4",
- "libc",
- "log",
- "rustix 0.38.44",
- "seccompiler",
-]
 
 [[package]]
 name = "bit-set"
@@ -2895,9 +2882,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lzma-rust2"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d3176655c152883186e161a1031192759660878ac04b2f776290b4f4e770a9"
+checksum = "e5999f9ccfee85f09b54a2205c5851f884c83e4e7ef056843ff68d7f2006cd82"
 
 [[package]]
 name = "lzma-sys"
@@ -4014,7 +4001,6 @@ dependencies = [
  "rattler_package_streaming",
  "rattler_redaction",
  "rattler_repodata_gateway",
- "rattler_sandbox",
  "rattler_shell",
  "rattler_solve",
  "rattler_upload",
@@ -4430,18 +4416,6 @@ dependencies = [
  "thiserror 2.0.17",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "rattler_sandbox"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68292c668ef45d693895d7d6c17db5dde1ae84ff8b108cc51fda4610f44834ed"
-dependencies = [
- "birdcage",
- "clap",
- "fs-err",
- "tokio",
 ]
 
 [[package]]
@@ -5070,15 +5044,6 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "seccompiler"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f6575e3c2b3a0fe2ef3e53855b6a8dead7c29f783da5e123d378c8c6a89017e"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -6427,9 +6392,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
+checksum = "32b130c0d2d49f8b6889abc456e795e82525204f27c42cf767cf0d7734e089b8"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,14 +21,6 @@ use rattler_upload::upload_from_args;
 use tempfile::{TempDir, tempdir};
 
 fn main() -> miette::Result<()> {
-    // Initialize sandbox in sync/single-threaded context before anything else
-    #[cfg(any(
-        all(target_os = "linux", target_arch = "x86_64"),
-        all(target_os = "linux", target_arch = "aarch64"),
-        target_os = "macos"
-    ))]
-    rattler_sandbox::init_sandbox();
-
     // Stack size varies significantly across platforms:
     // - Windows: only 1MB by default
     // - macOS/Linux: ~8MB by default

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -570,50 +570,28 @@ async fn run_process_with_replacements(
     sandbox_config: Option<&SandboxConfiguration>,
 ) -> Result<std::process::Output, std::io::Error> {
     let mut command = if let Some(sandbox_config) = sandbox_config {
-        #[cfg(any(
-            all(target_os = "linux", target_arch = "x86_64"),
-            all(target_os = "linux", target_arch = "aarch64"),
-            target_os = "macos"
-        ))]
-        {
-            tracing::info!("{}", sandbox_config);
+        tracing::info!("{}", sandbox_config);
 
-            // Try to find rattler-sandbox executable
-            if let Some(sandbox_exe) = find_rattler_sandbox() {
-                let mut cmd = tokio::process::Command::new(sandbox_exe);
+        // Try to find rattler-sandbox executable
+        if let Some(sandbox_exe) = find_rattler_sandbox() {
+            let mut cmd = tokio::process::Command::new(sandbox_exe);
 
-                // Add sandbox configuration arguments
-                let sandbox_args = sandbox_config.with_cwd(cwd).to_args();
-                cmd.args(&sandbox_args);
+            // Add sandbox configuration arguments
+            let sandbox_args = sandbox_config.with_cwd(cwd).to_args();
+            cmd.args(&sandbox_args);
 
-                // Add the actual command to execute (as positional arguments)
-                cmd.arg(args[0]);
-                cmd.args(&args[1..]);
+            // Add the actual command to execute (as positional arguments)
+            cmd.arg(args[0]);
+            cmd.args(&args[1..]);
 
-                cmd
-            } else {
-                tracing::error!("rattler-sandbox executable not found in PATH");
-                tracing::error!(
-                    "Please install it by running: pixi global install rattler-sandbox"
-                );
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::NotFound,
-                    "rattler-sandbox executable not found. Please install it with: pixi global install rattler-sandbox",
-                ));
-            }
-        }
-
-        // If the platform is not supported, log a warning and run the command without sandboxing
-        #[cfg(not(any(
-            all(target_os = "linux", target_arch = "x86_64"),
-            all(target_os = "linux", target_arch = "aarch64"),
-            target_os = "macos"
-        )))]
-        {
-            tracing::warn!("Sandboxing is not supported on this platform");
-            // mark variable as used
-            let _ = sandbox_config;
-            tokio::process::Command::new(args[0])
+            cmd
+        } else {
+            tracing::error!("rattler-sandbox executable not found in PATH");
+            tracing::error!("Please install it by running: pixi global install rattler-sandbox");
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "rattler-sandbox executable not found. Please install it with: pixi global install rattler-sandbox",
+            ));
         }
     } else {
         tokio::process::Command::new(args[0])

--- a/src/script/sandbox.rs
+++ b/src/script/sandbox.rs
@@ -165,37 +165,30 @@ impl SandboxConfiguration {
         }
     }
 
-    #[cfg(any(
-        all(target_os = "linux", target_arch = "x86_64"),
-        all(target_os = "linux", target_arch = "aarch64"),
-        target_os = "macos"
-    ))]
-    /// Get the list of exceptions for the sandbox
-    pub fn exceptions(&self) -> Vec<rattler_sandbox::Exception> {
-        let mut exceptions = Vec::new();
+    /// Convert the sandbox configuration to command-line arguments for the rattler-sandbox executable
+    pub fn to_args(&self) -> Vec<String> {
+        let mut args = Vec::new();
+
         if self.allow_network {
-            exceptions.push(rattler_sandbox::Exception::Networking);
+            args.push("--network".to_string());
         }
 
         for path in &self.read {
-            exceptions.push(rattler_sandbox::Exception::Read(
-                path.to_string_lossy().to_string(),
-            ));
+            args.push("--fs-read".to_string());
+            args.push(path.to_string_lossy().to_string());
         }
 
         for path in &self.read_execute {
-            exceptions.push(rattler_sandbox::Exception::ExecuteAndRead(
-                path.to_string_lossy().to_string(),
-            ));
+            args.push("--fs-exec-and-read".to_string());
+            args.push(path.to_string_lossy().to_string());
         }
 
         for path in &self.read_write {
-            exceptions.push(rattler_sandbox::Exception::ReadAndWrite(
-                path.to_string_lossy().to_string(),
-            ));
+            args.push("--fs-write-and-read".to_string());
+            args.push(path.to_string_lossy().to_string());
         }
 
-        exceptions
+        args
     }
 }
 


### PR DESCRIPTION
We will integrate with the sandbox through an external `rattler-sandbox` binary instead of embedding it in rattler-build.