### PR TITLE
fix: Add helpful error messages for invalid root-level field names

### DIFF
--- a/src/recipe/snapshots/rattler_build__recipe__parser__tests__invalid_root_field.snap
+++ b/src/recipe/snapshots/rattler_build__recipe__parser__tests__invalid_root_field.snap
@@ -1,0 +1,17 @@
+---
+source: src/recipe/parser.rs
+expression: err
+---
+  × Failed to parse recipe
+
+Error: 
+  × invalid field `test`.
+   ╭─[6:9]
+ 5 │ 
+ 6 │         test:
+   ·         ──┬─
+   ·           ╰── here
+ 7 │           - python:
+   ╰────
+  help: valid fields are `schema_version`, `package`, `context`, `source`,
+        `build`, `requirements`, `tests`, `about`, `extra`


### PR DESCRIPTION
When users provide an invalid field name at the root level of a recipe (e.g., "test" instead of "tests"), the error message now includes a helpful list of valid fields.

Changes:
- Added ALLOWED_FIELDS and EXPERIMENTAL_FIELD static arrays that define valid root-level fields in one place
- Generate help messages dynamically from these arrays, including proper handling of experimental mode (which adds "cache")
- Added test case to verify the help message appears correctly

This follows the same maintainable pattern used in output.rs with ALLOWED_KEYS_MULTI_OUTPUTS.

Example output:
```
  Error: invalid field `test`.
  help: valid fields are `schema_version`, `package`, `context`,
        `source`, `build`, `requirements`, `tests`, `about`, `extra`
```

Fixes #1971