### PR TITLE
feat: add test execution in debug mode

### DIFF
--- a/src/opt.rs
+++ b/src/opt.rs
@@ -895,6 +895,13 @@ pub struct DebugOpts {
     /// Name of the specific output to debug (only required when a recipe has multiple outputs)
     #[arg(long, help = "Name of the specific output to debug")]
     pub output_name: Option<String>,
+
+    /// Run tests in debug mode.
+    #[arg(
+        long,
+        help = "Run tests in debug mode. Optionally specify test index to run a specific test (default: run all tests)"
+    )]
+    pub test: Option<Option<usize>>,
 }
 
 #[derive(Debug, Clone)]
@@ -916,6 +923,10 @@ pub struct DebugData {
     pub common: CommonData,
     /// Name of the specific output to debug (if recipe has multiple outputs)
     pub output_name: Option<String>,
+    /// Whether test mode is enabled
+    pub test_mode: bool,
+    /// Test index to run in debug mode. None means run all tests, Some(n) means run test n.
+    pub test_index: Option<usize>,
 }
 
 impl DebugData {
@@ -933,6 +944,8 @@ impl DebugData {
             channels: opts.channels,
             common: CommonData::from_opts_and_config(opts.common, config.unwrap_or_default()),
             output_name: opts.output_name,
+            test_mode: opts.test.is_some(), // true if --test flag was provided
+            test_index: opts.test.flatten(), // None = all tests, Some(n) = specific test
         }
     }
 }


### PR DESCRIPTION
This PR adds a test debug mode, allowing users to set up a test environment and select a specific test to execute.

* Added a new `--test` CLI option to `DebugOpts` that allows users to run tests in debug mode and optionally specify the test index to focus on.
* Updated `DebugData` to include a `test_index` field, enabling the selection of a specific test for debugging; logic added to handle default and explicit test index values. [[1]](diffhunk://#diff-b91b0157c73f1643f94c1e8e2d0a24eb8f05d017d943005c8671f6244d58ad17R923-R924) [[2]](diffhunk://#diff-b91b0157c73f1643f94c1e8e2d0a24eb8f05d017d943005c8671f6244d58ad17R942)
* Enhanced the `debug_recipe` function in `src/lib.rs` to support test debug mode: sets up the test environment, validates the test index, displays available tests, and provides instructions for running tests after environment setup. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R1075-R1077) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R1183-R1223) [[3]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R1242)


Fixes #1951 
Fixes #655 