### PR TITLE
docs: Delete Admonition about downstream tests not being implemented

### DIFF
--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -936,9 +936,6 @@ tests:
 
 ### Downstream tests
 
-!!! warning
-    Downstream tests are not yet implemented in `rattler-build`.
-
 A downstream test can mention a single package that has a dependency on the package being built.
 The test will install the package and run the tests of the downstream package with our current
 package as a dependency.


### PR DESCRIPTION
To cite @wolfv :
> You can however run downstream tests with v1 recipes since a while. Just add downstream: mypkg as a test to the list

I don't know how evolved the feature is, but with the admonition, one might feel discouraged to use it altogether🙂