### PR TITLE
feat: add app section for Anaconda Navigator app discovery

### DIFF
--- a/crates/rattler_build_package/tests/integration_test.rs
+++ b/crates/rattler_build_package/tests/integration_test.rs
@@ -243,6 +243,7 @@ fn test_from_recipe_with_metadata() -> Result<(), Box<dyn std::error::Error>> {
         package,
         Build::default(),
         about,
+        Default::default(),
         Requirements::default(),
         Extra::default(),
         Vec::new(),

--- a/crates/rattler_build_recipe/src/stage0/app.rs
+++ b/crates/rattler_build_recipe/src/stage0/app.rs
@@ -1,0 +1,46 @@
+use serde::{Deserialize, Serialize};
+
+use super::Value;
+
+/// App section for Anaconda Navigator app discovery
+///
+/// When present in a recipe, the package will be discoverable as an application
+/// in Anaconda Navigator. The fields map to corresponding entries in index.json.
+#[derive(Debug, Serialize, Deserialize, Default, Clone, PartialEq)]
+pub struct App {
+    /// Command to launch the application (maps to app_entry in index.json)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub entry: Option<Value<String>>,
+
+    /// Icon filename for the application (maps to icon in index.json)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub icon: Option<Value<String>>,
+
+    /// Short description of the application (maps to summary in index.json)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<Value<String>>,
+
+    /// Application type: "web" or "desk" (maps to app_type in index.json)
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "type")]
+    pub app_type: Option<Value<String>>,
+}
+
+impl App {
+    /// Collect all template variables used in this section
+    pub fn used_variables(&self) -> std::collections::HashSet<String> {
+        let mut vars = std::collections::HashSet::new();
+        if let Some(v) = &self.entry {
+            vars.extend(v.used_variables());
+        }
+        if let Some(v) = &self.icon {
+            vars.extend(v.used_variables());
+        }
+        if let Some(v) = &self.summary {
+            vars.extend(v.used_variables());
+        }
+        if let Some(v) = &self.app_type {
+            vars.extend(v.used_variables());
+        }
+        vars
+    }
+}

--- a/crates/rattler_build_recipe/src/stage0/evaluate.rs
+++ b/crates/rattler_build_recipe/src/stage0/evaluate.rs
@@ -33,9 +33,9 @@ use rattler_digest::{Md5Hash, Sha256Hash};
 use crate::{
     ParseError, Span,
     stage0::{
-        self, About as Stage0About, Build as Stage0Build, Extra as Stage0Extra, License,
-        Package as Stage0Package, Requirements as Stage0Requirements, Source as Stage0Source,
-        Stage0Recipe, TestType as Stage0TestType,
+        self, About as Stage0About, App as Stage0App, Build as Stage0Build, Extra as Stage0Extra,
+        License, Package as Stage0Package, Requirements as Stage0Requirements,
+        Source as Stage0Source, Stage0Recipe, TestType as Stage0TestType,
         build::{
             BinaryRelocation as Stage0BinaryRelocation, DynamicLinking as Stage0DynamicLinking,
             ForceFileType as Stage0ForceFileType, PostProcess as Stage0PostProcess,
@@ -61,9 +61,9 @@ use crate::{
         types::{ConditionalList, Item, JinjaExpression, Value},
     },
     stage1::{
-        self, About as Stage1About, AllOrGlobVec, Dependency, Evaluate, EvaluationContext,
-        Extra as Stage1Extra, GlobVec, Package as Stage1Package, Recipe as Stage1Recipe,
-        Requirements as Stage1Requirements, Rpaths,
+        self, About as Stage1About, AllOrGlobVec, App as Stage1App, Dependency, Evaluate,
+        EvaluationContext, Extra as Stage1Extra, GlobVec, Package as Stage1Package,
+        Recipe as Stage1Recipe, Requirements as Stage1Requirements, Rpaths,
         build::{
             Build as Stage1Build, BuildString, DynamicLinking as Stage1DynamicLinking,
             ForceFileType as Stage1ForceFileType, PostProcess as Stage1PostProcess,
@@ -1617,6 +1617,19 @@ impl Evaluate for Stage0About {
     }
 }
 
+impl Evaluate for Stage0App {
+    type Output = Stage1App;
+
+    fn evaluate(&self, context: &EvaluationContext) -> Result<Self::Output, ParseError> {
+        Ok(Stage1App {
+            entry: evaluate_optional_string_value(&self.entry, context)?,
+            icon: evaluate_optional_string_value(&self.icon, context)?,
+            summary: evaluate_optional_string_value(&self.summary, context)?,
+            app_type: evaluate_optional_string_value(&self.app_type, context)?,
+        })
+    }
+}
+
 // Evaluate RunExports with dependency parsing
 impl Evaluate for Stage0RunExports {
     type Output = Stage1RunExports;
@@ -2638,6 +2651,7 @@ impl Evaluate for Stage0Recipe {
         let package = self.package.evaluate(&context_with_vars)?;
         let build = self.build.evaluate(&context_with_vars)?;
         let about = self.about.evaluate(&context_with_vars)?;
+        let app = self.app.evaluate(&context_with_vars)?;
         let requirements = self.requirements.evaluate(&context_with_vars)?;
         let extra = self.extra.evaluate(&context_with_vars)?;
 
@@ -2765,6 +2779,7 @@ impl Evaluate for Stage0Recipe {
             package,
             build,
             about,
+            app,
             requirements,
             extra,
             source,
@@ -2928,6 +2943,17 @@ fn merge_stage1_about(toplevel: stage1::About, output: stage1::About) -> stage1:
     }
 }
 
+/// Merge two Stage1 App configurations
+/// The output app takes precedence for non-empty fields
+fn merge_stage1_app(toplevel: stage1::App, output: stage1::App) -> stage1::App {
+    stage1::App {
+        entry: output.entry.or(toplevel.entry),
+        icon: output.icon.or(toplevel.icon),
+        summary: output.summary.or(toplevel.summary),
+        app_type: output.app_type.or(toplevel.app_type),
+    }
+}
+
 /// Helper to evaluate a package output into a Stage1Recipe
 /// This handles merging top-level recipe sections with output-specific sections
 fn evaluate_package_output_to_recipe(
@@ -3044,6 +3070,14 @@ fn evaluate_package_output_to_recipe(
 
         // Merge: output-specific fields take precedence
         merge_stage1_about(toplevel_about, output_about)
+    };
+
+    // Evaluate app section
+    // Merge: output-specific fields take precedence
+    let app = {
+        let toplevel_app = recipe.app.evaluate(context)?;
+        let output_app = output.app.evaluate(context)?;
+        merge_stage1_app(toplevel_app, output_app)
     };
 
     // Evaluate requirements
@@ -3183,6 +3217,7 @@ fn evaluate_package_output_to_recipe(
         package,
         build,
         about,
+        app,
         requirements,
         extra,
         source,

--- a/crates/rattler_build_recipe/src/stage0/mod.rs
+++ b/crates/rattler_build_recipe/src/stage0/mod.rs
@@ -2,6 +2,7 @@
 //! This means, it still contains Jinja templates and if-else statements.
 
 mod about;
+mod app;
 mod build;
 pub mod evaluate;
 mod extra;
@@ -15,6 +16,7 @@ mod tests;
 mod types;
 
 pub use about::{About, License};
+pub use app::App;
 pub use build::{BinaryRelocation, Build};
 pub use extra::Extra;
 pub use match_spec::SerializableMatchSpec;

--- a/crates/rattler_build_recipe/src/stage0/output.rs
+++ b/crates/rattler_build_recipe/src/stage0/output.rs
@@ -8,6 +8,7 @@ use serde::Serialize;
 
 use crate::stage0::{
     about::About,
+    app::App,
     build::Build,
     package::{Package, PackageMetadata},
     requirements::Requirements,
@@ -41,6 +42,7 @@ pub struct SingleOutputRecipe {
     pub build: Build,
     pub requirements: Requirements,
     pub about: About,
+    pub app: App,
     pub extra: crate::stage0::extra::Extra,
     #[serde(default, skip_serializing_if = "ConditionalList::is_empty")]
     pub source: ConditionalList<Source>,
@@ -73,6 +75,10 @@ pub struct MultiOutputRecipe {
     /// Top-level about information (inheritable by outputs)
     #[serde(default)]
     pub about: About,
+
+    /// Top-level app information (inheritable by outputs)
+    #[serde(default)]
+    pub app: App,
 
     /// Extra metadata
     #[serde(default)]
@@ -180,6 +186,10 @@ pub struct PackageOutput {
     #[serde(default)]
     pub about: About,
 
+    /// App information for this output
+    #[serde(default)]
+    pub app: App,
+
     /// Tests for this output
     #[serde(default, skip_serializing_if = "ConditionalList::is_empty")]
     pub tests: ConditionalList<TestType>,
@@ -258,6 +268,7 @@ impl SingleOutputRecipe {
             build,
             requirements,
             about,
+            app,
             extra,
             source,
             tests,
@@ -267,6 +278,7 @@ impl SingleOutputRecipe {
         vars.extend(build.used_variables());
         vars.extend(requirements.used_variables());
         vars.extend(about.used_variables());
+        vars.extend(app.used_variables());
         vars.extend(extra.used_variables());
         for src_item in source {
             vars.extend(collect_source_item_variables(src_item));
@@ -310,6 +322,7 @@ impl MultiOutputRecipe {
             source,
             build,
             about,
+            app,
             extra,
             tests,
             outputs,
@@ -328,6 +341,7 @@ impl MultiOutputRecipe {
         }
         vars.extend(build.used_variables());
         vars.extend(about.used_variables());
+        vars.extend(app.used_variables());
         vars.extend(extra.used_variables());
         for src_item in source {
             vars.extend(collect_source_item_variables(src_item));
@@ -457,6 +471,7 @@ impl PackageOutput {
             requirements,
             build,
             about,
+            app,
             tests,
         } = self;
 
@@ -468,6 +483,7 @@ impl PackageOutput {
         vars.extend(requirements.used_variables());
         vars.extend(build.used_variables());
         vars.extend(about.used_variables());
+        vars.extend(app.used_variables());
         for test_item in tests {
             vars.extend(collect_test_item_variables(test_item));
         }

--- a/crates/rattler_build_recipe/src/stage0/parser/app.rs
+++ b/crates/rattler_build_recipe/src/stage0/parser/app.rs
@@ -1,0 +1,16 @@
+use crate::stage0::App;
+use rattler_build_yaml_parser::ParseMapping;
+
+use super::{MarkedNode, ParseResult};
+
+/// Parse the `app` section of a recipe
+pub fn parse_app(yaml: &MarkedNode) -> ParseResult<App> {
+    yaml.validate_keys("app", &["entry", "icon", "summary", "type"])?;
+
+    Ok(App {
+        entry: yaml.try_get_field("entry")?,
+        icon: yaml.try_get_field("icon")?,
+        summary: yaml.try_get_field("summary")?,
+        app_type: yaml.try_get_field("type")?,
+    })
+}

--- a/crates/rattler_build_recipe/src/stage0/parser/mod.rs
+++ b/crates/rattler_build_recipe/src/stage0/parser/mod.rs
@@ -5,6 +5,7 @@
 //! error messages.
 
 mod about;
+mod app;
 mod build;
 mod extra;
 mod helpers;
@@ -196,6 +197,12 @@ fn parse_single_output_recipe(yaml: &MarkedNode) -> ParseResult<crate::stage0::S
         crate::stage0::Extra::default()
     };
 
+    let app = if let Some(app_node) = mapping.get("app") {
+        app::parse_app(app_node)?
+    } else {
+        crate::stage0::App::default()
+    };
+
     // Parse optional source section (can be empty)
     let source = if let Some(source_node) = mapping.get("source") {
         parse_source(source_node)?
@@ -218,6 +225,7 @@ fn parse_single_output_recipe(yaml: &MarkedNode) -> ParseResult<crate::stage0::S
             "package"
                 | "build"
                 | "about"
+                | "app"
                 | "requirements"
                 | "extra"
                 | "source"
@@ -230,7 +238,7 @@ fn parse_single_output_recipe(yaml: &MarkedNode) -> ParseResult<crate::stage0::S
                 format!("unknown top-level field '{}'", key_str),
                 *key.span(),
             )
-            .with_suggestion("valid top-level fields are: package, build, about, requirements, extra, source, tests, schema_version, context"));
+            .with_suggestion("valid top-level fields are: package, build, about, app, requirements, extra, source, tests, schema_version, context"));
         }
     }
 
@@ -240,6 +248,7 @@ fn parse_single_output_recipe(yaml: &MarkedNode) -> ParseResult<crate::stage0::S
         package,
         build,
         about,
+        app,
         requirements,
         extra,
         source,

--- a/crates/rattler_build_recipe/src/stage0/parser/output_parser.rs
+++ b/crates/rattler_build_recipe/src/stage0/parser/output_parser.rs
@@ -98,6 +98,12 @@ pub fn parse_multi_output_recipe(
         crate::stage0::Extra::default()
     };
 
+    let app = if let Some(app_node) = mapping.get("app") {
+        super::app::parse_app(app_node)?
+    } else {
+        crate::stage0::App::default()
+    };
+
     let tests = if let Some(tests_node) = mapping.get("tests") {
         parse_tests(tests_node)?
     } else {
@@ -128,6 +134,7 @@ pub fn parse_multi_output_recipe(
             "version",
             "build",
             "about",
+            "app",
             "extra",
             "source",
             "tests",
@@ -144,6 +151,7 @@ pub fn parse_multi_output_recipe(
         source,
         build,
         about,
+        app,
         extra,
         tests,
         outputs,
@@ -473,6 +481,13 @@ fn parse_package_output(
         crate::stage0::About::default()
     };
 
+    // Parse optional app
+    let app = if let Some(app_node) = mapping.get("app") {
+        super::app::parse_app(app_node)?
+    } else {
+        crate::stage0::App::default()
+    };
+
     // Parse optional tests
     let tests = if let Some(tests_node) = mapping.get("tests") {
         parse_tests(tests_node)?
@@ -491,6 +506,7 @@ fn parse_package_output(
             "requirements",
             "build",
             "about",
+            "app",
             "tests",
         ],
     )?;
@@ -502,6 +518,7 @@ fn parse_package_output(
         requirements,
         build,
         about,
+        app,
         tests,
     })
 }

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__error_tests__error_unknown_top_level_field.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__error_tests__error_unknown_top_level_field.snap
@@ -10,5 +10,5 @@ expression: error_with_source
    ·        ╰── invalid value for 'recipe': unknown top-level field 'unknown_section'
  9 │   some_field: some_value
    ╰────
-  help: valid top-level fields are: package, build, about, requirements,
+  help: valid top-level fields are: package, build, about, app, requirements,
         extra, source, tests, schema_version, context

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__complex_recipe_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__complex_recipe_snapshot.snap
@@ -92,6 +92,7 @@ about:
     templates and other formatting.
   documentation: https://${{ name }}.readthedocs.io
   repository: https://github.com/${{ org }}/${{ name }}
+app: {}
 extra:
   recipe-maintainers:
   - someone

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__conditionals_recipe_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__conditionals_recipe_snapshot.snap
@@ -76,6 +76,7 @@ about:
   description: null
   documentation: null
   repository: null
+app: {}
 extra:
   recipe-maintainers:
   - maintainer1

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__full_recipe_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__full_recipe_snapshot.snap
@@ -61,6 +61,7 @@ about:
   description: This package demonstrates all available fields in a recipe
   documentation: https://docs.example.com/
   repository: https://github.com/example/full-package
+app: {}
 extra:
   recipe-maintainers:
   - alice

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__license_files_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__license_files_snapshot.snap
@@ -50,4 +50,5 @@ about:
   description: null
   documentation: null
   repository: null
+app: {}
 extra: {}

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__minimal_recipe_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__minimal_recipe_snapshot.snap
@@ -47,4 +47,5 @@ about:
   description: null
   documentation: null
   repository: null
+app: {}
 extra: {}

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__multi_output_conditionals_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__multi_output_conditionals_snapshot.snap
@@ -47,6 +47,7 @@ about:
   description: null
   documentation: null
   repository: null
+app: {}
 extra: {}
 outputs:
 - staging:
@@ -125,6 +126,7 @@ outputs:
     description: null
     documentation: null
     repository: null
+  app: {}
   tests:
   - script:
       content:

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__multi_output_full_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__multi_output_full_snapshot.snap
@@ -54,6 +54,7 @@ about:
   description: null
   documentation: null
   repository: null
+app: {}
 extra:
   recipe-maintainers:
   - alice
@@ -142,6 +143,7 @@ outputs:
     description: null
     documentation: null
     repository: null
+  app: {}
   tests:
   - script:
       content:
@@ -197,6 +199,7 @@ outputs:
       It allows you to use complex project functionality from Python.
     documentation: null
     repository: null
+  app: {}
   tests:
   - python:
       imports:
@@ -250,3 +253,4 @@ outputs:
     description: null
     documentation: null
     repository: null
+  app: {}

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__multi_output_minimal_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__multi_output_minimal_snapshot.snap
@@ -51,6 +51,7 @@ about:
   description: null
   documentation: null
   repository: null
+app: {}
 extra: {}
 outputs:
 - staging:
@@ -118,3 +119,4 @@ outputs:
     description: null
     documentation: null
     repository: null
+  app: {}

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__multi_output_templates_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__multi_output_templates_snapshot.snap
@@ -53,6 +53,7 @@ about:
   description: null
   documentation: null
   repository: null
+app: {}
 extra: {}
 outputs:
 - staging:
@@ -122,6 +123,7 @@ outputs:
     description: null
     documentation: null
     repository: null
+  app: {}
 - package:
     name: ${{ name }}-lib
     version: ${{ version }}
@@ -170,3 +172,4 @@ outputs:
     description: null
     documentation: null
     repository: null
+  app: {}

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__multi_output_top_level_inherit_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__multi_output_top_level_inherit_snapshot.snap
@@ -52,6 +52,7 @@ about:
   description: null
   documentation: null
   repository: null
+app: {}
 extra: {}
 outputs:
 - package:
@@ -102,6 +103,7 @@ outputs:
     description: null
     documentation: null
     repository: null
+  app: {}
   tests:
   - python:
       imports:
@@ -155,6 +157,7 @@ outputs:
     description: null
     documentation: null
     repository: null
+  app: {}
   tests:
   - script:
       content:
@@ -209,3 +212,4 @@ outputs:
     description: null
     documentation: null
     repository: null
+  app: {}

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__run_exports_recipe_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__run_exports_recipe_snapshot.snap
@@ -71,6 +71,7 @@ about:
   description: null
   documentation: null
   repository: null
+app: {}
 extra:
   recipe-maintainers:
   - maintainer

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__script_parsing_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__script_parsing_snapshot.snap
@@ -47,6 +47,7 @@ about:
   description: null
   documentation: null
   repository: null
+app: {}
 extra: {}
 tests:
 - script:

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__single_output_compatibility.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__single_output_compatibility.snap
@@ -47,4 +47,5 @@ about:
   description: null
   documentation: null
   repository: null
+app: {}
 extra: {}

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__templates_recipe_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__templates_recipe_snapshot.snap
@@ -55,6 +55,7 @@ about:
   description: A templated package for ${{ platform }}
   documentation: null
   repository: null
+app: {}
 extra:
   recipe-maintainers:
   - foobar

--- a/crates/rattler_build_recipe/src/stage0/snapshots/rattler_build_recipe__stage0__test__roundtrip.snap
+++ b/crates/rattler_build_recipe/src/stage0/snapshots/rattler_build_recipe__stage0__test__roundtrip.snap
@@ -76,6 +76,7 @@ about:
   description: null
   documentation: null
   repository: null
+app: {}
 extra:
   recipe-maintainers:
   - maintainer1

--- a/crates/rattler_build_recipe/src/stage1/app.rs
+++ b/crates/rattler_build_recipe/src/stage1/app.rs
@@ -1,0 +1,58 @@
+use serde::{Deserialize, Serialize};
+
+/// Evaluated app section for Anaconda Navigator app discovery
+///
+/// This is the Stage 1 (evaluated) version of the app section.
+/// All Jinja templates have been resolved to concrete string values.
+///
+/// When present, the following fields are written to index.json:
+/// - `app_entry`: command to launch the app
+/// - `app_type`: "web" or "desk"
+/// - `icon`: icon filename
+/// - `summary`: short description
+/// - `type`: set to "app"
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct App {
+    /// Command to launch the application
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub entry: Option<String>,
+
+    /// Icon filename for the application
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub icon: Option<String>,
+
+    /// Short description of the application
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+
+    /// Application type: "web" or "desk"
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "type")]
+    pub app_type: Option<String>,
+}
+
+impl App {
+    /// Returns true if all fields are None
+    pub fn is_empty(&self) -> bool {
+        self.entry.is_none()
+            && self.icon.is_none()
+            && self.summary.is_none()
+            && self.app_type.is_none()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_app_is_empty() {
+        let app = App::default();
+        assert!(app.is_empty());
+
+        let app = App {
+            entry: Some("myapp launch".to_string()),
+            ..Default::default()
+        };
+        assert!(!app.is_empty());
+    }
+}

--- a/crates/rattler_build_recipe/src/stage1/mod.rs
+++ b/crates/rattler_build_recipe/src/stage1/mod.rs
@@ -16,6 +16,7 @@ use rattler_build_jinja::{Jinja, JinjaConfig, Variable};
 use rattler_conda_types::Platform;
 
 pub mod about;
+pub mod app;
 pub mod build;
 pub mod extra;
 pub mod hash;
@@ -29,6 +30,7 @@ pub mod tests;
 mod variant_tests;
 
 pub use about::About;
+pub use app::App;
 pub use build::{Build, Rpaths};
 pub use extra::Extra;
 pub use hash::{HashInfo, HashInput, compute_hash};

--- a/crates/rattler_build_recipe/src/stage1/recipe.rs
+++ b/crates/rattler_build_recipe/src/stage1/recipe.rs
@@ -4,7 +4,7 @@ use indexmap::IndexMap;
 use rattler_build_jinja::Variable;
 use serde::{Deserialize, Serialize};
 
-use super::{About, Build, Extra, Package, Requirements, Source, TestType};
+use super::{About, App, Build, Extra, Package, Requirements, Source, TestType};
 
 /// Staging cache - a build artifact that doesn't produce a package
 ///
@@ -133,6 +133,10 @@ pub struct Recipe {
     #[serde(default, skip_serializing_if = "About::is_empty")]
     pub about: About,
 
+    /// App section for Anaconda Navigator app discovery
+    #[serde(default, skip_serializing_if = "App::is_empty")]
+    pub app: App,
+
     /// Extra metadata
     #[serde(default, skip_serializing_if = "Extra::is_empty")]
     pub extra: Extra,
@@ -159,10 +163,12 @@ pub struct Recipe {
 impl Recipe {
     /// Create a new Recipe
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         package: Package,
         build: Build,
         about: About,
+        app: App,
         requirements: Requirements,
         extra: Extra,
         source: Vec<Source>,
@@ -175,6 +181,7 @@ impl Recipe {
             package,
             build,
             about,
+            app,
             requirements,
             extra,
             source,
@@ -192,6 +199,7 @@ impl Recipe {
         package: Package,
         build: Build,
         about: About,
+        app: App,
         requirements: Requirements,
         extra: Extra,
         source: Vec<Source>,
@@ -206,6 +214,7 @@ impl Recipe {
             package,
             build,
             about,
+            app,
             requirements,
             extra,
             source,
@@ -230,6 +239,11 @@ impl Recipe {
     /// Get the about section
     pub fn about(&self) -> &About {
         &self.about
+    }
+
+    /// Get the app section
+    pub fn app(&self) -> &App {
+        &self.app
     }
 
     /// Get the requirements section
@@ -279,6 +293,7 @@ mod tests {
             pkg.clone(),
             build.clone(),
             about.clone(),
+            App::default(),
             reqs.clone(),
             extra.clone(),
             Vec::new(),
@@ -324,6 +339,7 @@ mod tests {
             pkg.clone(),
             build.clone(),
             about.clone(),
+            App::default(),
             reqs.clone(),
             extra.clone(),
             Vec::new(),


### PR DESCRIPTION
## Summary

- Adds `app:` recipe section with fields `entry`, `icon`, `summary`, and `type` for Anaconda Navigator app discovery
- Implements full Stage 0 → Stage 1 evaluation pipeline including multi-output recipe support with field merging
- Injects app fields into `info/index.json` as `app_entry`, `app_type`, `icon`, `summary`, and `type: "app"`

Depends on https://github.com/conda/rattler/pull/2051 for the `IndexJson` struct fields (currently app fields are injected via JSON manipulation).

Closes #2099

## Test plan

- [x] All 245 `rattler_build_recipe` lib tests pass
- [x] All 116 `rattler-build` lib tests pass
- [x] Snapshot tests updated
- [ ] Test with a recipe containing an `app:` section and verify `info/index.json` output