### PR TITLE
feat: enable subcommand suggestions for mistyped commands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ content_inspector = "0.2.4"
 serde_with = { workspace = true }
 url = { workspace = true }
 tracing = { workspace = true }
-clap = { workspace = true, features = ["env", "cargo"] }
+clap = { workspace = true, features = ["env", "cargo", "suggestions"] }
 minijinja = { version = "2.11.0", features = [
   "unstable_machinery",
   "custom_syntax",


### PR DESCRIPTION
This adds the `suggestions` cargo feature to clap, which provides helpful suggestions when users mistype subcommands. When an incorrect subcommand is entered, clap will suggest similar valid subcommands.