### PR TITLE
fix: allow default filter to handle undefined variables

### DIFF
--- a/crates/rattler_build_jinja/src/lib.rs
+++ b/crates/rattler_build_jinja/src/lib.rs
@@ -5,7 +5,10 @@ mod jinja;
 mod utils;
 mod variable;
 
-pub use ast_variables::{JinjaExpression, JinjaTemplate};
+pub use ast_variables::{
+    JinjaExpression, JinjaTemplate, extract_default_guarded_variables_from_expression,
+    extract_default_guarded_variables_from_template,
+};
 pub use jinja::{Jinja, JinjaConfig};
 pub use rattler_build_types::NormalizedKey;
 pub use variable::Variable;


### PR DESCRIPTION
Fixes #2232 

By disallowing undefined jinja variables, we also broke the default filter.
This fixes this by refining how the undefined check works.

It basically works like this:
1) Check which variables are guarded by `default`
2) Remove guarded variables from the undefined variables list

There are a couple of subtleties involved:
- `${{ bar | default("x") + bar }}` should still fail -> ALL occurences of a variable in a expression have to be guarded to be accepted
- Sometimes we check expressions, sometimes the whole AST
- "default" has the abbreviation "d"
- `foo | replace("a", "b") | default("fallback")` this should also work -> we have to find the root variable of a filter chain