### PR TITLE
fix: skip overdepending check for packages without binaries

### DIFF
--- a/src/post_process/checks.rs
+++ b/src/post_process/checks.rs
@@ -372,6 +372,12 @@ pub fn perform_linking_checks(
         tracing::info!("{linked_package}");
     });
 
+    // If there are no binaries, skip the overdepending check.
+    // Packages without binaries can't link against libraries.
+    if package_files.is_empty() {
+        return Ok(());
+    }
+
     // If there are any unused run dependencies then it is "overdepending".
     for run_dependency in resolved_run_dependencies.iter() {
         if !package_files


### PR DESCRIPTION
Fixes issue #1949 where rattler-build incorrectly warns about overdepending for packages that contain no linkable binaries.

The overdepending check looks for unused library dependencies by checking which libraries the package's binaries link against. For packages without any binaries, this check is meaningless - there's nothing that could link to libraries.

This prevents false positives when building packages with only run dependencies like `pixi-build-api-version` (version constraint packages).

Fixes #1949

## AI Disclosure

Claude Code Web wrote this.