### PR TITLE
feat: implement CEP-28 customizable system DLL linkage checks for Windows

### DIFF
--- a/src/packaging.rs
+++ b/src/packaging.rs
@@ -702,6 +702,9 @@ pub fn package_conda(
 
     tracing::info!("Post-processing done!");
 
+    // Validate any dsolist JSON files being packaged (CEP-28)
+    post_process::checks::validate_dsolist_files(tmp.temp_dir.path())?;
+
     let info_folder = tmp.temp_dir.path().join("info");
 
     tracing::info!("Writing test files");


### PR DESCRIPTION
## Summary

- Add support for `dsolists.d/*.json` configuration files ([CEP-28](https://github.com/conda/ceps/blob/main/cep-0028.md)) that let packages define custom allow/deny patterns for Windows system DLLs
- Replace the hardcoded `WIN_ALLOWLIST` when dsolist files are present, bringing feature parity with Linux (sysroot packages) and macOS (`.tbd` files)
- Use case-insensitive glob matching for Windows DLL patterns

## How it works

1. Scans `<prefix>/etc/conda-build/dsolists.d/*.json` in both build and host prefixes
2. If allow lists found → use them; if only deny lists → default allow is `C:/Windows/System32/*.dll`; if neither → fall back to hardcoded `WIN_ALLOWLIST`
3. Linking checks now enforce `allow.match(lib) && !deny.match(lib)` instead of just `allow.match(lib)`

## Test plan

- [x] Unit tests for `load_dsolists` — valid JSON, wrong subdir, invalid version, missing dir, multiple files
- [x] Unit tests for `expand_dsolist` — wildcard passthrough, absolute path conversion, mixed patterns
- [x] All existing linking check tests still pass
- [ ] Manual verification with a real dsolist JSON on a Windows build