### PR TITLE
Clarify file_name behavior and archive extraction in recipe docs

### DIFF
--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -176,14 +176,39 @@ of the work folder.
 
 ##### Specifying a file name
 
-For URL and local paths you can specify a file name. If the source is an archive and a file name is set, automatic extraction is disabled.
+For URL and local path sources, `file_name` renames the downloaded file in the work directory.
+The primary use case is giving a clean name to pre-built binaries whose URL path segments are not
+descriptive:
 
 ```yaml
 source:
-  url: https://pypi.python.org/packages/source/b/bsdiff4/bsdiff4-1.1.4.tar.gz
-  # will put the file in the work directory as `bsdiff4-1.1.4.tar.gz`
-  file_name: bsdiff4-1.1.4.tar.gz
+  url: https://github.com/owner/project/releases/download/v1.0.0/project-v1.0.0-linux-amd64
+  sha256: <sha256>
+  file_name: project  # rename to a clean, platform-independent name
 ```
+
+!!! warning "Setting `file_name` disables automatic archive extraction"
+    When `file_name` is set on an archive source (`.tar.gz`, `.zip`, `.7z`, etc.), the archive is
+    **not extracted** — it is placed in the work directory as-is under the given name.
+    This is true even if `file_name` is set to the same name the archive would have had by default:
+
+    ```yaml
+    source:
+      url: https://pypi.python.org/packages/source/b/bsdiff4/bsdiff4-1.1.4.tar.gz
+      sha256: 5a022ff4c1d1de87232b1c70bde50afbb98212fd246be4a867d8737173cf1f8f
+      # The archive is NOT extracted — it is placed as bsdiff4-1.1.4.tar.gz in the work directory
+      file_name: bsdiff4-1.1.4.tar.gz
+    ```
+
+    To download an archive and have it extracted automatically (the default behaviour), omit
+    `file_name`:
+
+    ```yaml
+    source:
+      url: https://pypi.python.org/packages/source/b/bsdiff4/bsdiff4-1.1.4.tar.gz
+      sha256: 5a022ff4c1d1de87232b1c70bde50afbb98212fd246be4a867d8737173cf1f8f
+      # file_name is not set — the archive is extracted into the work directory
+    ```
 
 #### Source from `git`
 


### PR DESCRIPTION
## Summary
Improved documentation for the `file_name` parameter in recipe source specifications to clarify its behavior and interaction with automatic archive extraction.

## Key Changes
- Rewrote the `file_name` explanation to focus on its primary use case: renaming pre-built binaries with non-descriptive URL paths
- Added a prominent warning section explaining that setting `file_name` disables automatic archive extraction
- Provided concrete examples demonstrating:
  - How `file_name` works with pre-built binaries (recommended usage)
  - The behavior when `file_name` is set on archives (extraction is disabled)
  - How to properly download and extract archives without `file_name` (default behavior)
- Included SHA256 hashes in examples for completeness

## Notable Details
The documentation now clearly warns users that setting `file_name` on archive sources (`.tar.gz`, `.zip`, `.7z`, etc.) prevents automatic extraction, even if the filename matches what would have been used by default. This addresses a potential source of confusion where users might expect archives to be extracted regardless of the `file_name` setting.

https://claude.ai/code/session_01K2UTsBW6fy8CvDJ7bmweMG