### PR TITLE
Fixes for direct `crates/rattler_build_recipe_generator` testing

### DIFF
--- a/crates/rattler_build_recipe_generator/Cargo.toml
+++ b/crates/rattler_build_recipe_generator/Cargo.toml
@@ -8,8 +8,15 @@ repository.workspace = true
 description = "Recipe generation for PyPI, CRAN, CPAN, and LuaRocks packages"
 
 [features]
-default = []
+default = ['rustls-tls']
 cli = ["dep:clap"]
+native-tls = [
+  'reqwest/native-tls',
+]
+rustls-tls = [
+  'reqwest/rustls-tls',
+  'reqwest/rustls-tls-native-roots',
+]
 
 [dependencies]
 clap = { workspace = true, optional = true }


### PR DESCRIPTION
Two fixes to make it possible to test `crates/rattler_build_recipe_generator` directly:

- add missing `insta[yaml]` feature
- add TLS features