### PR TITLE
fix: prevent post-link scripts from leaking files into downstream packages

### DIFF
--- a/src/packaging.rs
+++ b/src/packaging.rs
@@ -22,7 +22,7 @@ use unicode_normalization::UnicodeNormalization;
 mod file_finder;
 mod file_mapper;
 mod metadata;
-pub use file_finder::{Files, TempFiles, content_type};
+pub use file_finder::{Files, TempFiles, content_type, record_files};
 pub use metadata::{contains_prefix_binary, contains_prefix_text, create_prefix_placeholder};
 use tempfile::NamedTempFile;
 
@@ -861,6 +861,7 @@ impl Output {
     pub async fn create_package(
         &self,
         tool_configuration: &tool_configuration::Configuration,
+        post_install_files: Option<&HashSet<PathBuf>>,
     ) -> Result<(PathBuf, PathsJson), PackagingError> {
         let span = tracing::info_span!("Packaging new files");
         let _enter = span.enter();
@@ -868,6 +869,7 @@ impl Output {
             &self.build_configuration.directories.host_prefix,
             &self.recipe.build().always_include_files,
             &self.recipe.build().files,
+            post_install_files,
         )?;
 
         package_conda(self, tool_configuration, &files_after)

--- a/src/render/solver.rs
+++ b/src/render/solver.rs
@@ -236,9 +236,13 @@ pub async fn install_packages(
 
     if !installed_packages.is_empty() && name.starts_with("host") {
         // we have to clean up extra files in the prefix
-        let extra_files =
-            Files::from_prefix(target_prefix, &Default::default(), &Default::default())
-                .into_diagnostic()?;
+        let extra_files = Files::from_prefix(
+            target_prefix,
+            &Default::default(),
+            &Default::default(),
+            None,
+        )
+        .into_diagnostic()?;
 
         tracing::info!(
             "Cleaning up {} files in the prefix from a previous build.",

--- a/src/staging.rs
+++ b/src/staging.rs
@@ -308,6 +308,7 @@ impl Output {
             self.prefix(),
             &staging.build.always_include_files,
             &staging.build.files,
+            None,
         )
         .into_diagnostic()?;
 

--- a/test-data/recipes/post-link-downstream/recipe.yaml
+++ b/test-data/recipes/post-link-downstream/recipe.yaml
@@ -1,0 +1,14 @@
+package:
+  name: post-link-downstream
+  version: "1.0.0"
+
+build:
+  skip:
+    - win
+  script:
+    - mkdir -p $PREFIX/lib/post-link-downstream
+    - echo "downstream marker" > $PREFIX/lib/post-link-downstream/marker.txt
+
+requirements:
+  host:
+    - post-link-leaker

--- a/test-data/recipes/post-link-leaker/recipe.yaml
+++ b/test-data/recipes/post-link-leaker/recipe.yaml
@@ -1,0 +1,15 @@
+package:
+  name: post-link-leaker
+  version: "1.0.0"
+
+build:
+  skip:
+    - win
+  script:
+    - mkdir -p $PREFIX/lib/post-link-leaker
+    - echo "marker" > $PREFIX/lib/post-link-leaker/marker.txt
+    - mkdir -p $PREFIX/bin
+    - echo '#!/bin/bash' > $PREFIX/bin/.post-link-leaker-post-link.sh
+    - echo 'mkdir -p "$PREFIX/lib/post-link-leaker-cache"' >> $PREFIX/bin/.post-link-leaker-post-link.sh
+    - echo 'echo "leaked" > "$PREFIX/lib/post-link-leaker-cache/leaked-cache.txt"' >> $PREFIX/bin/.post-link-leaker-post-link.sh
+    - chmod +x $PREFIX/bin/.post-link-leaker-post-link.sh


### PR DESCRIPTION
- When a host dependency has a post-link script that generates files (e.g. cache files), those files are not recorded in `conda-meta/`. `Files::from_prefix()` then incorrectly attributes them to the downstream package being built.
- This fix snapshots the host prefix before and after `install_environments()` to compute the delta of files added during installation (including post-link artifacts), then excludes them from new-file detection. The delta approach avoids interfering with files restored from a staging cache.
- Adds an end-to-end test with two recipes (`post-link-leaker` and `post-link-downstream`) that verifies leaked files are excluded.

Related: conda-forge/gtk3-feedstock#81