### PR TITLE
tests: verify license, test, and recipe files are included in package…

### DIFF
--- a/crates/rattler_build_package/Cargo.toml
+++ b/crates/rattler_build_package/Cargo.toml
@@ -51,3 +51,4 @@ url = { workspace = true }
 [dev-dependencies]
 insta = { workspace = true }
 rstest = { workspace = true }
+rattler_package_streaming = { workspace = true }


### PR DESCRIPTION
This PR updates integration tests for `rattler_build_package` to fully verify that additional files are correctly included in package archives.  

These changes address previous TODOs and improve confidence that files are packaged correctly without altering build behavior.