### PR TITLE
feat: make s3 support optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4226,7 +4226,6 @@ dependencies = [
  "miette",
  "minijinja",
  "num_cpus",
- "opendal",
  "pathdiff",
  "petgraph",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ default-run = "rattler-build"
 rust-version = "1.86.0"
 
 [features]
-default = ['rustls-tls', 'recipe-generation']
+default = ['rustls-tls', 'recipe-generation', 's3']
 native-tls = [
   'reqwest/native-tls',
   'rattler/native-tls',
@@ -74,6 +74,10 @@ tui = [
   'ansi-to-tui',
   'throbber-widgets-tui',
   'tui-input',
+]
+s3 = [
+  'rattler_networking/s3',
+  'rattler_upload/s3',
 ]
 recipe-generation = ["rattler_build_recipe_generator"]
 # This feature needs to add a dependency on
@@ -171,9 +175,6 @@ reflink-copy = "0.1.26"
 rayon = "1.11.0"
 regex = { workspace = true }
 async-recursion = { workspace = true }
-opendal = { version = "0.54.0", default-features = false, features = [
-  "services-s3",
-] }
 
 # Rattler crates
 rattler_config = { version = "0.2.11" }
@@ -186,12 +187,9 @@ rattler_conda_types = { workspace = true, features = ["rayon"] }
 rattler_digest = { workspace = true }
 rattler_index = { version = "0.25.5", default-features = false }
 rattler_networking = { version = "0.25.16", default-features = false, features = [
-  "s3",
   "rattler_config",
 ] }
-rattler_upload = { version = "0.3.4", default-features = false, features = [
-  "s3",
-] }
+rattler_upload = { version = "0.3.4", default-features = false }
 rattler_redaction = { version = "0.1.12" }
 rattler_repodata_gateway = { version = "0.24.7", default-features = false, features = [
   "gateway",

--- a/py-rattler-build/pixi.lock
+++ b/py-rattler-build/pixi.lock
@@ -3786,7 +3786,7 @@ packages:
   - __glibc >=2.17
   license: BSD-3-Clause
   input:
-    hash: 38541d6788d5bf0338ad1c5f71a9c116ddb8a6ed9f19e7e42b9288095dfed289
+    hash: 750be6b0351f15dd166a306610b756eddddc00df36d1d18019d7430625795e98
     globs:
     - pyproject.toml
 - conda: .
@@ -3801,7 +3801,7 @@ packages:
   - __osx >=10.13
   license: BSD-3-Clause
   input:
-    hash: 38541d6788d5bf0338ad1c5f71a9c116ddb8a6ed9f19e7e42b9288095dfed289
+    hash: 750be6b0351f15dd166a306610b756eddddc00df36d1d18019d7430625795e98
     globs:
     - pyproject.toml
 - conda: .
@@ -3816,7 +3816,7 @@ packages:
   - __osx >=11.0
   license: BSD-3-Clause
   input:
-    hash: 38541d6788d5bf0338ad1c5f71a9c116ddb8a6ed9f19e7e42b9288095dfed289
+    hash: 750be6b0351f15dd166a306610b756eddddc00df36d1d18019d7430625795e98
     globs:
     - pyproject.toml
 - conda: .
@@ -3829,7 +3829,7 @@ packages:
   - python_abi 3.8.* *_cp38
   license: BSD-3-Clause
   input:
-    hash: 38541d6788d5bf0338ad1c5f71a9c116ddb8a6ed9f19e7e42b9288095dfed289
+    hash: 750be6b0351f15dd166a306610b756eddddc00df36d1d18019d7430625795e98
     globs:
     - pyproject.toml
 - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,7 @@ pub fn get_tool_config(
 ) -> miette::Result<Configuration> {
     let client = tool_configuration::reqwest_client_from_auth_storage(
         build_data.common.auth_file.clone(),
+        #[cfg(feature = "s3")]
         build_data.common.s3_config.clone(),
         build_data.common.mirror_config.clone(),
         build_data.common.allow_insecure_host.clone(),
@@ -694,6 +695,7 @@ pub async fn run_test(
         .with_reqwest_client(
             tool_configuration::reqwest_client_from_auth_storage(
                 test_data.common.auth_file,
+                #[cfg(feature = "s3")]
                 test_data.common.s3_config,
                 test_data.common.mirror_config,
                 test_data.common.allow_insecure_host.clone(),
@@ -752,6 +754,7 @@ pub async fn rebuild(
 ) -> miette::Result<()> {
     let reqwest_client = tool_configuration::reqwest_client_from_auth_storage(
         rebuild_data.common.auth_file,
+        #[cfg(feature = "s3")]
         rebuild_data.common.s3_config.clone(),
         rebuild_data.common.mirror_config.clone(),
         rebuild_data.common.allow_insecure_host.clone(),

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -11,7 +11,9 @@ use rattler_conda_types::{
     NamedChannelOrUrl, Platform, compression_level::CompressionLevel, package::ArchiveType,
 };
 use rattler_config::config::build::PackageFormatAndCompression;
-use rattler_networking::{mirror_middleware, s3_middleware};
+use rattler_networking::mirror_middleware;
+#[cfg(feature = "s3")]
+use rattler_networking::s3_middleware;
 use rattler_solve::ChannelPriority;
 use rattler_upload::upload::opt::{Config, UploadOpts};
 use serde_json::{Value, json};
@@ -231,6 +233,7 @@ pub struct CommonData {
     pub experimental: bool,
     pub auth_file: Option<PathBuf>,
     pub channel_priority: ChannelPriority,
+    #[cfg(feature = "s3")]
     pub s3_config: HashMap<String, s3_middleware::S3Config>,
     pub mirror_config: HashMap<Url, Vec<mirror_middleware::Mirror>>,
     pub allow_insecure_host: Option<Vec<String>>,
@@ -285,11 +288,14 @@ impl CommonData {
             mirror_config.insert(ensure_trailing_slash(key), mirrors);
         }
 
+        #[cfg(feature = "s3")]
         let s3_config = rattler_networking::s3_middleware::compute_s3_config(&config.s3_options.0);
+
         Self {
             output_dir: output_dir.unwrap_or_else(|| PathBuf::from("./output")),
             experimental,
             auth_file,
+            #[cfg(feature = "s3")]
             s3_config,
             mirror_config,
             channel_priority: channel_priority.unwrap_or(ChannelPriority::Strict),

--- a/src/tool_configuration.rs
+++ b/src/tool_configuration.rs
@@ -107,7 +107,7 @@ impl BaseClient {
                 .read_timeout(std::time::Duration::from_secs(timeout))
         };
 
-        let mut client_builder = reqwest_middleware::ClientBuilder::new(
+        let client_builder = reqwest_middleware::ClientBuilder::new(
             common_settings(reqwest::Client::builder())
                 .build()
                 .expect("failed to create client"),


### PR DESCRIPTION
This PR makes the s3 support in rattler-build optional (but enabled by default).