### PR TITLE
fix: add missing label to MissingField error in script parser

### DIFF
--- a/src/recipe/parser/script.rs
+++ b/src/recipe/parser/script.rs
@@ -39,7 +39,8 @@ impl TryConvertNode<Script> for RenderedNode {
             RenderedNode::Mapping(map) => map.try_convert(name),
             RenderedNode::Null(_) => Err(vec![_partialerror!(
                 *self.span(),
-                ErrorKind::MissingField(Cow::Owned(name.to_owned()))
+                ErrorKind::MissingField(Cow::Owned(name.to_owned())),
+                label = format!("required field `{}` is missing", name)
             )]),
         }
     }


### PR DESCRIPTION
Continues the work started in #398 and #805 to improve `_partialerror!` 
diagnostic messages throughout the codebase.

This PR adds a missing `label` to the `MissingField` error in 
`src/recipe/parser/script.rs`, making it clearer to users which required 
field is absent when parsing a recipe script section.

Fixes #399