### PR TITLE
fix: always set `SP_DIR` during script execution

### DIFF
--- a/crates/rattler_build_core/src/env_vars.rs
+++ b/crates/rattler_build_core/src/env_vars.rs
@@ -2,7 +2,7 @@
 use std::path::{Path, PathBuf};
 use std::{collections::HashMap, env};
 
-use rattler_conda_types::Platform;
+use rattler_conda_types::{Platform, RepoDataRecord};
 
 use crate::linux;
 use crate::macos;
@@ -84,6 +84,57 @@ pub fn python_vars(output: &Output) -> HashMap<String, Option<String>> {
 
     if let Some(npy_version) = output.variant().get(&"numpy".into()) {
         let npy_ver = npy_version.to_string();
+        let npy_ver: Vec<_> = npy_ver.split('.').take(2).collect();
+        let npy_ver = npy_ver.join(".");
+        insert!(result, "NPY_VER", npy_ver);
+        insert!(result, "NPY_DISTUTILS_APPEND_FLAGS", "1");
+    }
+
+    result
+}
+
+/// Returns Python-related environment variables derived from solved package records.
+///
+/// This is used in test environments where we have the solve result but no `Output`.
+/// Extracts python and numpy versions from the resolved records.
+pub fn python_vars_from_records(
+    records: &[RepoDataRecord],
+    prefix: &Path,
+    platform: Platform,
+) -> HashMap<String, Option<String>> {
+    let mut result = HashMap::new();
+
+    if platform.is_windows() {
+        let python = prefix.join("python.exe");
+        insert!(result, "PYTHON", python.to_string_lossy());
+    } else {
+        let python = prefix.join("bin/python");
+        insert!(result, "PYTHON", python.to_string_lossy());
+    }
+
+    let python_version = records
+        .iter()
+        .find(|r| r.package_record.name.as_normalized() == "python")
+        .map(|r| r.package_record.version.to_string());
+
+    if let Some(py_ver) = python_version {
+        let py_ver: Vec<_> = py_ver.split('.').take(2).collect();
+        let py_ver_str = py_ver.join(".");
+        let stdlib_dir = get_stdlib_dir(prefix, platform, &py_ver_str);
+        let site_packages_dir = get_sitepackages_dir(prefix, platform, &py_ver_str);
+        let py3k = if py_ver[0] == "3" { "1" } else { "0" };
+        insert!(result, "PY3K", py3k);
+        insert!(result, "PY_VER", py_ver_str);
+        insert!(result, "STDLIB_DIR", stdlib_dir.to_string_lossy());
+        insert!(result, "SP_DIR", site_packages_dir.to_string_lossy());
+    }
+
+    let numpy_version = records
+        .iter()
+        .find(|r| r.package_record.name.as_normalized() == "numpy")
+        .map(|r| r.package_record.version.to_string());
+
+    if let Some(npy_ver) = numpy_version {
         let npy_ver: Vec<_> = npy_ver.split('.').take(2).collect();
         let npy_ver = npy_ver.join(".");
         insert!(result, "NPY_VER", npy_ver);

--- a/crates/rattler_build_core/src/package_test/run_test.rs
+++ b/crates/rattler_build_core/src/package_test/run_test.rs
@@ -157,13 +157,18 @@ impl Tests {
         environment: &Path,
         cwd: &Path,
         pkg_vars: &HashMap<String, String>,
+        resolved_records: &[rattler_conda_types::RepoDataRecord],
     ) -> Result<(), TestError> {
         tracing::info!("Testing commands:");
 
         let platform = Platform::current();
         let mut env_vars = env_vars::os_vars(environment, &platform);
         env_vars.retain(|key, _| key != ShellEnum::default().path_var(&platform));
-        env_vars.extend(env_vars::python_vars_from_prefix(environment, platform));
+        env_vars.extend(env_vars::python_vars_from_records(
+            resolved_records,
+            environment,
+            platform,
+        ));
         env_vars.extend(pkg_vars.iter().map(|(k, v)| (k.clone(), Some(v.clone()))));
         env_vars.insert(
             "PREFIX".to_string(),
@@ -509,7 +514,7 @@ pub async fn run_test(
         .map_err(|e| TestError::MatchSpecParse(e.to_string()))?;
         dependencies.push(match_spec);
 
-        create_environment(
+        let resolved_records = create_environment(
             "test",
             &dependencies,
             &host_platform,
@@ -527,7 +532,8 @@ pub async fn run_test(
         let (test_folder, tests) = legacy_tests_from_folder(&package_folder).await?;
 
         for test in tests {
-            test.run(&prefix, &test_folder, &env).await?;
+            test.run(&prefix, &test_folder, &env, &resolved_records)
+                .await?;
         }
 
         tracing::info!(
@@ -922,7 +928,7 @@ async fn run_commands_test(
         .unwrap_or(&config.current_platform);
 
     let run_prefix = test_directory.join("test_run_env");
-    create_environment(
+    let resolved_records = create_environment(
         "test",
         &dependencies,
         platform,
@@ -939,7 +945,11 @@ async fn run_commands_test(
     let platform = Platform::current();
     let mut env_vars = env_vars::os_vars(&run_prefix, &platform);
     env_vars.retain(|key, _| key != ShellEnum::default().path_var(&platform));
-    env_vars.extend(env_vars::python_vars_from_prefix(&run_prefix, platform));
+    env_vars.extend(env_vars::python_vars_from_records(
+        &resolved_records,
+        &run_prefix,
+        platform,
+    ));
     env_vars.extend(pkg_vars.iter().map(|(k, v)| (k.clone(), Some(v.clone()))));
     env_vars.insert(
         "PREFIX".to_string(),


### PR DESCRIPTION
We did not always set the `SP_DIR` variable that points to the `site-packages` folder. This was sometimes unset because for noarch packages, we cannot statically derive it (as we do not know the Python version chosen ahead of time). 

However, this leads to increased friction when trying to build packages cross-platform. The idea of this PR is to always set the SP_DIR if `python` is installed in the `host` environment.