### PR TITLE
docs: change `build/run_exports` to `requirements/`

### DIFF
--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -1207,7 +1207,7 @@ See the [Jinja Reference](./jinja.md) for more information.
 #### Pin subpackage
 
 Pin subpackage refers to another package from the same recipe file. It is
-commonly used in the `build/run_exports` section to export a run export from the
+commonly used in the `requirements/run_exports` section to export a run export from the
 package, or with multiple outputs to refer to a previous build.
 
 It looks something like:


### PR DESCRIPTION
This seems to be a typo since recipe v1 changed the location of `run_exports` to `requirements/` section.