### PR TITLE
fix(docs): social tag generation

### DIFF
--- a/docs/layouts/custom.yml
+++ b/docs/layouts/custom.yml
@@ -2,6 +2,53 @@
 # Uses Moranga font and Paxton mascot
 size: {width: 1200, height: 630}
 
+definitions:
+  # Site name
+  - &site_name >-
+      {{ config.site_name }}
+
+  # Page title
+  - &page_title >-
+      {%- if layout.title -%}
+        {{ layout.title }}
+      {%- else -%}
+        {{ page.meta.get("title", page.title) }}
+      {%- endif -%}
+
+  # Page title with site name
+  - &page_title_with_site_name >-
+      {%- if not page.is_homepage -%}
+        {{ page.meta.get("title", page.title) }} - {{ config.site_name }}
+      {%- else -%}
+        {{ config.site_name }}
+      {%- endif -%}
+
+  # Page description
+  - &page_description >-
+      {%- if layout.description -%}
+        {{ layout.description }}
+      {%- else -%}
+        {{ page.meta.get("description", config.site_description) | x }}
+      {%- endif -%}
+
+tags:
+
+  # Open Graph
+  og:type: website
+  og:title: *page_title_with_site_name
+  og:description: *page_description
+  og:image: "{{ image.url }}"
+  og:image:type: "{{ image.type }}"
+  og:image:width: "{{ image.width }}"
+  og:image:height: "{{ image.height }}"
+  og:url: "{{ page.canonical_url }}"
+
+  # Twitter
+  twitter:card: summary_large_image
+  twitter:title: *page_title_with_site_name
+  twitter:description: *page_description
+  twitter:image: "{{ image.url }}"
+
 layers:
   # Background - brand navy
   - background:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -162,6 +162,7 @@ nav:
 plugins:
   - search
   - social:
+      enabled: true
       cards_layout_dir: docs/layouts
       cards_layout: custom
       debug: false

--- a/pixi.toml
+++ b/pixi.toml
@@ -111,7 +111,7 @@ scripts = ["scripts/activate.bat"]
 cairosvg = ">=2.8.2,<3"
 mike = ">=2.1.3,<3"
 mkdocs = ">=1.6.1,<2"
-mkdocs-material = ">=9.6.20,<10"
+mkdocs-material = ">=9.7.0,<10"
 mkdocstrings = ">=0.30.1,<0.31"
 mkdocstrings-python = ">=1.18.2,<2"
 pillow = ">=11.3.0,<12"


### PR DESCRIPTION
These got lost in the process, and thus no actual `og:image` etc. tags were created.