### PR TITLE
fix: publish pre release on win

### DIFF
--- a/.github/workflows/publish-pre-release.yml
+++ b/.github/workflows/publish-pre-release.yml
@@ -35,7 +35,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
         with:
           submodules: recursive
-      - run: |
+      - name: Copy checkout directory
+        run: |
           New-Item ${{ matrix.working-directory }} -ItemType Directory
           Copy-Item D:/a/rattler-build/rattler-build/* ${{ matrix.working-directory }} -Recurse -Force
         working-directory: "D:/"


### PR DESCRIPTION
Manually copy default checkout dir to `D:/pixi` as changing default checkout path outside `$GITHUB_WORKSPACE` is not supported currently. https://github.com/actions/checkout/issues?q=is%3Aissue%20state%3Aopen%20GITHUB_WORKSPACE

workflow run: https://github.com/Glatzel/rattler-build/actions/runs/22379188674/job/64775974286