### PR TITLE
Move timestamp generation outside build output loop

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -482,6 +482,8 @@ pub async fn get_build_output(
         .or_else(|| outputs_and_variants.first().map(|o| o.name.clone()))
         .unwrap_or_else(|| "build".to_string());
 
+    let timestamp = chrono::Utc::now();
+
     for discovered_output in outputs_and_variants {
         let recipe = &discovered_output.recipe;
 
@@ -552,7 +554,6 @@ pub async fn get_build_output(
             .collect::<Result<Vec<_>, _>>()
             .into_diagnostic()?;
 
-        let timestamp = chrono::Utc::now();
         let virtual_package_override = VirtualPackageOverrides::from_env();
         let output = Output {
             recipe: discovered_output.recipe.clone(),


### PR DESCRIPTION
## Summary
Refactored the timestamp generation in `get_build_output` to occur once before the loop rather than on each iteration, improving efficiency and ensuring consistent timestamps across all discovered outputs.

## Key Changes
- Moved `let timestamp = chrono::Utc::now();` from inside the loop to before it
- This ensures a single timestamp is used for all outputs processed in the function, rather than generating a new timestamp for each iteration

## Implementation Details
The timestamp is now captured once at the beginning of the output processing logic, before iterating through `outputs_and_variants`. This change maintains the same functionality while reducing unnecessary system calls and ensuring temporal consistency across all outputs generated in a single `get_build_output` invocation.

https://claude.ai/code/session_016o7zwyeswXwNYRqVsppVjw