### PR TITLE
Update playground URL to playground.rattler.build

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ There is also a [terminal user interface (TUI)](https://prefix-dev.github.io/rat
 
 ### Playground
 
-Want to try `rattler-build` recipes without installing anything? The [online playground](https://wasm-support.rattler-build-playground.pages.dev/) lets you edit recipes, tweak variant configurations, and see evaluated output — all in the browser.
+Want to try `rattler-build` recipes without installing anything? The [online playground](https://playground.rattler.build/) lets you edit recipes, tweak variant configurations, and see evaluated output — all in the browser.
 
 ### The recipe format
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,8 @@ is a standard "conda" package that can be installed using [`pixi`](https://pixi.
 
 You can use `rattler-build` to publish packages to prefix.dev, anaconda.org, JFrog Artifactory, S3 buckets, or Quetz Servers.
 
+**Try it out!** You can experiment with rattler-build directly in your browser using our [online playground](https://playground.rattler.build/).
+
 ![](https://user-images.githubusercontent.com/885054/244683824-fd1b3896-84c7-498c-b406-40ab2a9e450c.svg)
 
 ## Installation


### PR DESCRIPTION
- Updated README.md to use new playground URL
- Added playground mention to docs/index.md

Closes #2227