### PR TITLE
Cache prefix info from staging environments for linking checks

### DIFF
--- a/py-rattler-build/rust/src/build.rs
+++ b/py-rattler-build/rust/src/build.rs
@@ -225,6 +225,7 @@ pub fn build_rendered_variant_py(
         finalized_sources: None,
         finalized_cache_dependencies: None,
         finalized_cache_sources: None,
+        cached_prefix_info: None,
         build_summary: Arc::new(Mutex::new(BuildSummary::default())),
         system_tools: SystemTools::default(),
         extra_meta: None,

--- a/src/build.rs
+++ b/src/build.rs
@@ -137,10 +137,12 @@ pub async fn run_build(
     // This will build or restore staging caches and return their dependencies/sources if inherited
     let staging_result = output.process_staging_caches(tool_configuration).await?;
 
-    // If we inherit from a staging cache, store its dependencies and sources
-    if let Some((deps, sources)) = staging_result {
+    // If we inherit from a staging cache, store its dependencies, sources,
+    // and cached prefix info (for linking checks)
+    if let Some((deps, sources, cached_prefix_info)) = staging_result {
         output.finalized_cache_dependencies = Some(deps);
         output.finalized_cache_sources = Some(sources);
+        output.cached_prefix_info = Some(cached_prefix_info);
     }
 
     // Fetch sources for this output

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -600,6 +600,7 @@ pub async fn get_build_output(
             finalized_sources: None,
             finalized_cache_dependencies: None,
             finalized_cache_sources: None,
+            cached_prefix_info: None,
             system_tools: SystemTools::new(),
             build_summary: Arc::new(Mutex::new(BuildSummary::default())),
             extra_meta: Some(

--- a/src/post_process/package_nature.rs
+++ b/src/post_process/package_nature.rs
@@ -215,26 +215,6 @@ impl PrefixInfo {
         Ok(prefix_info)
     }
 
-    /// Find a package that provides a file matching the given relative path
-    /// (e.g., `libz.1.dylib`). Searches path_to_package entries by filename.
-    pub fn find_package_by_filename(&self, rel_path: &Path) -> Option<PackageName> {
-        // First try direct lookup with common lib/ prefix
-        let with_lib_prefix: CaseInsensitivePathBuf = Path::new("lib").join(rel_path).into();
-        if let Some(package) = self.path_to_package.get(&with_lib_prefix) {
-            return Some(package.clone());
-        }
-
-        // Fallback: search by filename
-        if let Some(filename) = rel_path.file_name() {
-            for (path, package) in &self.path_to_package {
-                if path.path.file_name() == Some(filename) {
-                    return Some(package.clone());
-                }
-            }
-        }
-        None
-    }
-
     /// Merge cached prefix info (from a staging cache) into this PrefixInfo.
     /// Cached entries are only added if they don't already exist.
     pub fn merge_cached(&mut self, cached: &CachedPrefixInfo) {
@@ -272,10 +252,7 @@ pub struct CachedPrefixInfo {
 impl CachedPrefixInfo {
     /// Build a CachedPrefixInfo from a PrefixInfo and the staging cache's
     /// prefix files (build artifacts).
-    pub(crate) fn from_prefix_info(
-        info: &PrefixInfo,
-        staging_prefix_files: &[PathBuf],
-    ) -> Self {
+    pub(crate) fn from_prefix_info(info: &PrefixInfo, staging_prefix_files: &[PathBuf]) -> Self {
         Self {
             path_to_package: info
                 .path_to_package

--- a/src/post_process/package_nature.rs
+++ b/src/post_process/package_nature.rs
@@ -18,10 +18,11 @@ use std::{
     hash::Hash,
     ops::Sub,
     path::{Path, PathBuf},
+    str::FromStr,
 };
 
 /// The nature of a package
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, serde::Serialize, serde::Deserialize)]
 pub enum PackageNature {
     /// Libraries
     RunExportsLibrary,
@@ -212,6 +213,57 @@ impl PrefixInfo {
         }
 
         Ok(prefix_info)
+    }
+
+    /// Merge cached prefix info (from a staging cache) into this PrefixInfo.
+    /// Cached entries are only added if they don't already exist.
+    pub fn merge_cached(&mut self, cached: &CachedPrefixInfo) {
+        for (name_str, nature) in &cached.package_to_nature {
+            if let Ok(name) = PackageName::from_str(name_str) {
+                self.package_to_nature.entry(name).or_insert(nature.clone());
+            }
+        }
+        for (path_str, name_str) in &cached.path_to_package {
+            if let Ok(name) = PackageName::from_str(name_str) {
+                let path_buf: CaseInsensitivePathBuf = PathBuf::from(path_str).into();
+                self.path_to_package.entry(path_buf).or_insert(name);
+            }
+        }
+    }
+}
+
+/// Serializable prefix info for storing in staging cache metadata.
+/// Maps file paths to their owning packages and packages to their nature,
+/// so that linking checks can attribute libraries without needing the
+/// original conda-meta records installed.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct CachedPrefixInfo {
+    /// Maps file paths (relative to prefix) to package names
+    pub path_to_package: HashMap<String, String>,
+    /// Maps package names to their nature
+    pub package_to_nature: HashMap<String, PackageNature>,
+}
+
+impl CachedPrefixInfo {
+    /// Build a CachedPrefixInfo from a PrefixInfo
+    pub(crate) fn from_prefix_info(info: &PrefixInfo) -> Self {
+        Self {
+            path_to_package: info
+                .path_to_package
+                .iter()
+                .map(|(path, name)| {
+                    (
+                        path.path.to_string_lossy().to_string(),
+                        name.as_normalized().to_string(),
+                    )
+                })
+                .collect(),
+            package_to_nature: info
+                .package_to_nature
+                .iter()
+                .map(|(name, nature)| (name.as_normalized().to_string(), nature.clone()))
+                .collect(),
+        }
     }
 }
 

--- a/src/render/resolved_dependencies.rs
+++ b/src/render/resolved_dependencies.rs
@@ -1103,6 +1103,11 @@ impl Output {
 
     /// Install the environments of the outputs. Assumes that the dependencies
     /// for the environment have already been resolved.
+    ///
+    /// When this output inherits from a staging cache, the cache's host
+    /// dependencies are merged into the host environment so that their
+    /// shared libraries and `conda-meta` records are present during
+    /// post-processing (linking checks, relinking, etc.).
     pub async fn install_environments(
         &self,
         tool_configuration: &Configuration,
@@ -1138,6 +1143,58 @@ impl Output {
                 dependencies.run
             );
             return Ok(());
+        }
+
+        // When inheriting from a staging cache, the cache's host packages
+        // (e.g. zlib, libiconv) must also be installed in the host prefix.
+        // Without them the linking checks cannot attribute shared libraries
+        // to their providing packages and will report false overlinking.
+        if let Some(cache_deps) = &self.finalized_cache_dependencies {
+            if let Some(cache_host) = &cache_deps.host {
+                let mut merged = dependencies.clone();
+
+                let host = merged.host.get_or_insert_with(|| ResolvedDependencies {
+                    specs: Vec::new(),
+                    resolved: Vec::new(),
+                });
+
+                // Add cache host packages that aren't already present
+                let existing_names: std::collections::HashSet<_> = host
+                    .resolved
+                    .iter()
+                    .map(|r| r.package_record.name.clone())
+                    .collect();
+
+                for record in &cache_host.resolved {
+                    if !existing_names.contains(&record.package_record.name) {
+                        host.resolved.push(record.clone());
+                        // Also add the spec so the package is tracked as explicit
+                        for spec in &cache_host.specs {
+                            if spec.spec().name.as_ref()
+                                == Some(&rattler_conda_types::PackageNameMatcher::Exact(
+                                    record.package_record.name.clone(),
+                                ))
+                            {
+                                host.specs.push(spec.clone());
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                tracing::info!(
+                    "Merged {} host packages from staging cache into host environment",
+                    cache_host.resolved.len().saturating_sub(
+                        cache_host
+                            .resolved
+                            .iter()
+                            .filter(|r| existing_names.contains(&r.package_record.name))
+                            .count()
+                    )
+                );
+
+                return install_environments(self, &merged, tool_configuration).await;
+            }
         }
 
         install_environments(self, dependencies, tool_configuration).await

--- a/src/staging.rs
+++ b/src/staging.rs
@@ -382,7 +382,8 @@ impl Output {
         // from the host environment while conda-meta records are still present.
         // This data is needed by linking checks in inheriting outputs.
         let prefix_info = PrefixInfo::from_prefix(self.prefix()).into_diagnostic()?;
-        let cached_prefix_info = CachedPrefixInfo::from_prefix_info(&prefix_info);
+        let cached_prefix_info =
+            CachedPrefixInfo::from_prefix_info(&prefix_info, &copied_files);
 
         // Save metadata
         let metadata = StagingCacheMetadata {

--- a/src/staging.rs
+++ b/src/staging.rs
@@ -382,8 +382,7 @@ impl Output {
         // from the host environment while conda-meta records are still present.
         // This data is needed by linking checks in inheriting outputs.
         let prefix_info = PrefixInfo::from_prefix(self.prefix()).into_diagnostic()?;
-        let cached_prefix_info =
-            CachedPrefixInfo::from_prefix_info(&prefix_info, &copied_files);
+        let cached_prefix_info = CachedPrefixInfo::from_prefix_info(&prefix_info, &copied_files);
 
         // Save metadata
         let metadata = StagingCacheMetadata {

--- a/src/staging.rs
+++ b/src/staging.rs
@@ -23,6 +23,7 @@ use crate::{
     env_vars,
     metadata::{Output, build_reindexed_channels},
     packaging::Files,
+    post_process::package_nature::{CachedPrefixInfo, PrefixInfo},
     render::resolved_dependencies::{
         FinalizedDependencies, RunExportsDownload, install_environments, resolve_dependencies,
     },
@@ -72,6 +73,13 @@ pub struct StagingCacheMetadata {
 
     /// The variant configuration that was used
     pub variant: BTreeMap<NormalizedKey, Variable>,
+
+    /// Cached prefix info (path-to-package and package nature mappings)
+    /// from the host environment at staging cache build time.
+    /// This allows linking checks to attribute shared libraries to their
+    /// providing packages without needing the conda-meta records installed.
+    #[serde(default)]
+    pub cached_prefix_info: CachedPrefixInfo,
 }
 
 impl Output {
@@ -142,7 +150,7 @@ impl Output {
     /// 2. If yes, restore the cached files to the prefix
     /// 3. If no, build the staging cache and save it
     ///
-    /// Returns the finalized dependencies and sources from the staging cache
+    /// Returns the finalized dependencies, sources, and cached prefix info
     pub async fn build_or_restore_staging_cache(
         &self,
         staging: &StagingCache,
@@ -151,6 +159,7 @@ impl Output {
         (
             FinalizedDependencies,
             Vec<rattler_build_recipe::stage1::Source>,
+            CachedPrefixInfo,
         ),
         miette::Error,
     > {
@@ -217,6 +226,7 @@ impl Output {
         (
             FinalizedDependencies,
             Vec<rattler_build_recipe::stage1::Source>,
+            CachedPrefixInfo,
         ),
         miette::Error,
     > {
@@ -368,6 +378,12 @@ impl Output {
         .run()
         .into_diagnostic()?;
 
+        // Capture prefix info (path-to-package and package nature mappings)
+        // from the host environment while conda-meta records are still present.
+        // This data is needed by linking checks in inheriting outputs.
+        let prefix_info = PrefixInfo::from_prefix(self.prefix()).into_diagnostic()?;
+        let cached_prefix_info = CachedPrefixInfo::from_prefix_info(&prefix_info);
+
         // Save metadata
         let metadata = StagingCacheMetadata {
             name: staging.name.clone(),
@@ -377,6 +393,7 @@ impl Output {
             work_dir_files: copied_work_dir.copied_paths().to_vec(),
             prefix: self.prefix().to_path_buf(),
             variant: staging.used_variant.clone(),
+            cached_prefix_info,
         };
 
         let metadata_json = serde_json::to_string_pretty(&metadata).into_diagnostic()?;
@@ -388,7 +405,11 @@ impl Output {
             metadata.work_dir_files.len()
         );
 
-        Ok((finalized_dependencies, finalized_sources))
+        Ok((
+            finalized_dependencies,
+            finalized_sources,
+            metadata.cached_prefix_info,
+        ))
     }
 
     /// Restore a staging cache from disk
@@ -400,6 +421,7 @@ impl Output {
         (
             FinalizedDependencies,
             Vec<rattler_build_recipe::stage1::Source>,
+            CachedPrefixInfo,
         ),
         miette::Error,
     > {
@@ -439,7 +461,11 @@ impl Output {
             metadata.name
         );
 
-        Ok((metadata.finalized_dependencies, metadata.finalized_sources))
+        Ok((
+            metadata.finalized_dependencies,
+            metadata.finalized_sources,
+            metadata.cached_prefix_info,
+        ))
     }
 
     /// Process all staging caches for this output
@@ -454,6 +480,7 @@ impl Output {
         Option<(
             FinalizedDependencies,
             Vec<rattler_build_recipe::stage1::Source>,
+            CachedPrefixInfo,
         )>,
         miette::Error,
     > {
@@ -470,7 +497,7 @@ impl Output {
                 "Building or restoring staging cache: {}",
                 staging_cache.name
             );
-            let (_deps, _sources) = self
+            let (_deps, _sources, _prefix_info) = self
                 .build_or_restore_staging_cache(staging_cache, tool_configuration)
                 .await?;
         }
@@ -491,11 +518,11 @@ impl Output {
                 })?;
 
             // Get or build the cache
-            let (deps, sources) = self
+            let (deps, sources, cached_prefix_info) = self
                 .build_or_restore_staging_cache(staging, tool_configuration)
                 .await?;
 
-            Ok(Some((deps, sources)))
+            Ok(Some((deps, sources, cached_prefix_info)))
         } else {
             Ok(None)
         }

--- a/src/types/build_output.rs
+++ b/src/types/build_output.rs
@@ -20,6 +20,7 @@ use std::{
 
 use crate::{
     console_utils::github_integration_enabled,
+    post_process::package_nature::CachedPrefixInfo,
     render::resolved_dependencies::FinalizedDependencies,
     system_tools::SystemTools,
     types::{BuildConfiguration, BuildSummary, PlatformWithVirtualPackages},
@@ -49,6 +50,13 @@ pub struct BuildOutput {
     /// The finalized sources from the cache (if there is a cache instruction)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub finalized_cache_sources: Option<Vec<Source>>,
+
+    /// Cached prefix info from the staging cache's host environment.
+    /// Used by linking checks to attribute shared libraries to packages
+    /// that were installed during the staging cache build but are not
+    /// physically present in the current host prefix.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cached_prefix_info: Option<CachedPrefixInfo>,
 
     /// Summary of the build
     #[serde(skip)]


### PR DESCRIPTION
## Summary
This PR enables linking checks to correctly attribute shared libraries to packages from inherited staging caches by caching and merging prefix information (path-to-package and package nature mappings) from the staging cache's host environment.

## Problem
When an output inherits from a staging cache, the cache's host dependencies are installed into the prefix but their `conda-meta` records are not present. This causes linking checks to fail when trying to attribute shared libraries to packages that were built in the staging cache, since the package metadata is unavailable.

## Solution
The changes implement a caching mechanism for prefix information:

- **New `CachedPrefixInfo` struct**: A serializable representation of `PrefixInfo` that stores path-to-package and package nature mappings as strings, suitable for storage in staging cache metadata
- **Capture at cache build time**: When building a staging cache, the prefix info is captured from the host environment (while `conda-meta` records are present) and stored in the cache metadata
- **Merge during post-processing**: When performing linking checks on an output that inherits from a staging cache, the cached prefix info is merged into the current prefix info, allowing the checks to attribute libraries to their providing packages
- **Serialization support**: Added `Clone`, `Serialize`, and `Deserialize` derives to `PackageNature` to support serialization

## Key Changes
- Added `CachedPrefixInfo` struct with serialization support for storing prefix mappings
- Implemented `PrefixInfo::merge_cached()` to merge cached mappings into the current prefix info
- Updated `StagingCacheMetadata` to include `cached_prefix_info` field
- Modified staging cache build/restore functions to return `CachedPrefixInfo` alongside dependencies and sources
- Updated `BuildOutput` to store `cached_prefix_info` from inherited staging caches
- Modified linking checks to merge cached prefix info before performing attribution
- Updated all call sites to handle the new return type

## Implementation Details
- The `CachedPrefixInfo` uses `String` keys instead of `PackageName` to avoid deserialization failures if package name formats change
- Cached entries are only added if they don't already exist (via `entry().or_insert()`)
- The cached prefix info is marked with `#[serde(default)]` for backward compatibility with existing cache metadata

https://claude.ai/code/session_014mGW5MYfcfu8NFWxUJbU1J