### PR TITLE
fix: sdist build maturin

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -46,12 +46,6 @@ jobs:
           working-directory: py-rattler-build
           command: sdist
           args: --out dist
-      #   - name: "Test sdist"
-      #     run: |
-      #       rustup default $(cat rust-toolchain)
-      #       cd py-rattler-build
-      #       pip install dist/${{ env.PACKAGE_NAME }}-*.tar.gz --force-reinstall
-      #       python -c "import rattler_build; print(rattler_build.rattler_build_version())"
       - name: "Upload sdist"
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v4
         with:


### PR DESCRIPTION
While the current approach works, it actually has to fallback to guessing where the Cargo.toml is. This makes it explicit