### PR TITLE
ci(perf): Optimize CI performance with sccache and Windows dev drive

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,6 +43,19 @@ jobs:
         with:
           submodules: recursive
           persist-credentials: false
+      # Use a ReFS dev drive on Windows for ~30x faster I/O than the C: drive
+      - name: Set up Windows dev drive
+        if: runner.os == 'Windows'
+        uses: samypr100/setup-dev-drive@cf663fdf88945e3faaa980ec525b5bc2350fbf9d # v3
+        with:
+          drive-size: 50GB
+          env-mapping: |
+            CARGO_HOME,{{ DEV_DRIVE }}/.cargo
+      - name: Redirect cargo target directory to dev drive
+        if: runner.os == 'Windows'
+        run: |
+          New-Item -ItemType Directory -Path "$env:DEV_DRIVE/target-pixi" -Force | Out-Null
+          New-Item -ItemType Junction -Path "target-pixi" -Target "$env:DEV_DRIVE/target-pixi" | Out-Null
       - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           cache: true
@@ -92,6 +105,19 @@ jobs:
         with:
           submodules: recursive
           persist-credentials: false
+      # Use a ReFS dev drive on Windows for ~30x faster I/O than the C: drive
+      - name: Set up Windows dev drive
+        if: runner.os == 'Windows'
+        uses: samypr100/setup-dev-drive@cf663fdf88945e3faaa980ec525b5bc2350fbf9d # v3
+        with:
+          drive-size: 50GB
+          env-mapping: |
+            CARGO_HOME,{{ DEV_DRIVE }}/.cargo
+      - name: Redirect cargo target directory to dev drive
+        if: runner.os == 'Windows'
+        run: |
+          New-Item -ItemType Directory -Path "$env:DEV_DRIVE/target-pixi" -Force | Out-Null
+          New-Item -ItemType Junction -Path "target-pixi" -Target "$env:DEV_DRIVE/target-pixi" | Out-Null
       - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           cache: true


### PR DESCRIPTION
## Summary
Speeds up the Windows CI jobs by moving build I/O onto a ReFS **dev drive**, which is roughly ~30x faster than the standard `C:` drive that otherwise dominates Windows build/test wall time.

## Changes
- Add `samypr100/setup-dev-drive` to create a 50GB ReFS dev drive on Windows runners.
- Map `CARGO_HOME` onto the dev drive via the action's `env-mapping`.
- Redirect the cargo target directory (`target-pixi`, set by pixi's activation scripts) onto the dev drive via a junction.
- Applied to both the `test` and `e2e-test` jobs; Windows-only via `if: runner.os == 'Windows'`.

## Notes
This was rebased onto `main` after the CI refactor that moved builds to pixi. The earlier sccache changes from this branch are no longer needed — `main` already enables sccache globally through pixi (`RUSTC_WRAPPER = "sccache"` in `pixi.toml` + `SCCACHE_GHA_ENABLED`), so this PR now contains only the dev-drive optimization.