### PR TITLE
[docs] Correct note on variants interacting with `run` dependencies

### DIFF
--- a/docs/variants.md
+++ b/docs/variants.md
@@ -31,7 +31,7 @@ numpy:
 - "1.20"
 ```
 
-If we have a recipe, that has a `build`, `host` or `run` dependency on `python`
+If we have a recipe that has a `build` or `host` dependency on `python`,
 we will build multiple variants of this package, one for each configured
 `python` version ("3.8", "3.9" and "3.10").
 


### PR DESCRIPTION
This is not correct, as I discovered that removing a `host` dependency on `python` (but keeping the `run` dependency) would change the behavior.

(Also moved the comma, the sentence flows a bit better this way IMO, happy to revert)