### PR TITLE
fix: parse values as MatchSpec before extracting package name

### DIFF
--- a/crates/rattler_build_recipe/src/stage0/evaluate.rs
+++ b/crates/rattler_build_recipe/src/stage0/evaluate.rs
@@ -954,10 +954,10 @@ pub fn evaluate_package_name_list(
                 // Templates like `${{ compiler('cxx') }}` render to strings
                 // such as `gxx_linux-64 =13` which are valid MatchSpecs but
                 // not valid bare PackageNames.
-                if let Ok(ms) = MatchSpec::from_str(&s, ParseStrictness::Lenient) {
-                    if let Some(PackageNameMatcher::Exact(name)) = ms.name {
-                        return Ok(Some(name));
-                    }
+                if let Ok(ms) = MatchSpec::from_str(&s, ParseStrictness::Lenient)
+                    && let Some(PackageNameMatcher::Exact(name)) = ms.name
+                {
+                    return Ok(Some(name));
                 }
                 PackageName::from_str(&s).map(Some).map_err(|e| {
                     ParseError::invalid_value(


### PR DESCRIPTION
When `compiler()` or `stdlib()` Jinja functions are used in `ignore_run_exports.from_package`, they render to strings like `gxx_linux-64 =13`. The `evaluate_package_name_list()` function tried to parse these directly as a `PackageName`, which fails because bare package names cannot contain spaces or `=`.

The old code parsed these values as `MatchSpec` first (which handles `gxx_linux-64 =13` as package `gxx_linux-64` with version `=13`) and then extracted the `.name` field.

Apply the same approach: attempt MatchSpec parsing first and extract the package name, falling back to direct PackageName parsing.

Fixes rendering failures for feedstocks like nettle, mamba, cccl, fenics-ffcx, and others that use `compiler()`/`stdlib()` in `ignore_run_exports`.