### PR TITLE
fix: use build script on empty content

### DIFF
--- a/crates/rattler_build_recipe/src/stage0/evaluate.rs
+++ b/crates/rattler_build_recipe/src/stage0/evaluate.rs
@@ -1283,7 +1283,7 @@ pub fn evaluate_script(
             !env.is_empty() || interpreter.is_some() || cwd.is_some() || !secrets.is_empty();
 
         let content = if commands.is_empty() {
-            ScriptContentOutput::Default
+            ScriptContentOutput::Commands(Vec::new())
         } else if commands.len() == 1 && !has_additional_options && !script.content_explicit {
             // Single command with no additional options and NOT explicitly using content: field
             // This serializes as a simple string: `script: "cmd"`
@@ -5254,5 +5254,38 @@ package:
             }
             _ => panic!("Expected single recipe"),
         }
+    }
+
+    #[test]
+    fn test_evaluate_script_empty_conditional_returns_commands_not_default() {
+        use rattler_build_script::ScriptContent;
+
+        // Create a Script with a conditional content list where the condition is false
+        // and has no else branch — this should produce Commands([]), NOT Default
+        let script = crate::stage0::types::Script {
+            content: Some(ConditionalList::new(vec![Item::Conditional(Conditional {
+                condition: JinjaExpression::new("win".to_string()).unwrap(),
+                then: NestedItemList::new(vec![Item::Value(Value::new_concrete(
+                    "echo hello".to_string(),
+                    None,
+                ))]),
+                else_value: None,
+                condition_span: None,
+            })])),
+            ..Default::default()
+        };
+
+        // Context where `win` is false — so the conditional produces no commands
+        let mut ctx = EvaluationContext::new();
+        ctx.insert("win".to_string(), Variable::from(false));
+
+        let result = evaluate_script(&script, &ctx).unwrap();
+
+        // The script content should be Commands([]), not Default
+        assert_eq!(result.content, ScriptContent::Commands(vec![]));
+        assert!(
+            !result.content.is_default(),
+            "Empty conditional script must not fall back to Default (which discovers build.sh)"
+        );
     }
 }

--- a/test-data/recipes/test-conditional-script-empty/build.sh
+++ b/test-data/recipes/test-conditional-script-empty/build.sh
@@ -1,0 +1,1 @@
+echo "Hello" > $PREFIX/test.txt

--- a/test-data/recipes/test-conditional-script-empty/recipe.yaml
+++ b/test-data/recipes/test-conditional-script-empty/recipe.yaml
@@ -1,0 +1,9 @@
+package:
+  name: test-conditional-script-empty
+  version: "0.1.0"
+
+tests:
+  - script:
+      - if: win
+        then:
+          - echo "This should only run on Windows"

--- a/test/end-to-end/__snapshots__/test_tests.ambr
+++ b/test/end-to-end/__snapshots__/test_tests.ambr
@@ -1,4 +1,11 @@
 # serializer version: 1
+# name: test_conditional_script_empty
+  '''
+  - script:
+      content: ''
+  
+  '''
+# ---
 # name: test_perl_tests
   '''
   - perl:

--- a/test/end-to-end/test_tests.py
+++ b/test/end-to-end/test_tests.py
@@ -43,6 +43,26 @@ def test_source_files_copied_to_test(
     ).exists()
 
 
+@pytest.mark.skipif(os.name == "nt", reason="recipe uses build.sh (unix only)")
+def test_conditional_script_empty(
+    rattler_build: RattlerBuild, recipes: Path, tmp_path: Path, snapshot
+):
+    """Test that a conditional test script evaluating to empty does not fall back to build.sh."""
+    rattler_build.build(
+        recipes / "test-conditional-script-empty",
+        tmp_path,
+        extra_args=["--test=skip"],
+    )
+    pkg = get_extracted_package(tmp_path, "test-conditional-script-empty")
+
+    assert (pkg / "info" / "tests" / "tests.yaml").exists()
+    content = (pkg / "info" / "tests" / "tests.yaml").read_text()
+
+    # The test script must not contain the build script content
+    assert "Hello" not in content
+    assert snapshot == content
+
+
 @pytest.mark.skipif(
     os.name != "nt", reason="recipe does not support execution on windows"
 )


### PR DESCRIPTION
Fixes #2258
When a script was empty, it just used the build-script.