### PR TITLE
fix: abi3 Python run export ignore also needed for build run exports filtering

### DIFF
--- a/src/render/resolved_dependencies.rs
+++ b/src/render/resolved_dependencies.rs
@@ -806,6 +806,19 @@ pub(crate) async fn resolve_dependencies(
         None
     };
 
+    // For version-independent (abi3) packages, ignore run exports from `python` itself
+    // (e.g. `python_abi` or `cross-python`) since these packages are Python-version
+    // independent. Run exports from `python-abi3` (e.g. `cpython >=3.X`) are still kept. See CEP-20.
+    let ignore_run_exports = if output.recipe.build.python.version_independent {
+        let mut ignore = requirements.ignore_run_exports.clone();
+        let python: PackageName = "python".parse().expect("valid package name");
+        ignore.from_package.push(python.clone());
+        ignore.by_name.push(python);
+        ignore
+    } else {
+        requirements.ignore_run_exports.clone()
+    };
+
     let build_env = if !requirements.build.is_empty() && !merge_build_host {
         let build_env_specs = apply_variant(
             &requirements.build,
@@ -888,11 +901,7 @@ pub(crate) async fn resolve_dependencies(
         build_run_exports.extend(build_env.run_exports(true));
     }
 
-    let build_run_exports = filter_run_exports(
-        &requirements.ignore_run_exports,
-        &build_run_exports,
-        "build",
-    )?;
+    let build_run_exports = filter_run_exports(&ignore_run_exports, &build_run_exports, "build")?;
 
     host_env_specs.extend(build_run_exports.strong.iter().cloned());
 
@@ -1024,20 +1033,6 @@ pub(crate) async fn resolve_dependencies(
     if let Some(host_env) = &host_env {
         host_run_exports.extend(host_env.run_exports(true));
     }
-
-    // For version-independent (abi3) packages, ignore run exports from
-    // `python` itself (e.g. `python_abi`) since these packages are
-    // Python-version independent. Run exports from `python-abi3` (e.g.
-    // `cpython >=3.X`) are still kept. See CEP-20.
-    let ignore_run_exports = if output.recipe.build.python.version_independent {
-        let mut ignore = requirements.ignore_run_exports.clone();
-        let python: PackageName = "python".parse().expect("valid package name");
-        ignore.from_package.push(python.clone());
-        ignore.by_name.push(python);
-        ignore
-    } else {
-        requirements.ignore_run_exports.clone()
-    };
 
     // And filter the run exports
     let host_run_exports = filter_run_exports(&ignore_run_exports, &host_run_exports, "host")?;


### PR DESCRIPTION
Fixes the `ruff-feedstock`, because otherwise the `cross-python` package adds an unwanted `python` run-export from the build to the run environment.