### PR TITLE
feat: add `package extract` subcommand

### DIFF
--- a/docs/debugging_builds.md
+++ b/docs/debugging_builds.md
@@ -18,6 +18,49 @@ rattler-build debug-shell
 bash -x conda_build.sh
 ```
 
+## Inspecting and Extracting Packages
+
+The `rattler-build package` subcommand provides utilities for inspecting and extracting built packages, which is useful for debugging package contents.
+
+### Inspecting Packages
+
+Use `package inspect` to view package metadata without extracting:
+
+```bash
+# Basic package information
+rattler-build package inspect mypackage-1.0-h12345.conda
+
+# Show all information including file listing
+rattler-build package inspect mypackage-1.0-h12345.conda --all
+
+# Show specific sections
+rattler-build package inspect mypackage-1.0-h12345.conda --paths      # File listing with hashes
+rattler-build package inspect mypackage-1.0-h12345.conda --about      # Extended about info
+rattler-build package inspect mypackage-1.0-h12345.conda --run-exports # Run exports
+
+# Output as JSON for scripting
+rattler-build package inspect mypackage-1.0-h12345.conda --json
+```
+
+### Extracting Packages
+
+Use `package extract` to extract a package to a directory for inspection:
+
+```bash
+# Extract to a directory named after the package
+rattler-build package extract mypackage-1.0-h12345.conda
+
+# Extract to a custom destination
+rattler-build package extract mypackage-1.0-h12345.conda -d my-extracted
+
+# Extract directly from a URL (supports authenticated channels)
+rattler-build package extract https://conda.anaconda.org/conda-forge/linux-64/python-3.11.0-h12345.conda
+```
+
+After extraction, the command reports the SHA256/MD5 checksums and file size, which is useful for verifying package integrity.
+
+Both `.conda` and `.tar.bz2` package formats are supported.
+
 ## Build Directory Structure
 
 When rattler-build builds a package, it creates:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1374,6 +1374,7 @@ Inspect and display information about a built package
 
 
 
+
 #### `extract`
 
 Extract a conda package to a directory
@@ -1393,6 +1394,7 @@ Extract a conda package to a directory
 - `-d`, `--dest <DEST>`
 
 	Destination directory for extraction (defaults to package name without extension)
+
 
 
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -19,6 +19,7 @@ This document contains the help content for the `rattler-build` command-line pro
 * `debug` — Debug a recipe by setting up the environment without running the build script
 * `create-patch` — Create a patch for a directory
 * `debug-shell` — Open a debug shell in the build environment
+* `package` — Package-related subcommands
 
 ##### **Options:**
 
@@ -1313,6 +1314,85 @@ Open a debug shell in the build environment
 	Output directory containing rattler-build-log.txt
 
 	- Default value: `./output`
+
+
+
+
+### `package`
+
+Package-related subcommands
+
+**Usage:** `rattler-build package <COMMAND>`
+
+##### **Subcommands:**
+
+* `inspect` — Inspect and display information about a built package
+* `extract` — Extract a conda package to a directory
+
+
+
+#### `inspect`
+
+Inspect and display information about a built package
+
+**Usage:** `rattler-build package inspect [OPTIONS] <PACKAGE_FILE>`
+
+##### **Arguments:**
+
+- `<PACKAGE_FILE>`
+
+	Path to the package file (.conda, .tar.bz2)
+
+
+
+##### **Options:**
+
+- `--paths`
+
+	Show detailed file listing with hashes and sizes
+
+
+- `--about`
+
+	Show extended about information
+
+
+- `--run-exports`
+
+	Show run exports
+
+
+- `--all`
+
+	Show all available information
+
+
+- `--json`
+
+	Output as JSON
+
+
+
+
+#### `extract`
+
+Extract a conda package to a directory
+
+**Usage:** `rattler-build package extract [OPTIONS] <PACKAGE_FILE>`
+
+##### **Arguments:**
+
+- `<PACKAGE_FILE>`
+
+	Path to the package file (.conda, .tar.bz2) or a URL to download from
+
+
+
+##### **Options:**
+
+- `-d`, `--dest <DEST>`
+
+	Destination directory for extraction (defaults to package name without extension)
 
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1492,3 +1492,8 @@ pub async fn debug_recipe(
 pub fn show_package_info(args: InspectOpts) -> miette::Result<()> {
     package_info::package_info(args)
 }
+
+/// Extract a conda package to a directory
+pub async fn extract_package(args: opt::ExtractOpts) -> miette::Result<()> {
+    package_info::extract_package(args).await
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use miette::IntoDiagnostic;
 use rattler_build::{
     build_recipes,
     console_utils::init_logging,
-    debug_recipe, get_recipe_path,
+    debug_recipe, extract_package, get_recipe_path,
     opt::{
         App, BuildData, DebugData, DebugShellOpts, PackageCommands, PublishData, RebuildData,
         ShellCompletion, SubCommands, TestData,
@@ -375,6 +375,7 @@ async fn async_main() -> miette::Result<()> {
         Some(SubCommands::DebugShell(opts)) => debug_shell(opts).into_diagnostic(),
         Some(SubCommands::Package(cmd)) => match cmd {
             PackageCommands::Inspect(opts) => show_package_info(opts),
+            PackageCommands::Extract(opts) => extract_package(opts).await,
         },
         None => {
             _ = App::command().print_long_help();

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -104,6 +104,8 @@ pub struct DebugShellOpts {
 pub enum PackageCommands {
     /// Inspect and display information about a built package
     Inspect(InspectOpts),
+    /// Extract a conda package to a directory
+    Extract(ExtractOpts),
 }
 
 /// Shell completion options.
@@ -1184,4 +1186,15 @@ impl InspectOpts {
     pub fn show_run_exports(&self) -> bool {
         self.run_exports || self.all
     }
+}
+
+/// Options for the `package extract` command.
+#[derive(Parser, Debug, Clone)]
+pub struct ExtractOpts {
+    /// Path to the package file (.conda, .tar.bz2) or a URL to download from
+    pub package_file: PackageSource,
+
+    /// Destination directory for extraction (defaults to package name without extension)
+    #[arg(short = 'd', long)]
+    pub dest: Option<PathBuf>,
 }

--- a/src/package_info.rs
+++ b/src/package_info.rs
@@ -6,7 +6,9 @@ use std::sync::Arc;
 use fs_err as fs;
 use indicatif::HumanBytes;
 use miette::{Context, IntoDiagnostic};
-use rattler_conda_types::package::{AboutJson, IndexJson, PathType, PathsJson, RunExportsJson};
+use rattler_conda_types::package::{
+    AboutJson, ArchiveType, IndexJson, PathType, PathsJson, RunExportsJson,
+};
 use rattler_networking::{AuthenticationMiddleware, AuthenticationStorage};
 use rattler_package_streaming::seek::read_package_file;
 use reqwest::Client;
@@ -329,14 +331,10 @@ fn output_human_readable(
 }
 
 /// Strips package extensions (.tar.bz2 or .conda) from a filename
-fn strip_package_extension(filename: &str) -> String {
-    if let Some(stripped) = filename.strip_suffix(".tar.bz2") {
-        stripped.to_string()
-    } else if let Some(stripped) = filename.strip_suffix(".conda") {
-        stripped.to_string()
-    } else {
-        filename.to_string()
-    }
+fn strip_package_extension(filename: &str) -> &str {
+    ArchiveType::split_str(filename)
+        .map(|(base, _)| base)
+        .unwrap_or(filename)
 }
 
 /// Creates an HTTP client with authentication middleware

--- a/src/package_info.rs
+++ b/src/package_info.rs
@@ -340,6 +340,7 @@ fn strip_package_extension(filename: &str) -> String {
 }
 
 /// Creates an HTTP client with authentication middleware
+/// TODO: Refactor to use rattler-build-networking when its available.
 fn create_authenticated_client() -> miette::Result<reqwest_middleware::ClientWithMiddleware> {
     let download_client = Client::builder()
         .no_gzip()


### PR DESCRIPTION
Add a new `rattler-build package extract` command that allows users to extract conda packages (.conda or .tar.bz2) to a directory. This command supports:

- Extracting local package files
- Downloading and extracting packages from URLs (with authentication support)
- Custom destination directory via -d/--dest flag
- Automatic destination naming based on package filename

This functionality mirrors the `rattler extract` command from rattler (added in conda/rattler#1832) but integrates it into rattler-build's `package` subcommand alongside the existing `inspect` command.

Documentation for package inspect/extract has been added to the debugging builds guide.