### PR TITLE
feat: add `expected-commit` verification to git sources

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -17,6 +17,7 @@ This document contains the help content for the `rattler-build` command-line pro
 * `auth` — Handle authentication to external channels
 * `debug` — Debug a recipe by setting up the environment without running the build script
 * `create-patch` — Create a patch for a directory
+* `debug-shell` — Open a debug shell in the build environment
 
 ##### **Options:**
 
@@ -987,13 +988,13 @@ Debug a recipe by setting up the environment without running the build script
 
 Create a patch for a directory
 
-**Usage:** `rattler-build create-patch [OPTIONS] --directory <DIRECTORY>`
+**Usage:** `rattler-build create-patch [OPTIONS]`
 
 ##### **Options:**
 
 - `-d`, `--directory <DIRECTORY>`
 
-	Directory where we want to create the patch
+	Directory where we want to create the patch. Defaults to current directory if not specified
 
 
 - `--name <NAME>`
@@ -1017,10 +1018,42 @@ Create a patch for a directory
 	Comma-separated list of file names (or glob patterns) that should be excluded from the diff
 
 
+- `--add <ADD>`
+
+	Include new files matching these glob patterns (e.g., "*.txt", "src/**/*.rs")
+
+
+- `--include <INCLUDE>`
+
+	Only include modified files matching these glob patterns (e.g., "*.c", "src/**/*.rs") If not specified, all modified files are included (subject to --exclude)
+
+
 - `--dry-run`
 
-	Perform a dry-run: analyse changes and log the diff, but don't write the patch file
+	Perform a dry-run: analyze changes and log the diff, but don't write the patch file
 
+
+
+
+
+### `debug-shell`
+
+Open a debug shell in the build environment
+
+**Usage:** `rattler-build debug-shell [OPTIONS]`
+
+##### **Options:**
+
+- `--work-dir <WORK_DIR>`
+
+	Work directory to use (reads from last build in rattler-build-log.txt if not specified)
+
+
+- `-o`, `--output-dir <OUTPUT_DIR>`
+
+	Output directory containing rattler-build-log.txt
+
+	- Default value: `./output`
 
 
 

--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -246,15 +246,19 @@ source:
   lfs: true # note: defaults to false
 ```
 
-##### Verifying commit hash with `expected-commit`
+##### Verifying commit hash with `expected_commit`
 
-For security and reproducibility, you can specify an `expected-commit` field to verify that the checked out commit matches the expected SHA hash. This is useful to detect if a tag or branch has been moved to point to a different commit:
+!!! note
+    This feature is only available with `--experimental` as it was not part of the standardization yet.
+
+
+For security and reproducibility, you can specify an `expected_commit` field to verify that the checked out commit matches the expected SHA hash. This is useful to detect if a tag or branch has been moved to point to a different commit:
 
 ```yaml
 source:
   git: https://github.com/ilanschnell/bsdiff4.git
   tag: "1.1.4"
-  expected-commit: 50a1f7ed6c168eb0815d424cba2df62790f168f0
+  expected_commit: 50a1f7ed6c168eb0815d424cba2df62790f168f0
 ```
 
 If the actual commit does not match the expected commit, the build will fail with an error message indicating the mismatch. This feature is inspired by [Wolfi/Melange](https://github.com/wolfi-dev/wolfi-os) and provides an additional layer of security for your builds.

--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -246,6 +246,19 @@ source:
   lfs: true # note: defaults to false
 ```
 
+##### Verifying commit hash with `expected-commit`
+
+For security and reproducibility, you can specify an `expected-commit` field to verify that the checked out commit matches the expected SHA hash. This is useful to detect if a tag or branch has been moved to point to a different commit:
+
+```yaml
+source:
+  git: https://github.com/ilanschnell/bsdiff4.git
+  tag: "1.1.4"
+  expected-commit: 50a1f7ed6c168eb0815d424cba2df62790f168f0
+```
+
+If the actual commit does not match the expected commit, the build will fail with an error message indicating the mismatch. This feature is inspired by [Wolfi/Melange](https://github.com/wolfi-dev/wolfi-os) and provides an additional layer of security for your builds.
+
 #### Source from a local path
 
 If the path is relative, it is taken relative to the recipe directory. The

--- a/src/recipe/parser.rs
+++ b/src/recipe/parser.rs
@@ -296,7 +296,21 @@ impl Recipe {
                             )])
                         }
                     }
-                    "source" => source = value.try_convert(key_str)?,
+                    "source" => {
+                        source = value.try_convert(key_str)?;
+                        // Validate experimental features in sources
+                        if !experimental {
+                            for src in &source {
+                                if let crate::recipe::parser::Source::Git(git_src) = src && git_src.expected_commit().is_some() {
+                                    return Err(vec![_partialerror!(
+                                        *value.span(),
+                                        ErrorKind::ExperimentalOnly("expected_commit".to_string()),
+                                        help = "The `expected_commit` field in git sources is only allowed in experimental mode (`--experimental`)"
+                                    )]);
+                                }
+                            }
+                        }
+                    }
                     "build" => build = value.try_convert(key_str)?,
                     "requirements" => requirements = value.try_convert(key_str)?,
                     "tests" => tests = value.try_convert(key_str)?,

--- a/src/recipe/parser.rs
+++ b/src/recipe/parser.rs
@@ -643,7 +643,7 @@ mod tests {
         let err: ParseErrors<_> = recipe.unwrap_err().into();
         assert_miette_snapshot!(err);
     }
-    
+
     #[test]
     fn test_noarch_conditional() {
         // Test that null/empty values for noarch are accepted and use the default (no noarch)

--- a/src/recipe/parser/snapshots/rattler_build__recipe__parser__source__tests__git_source_with_expected_commit.snap
+++ b/src/recipe/parser/snapshots/rattler_build__recipe__parser__source__tests__git_source_with_expected_commit.snap
@@ -1,0 +1,8 @@
+---
+source: src/recipe/parser/source.rs
+assertion_line: 735
+expression: yaml
+---
+git: https://test.com/test.git
+rev: refs/tags/v1.0.0
+expected_commit: abc123def456

--- a/src/recipe/parser/source.rs
+++ b/src/recipe/parser/source.rs
@@ -327,14 +327,16 @@ impl TryConvertNode<GitSource> for RenderedMappingNode {
                 "lfs" => {
                     lfs = v.try_convert("lfs")?;
                 }
-                "expected-commit" => {
-                    expected_commit = Some(v.try_convert("expected-commit")?);
+                "expected_commit" => {
+                    // Make sure that `--experimental` mode is enabled
+
+                    expected_commit = Some(v.try_convert("expected_commit")?);
                 }
                 _ => {
                     return Err(vec![_partialerror!(
                         *k.span(),
                         ErrorKind::InvalidField(k.as_str().to_owned().into()),
-                        help = "valid fields for git `source` are `git`, `rev`, `tag`, `branch`, `depth`, `patches`, `lfs`, `expected-commit` and `target_directory`"
+                        help = "valid fields for git `source` are `git`, `rev`, `tag`, `branch`, `depth`, `patches`, `lfs`, `expected_commit` and `target_directory`"
                     )])
                 }
             }

--- a/src/recipe/parser/source.rs
+++ b/src/recipe/parser/source.rs
@@ -192,6 +192,9 @@ pub struct GitSource {
     /// Optionally request the lfs pull in git source
     #[serde(default, skip_serializing_if = "should_not_serialize_lfs")]
     pub lfs: bool,
+    /// Optionally an expected commit hash to verify after checkout
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_commit: Option<String>,
 }
 
 /// A helper method to skip serializing the lfs flag if it is false.
@@ -217,6 +220,7 @@ impl GitSource {
             patches,
             target_directory,
             lfs,
+            expected_commit: None,
         }
     }
 
@@ -249,6 +253,11 @@ impl GitSource {
     pub const fn lfs(&self) -> bool {
         self.lfs
     }
+
+    /// Get the expected commit hash.
+    pub fn expected_commit(&self) -> Option<&str> {
+        self.expected_commit.as_deref()
+    }
 }
 
 impl TryConvertNode<GitSource> for RenderedMappingNode {
@@ -259,6 +268,7 @@ impl TryConvertNode<GitSource> for RenderedMappingNode {
         let mut patches = Vec::new();
         let mut target_directory = None;
         let mut lfs = false;
+        let mut expected_commit = None;
 
         self.iter().map(|(k, v)| {
             match k.as_str() {
@@ -317,11 +327,14 @@ impl TryConvertNode<GitSource> for RenderedMappingNode {
                 "lfs" => {
                     lfs = v.try_convert("lfs")?;
                 }
+                "expected-commit" => {
+                    expected_commit = Some(v.try_convert("expected-commit")?);
+                }
                 _ => {
                     return Err(vec![_partialerror!(
                         *k.span(),
                         ErrorKind::InvalidField(k.as_str().to_owned().into()),
-                        help = "valid fields for git `source` are `git`, `rev`, `tag`, `branch`, `depth`, `patches`, `lfs` and `target_directory`"
+                        help = "valid fields for git `source` are `git`, `rev`, `tag`, `branch`, `depth`, `patches`, `lfs`, `expected-commit` and `target_directory`"
                     )])
                 }
             }
@@ -354,6 +367,7 @@ impl TryConvertNode<GitSource> for RenderedMappingNode {
             patches,
             target_directory,
             lfs,
+            expected_commit,
         })
     }
 }
@@ -652,6 +666,7 @@ mod tests {
             patches: Vec::new(),
             target_directory: None,
             lfs: false,
+            expected_commit: None,
         };
 
         let yaml = serde_yaml::to_string(&git).unwrap();
@@ -672,6 +687,7 @@ mod tests {
             patches: Vec::new(),
             target_directory: None,
             lfs: false,
+            expected_commit: None,
         };
 
         let yaml = serde_yaml::to_string(&git).unwrap();
@@ -700,5 +716,50 @@ mod tests {
 
         let json = serde_json::to_string(&path_source).unwrap();
         serde_json::from_str::<PathSource>(&json).unwrap();
+    }
+
+    #[test]
+    fn test_git_source_with_expected_commit() {
+        let git = GitSource {
+            url: GitUrl::Url(Url::parse("https://test.com/test.git").unwrap()),
+            rev: GitRev::Tag("v1.0.0".into()),
+            depth: None,
+            patches: Vec::new(),
+            target_directory: None,
+            lfs: false,
+            expected_commit: Some("abc123def456".to_string()),
+        };
+
+        let yaml = serde_yaml::to_string(&git).unwrap();
+
+        insta::assert_snapshot!(yaml);
+
+        let parsed_git: GitSource = serde_yaml::from_str(&yaml).unwrap();
+
+        assert_eq!(parsed_git.expected_commit, git.expected_commit);
+        assert_eq!(parsed_git.expected_commit(), Some("abc123def456"));
+    }
+
+    #[test]
+    fn test_git_source_without_expected_commit() {
+        let git = GitSource {
+            url: GitUrl::Url(Url::parse("https://test.com/test.git").unwrap()),
+            rev: GitRev::Tag("v1.0.0".into()),
+            depth: None,
+            patches: Vec::new(),
+            target_directory: None,
+            lfs: false,
+            expected_commit: None,
+        };
+
+        let yaml = serde_yaml::to_string(&git).unwrap();
+
+        // expected_commit should not appear in serialized yaml when None
+        assert!(!yaml.contains("expected"));
+
+        let parsed_git: GitSource = serde_yaml::from_str(&yaml).unwrap();
+
+        assert_eq!(parsed_git.expected_commit, None);
+        assert_eq!(parsed_git.expected_commit(), None);
     }
 }

--- a/src/recipe/parser/source.rs
+++ b/src/recipe/parser/source.rs
@@ -328,8 +328,7 @@ impl TryConvertNode<GitSource> for RenderedMappingNode {
                     lfs = v.try_convert("lfs")?;
                 }
                 "expected_commit" => {
-                    // Make sure that `--experimental` mode is enabled
-
+                    // We are parsing here, but later validating that --experimental was enabled
                     expected_commit = Some(v.try_convert("expected_commit")?);
                 }
                 _ => {

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -91,6 +91,15 @@ pub enum SourceError {
     #[error("Failed to run git command: {0}")]
     GitErrorStr(&'static str),
 
+    #[error(
+        "Git commit mismatch: expected commit '{expected}' but got '{actual}' for revision '{rev}'"
+    )]
+    GitCommitMismatch {
+        expected: String,
+        actual: String,
+        rev: String,
+    },
+
     #[error("{0}")]
     UnknownError(String),
 

--- a/test-data/recipes/git_source_expected_commit/recipe.yaml
+++ b/test-data/recipes/git_source_expected_commit/recipe.yaml
@@ -5,7 +5,7 @@ package:
 source:
   - git: https://github.com/prefix-dev/rattler-build
     tag: v0.1.0
-    expected-commit: df83c1edf287a756b8fc995e03e9632af0344777
+    expected_commit: df83c1edf287a756b8fc995e03e9632af0344777
 
 build:
   script:

--- a/test-data/recipes/git_source_expected_commit/recipe.yaml
+++ b/test-data/recipes/git_source_expected_commit/recipe.yaml
@@ -1,0 +1,12 @@
+package:
+  name: "git_source_expected_commit"
+  version: "1"
+
+source:
+  - git: https://github.com/prefix-dev/rattler-build
+    tag: v0.1.0
+    expected-commit: df83c1edf287a756b8fc995e03e9632af0344777
+
+build:
+  script:
+    - test -f README.md


### PR DESCRIPTION
This PR implements the feature requested in issue #1895, adding an optional `expected-commit` field to git source configurations.

Changes:
- Added `expected_commit` field to GitSource struct in source.rs
- Added GitCommitMismatch error variant to SourceError enum for structured error handling with expected, actual, and rev fields
- Implemented verification logic in git_source.rs to compare actual commit against expected commit after checkout
- Added comprehensive unit tests for serialization/deserialization
- Added integration tests for both success and failure cases
- Created test recipe demonstrating the feature
- Updated documentation in recipe_file.md with usage examples

The feature helps ensure security and reproducibility by detecting when a git tag or branch has been moved to point to a different commit than expected.

Closes #1895