### PR TITLE
feat: add `package inspect` subcommand

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ mod env_vars;
 pub mod hash;
 mod linux;
 mod macos;
+mod package_info;
 mod post_process;
 mod publish;
 pub mod rebuild;
@@ -1485,4 +1486,9 @@ pub async fn debug_recipe(
     }
 
     Ok(())
+}
+
+/// Display information about a built package
+pub fn show_package_info(args: InspectOpts) -> miette::Result<()> {
+    package_info::package_info(args)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,10 +14,10 @@ use rattler_build::{
     console_utils::init_logging,
     debug_recipe, get_recipe_path,
     opt::{
-        App, BuildData, DebugData, DebugShellOpts, PublishData, RebuildData, ShellCompletion,
-        SubCommands, TestData,
+        App, BuildData, DebugData, DebugShellOpts, PackageCommands, PublishData, RebuildData,
+        ShellCompletion, SubCommands, TestData,
     },
-    publish_packages, rebuild, run_test,
+    publish_packages, rebuild, run_test, show_package_info,
     source::create_patch,
 };
 use rattler_config::config::ConfigBase;
@@ -373,6 +373,9 @@ async fn async_main() -> miette::Result<()> {
             }
         }
         Some(SubCommands::DebugShell(opts)) => debug_shell(opts).into_diagnostic(),
+        Some(SubCommands::Package(cmd)) => match cmd {
+            PackageCommands::Inspect(opts) => show_package_info(opts),
+        },
         None => {
             _ = App::command().print_long_help();
             Ok(())

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -81,6 +81,10 @@ pub enum SubCommands {
 
     /// Open a debug shell in the build environment
     DebugShell(DebugShellOpts),
+
+    /// Package-related subcommands
+    #[command(subcommand)]
+    Package(PackageCommands),
 }
 
 /// Options for the debug-shell command
@@ -93,6 +97,13 @@ pub struct DebugShellOpts {
     /// Output directory containing rattler-build-log.txt
     #[arg(short, long, default_value = "./output")]
     pub output_dir: PathBuf,
+}
+
+/// Package-related subcommands.
+#[derive(Parser, Debug, Clone)]
+pub enum PackageCommands {
+    /// Inspect and display information about a built package
+    Inspect(InspectOpts),
 }
 
 /// Shell completion options.
@@ -1129,4 +1140,48 @@ pub struct CreatePatchOpts {
     /// Perform a dry-run: analyze changes and log the diff, but don't write the patch file.
     #[arg(long, default_value = "false")]
     pub dry_run: bool,
+}
+
+/// Options for the `package inspect` command.
+#[derive(Parser, Debug, Clone)]
+pub struct InspectOpts {
+    /// Path to the package file (.conda, .tar.bz2)
+    pub package_file: PathBuf,
+
+    /// Show detailed file listing with hashes and sizes
+    #[arg(long)]
+    pub paths: bool,
+
+    /// Show extended about information
+    #[arg(long)]
+    pub about: bool,
+
+    /// Show run exports
+    #[arg(long)]
+    pub run_exports: bool,
+
+    /// Show all available information
+    #[arg(long)]
+    pub all: bool,
+
+    /// Output as JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+impl InspectOpts {
+    /// Check if paths should be shown (either explicitly or via --all)
+    pub fn show_paths(&self) -> bool {
+        self.paths || self.all
+    }
+
+    /// Check if about info should be shown (either explicitly or via --all)
+    pub fn show_about(&self) -> bool {
+        self.about || self.all
+    }
+
+    /// Check if run exports should be shown (either explicitly or via --all)
+    pub fn show_run_exports(&self) -> bool {
+        self.run_exports || self.all
+    }
 }

--- a/src/package_info.rs
+++ b/src/package_info.rs
@@ -1,0 +1,322 @@
+//! Display information about a built package
+
+use std::path::Path;
+
+use fs_err as fs;
+use indicatif::HumanBytes;
+use miette::IntoDiagnostic;
+use rattler_conda_types::package::{AboutJson, IndexJson, PathType, PathsJson, RunExportsJson};
+use rattler_package_streaming::seek::read_package_file;
+
+use crate::opt::InspectOpts;
+
+/// Package metadata read from the archive
+struct PackageMetadata {
+    index: IndexJson,
+    about: Option<AboutJson>,
+    paths: Option<PathsJson>,
+    run_exports: Option<RunExportsJson>,
+}
+
+/// Read and display information about a package
+pub fn package_info(args: InspectOpts) -> miette::Result<()> {
+    let package_path = &args.package_file;
+
+    // Validate that the path exists and is a file
+    if !package_path.exists() {
+        return Err(miette::miette!(
+            "Package file does not exist: {}",
+            package_path.display()
+        ));
+    }
+
+    if !package_path.is_file() {
+        return Err(miette::miette!(
+            "Path is not a file: {}. Expected a package file (.conda or .tar.bz2)",
+            package_path.display()
+        ));
+    }
+
+    // Read metadata directly from the package file
+    let metadata = read_package_metadata(package_path)?;
+
+    // Output as JSON if requested
+    if args.json {
+        output_json(
+            &metadata.index,
+            &metadata.about,
+            &metadata.paths,
+            &metadata.run_exports,
+            &args,
+        )?;
+        return Ok(());
+    }
+
+    // Output human-readable format
+    output_human_readable(
+        &metadata.index,
+        &metadata.about,
+        &metadata.paths,
+        &metadata.run_exports,
+        &args,
+        package_path,
+    )?;
+
+    Ok(())
+}
+
+/// Read package metadata directly from the archive
+fn read_package_metadata(package_path: &Path) -> miette::Result<PackageMetadata> {
+    // Read index.json (required)
+    let index_json: IndexJson = read_package_file(package_path)
+        .into_diagnostic()
+        .map_err(|e| miette::miette!("Failed to read index.json from package: {}", e))?;
+
+    // Read about.json (optional)
+    let about_json: Option<AboutJson> = read_package_file(package_path).ok();
+
+    // Read paths.json (optional)
+    let paths_json: Option<PathsJson> = read_package_file(package_path).ok();
+
+    // Read run_exports.json (optional)
+    let run_exports_json: Option<RunExportsJson> = read_package_file(package_path).ok();
+
+    Ok(PackageMetadata {
+        index: index_json,
+        about: about_json,
+        paths: paths_json,
+        run_exports: run_exports_json,
+    })
+}
+
+/// Output package information in JSON format
+fn output_json(
+    index_json: &IndexJson,
+    about_json: &Option<AboutJson>,
+    paths_json: &Option<PathsJson>,
+    run_exports_json: &Option<RunExportsJson>,
+    args: &InspectOpts,
+) -> miette::Result<()> {
+    let mut output = serde_json::Map::new();
+
+    // Always include index info
+    output.insert(
+        "index".to_string(),
+        serde_json::to_value(index_json).into_diagnostic()?,
+    );
+
+    // Include about info if requested or available
+    if args.show_about()
+        && let Some(about) = about_json
+    {
+        output.insert(
+            "about".to_string(),
+            serde_json::to_value(about).into_diagnostic()?,
+        );
+    }
+
+    // Include paths if requested
+    if args.show_paths()
+        && let Some(paths) = paths_json
+    {
+        output.insert(
+            "paths".to_string(),
+            serde_json::to_value(paths).into_diagnostic()?,
+        );
+    }
+
+    // Include run_exports if requested
+    if args.show_run_exports()
+        && let Some(run_exports) = run_exports_json
+    {
+        output.insert(
+            "run_exports".to_string(),
+            serde_json::to_value(run_exports).into_diagnostic()?,
+        );
+    }
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&output).into_diagnostic()?
+    );
+
+    Ok(())
+}
+
+/// Output package information in human-readable format
+fn output_human_readable(
+    index_json: &IndexJson,
+    about_json: &Option<AboutJson>,
+    paths_json: &Option<PathsJson>,
+    run_exports_json: &Option<RunExportsJson>,
+    args: &InspectOpts,
+    package_path: &Path,
+) -> miette::Result<()> {
+    // Package file info
+    if package_path.is_file() {
+        let size = fs::metadata(package_path).map(|m| m.len()).unwrap_or(0);
+        tracing::info!("Package: {} ({})", package_path.display(), HumanBytes(size));
+    } else {
+        tracing::info!("Package directory: {}", package_path.display());
+    }
+
+    // Basic package information
+    let mut table = comfy_table::Table::new();
+    table
+        .load_preset(comfy_table::presets::UTF8_FULL_CONDENSED)
+        .apply_modifier(comfy_table::modifiers::UTF8_ROUND_CORNERS)
+        .set_header(vec!["Property", "Value"]);
+
+    table.add_row(vec!["Name", &index_json.name.as_normalized()]);
+    table.add_row(vec!["Version", &index_json.version.to_string()]);
+    table.add_row(vec!["Build", &index_json.build]);
+    table.add_row(vec!["Build number", &index_json.build_number.to_string()]);
+
+    if let Some(ref subdir) = index_json.subdir {
+        table.add_row(vec!["Subdir", subdir.as_str()]);
+    }
+
+    if let Some(timestamp) = index_json.timestamp {
+        // Format timestamp as a readable date (e.g., "2025-11-25 07:56:45 UTC")
+        let formatted_time = timestamp
+            .datetime()
+            .format("%Y-%m-%d %H:%M:%S UTC")
+            .to_string();
+        table.add_row(vec!["Timestamp", &formatted_time]);
+    }
+
+    // Add about.json fields to the main table if available
+    if let Some(about) = about_json {
+        if let Some(license) = &about.license {
+            table.add_row(vec!["License", license]);
+        }
+        if let Some(ref summary) = about.summary
+            && !summary.is_empty()
+        {
+            table.add_row(vec!["Summary", summary]);
+        }
+        if let Some(ref description) = about.description
+            && !description.is_empty()
+        {
+            table.add_row(vec!["Description", description]);
+        }
+        if !about.home.is_empty() {
+            let homes = about
+                .home
+                .iter()
+                .map(|h| h.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            table.add_row(vec!["Homepage", &homes]);
+        }
+        if !about.dev_url.is_empty() {
+            let dev_urls = about
+                .dev_url
+                .iter()
+                .map(|u| u.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            table.add_row(vec!["Development URL", &dev_urls]);
+        }
+        if !about.doc_url.is_empty() {
+            let doc_urls = about
+                .doc_url
+                .iter()
+                .map(|u| u.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            table.add_row(vec!["Documentation URL", &doc_urls]);
+        }
+    }
+
+    tracing::info!("\n{}", table);
+
+    // Dependencies
+    if !index_json.depends.is_empty() {
+        tracing::info!("\nRun dependencies:");
+        let mut dep_table = comfy_table::Table::new();
+        dep_table
+            .load_preset(comfy_table::presets::UTF8_FULL_CONDENSED)
+            .apply_modifier(comfy_table::modifiers::UTF8_ROUND_CORNERS)
+            .set_header(vec!["Package"]);
+
+        for dep in &index_json.depends {
+            dep_table.add_row(vec![dep]);
+        }
+
+        tracing::info!("{}", dep_table);
+    }
+
+    if !index_json.constrains.is_empty() {
+        tracing::info!("\nConstraints:");
+        let mut constraint_table = comfy_table::Table::new();
+        constraint_table
+            .load_preset(comfy_table::presets::UTF8_FULL_CONDENSED)
+            .apply_modifier(comfy_table::modifiers::UTF8_ROUND_CORNERS)
+            .set_header(vec!["Constraint"]);
+
+        for constraint in &index_json.constrains {
+            constraint_table.add_row(vec![constraint]);
+        }
+
+        tracing::info!("{}", constraint_table);
+    }
+
+    // Paths (only with --paths flag)
+    if args.show_paths()
+        && let Some(paths) = paths_json
+    {
+        tracing::info!("\nPackage files ({} total):", paths.paths.len());
+
+        let mut paths_table = comfy_table::Table::new();
+        paths_table
+            .load_preset(comfy_table::presets::UTF8_FULL_CONDENSED)
+            .apply_modifier(comfy_table::modifiers::UTF8_ROUND_CORNERS)
+            .set_header(vec!["Path", "Size", "Type", "Prefix", "SHA256"]);
+
+        for entry in &paths.paths {
+            let path_type = match entry.path_type {
+                PathType::HardLink => "file",
+                PathType::SoftLink => "symlink",
+                PathType::Directory => "dir",
+            };
+
+            let size = entry
+                .size_in_bytes
+                .map(|s| HumanBytes(s).to_string())
+                .unwrap_or_else(|| "-".to_string());
+
+            let sha256 = entry
+                .sha256
+                .as_ref()
+                .map(hex::encode)
+                .unwrap_or_else(|| "-".to_string());
+
+            let prefix_info = if let Some(prefix_placeholder) = &entry.prefix_placeholder {
+                match prefix_placeholder.file_mode {
+                    rattler_conda_types::package::FileMode::Binary => "binary",
+                    rattler_conda_types::package::FileMode::Text => "text",
+                }
+            } else {
+                "-"
+            };
+
+            let path = entry.relative_path.to_string_lossy();
+            paths_table.add_row(vec![&*path, &size, path_type, prefix_info, &sha256]);
+        }
+
+        tracing::info!("{}", paths_table);
+    }
+
+    // Run exports (only with --run-exports flag)
+    if args.show_run_exports()
+        && let Some(run_exports) = run_exports_json
+        && !run_exports.is_empty()
+    {
+        tracing::info!("\nRun exports:");
+        let run_exports_str = serde_json::to_string_pretty(run_exports).into_diagnostic()?;
+        tracing::info!("{}", run_exports_str);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Add a new `package inspect` subcommand to display information about built packages. The command reads metadata directly from package archives (.conda, .tar.bz2) without extraction.

Usage: rattler-build package inspect <package-file> [OPTIONS]

Features:
- Display package metadata (name, version, build, subdir, timestamp)
- Show package information (license, summary, description, URLs)
- List runtime dependencies and constraints
- Display file listings with sizes and SHA256 hashes (--paths)
- Show run exports information (--run-exports)
- JSON output support (--json)
- All flag to show everything (--all)

Example output:

```
> rattler-build package inspect output\win-64\curl-8.0.1-h9490d1a_0.conda --all
 Package: output\win-64\curl-8.0.1-h9490d1a_0.conda (385.44 KiB)

 ╭───────────────────┬────────────────────────────────────────────────────────────────────────────╮
 │ Property          ┆ Value                                                                      │
 ╞═══════════════════╪════════════════════════════════════════════════════════════════════════════╡
 │ Name              ┆ curl                                                                       │
 │ Version           ┆ 8.0.1                                                                      │
 │ Build             ┆ h9490d1a_0                                                                 │
 │ Build number      ┆ 0                                                                          │
 │ Subdir            ┆ win-64                                                                     │
 │ Timestamp         ┆ 2025-11-25 07:56:45 UTC                                                    │
 │ License           ┆ curl                                                                       │
 │ Summary           ┆ tool and library for transferring data with URL syntax                     │
 │ Description       ┆ Curl is an open source command line tool and library for transferring data │
 │                   ┆ with URL syntax. It is used in command lines or scripts to transfer data.  │
 │ Homepage          ┆ http://curl.haxx.se/                                                       │
 │ Development URL   ┆ https://github.com/curl/curl                                               │
 │ Documentation URL ┆ https://curl.haxx.se/docs/                                                 │
 ╰───────────────────┴────────────────────────────────────────────────────────────────────────────╯

 Run dependencies:
 ╭────────────────────────────╮
 │ Package                    │
 ╞════════════════════════════╡
 │ vc >=14.1,<15              │
 │ vc14_runtime >=14.16.27033 │
 │ libzlib >=1.3.1,<2.0a0     │
 ╰────────────────────────────╯

 Package files (21 total):
 ╭──────────────────────────────────────────────────┬────────────┬──────┬────────┬──────────────────────────────────────────────────────────────────╮
 │ Path                                             ┆ Size       ┆ Type ┆ Prefix ┆ SHA256                                                           │
 ╞══════════════════════════════════════════════════╪════════════╪══════╪════════╪══════════════════════════════════════════════════════════════════╡
 │ Library/bin/curl-config                          ┆ 6.18 KiB   ┆ file ┆ text   ┆ cfb556a9977a2b5369c7784a1150427e73d933bedc2f2f3b4f4699f7e195cda2 │
 │ Library/bin/curl.exe                             ┆ 165.50 KiB ┆ file ┆ -      ┆ 28e2fe03d09d861b60464417a606fa9e64456f50747d18326d07d1cb12d6f5a3 │
 │ Library/bin/libcurl.dll                          ┆ 500.00 KiB ┆ file ┆ -      ┆ 457fe015b06ef17f67bae2cf19791d7094b22232cf4f7f36370432ed0ae48da4 │
 │ Library/include/curl/curl.h                      ┆ 124.84 KiB ┆ file ┆ -      ┆ 3c35502a677855429e5158fb445c6db11aa8eab1baabda07be5e3bf8a68a9fda │
 │ Library/include/curl/curlver.h                   ┆ 2.97 KiB   ┆ file ┆ -      ┆ 0643bb8ed1f79eaaf8758304262eb2ed1e8a418344ae277e33850495aba9444b │
 │ Library/include/curl/easy.h                      ┆ 3.93 KiB   ┆ file ┆ -      ┆ b9c5aed96b32f76fd09338cb3b4066c8082b702165960e4026a0a4e0d3612634 │
 │ Library/include/curl/header.h                    ┆ 2.84 KiB   ┆ file ┆ -      ┆ 614be48a86f4e5d304c5aa40ef1c85245e25b97732921c3631840146669d992f │
 │ Library/include/curl/mprintf.h                   ┆ 2.07 KiB   ┆ file ┆ -      ┆ 637de71d034d478ad47237c376c02eefa50514ada9f2a037ca42c6ffdf66c3dc │
 │ Library/include/curl/multi.h                     ┆ 16.91 KiB  ┆ file ┆ -      ┆ 3dd2ff1eeea4298f08d0aa5c6a46140644b6ee2e710ee8bc64513e732f32975c │
 │ Library/include/curl/options.h                   ┆ 2.34 KiB   ┆ file ┆ -      ┆ 5716018d27e783283825bed2a8a051190487722fdeb64b7aa2d03a997e99b8d1 │
 │ Library/include/curl/stdcheaders.h               ┆ 1.33 KiB   ┆ file ┆ -      ┆ d7588b86814a35ffc3766ff6242e6f6705e04401fc9c208a195caff3503af81c │
 │ Library/include/curl/system.h                    ┆ 18.67 KiB  ┆ file ┆ -      ┆ afdcf4eff603a098a00a039b50a2c7576f0b1df24b02b25dd2bcf770f2472c9c │
 │ Library/include/curl/typecheck-gcc.h             ┆ 42.45 KiB  ┆ file ┆ -      ┆ d185380689acef7cee201b07cfbf20aa29f3ab7f19ba08895f927cffe028edb5 │
 │ Library/include/curl/urlapi.h                    ┆ 5.28 KiB   ┆ file ┆ -      ┆ dd631108b8503994fcf6c416eeaea2973822fc778ea2cff440c6b6e21c8712d2 │
 │ Library/include/curl/websockets.h                ┆ 2.68 KiB   ┆ file ┆ -      ┆ df5effcf55908ce67501008f99ce1ac4d01cfc48d2788d6a106dc6bfda009078 │
 │ Library/lib/cmake/CURL/CURLConfig.cmake          ┆ 2.11 KiB   ┆ file ┆ -      ┆ 4e4980a002ea4715066ba7d8fa61e06bcafdd575c031bf7173a51892cbc5a151 │
 │ Library/lib/cmake/CURL/CURLConfigVersion.cmake   ┆ 2.76 KiB   ┆ file ┆ -      ┆ 8ca38049d30ba1cacda54ce362a84e68a120bf69ed3cca06b323e32cee45fbac │
 │ Library/lib/cmake/CURL/CURLTargets-release.cmake ┆ 1.28 KiB   ┆ file ┆ -      ┆ 6585864caed322f39124baf9c594a098d47effbd9ab2ae6cf58cf8598619b46c │
 │ Library/lib/cmake/CURL/CURLTargets.cmake         ┆ 4.20 KiB   ┆ file ┆ -      ┆ 7bae05153b190cda1dc0e826b1f4d9154e4270ad521b1b6fa49696cf8f5e19da │
 │ Library/lib/libcurl_imp.lib                      ┆ 19.74 KiB  ┆ file ┆ -      ┆ ac9695ac81a1abe4987834255d3ff19c710a07b052ec21fae4af7c606f538c06 │
 │ Library/lib/pkgconfig/libcurl.pc                 ┆ 1.96 KiB   ┆ file ┆ text   ┆ c798eb2b1d6093c51911d17180551def2cc212123532a7fe1247106bb9bddc6b │
 ╰──────────────────────────────────────────────────┴────────────┴──────┴────────┴──────────────────────────────────────────────────────────────────╯
 ```
 
 Or with the `--json` flag.
 
 ```json
 > rattler-build package inspect output\win-64\curl-8.0.1-h9490d1a_0.conda --json
{
  "index": {
    "arch": "x86_64",
    "build": "h9490d1a_0",
    "build_number": 0,
    "depends": [
      "vc >=14.1,<15",
      "vc14_runtime >=14.16.27033",
      "libzlib >=1.3.1,<2.0a0"
    ],
    "license": "curl",
    "name": "curl",
    "platform": "win",
    "subdir": "win-64",
    "timestamp": 1764057405164,
    "version": "8.0.1"
  }
}
```