### PR TITLE
fix: win pre-release build (aws-lc-sys compilation)

### DIFF
--- a/.github/workflows/publish-pre-release.yml
+++ b/.github/workflows/publish-pre-release.yml
@@ -22,15 +22,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+          - os: macos-latest
+          - os: windows-latest
+            checkout-path: 'D:\pixi'
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: ${{ matrix.checkout-path || github.workspace }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
         with:
           submodules: recursive
+          path: ${{ matrix.checkout-path || '.' }}
       - uses: prefix-dev/setup-pixi@v0.9.4
         with:
           environments: packaging
+          manifest-path: ${{ matrix.checkout-path && format('{0}\pixi.toml', matrix.checkout-path) || 'pixi.toml' }}
       - name: Configure sccache
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:


### PR DESCRIPTION
aws-lc-sys did not compile properly, because some include path got too long for the 280 char limit on Windows. 

This PR tries to build things in a folder at `C:\pixi` instead.