### PR TITLE
Use rattler_index native/rustls-tls features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ native-tls = [
   'rattler_repodata_gateway/native-tls',
   'rattler_networking/native-tls',
   'rattler_package_streaming/native-tls',
+  'rattler_index/native-tls',
 ]
 rustls-tls = [
   'reqwest/rustls-tls',
@@ -75,6 +76,7 @@ rustls-tls = [
   'rattler_repodata_gateway/rustls-tls',
   'rattler_networking/rustls-tls',
   'rattler_package_streaming/rustls-tls',
+  'rattler_index/rustls-tls',
 ]
 tui = [
   'ratatui',


### PR DESCRIPTION
xref https://github.com/conda-forge/rattler-build-feedstock/pull/158#discussion_r2675554207

unfortunately there are still other usages of rustls that we can't get as easily. mostly from AWS crates

```
rustls v0.23.35
├── aws-smithy-http-client v1.1.5
│   └── rattler_s3 v0.1.18
│       └── rattler_index v0.27.8
│           └── rattler-build v0.55.1 (/Users/pavel/projects/rattler-build)
├── hyper-rustls v0.27.7
│   ├── aws-smithy-http-client v1.1.5 (*)
│   └── reqwest v0.12.26
│       ├── http-cache-semantics v2.1.0
│       │   └── rattler_repodata_gateway v0.25.7
│       │       └── rattler-build v0.55.1 (/Users/pavel/projects/rattler-build)
│       ├── http-range-client v0.9.1 (https://github.com/pka/http-range-client.git#fccfa852)
│       │   └── rattler-build v0.55.1 (/Users/pavel/projects/rattler-build)
│       ├── opendal v0.54.1
│       │   ├── rattler_index v0.27.8 (*)
│       │   └── rattler_upload v0.4.7
│       │       └── rattler-build v0.55.1 (/Users/pavel/projects/rattler-build)
│       ├── rattler v0.39.7
│       │   └── rattler-build v0.55.1 (/Users/pavel/projects/rattler-build)
│       ├── rattler-build v0.55.1 (/Users/pavel/projects/rattler-build)
│       ├── rattler_cache v0.6.6
│       │   ├── rattler v0.39.7 (*)
│       │   ├── rattler-build v0.55.1 (/Users/pavel/projects/rattler-build)
│       │   └── rattler_repodata_gateway v0.25.7 (*)
│       ├── rattler_index v0.27.8 (*)
│       ├── rattler_networking v0.25.29
│       │   ├── rattler v0.39.7 (*)
│       │   ├── rattler-build v0.55.1 (/Users/pavel/projects/rattler-build)
│       │   ├── rattler_cache v0.6.6 (*)
│       │   ├── rattler_index v0.27.8 (*)
│       │   ├── rattler_package_streaming v0.23.21
│       │   │   ├── rattler v0.39.7 (*)
│       │   │   ├── rattler-build v0.55.1 (/Users/pavel/projects/rattler-build)
│       │   │   ├── rattler_cache v0.6.6 (*)
│       │   │   ├── rattler_index v0.27.8 (*)
│       │   │   ├── rattler_repodata_gateway v0.25.7 (*)
│       │   │   └── rattler_upload v0.4.7 (*)
│       │   ├── rattler_repodata_gateway v0.25.7 (*)
│       │   ├── rattler_s3 v0.1.18 (*)
│       │   └── rattler_upload v0.4.7 (*)
│       ├── rattler_package_streaming v0.23.21 (*)
│       ├── rattler_redaction v0.1.13
│       │   ├── rattler-build v0.55.1 (/Users/pavel/projects/rattler-build)
│       │   ├── rattler_cache v0.6.6 (*)
│       │   ├── rattler_conda_types v0.42.4
│       │   │   ├── rattler v0.39.7 (*)
│       │   │   ├── rattler-build v0.55.1 (/Users/pavel/projects/rattler-build)
│       │   │   ├── rattler_cache v0.6.6 (*)
│       │   │   ├── rattler_config v0.2.23
│       │   │   │   ├── rattler-build v0.55.1 (/Users/pavel/projects/rattler-build)
│       │   │   │   ├── rattler_networking v0.25.29 (*)
│       │   │   │   └── rattler_upload v0.4.7 (*)
│       │   │   ├── rattler_index v0.27.8 (*)
│       │   │   ├── rattler_menuinst v0.2.42
│       │   │   │   ├── rattler v0.39.7 (*)
│       │   │   │   └── rattler-build v0.55.1 (/Users/pavel/projects/rattler-build)
│       │   │   ├── rattler_package_streaming v0.23.21 (*)
│       │   │   ├── rattler_repodata_gateway v0.25.7 (*)
│       │   │   ├── rattler_shell v0.25.15
│       │   │   │   ├── rattler v0.39.7 (*)
│       │   │   │   ├── rattler-build v0.55.1 (/Users/pavel/projects/rattler-build)
│       │   │   │   └── rattler_menuinst v0.2.42 (*)
│       │   │   ├── rattler_solve v4.1.2
│       │   │   │   ├── rattler-build v0.55.1 (/Users/pavel/projects/rattler-build)
│       │   │   │   └── rattler_upload v0.4.7 (*)
│       │   │   ├── rattler_upload v0.4.7 (*)
│       │   │   └── rattler_virtual_packages v2.3.4
│       │   │       └── rattler-build v0.55.1 (/Users/pavel/projects/rattler-build)
│       │   ├── rattler_package_streaming v0.23.21 (*)
│       │   ├── rattler_repodata_gateway v0.25.7 (*)
│       │   └── rattler_upload v0.4.7 (*)
│       ├── rattler_repodata_gateway v0.25.7 (*)
│       ├── rattler_upload v0.4.7 (*)
│       ├── reqsign v0.16.5
│       │   └── opendal v0.54.1 (*)
│       ├── reqwest-middleware v0.4.2
│       │   ├── rattler v0.39.7 (*)
│       │   ├── rattler-build v0.55.1 (/Users/pavel/projects/rattler-build)
│       │   ├── rattler_cache v0.6.6 (*)
│       │   ├── rattler_networking v0.25.29 (*)
│       │   ├── rattler_package_streaming v0.23.21 (*)
│       │   ├── rattler_redaction v0.1.13 (*)
│       │   ├── rattler_repodata_gateway v0.25.7 (*)
│       │   ├── rattler_upload v0.4.7 (*)
│       │   └── reqwest-retry v0.8.0
│       │       ├── rattler-build v0.55.1 (/Users/pavel/projects/rattler-build)
│       │       └── rattler_upload v0.4.7 (*)
│       └── reqwest-retry v0.8.0 (*)
├── reqwest v0.12.26 (*)
└── tokio-rustls v0.26.4
    ├── aws-smithy-http-client v1.1.5 (*)
    ├── hyper-rustls v0.27.7 (*)
    └── reqwest v0.12.26 (*)
```