### PR TITLE
fix: package_contents lib not found on windows

### DIFF
--- a/src/package_test/content_test.rs
+++ b/src/package_test/content_test.rs
@@ -178,11 +178,6 @@ impl PackageContentsTest {
                                 raw.to_string(),
                                 GlobSet::builder()
                                     .add(Glob::new(&format!("Library/bin/{raw}.dll"))?)
-                                    .build()?,
-                            ));
-                            res.push((
-                                raw.to_string(),
-                                GlobSet::builder()
                                     .add(Glob::new(&format!("Library/lib/{raw}.lib"))?)
                                     .build()?,
                             ));


### PR DESCRIPTION
When testing this recipe on windows, `proj.lib` is found, but rattler still throw `error -   No match for lib glob: proj`. I think it also requires to find both `Library/lib/proj.lib` and `Library/bin/proj.dll`. This pr merge the two `GlobSet` and might fix the problem.

<details>
<summary>recipe.yaml</summary>

```yaml
context:
  name: proj
  version: "9.7.1"
package:
  version: ${{ version }}
  name: ${{ name }}
source:
  url: https://github.com/OSGeo/PROJ/archive/refs/tags/${{ version }}.tar.gz
build:
  number: 3
  script: pwsh -Command "& ${{'$env:RECIPE_DIR' if win else '$RECIPE_DIR'}}/build-${{ name }}.ps1"
requirements:
  build:
    - ${{ compiler('c') }}
    - ${{ compiler('cxx') }}
    - cmake
    - make
  host:
    - sqlite
    - libtiff
    - libcurl
  run:
    - sqlite
    - libtiff
    - libcurl
tests:
  - package_contents:
      include:
        - proj.h
      lib:
        - proj
      bin:
        - cs2cs
        - proj
        - cct
        - geod
        - gie
        - invgeod
        - invproj
  - script: projinfo -s EPSG:2230 -t EPSG:26946
 ```

</details>

[github workflow link](https://github.com/Glatzel/demon-forge/actions/runs/20650784416/job/59295350131?pr=614#step:5:948)