### PR TITLE
feat: add sentinel file to skip output directories

### DIFF
--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -23,7 +23,7 @@ mod directories;
 
 pub use build_configuration::BuildConfiguration;
 pub use build_output::BuildOutput as Output;
-pub use directories::Directories;
+pub use directories::{Directories, RATTLER_BUILD_IGNORE_FILE};
 
 /// Settings when creating the package (compression etc.)
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
I thought we implemented this already 🤦 

The idea is that a sentinel file will block us from recursing further into directories that are created by rattler-build, such as the output directory. If we detect this, then we stop iterating. 