### PR TITLE
fix: reduce verbosity of rpath conversion logging

### DIFF
--- a/src/linux/link.rs
+++ b/src/linux/link.rs
@@ -233,7 +233,12 @@ impl Relinker for SharedObject {
                     },
                 )?;
 
-                tracing::info!("New relative path: $ORIGIN/{}", relative_path.display());
+                tracing::debug!(
+                    "Converted rpath {} to $ORIGIN/{} for {:?}",
+                    rpath.display(),
+                    relative_path.display(),
+                    self.path
+                );
                 final_rpaths.push(PathBuf::from(format!(
                     "$ORIGIN/{}",
                     relative_path.to_string_lossy()


### PR DESCRIPTION
I sometimes see this in logs:

```
 │ ╭─ Packaging new files
 │ │ Copying done!
 │ │ New relative path: $ORIGIN/../../../../lib
 │ │ New relative path: $ORIGIN/../../../../lib
 │ │ New relative path: $ORIGIN/../../../../lib
 │ │ New relative path: $ORIGIN/../../../../lib
 │ │ New relative path: $ORIGIN/../../../lib
 │ │ New relative path: $ORIGIN/../../../lib
 │ │ New relative path: $ORIGIN/../../../../lib
 │ │ New relative path: $ORIGIN/../../../../lib
 │ │ New relative path: $ORIGIN/../../../../lib
 │ │ New relative path: $ORIGIN/../../../../lib
 │ │ New relative path: $ORIGIN/../../../../lib
 │ │ New relative path: $ORIGIN/../../../../lib
 │ │ New relative path: $ORIGIN/../../../../lib
 │ │ New relative path: $ORIGIN/../../../../lib
 │ │ New relative path: $ORIGIN/../../../../lib
 │ │ New relative path: $ORIGIN/../../../../lib
 │ │ New relative path: $ORIGIN/../../../../lib
 ```

This seems very unhelpful and a bit verbose. So this PR changes the 'New relative path' log message from `info` to `debug` level and add more context (original `rpath` and file path). This prevents the verbose and repetitive output during normal package builds while still making the information available for debugging.