### PR TITLE
perf: add custom memory allocator for improved performance

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -113,7 +113,8 @@ jobs:
       CARGO_PROFILE_OPT_LEVEL: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) && 's' || '0' }}
 
       # Sets the default features which are always used also when `--no-default` is used.
-      REQUIRED_FEATURES: recipe-generation
+      # Enable the `performance` feature for release builds to use optimized memory allocators.
+      REQUIRED_FEATURES: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) && 'recipe-generation,performance' || 'recipe-generation' }}
 
     steps:
       - name: Checkout source code

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3019,6 +3019,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3197,6 +3207,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -4211,6 +4230,7 @@ dependencies = [
  "pretty_assertions",
  "ratatui",
  "rattler",
+ "rattler_build_allocator",
  "rattler_build_recipe_generator",
  "rattler_cache",
  "rattler_conda_types",
@@ -4268,6 +4288,14 @@ dependencies = [
  "xz2",
  "zip 5.1.1",
  "zstd",
+]
+
+[[package]]
+name = "rattler_build_allocator"
+version = "0.1.0"
+dependencies = [
+ "mimalloc",
+ "tikv-jemallocator",
 ]
 
 [[package]]
@@ -6084,6 +6112,26 @@ checksum = "1d36b5738d666a2b4c91b7c24998a8588db724b3107258343ebf8824bf55b06d"
 dependencies = [
  "rand 0.8.5",
  "ratatui",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ default-run = "rattler-build"
 rust-version = "1.89.0"
 
 [workspace]
-members = ["rust-tests", "crates/rattler_build_recipe_generator"]
+members = ["rust-tests", "crates/rattler_build_recipe_generator", "crates/rattler_build_allocator"]
 
 [workspace.package]
 authors = ["rattler-build contributors <hi@prefix.dev>"]
@@ -52,6 +52,10 @@ zip = { version = "5.1.1", default-features = false, features = ["deflate"] }
 
 [features]
 default = ['rustls-tls', 'recipe-generation', 's3']
+# Enable optimized memory allocators for release builds.
+# This provides significant performance improvements, especially on Linux musl.
+# Disabled by default due to increased compile time.
+performance = ["rattler_build_allocator"]
 native-tls = [
   'reqwest/native-tls',
   'rattler/native-tls',
@@ -219,6 +223,7 @@ dialoguer = "0.12.0"
 rattler_build_recipe_generator = { path = "crates/rattler_build_recipe_generator", optional = true, features = [
   "cli",
 ] }
+rattler_build_allocator = { path = "crates/rattler_build_allocator", optional = true }
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 sha2 = { workspace = true, features = ["asm"] }

--- a/crates/rattler_build_allocator/Cargo.toml
+++ b/crates/rattler_build_allocator/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "rattler_build_allocator"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "A crate that provides the best memory allocator for different platforms"
+
+[lib]
+doctest = false
+
+# Use mimalloc on Windows
+[target.'cfg(windows)'.dependencies]
+mimalloc = "0.1.43"
+
+# Use jemalloc on supported unix platforms (excluding OpenBSD and FreeBSD)
+[target.'cfg(all(not(windows), not(target_os = "openbsd"), not(target_os = "freebsd"), any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "powerpc64")))'.dependencies]
+tikv-jemallocator = "0.6.0"

--- a/crates/rattler_build_allocator/src/lib.rs
+++ b/crates/rattler_build_allocator/src/lib.rs
@@ -1,0 +1,28 @@
+//! This crate provides the best memory allocator for different platforms.
+//!
+//! On Windows, we use mimalloc because it provides good performance.
+//! On most Unix platforms (Linux, macOS), we use jemalloc for its excellent
+//! performance characteristics with multi-threaded applications.
+//!
+//! This crate is designed to be used as a dependency that, when included,
+//! automatically sets the global allocator. Simply add this crate as a
+//! dependency and the allocator will be configured.
+
+// Use mimalloc on Windows
+#[cfg(windows)]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+// Use jemalloc on supported unix platforms
+#[cfg(all(
+    not(windows),
+    not(target_os = "openbsd"),
+    not(target_os = "freebsd"),
+    any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "powerpc64"
+    )
+))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,10 @@
 //! This is the main entry point for the `rattler-build` binary.
 
+// Use custom allocators for improved performance when the `performance` feature is enabled.
+// This must be at the crate root to set the global allocator.
+#[cfg(feature = "performance")]
+use rattler_build_allocator as _;
+
 use std::{
     fs::File,
     io::{self, IsTerminal},


### PR DESCRIPTION
Introduce a new `rattler_build_allocator` crate that provides platform-optimized memory allocators:
- Windows: mimalloc
- Linux/macOS (x86_64, aarch64, ppc64): jemalloc

The allocator is enabled via the `performance` feature flag, which is automatically enabled for release builds (main branch and tags) in CI.

This approach was borrowed from pixi, where it showed significant performance improvements, especially on Linux musl (~12x faster).

The feature is disabled by default to avoid increased compile times during local development.