### PR TITLE
feat: base platform selectors on host_platform instead of target_platform

### DIFF
--- a/crates/rattler_build_jinja/src/jinja.rs
+++ b/crates/rattler_build_jinja/src/jinja.rs
@@ -188,41 +188,42 @@ impl Jinja {
             Value::from(config.host_platform.to_string()),
         );
 
-        // Add common platform shortcuts
+        // Add common platform shortcuts based on the host platform
+        // (the platform where the package will run)
         context.insert(
             "unix".to_string(),
-            Value::from(config.target_platform.is_unix()),
+            Value::from(config.host_platform.is_unix()),
         );
         context.insert(
             "linux".to_string(),
-            Value::from(config.target_platform.is_linux()),
+            Value::from(config.host_platform.is_linux()),
         );
         context.insert(
             "osx".to_string(),
-            Value::from(config.target_platform.is_osx()),
+            Value::from(config.host_platform.is_osx()),
         );
         context.insert(
             "win".to_string(),
-            Value::from(config.target_platform.is_windows()),
+            Value::from(config.host_platform.is_windows()),
         );
 
         // Add architecture aliases (e.g., "x86_64", "aarch64", "ppc64le")
-        // All known architectures are defined, with only the current target's architecture being true
-        let current_arch = config.target_platform.arch();
+        // All known architectures are defined, with only the host platform's architecture being true
+        let current_arch = config.host_platform.arch();
         for arch in Arch::iter() {
             context.insert(arch.to_string(), Value::from(current_arch == Some(arch)));
         }
 
         // Add platform aliases (e.g., "linux64", "osx64", "win64")
         // These are the platform string with "-" removed (e.g., "linux-64" -> "linux64")
-        // All known platforms get an alias, with only the current target_platform being true
+        // All known platforms get an alias, with only the current host_platform being true
         for platform in Platform::iter() {
             // Skip noarch and unknown platforms
             if matches!(platform, Platform::NoArch | Platform::Unknown) {
                 continue;
             }
             let alias = platform.to_string().replace('-', "");
-            context.insert(alias, Value::from(platform == config.target_platform));
+            context.insert(alias, Value::from(platform == config.host_platform));
         }
 
         // Add variant variables to context
@@ -998,9 +999,11 @@ mod tests {
     }
 
     #[test]
-    #[rustfmt::skip]
     // git version is too old in cross container for aarch64
-    #[cfg(not(all(any(target_arch = "aarch64", target_arch = "powerpc64"), target_os = "linux")))]
+    #[cfg(not(all(
+        any(target_arch = "aarch64", target_arch = "powerpc64"),
+        target_os = "linux"
+    )))]
     fn eval_git() {
         let options = JinjaConfig {
             target_platform: Platform::Linux64,
@@ -1021,17 +1024,38 @@ mod tests {
 
         with_temp_dir("rattler_build_recipe_jinja_eval_git", |path| {
             create_repo_with_tag(path, "v0.1.0").expect("Failed to clone the git repo");
-            assert_eq!(jinja.eval(&format!("git.latest_tag({:?})", path)).expect("test 0").as_str().unwrap(), "v0.1.0");
-            assert_eq!(jinja.eval(&format!("git.latest_tag_rev({:?})", path)).expect("test 1 left").as_str().unwrap(), jinja.eval(&format!("git.head_rev({:?})", path)).expect("test 1 right").as_str().unwrap());
             assert_eq!(
-                jinja_wo_experimental.eval(&format!("git.latest_tag({:?})", path)).expect_err("test 2").to_string(),
+                jinja
+                    .eval(&format!("git.latest_tag({:?})", path))
+                    .expect("test 0")
+                    .as_str()
+                    .unwrap(),
+                "v0.1.0"
+            );
+            assert_eq!(
+                jinja
+                    .eval(&format!("git.latest_tag_rev({:?})", path))
+                    .expect("test 1 left")
+                    .as_str()
+                    .unwrap(),
+                jinja
+                    .eval(&format!("git.head_rev({:?})", path))
+                    .expect("test 1 right")
+                    .as_str()
+                    .unwrap()
+            );
+            assert_eq!(
+                jinja_wo_experimental
+                    .eval(&format!("git.latest_tag({:?})", path))
+                    .expect_err("test 2")
+                    .to_string(),
                 "invalid operation: Experimental feature: provide the `--experimental` flag to enable this feature (in <expression>:1)",
             );
         });
     }
 
     #[test]
-    #[rustfmt::skip]
+
     fn eval_load_from_file() {
         let options = JinjaConfig {
             target_platform: Platform::Linux64,
@@ -1048,7 +1072,10 @@ mod tests {
         let path_str = to_forward_slash_lossy(&path);
         fs::write(&path, "{ \"hello\": \"world\" }").unwrap();
         assert_eq!(
-            jinja.eval(&format!("load_from_file('{}')['hello']", path_str)).expect("test 1").as_str(),
+            jinja
+                .eval(&format!("load_from_file('{}')['hello']", path_str))
+                .expect("test 1")
+                .as_str(),
             Some("world"),
         );
 
@@ -1056,7 +1083,10 @@ mod tests {
         fs::write(&path, "hello: world").unwrap();
         let path_str = to_forward_slash_lossy(&path);
         assert_eq!(
-            jinja.eval(&format!("load_from_file('{}')['hello']", path_str)).expect("test 2").as_str(),
+            jinja
+                .eval(&format!("load_from_file('{}')['hello']", path_str))
+                .expect("test 2")
+                .as_str(),
             Some("world"),
         );
 
@@ -1064,7 +1094,10 @@ mod tests {
         let path_str = to_forward_slash_lossy(&path);
         fs::write(&path, "hello = 'world'").unwrap();
         assert_eq!(
-            jinja.eval(&format!("load_from_file('{}')['hello']", path_str)).expect("test 3").as_str(),
+            jinja
+                .eval(&format!("load_from_file('{}')['hello']", path_str))
+                .expect("test 3")
+                .as_str(),
             Some("world"),
         );
     }
@@ -1132,7 +1165,7 @@ mod tests {
     }
 
     #[test]
-    #[rustfmt::skip]
+
     fn eval() {
         let options = JinjaConfig {
             target_platform: Platform::Linux64,
@@ -1149,8 +1182,18 @@ mod tests {
         assert!(jinja.eval("linux").expect("test 4").is_true());
         assert!(jinja.eval("unix and not win").expect("test 5").is_true());
         assert!(!jinja.eval("unix and not linux").expect("test 6").is_true());
-        assert!(jinja.eval("(unix and not osx) or win").expect("test 7").is_true());
-        assert!(jinja.eval("(unix and not osx) or win or osx").expect("test 8").is_true());
+        assert!(
+            jinja
+                .eval("(unix and not osx) or win")
+                .expect("test 7")
+                .is_true()
+        );
+        assert!(
+            jinja
+                .eval("(unix and not osx) or win or osx")
+                .expect("test 8")
+                .is_true()
+        );
         assert!(jinja.eval("linux and x86_64").expect("test 9").is_true());
         assert!(!jinja.eval("linux and aarch64").expect("test 10").is_true());
     }
@@ -1190,8 +1233,74 @@ mod tests {
     }
 
     #[test]
+    fn eval_platform_shortcuts_use_host_platform() {
+        // When host_platform differs from target_platform, the platform
+        // shortcuts (unix, linux, osx, win) and arch variables should
+        // reflect the host_platform (where the package runs).
+        let options = JinjaConfig {
+            target_platform: Platform::Linux64,
+            host_platform: Platform::OsxArm64,
+            build_platform: Platform::Linux64,
+            ..Default::default()
+        };
+
+        let jinja = Jinja::new(options);
+
+        // Platform shortcuts should reflect host_platform (osx-arm64), not target (linux-64)
+        assert!(jinja.eval("unix").expect("osx is unix").is_true());
+        assert!(jinja.eval("osx").expect("host is osx").is_true());
+        assert!(!jinja.eval("linux").expect("host is not linux").is_true());
+        assert!(!jinja.eval("win").expect("host is not win").is_true());
+
+        // Arch should reflect host_platform (arm64), not target (x86_64)
+        assert!(jinja.eval("arm64").expect("host is arm64").is_true());
+        assert!(!jinja.eval("x86_64").expect("host is not x86_64").is_true());
+
+        // Platform aliases should reflect host_platform
+        assert!(jinja.eval("osxarm64").expect("host is osxarm64").is_true());
+        assert!(
+            !jinja
+                .eval("linux64")
+                .expect("host is not linux64")
+                .is_true()
+        );
+
+        // The string variables should still report their respective values
+        assert!(
+            jinja
+                .eval("target_platform == \"linux-64\"")
+                .expect("target_platform string")
+                .is_true()
+        );
+        assert!(
+            jinja
+                .eval("host_platform == \"osx-arm64\"")
+                .expect("host_platform string")
+                .is_true()
+        );
+    }
+
+    #[test]
+    fn eval_platform_shortcuts_windows_host() {
+        // Verify win shortcut works when host is Windows
+        let options = JinjaConfig {
+            target_platform: Platform::Linux64,
+            host_platform: Platform::Win64,
+            build_platform: Platform::Linux64,
+            ..Default::default()
+        };
+
+        let jinja = Jinja::new(options);
+
+        assert!(jinja.eval("win").expect("host is win").is_true());
+        assert!(!jinja.eval("unix").expect("host is not unix").is_true());
+        assert!(!jinja.eval("linux").expect("host is not linux").is_true());
+        assert!(!jinja.eval("osx").expect("host is not osx").is_true());
+        assert!(jinja.eval("x86_64").expect("host is x86_64").is_true());
+    }
+
+    #[test]
     #[should_panic]
-    #[rustfmt::skip]
     fn eval2() {
         let options = JinjaConfig {
             target_platform: Platform::Linux64,
@@ -1326,7 +1435,7 @@ mod tests {
     }
 
     #[test]
-    #[rustfmt::skip]
+
     fn eval_match() {
         let variant = BTreeMap::from_iter(vec![("python".into(), "3.7".into())]);
 
@@ -1339,17 +1448,47 @@ mod tests {
         };
         let jinja = Jinja::new(options);
 
-        assert!(jinja.eval("match(python, '==3.7')").expect("test 1").is_true());
-        assert!(jinja.eval("match(python, '>=3.7')").expect("test 2").is_true());
-        assert!(jinja.eval("match(python, '>=3.7,<3.9')").expect("test 3").is_true());
+        assert!(
+            jinja
+                .eval("match(python, '==3.7')")
+                .expect("test 1")
+                .is_true()
+        );
+        assert!(
+            jinja
+                .eval("match(python, '>=3.7')")
+                .expect("test 2")
+                .is_true()
+        );
+        assert!(
+            jinja
+                .eval("match(python, '>=3.7,<3.9')")
+                .expect("test 3")
+                .is_true()
+        );
 
-        assert!(!jinja.eval("match(python, '!=3.7')").expect("test 4").is_true());
-        assert!(!jinja.eval("match(python, '<3.7')").expect("test 5").is_true());
-        assert!(!jinja.eval("match(python, '>3.5,<3.7')").expect("test 6").is_true());
+        assert!(
+            !jinja
+                .eval("match(python, '!=3.7')")
+                .expect("test 4")
+                .is_true()
+        );
+        assert!(
+            !jinja
+                .eval("match(python, '<3.7')")
+                .expect("test 5")
+                .is_true()
+        );
+        assert!(
+            !jinja
+                .eval("match(python, '>3.5,<3.7')")
+                .expect("test 6")
+                .is_true()
+        );
     }
 
     #[test]
-    #[rustfmt::skip]
+
     fn eval_complicated_match() {
         let variant = BTreeMap::from_iter(vec![("python".into(), "3.7.* *_cpython".into())]);
 
@@ -1362,13 +1501,43 @@ mod tests {
         };
         let jinja = Jinja::new(options);
 
-        assert!(jinja.eval("match(python, '==3.7')").expect("test 1").is_true());
-        assert!(jinja.eval("match(python, '>=3.7')").expect("test 2").is_true());
-        assert!(jinja.eval("match(python, '>=3.7,<3.9')").expect("test 3").is_true());
+        assert!(
+            jinja
+                .eval("match(python, '==3.7')")
+                .expect("test 1")
+                .is_true()
+        );
+        assert!(
+            jinja
+                .eval("match(python, '>=3.7')")
+                .expect("test 2")
+                .is_true()
+        );
+        assert!(
+            jinja
+                .eval("match(python, '>=3.7,<3.9')")
+                .expect("test 3")
+                .is_true()
+        );
 
-        assert!(!jinja.eval("match(python, '!=3.7')").expect("test 4").is_true());
-        assert!(!jinja.eval("match(python, '<3.7')").expect("test 5").is_true());
-        assert!(!jinja.eval("match(python, '>3.5,<3.7')").expect("test 6").is_true());
+        assert!(
+            !jinja
+                .eval("match(python, '!=3.7')")
+                .expect("test 4")
+                .is_true()
+        );
+        assert!(
+            !jinja
+                .eval("match(python, '<3.7')")
+                .expect("test 5")
+                .is_true()
+        );
+        assert!(
+            !jinja
+                .eval("match(python, '>3.5,<3.7')")
+                .expect("test 6")
+                .is_true()
+        );
     }
 
     fn with_env((key, value): (impl AsRef<str>, impl AsRef<str>), f: impl Fn()) {

--- a/crates/rattler_build_recipe/src/variant_render.rs
+++ b/crates/rattler_build_recipe/src/variant_render.rs
@@ -103,8 +103,13 @@ impl RenderConfig {
     }
 
     /// Set the target platform
+    ///
+    /// This also sets `host_platform` to the same value (mirroring the CLI
+    /// behavior). Call [`with_host_platform`](Self::with_host_platform) afterwards
+    /// if you need a different host platform.
     pub fn with_target_platform(mut self, platform: rattler_conda_types::Platform) -> Self {
         self.target_platform = platform;
+        self.host_platform = platform;
         self
     }
 

--- a/crates/rattler_build_variant_config/src/conda_build_config.rs
+++ b/crates/rattler_build_variant_config/src/conda_build_config.rs
@@ -208,6 +208,7 @@ mod tests {
     fn test_selector_context() {
         let config = JinjaConfig {
             target_platform: Platform::Linux64,
+            host_platform: Platform::Linux64,
             ..Default::default()
         };
         let jinja = conda_build_config_jinja(&config);
@@ -232,6 +233,7 @@ mod tests {
         // fix the platform for the snapshots
         let jinja_config = JinjaConfig {
             target_platform: Platform::OsxArm64,
+            host_platform: Platform::OsxArm64,
             ..Default::default()
         };
 

--- a/crates/rattler_build_variant_config/src/config.rs
+++ b/crates/rattler_build_variant_config/src/config.rs
@@ -153,6 +153,7 @@ impl VariantConfig {
     ) -> Result<Self, VariantConfigError> {
         let jinja_config = rattler_build_jinja::JinjaConfig {
             target_platform,
+            host_platform: target_platform,
             ..Default::default()
         };
         Self::from_files_with_context(paths, &jinja_config)

--- a/crates/rattler_build_variant_config/src/evaluate.rs
+++ b/crates/rattler_build_variant_config/src/evaluate.rs
@@ -160,6 +160,7 @@ vc:
         // Test with Linux platform (unix = true)
         let jinja_config = JinjaConfig {
             target_platform: Platform::Linux64,
+            host_platform: Platform::Linux64,
             ..Default::default()
         };
         let config = evaluate_variant_config(&stage0, &jinja_config).unwrap();
@@ -183,6 +184,7 @@ vc:
         // Test with Windows platform (win = true)
         let jinja_config = JinjaConfig {
             target_platform: Platform::Win64,
+            host_platform: Platform::Win64,
             ..Default::default()
         };
         let config = evaluate_variant_config(&stage0, &jinja_config).unwrap();
@@ -202,6 +204,7 @@ target:
 
         let jinja_config = JinjaConfig {
             target_platform: Platform::Linux64,
+            host_platform: Platform::Linux64,
             ..Default::default()
         };
         let config = evaluate_variant_config(&stage0, &jinja_config).unwrap();
@@ -226,6 +229,7 @@ mixed:
 
         let jinja_config = JinjaConfig {
             target_platform: Platform::Linux64,
+            host_platform: Platform::Linux64,
             ..Default::default()
         };
         let config = evaluate_variant_config(&stage0, &jinja_config).unwrap();
@@ -250,6 +254,7 @@ python:
 
         let jinja_config = JinjaConfig {
             target_platform: Platform::Linux64,
+            host_platform: Platform::Linux64,
             ..Default::default()
         };
         let config = evaluate_variant_config(&stage0, &jinja_config).unwrap();

--- a/crates/rattler_build_variant_config/tests/integration_tests.rs
+++ b/crates/rattler_build_variant_config/tests/integration_tests.rs
@@ -97,6 +97,7 @@ fn test_conda_build_config_linux() {
     let path = test_data_dir().join("conda_build_config/conda_build_config.yaml");
     let context = JinjaConfig {
         target_platform: Platform::Linux64,
+        host_platform: Platform::Linux64,
         ..Default::default()
     };
 
@@ -109,6 +110,7 @@ fn test_conda_build_config_osx() {
     let path = test_data_dir().join("conda_build_config/conda_build_config.yaml");
     let context = JinjaConfig {
         target_platform: Platform::OsxArm64,
+        host_platform: Platform::OsxArm64,
         ..Default::default()
     };
 
@@ -121,6 +123,7 @@ fn test_conda_build_config_win() {
     let path = test_data_dir().join("conda_build_config/conda_build_config.yaml");
     let context = JinjaConfig {
         target_platform: Platform::Win64,
+        host_platform: Platform::Win64,
         ..Default::default()
     };
 
@@ -190,6 +193,7 @@ fn test_flatten_selectors_linux() {
     let path = test_data_dir().join("with_selectors/variants.yaml");
     let jinja_config = rattler_build_jinja::JinjaConfig {
         target_platform: Platform::Linux64,
+        host_platform: Platform::Linux64,
         build_platform: Platform::Linux64,
         ..Default::default()
     };
@@ -209,6 +213,7 @@ fn test_flatten_selectors_win() {
     let path = test_data_dir().join("with_selectors/variants.yaml");
     let jinja_config = rattler_build_jinja::JinjaConfig {
         target_platform: Platform::Win64,
+        host_platform: Platform::Win64,
         build_platform: Platform::Win64,
         ..Default::default()
     };
@@ -230,6 +235,7 @@ fn test_load_conda_build_config_with_types() {
     let path = test_data_dir().join("variant_files/variant_config_1.yaml");
     let context = JinjaConfig {
         target_platform: Platform::Linux64,
+        host_platform: Platform::Linux64,
         ..Default::default()
     };
 
@@ -268,6 +274,7 @@ fn test_load_variant_config_with_types() {
 
     let jinja_config = rattler_build_jinja::JinjaConfig {
         target_platform: Platform::Linux64,
+        host_platform: Platform::Linux64,
         ..Default::default()
     };
     let config = VariantConfig::from_file_with_context(&path, &jinja_config).unwrap();
@@ -343,6 +350,7 @@ compiler:
 "#;
     let jinja_config = rattler_build_jinja::JinjaConfig {
         target_platform: Platform::Linux64,
+        host_platform: Platform::Linux64,
         ..Default::default()
     };
     let result = VariantConfig::from_yaml_str_with_context(yaml, &jinja_config);
@@ -369,6 +377,7 @@ compiler:
 "#;
     let jinja_config = rattler_build_jinja::JinjaConfig {
         target_platform: Platform::Linux64,
+        host_platform: Platform::Linux64,
         ..Default::default()
     };
     let result = VariantConfig::from_yaml_str_with_context(yaml, &jinja_config);

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -46,6 +46,8 @@ This document contains the help content for the `rattler-build` command-line pro
 			Use JSON logging output
 		- `plain`:
 			Use plain logging output
+		- `simple`:
+			Use simple logging output (colored, no box-drawing frames)
 
 
 - `--wrap-log-lines <WRAP_LOG_LINES>`
@@ -250,6 +252,11 @@ e.g. `tar-bz2:<number>` (from 1 to 9) or `conda:<number>` (from -7 to
 - `--debug`
 
 	Enable debug output in build scripts
+
+
+- `--markdown-summary <MARKDOWN_SUMMARY>`
+
+	Write a markdown summary to the specified file (appends to the file). Useful for generating PR comments or custom reports
 
 
 - `--error-prefix-in-binary`
@@ -491,6 +498,11 @@ e.g. `tar-bz2:<number>` (from 1 to 9) or `conda:<number>` (from -7 to
 	Enable debug output in build scripts
 
 
+- `--markdown-summary <MARKDOWN_SUMMARY>`
+
+	Write a markdown summary to the specified file (appends to the file). Useful for generating PR comments or custom reports
+
+
 - `--error-prefix-in-binary`
 
 	Error if the host prefix is detected in any binary files
@@ -595,7 +607,7 @@ These test files are written at "package creation time" and are part of the pack
 
 - `-p`, `--package-file <PACKAGE_FILE>`
 
-	The package file to test
+	The package file or extracted package directory to test
 
 
 - `--compression-threads <COMPRESSION_THREADS>`

--- a/docs/selectors.md
+++ b/docs/selectors.md
@@ -10,8 +10,8 @@ follows
 the same syntax as a Python expression.
 
 During rendering, several variables are set based on the platform and variant
-being built. For example, the `unix` variable is true for macOS and Linux, while
-`win` is true for Windows. Consider the following recipe executed on Linux:
+being built. For example, the `unix` variable is true when the host platform is macOS or Linux, while
+`win` is true when the host platform is Windows. Consider the following recipe executed on Linux:
 
 ```yaml
 requirements:
@@ -67,13 +67,14 @@ The following variables are available during rendering of the recipe:
 |----------------------|------------------------------------------------------------------------|
 | `target_platform`    | the configured `target_platform` for the build                         |
 | `build_platform`     | the configured `build_platform` for the build                          |
-| `linux`              | "true" if `target_platform` is Linux                                   |
-| `osx`                | "true" if `target_platform` is OSX / macOS                             |
-| `win`                | "true" if `target_platform` is Windows                                 |
-| `unix`               | "true" if `target_platform` is a Unix (macOS or Linux)                 |
-| `x86`, `x86_64`      | x86 32/64-bit Architecture                                             |
-| `aarch64`            | 64-bit Arm (if `target_platform` is `linux-aarch64`)                   |
-| `arm64`              | 64-bit Arm (if `target_platform` is `osx-arm64` or `win-arm64`)        |
+| `host_platform`      | the configured `host_platform` for the build                           |
+| `linux`              | "true" if `host_platform` is Linux                                     |
+| `osx`                | "true" if `host_platform` is OSX / macOS                               |
+| `win`                | "true" if `host_platform` is Windows                                   |
+| `unix`               | "true" if `host_platform` is a Unix (macOS or Linux)                   |
+| `x86`, `x86_64`      | x86 32/64-bit Architecture (based on `host_platform`)                  |
+| `aarch64`            | 64-bit Arm (if `host_platform` is `linux-aarch64`)                     |
+| `arm64`              | 64-bit Arm (if `host_platform` is `osx-arm64` or `win-arm64`)          |
 | `armV6l`, `armV7l`   | 32-bit Arm                                                             |
 | `ppc64`, `s390x`,    | Big endian                                                             |
 | `ppc64le`            | Little endian                                                          |
@@ -150,9 +151,9 @@ Some notable options are:
 ```yaml
 - if: python == "3.8" # equal
 - if: python != "3.8" # not equal
-- if: python and linux # true if python variant is set and the target_platform is linux
-- if: python and not linux # true if python variant is set and the target_platform is not linux
-- if: python and (linux or osx) # true if python variant is set and the target_platform is linux or osx
+- if: python and linux # true if python variant is set and the host_platform is linux
+- if: python and not linux # true if python variant is set and the host_platform is not linux
+- if: python and (linux or osx) # true if python variant is set and the host_platform is linux or osx
 ```
 
 [minijinja]: https://github.com/mitsuhiko/minijinja

--- a/py-rattler-build/rust/src/jinja_config.rs
+++ b/py-rattler-build/rust/src/jinja_config.rs
@@ -43,7 +43,7 @@ impl PyJinjaConfig {
             .map(|p| Platform::from_str(&p))
             .transpose()
             .map_err(RattlerBuildError::from)?
-            .unwrap_or_else(Platform::current);
+            .unwrap_or(target_platform);
 
         let build_platform = build_platform
             .map(|p| Platform::from_str(&p))

--- a/py-rattler-build/rust/src/render.rs
+++ b/py-rattler-build/rust/src/render.rs
@@ -51,7 +51,7 @@ impl PyRenderConfig {
             .map(|p| p.parse::<Platform>())
             .transpose()
             .map_err(RattlerBuildError::from)?
-            .unwrap_or_else(Platform::current);
+            .unwrap_or(target_platform);
 
         let extra_context = extra_context
             .map(|dict| {

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -1065,6 +1065,51 @@ def test_noarch_variants(rattler_build: RattlerBuild, recipes: Path, tmp_path: P
     }
 
 
+def test_platform_selectors_use_host_platform(
+    rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
+):
+    """Test that platform selectors (unix, win, etc.) are based on host_platform, not target_platform.
+
+    When --host-platform and --target-platform differ, the selectors should
+    reflect the host platform (where the package will run).
+    """
+    path_to_recipe = recipes / "noarch_variant"
+    args = rattler_build.build_args(path_to_recipe, tmp_path)
+
+    # Set host_platform=linux-64 but target_platform=win-64
+    # The `unix` selector should be true (based on host), not `win` (based on target)
+    output = rattler_build(
+        *args,
+        "--host-platform=linux-64",
+        "--target-platform=win-64",
+        "--render-only",
+        stderr=DEVNULL,
+    )
+
+    rendered = json.loads(output)
+    assert len(rendered) == 2
+
+    # unix should be true because host_platform is linux-64
+    assert rendered[0]["recipe"]["requirements"]["run"] == ["__unix"]
+    assert "unix" in rendered[0]["recipe"]["build"]["string"]
+
+    # Now flip: host_platform=win-64, target_platform=linux-64
+    output = rattler_build(
+        *args,
+        "--host-platform=win-64",
+        "--target-platform=linux-64",
+        "--render-only",
+        stderr=DEVNULL,
+    )
+
+    rendered = json.loads(output)
+    assert len(rendered) == 2
+
+    # win should be true because host_platform is win-64
+    assert rendered[0]["recipe"]["requirements"]["run"] == ["__win >=11.0.123 foobar"]
+    assert "win" in rendered[0]["recipe"]["build"]["string"]
+
+
 def test_regex_post_process(rattler_build: RattlerBuild, recipes: Path, tmp_path: Path):
     path_to_recipe = recipes / "regex_post_process"
     args = rattler_build.build_args(


### PR DESCRIPTION
The jinja variables unix, linux, osx, win, architecture aliases (x86_64, aarch64, etc.), and platform aliases (linux64, osxarm64, etc.) now reflect the host_platform (where the package will run) instead of target_platform.

This is mostly relevant for `noarch` packages, where I still want the selector `unix` to work.

Also ensures host_platform defaults to target_platform (rather than Platform::current()) when only target_platform is specified, both in the Rust RenderConfig builder and in the Python bindings.