### PR TITLE
fix: end-to-end tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ target-pixi
 
 # generated tutorial markdown (from notebooks)
 docs/py-rattler-build/tutorials/
+
+# pytest temp directories
+pytest-temp

--- a/pixi.lock
+++ b/pixi.lock
@@ -97,6 +97,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/perl-5.32.1-7_hd590300_perl5.conda
       - conda: https://prefix.dev/conda-forge/linux-64/pkg-config-0.29.2-h4bc722e_1009.conda
       - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/powershell-7.5.4-hfc2019e_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-7.4.2-pyhd8ed1ab_0.conda
@@ -354,6 +355,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/perl-5.32.1-7_h4614cfb_perl5.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/pkg-config-0.29.2-hde07d2e_1009.conda
       - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/powershell-7.5.4-h820172f_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-7.4.2-pyhd8ed1ab_0.conda
@@ -461,6 +463,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/perl-5.32.1.1-7_h57928b3_strawberry.conda
       - conda: https://prefix.dev/conda-forge/win-64/pkg-config-0.29.2-h88c491f_1009.conda
       - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/powershell-7.5.4-h11686cb_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-7.4.2-pyhd8ed1ab_0.conda
@@ -1273,6 +1276,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/pkg-config-0.29.2-h4bc722e_1009.conda
       - conda: https://prefix.dev/conda-forge/noarch/platformdirs-4.9.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/powershell-7.5.4-hfc2019e_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/prettier-3.8.1-h7e4c9f4_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
@@ -1558,6 +1562,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/pkg-config-0.29.2-hde07d2e_1009.conda
       - conda: https://prefix.dev/conda-forge/noarch/platformdirs-4.9.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/powershell-7.5.4-h820172f_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/prettier-3.8.1-h9907cc9_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
@@ -1676,6 +1681,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/pkg-config-0.29.2-h88c491f_1009.conda
       - conda: https://prefix.dev/conda-forge/noarch/platformdirs-4.9.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/powershell-7.5.4-h11686cb_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/prettier-3.8.1-hc95d2ff_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
@@ -8025,6 +8031,29 @@ packages:
   license_family: MIT
   size: 25877
   timestamp: 1764896838868
+- conda: https://prefix.dev/conda-forge/linux-64/powershell-7.5.4-hfc2019e_1.conda
+  sha256: e0309a3dedf73cfee30340e3ad871b1568a65d58e1d204738bece0166676922e
+  md5: 939dabe1089a3bc6fb55dfa7bcf0c21a
+  depends:
+  - icu
+  license: MIT
+  license_family: MIT
+  size: 66820802
+  timestamp: 1767216494328
+- conda: https://prefix.dev/conda-forge/osx-arm64/powershell-7.5.4-h820172f_1.conda
+  sha256: b31435953ba749fab68e5dfdb7ff76dc8df0461bbc78f2790917537f85fecc1c
+  md5: 1a2bfc512d3028ba893689899c38838e
+  license: MIT
+  license_family: MIT
+  size: 61950482
+  timestamp: 1767216637975
+- conda: https://prefix.dev/conda-forge/win-64/powershell-7.5.4-h11686cb_1.conda
+  sha256: 96eeaa407dbf1d56cbfa479974d5d27083c31a69f31023895f857ea340e08395
+  md5: d81b4702acddabe4d1ca0ac41e11fa92
+  license: MIT
+  license_family: MIT
+  size: 98686353
+  timestamp: 1767216571146
 - conda: https://prefix.dev/conda-forge/linux-64/prettier-3.8.1-h7e4c9f4_0.conda
   sha256: 11889a9e414f7c35dc0de59ce195b9b73e65881d5d3bbe7e2e14a59fe47d702e
   md5: 206c0500b835e80dfee8e3ad2e5776ce

--- a/pixi.toml
+++ b/pixi.toml
@@ -99,6 +99,8 @@ syrupy = "4.6.*"
 boto3 = "*"
 
 
+
+
 [feature.lint.dependencies]
 actionlint = ">=1.7.4,<2"
 cargo-deny = ">=0.18.3,<0.19"
@@ -157,23 +159,28 @@ RUSTC_WRAPPER = "sccache"
 build-package = "python scripts/build_package.py"
 upload-package = "python scripts/upload_package.py"
 
-
-[target.linux-64.dependencies]
+[target.linux.dependencies]
 clang = ">=18.1.8,<19.0"
 mold = ">=2.33.0,<3.0"
 patchelf = ">=0.17.2,<0.18"
+powershell = ">=7.5.4,<8"
 
 [target.osx-64.dependencies]
 patchelf = ">=0.18.0,<0.19"
 
 [target.osx-arm64.dependencies]
 patchelf = ">=0.18.0,<0.19"
+powershell = ">=7.5.4,<8"
 
-[target.linux-64.activation]
+[target.win.dependencies]
+powershell = ">=7.5.4,<8"
+
+[target.linux.activation]
 scripts = ["scripts/activate.sh"]
-[target.osx-arm64.activation]
+
+[target.osx.activation]
 scripts = ["scripts/activate.sh"]
-[target.win-64.activation]
+[target.win.activation]
 scripts = ["scripts/activate.bat"]
 
 [feature.docs.dependencies]

--- a/py-rattler-build/tests/unit/test_variant_config.py
+++ b/py-rattler-build/tests/unit/test_variant_config.py
@@ -1,6 +1,5 @@
 """Tests for VariantConfig Python bindings."""
 
-import tempfile
 from pathlib import Path
 
 from rattler_build import PlatformConfig, VariantConfig
@@ -78,7 +77,7 @@ numpy:
     assert len(python_values) == 3
 
 
-def test_variant_config_from_file() -> None:
+def test_variant_config_from_file(tmp_path: Path) -> None:
     """Test loading VariantConfig from a file."""
     yaml_content = """
 python:
@@ -88,20 +87,14 @@ rust:
   - "1.70"
 """
 
-    # Create a temporary file
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
-        f.write(yaml_content)
-        temp_path = Path(f.name)
+    temp_path = tmp_path / "variant.yaml"
+    temp_path.write_text(yaml_content)
 
-    try:
-        config = VariantConfig.from_file(temp_path)
+    config = VariantConfig.from_file(temp_path)
 
-        keys = config.keys()
-        assert "python" in keys
-        assert "rust" in keys
-    finally:
-        # Clean up
-        temp_path.unlink()
+    keys = config.keys()
+    assert "python" in keys
+    assert "rust" in keys
 
 
 def test_variant_config_with_different_types() -> None:
@@ -198,7 +191,7 @@ zip_keys:
     assert len(combinations) == 2  # Not 4
 
 
-def test_variant_config_from_file_with_context() -> None:
+def test_variant_config_from_file_with_context(tmp_path: Path) -> None:
     """Test loading VariantConfig with JinjaConfig context."""
     from rattler_build import JinjaConfig
 
@@ -210,36 +203,30 @@ c_compiler:
     then: msvc
 """
 
-    # Create a temporary file
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
-        f.write(yaml_content)
-        temp_path = Path(f.name)
+    temp_path = tmp_path / "variant.yaml"
+    temp_path.write_text(yaml_content)
 
-    try:
-        # Load with Linux context
-        platform_config = PlatformConfig(target_platform="linux-64")
+    # Load with Linux context
+    platform_config = PlatformConfig(target_platform="linux-64")
 
-        jinja_config_linux = JinjaConfig(platform=platform_config)
-        config_linux = VariantConfig.from_file_with_context(temp_path, jinja_config_linux)
+    jinja_config_linux = JinjaConfig(platform=platform_config)
+    config_linux = VariantConfig.from_file_with_context(temp_path, jinja_config_linux)
 
-        values_linux = config_linux.get_values("c_compiler")
-        assert values_linux is not None
-        assert "gcc" in values_linux
-        assert "msvc" not in values_linux
+    values_linux = config_linux.get_values("c_compiler")
+    assert values_linux is not None
+    assert "gcc" in values_linux
+    assert "msvc" not in values_linux
 
-        # Load with Windows context
-        platform_config = PlatformConfig(target_platform="win-64")
+    # Load with Windows context
+    platform_config = PlatformConfig(target_platform="win-64")
 
-        jinja_config_win = JinjaConfig(platform=platform_config)
-        config_win = VariantConfig.from_file_with_context(temp_path, jinja_config_win)
+    jinja_config_win = JinjaConfig(platform=platform_config)
+    config_win = VariantConfig.from_file_with_context(temp_path, jinja_config_win)
 
-        values_win = config_win.get_values("c_compiler")
-        assert values_win is not None
-        assert "msvc" in values_win
-        assert "gcc" not in values_win
-    finally:
-        # Clean up
-        temp_path.unlink()
+    values_win = config_win.get_values("c_compiler")
+    assert values_win is not None
+    assert "msvc" in values_win
+    assert "gcc" not in values_win
 
 
 def test_variant_config_from_yaml_with_context() -> None:
@@ -274,7 +261,7 @@ cxx_compiler:
     assert "gxx" in cxx_values
 
 
-def test_variant_config_from_conda_build_config() -> None:
+def test_variant_config_from_conda_build_config(tmp_path: Path) -> None:
     """Test loading conda_build_config.yaml format with selectors."""
     from rattler_build import JinjaConfig
 
@@ -289,59 +276,53 @@ c_compiler:
   - vs2019    # [win]
 """
 
-    # Create a temporary file
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
-        f.write(yaml_content)
-        temp_path = Path(f.name)
+    temp_path = tmp_path / "variant.yaml"
+    temp_path.write_text(yaml_content)
 
-    try:
-        # Load with Linux context
-        platform_config = PlatformConfig(target_platform="linux-64")
+    # Load with Linux context
+    platform_config = PlatformConfig(target_platform="linux-64")
 
-        jinja_config_linux = JinjaConfig(platform=platform_config)
-        config_linux = VariantConfig.from_conda_build_config(temp_path, jinja_config_linux)
+    jinja_config_linux = JinjaConfig(platform=platform_config)
+    config_linux = VariantConfig.from_conda_build_config(temp_path, jinja_config_linux)
 
-        python_values = config_linux.get_values("python")
-        assert python_values is not None
-        assert len(python_values) == 2  # 3.9 and 3.10 (unix selector)
+    python_values = config_linux.get_values("python")
+    assert python_values is not None
+    assert len(python_values) == 2  # 3.9 and 3.10 (unix selector)
 
-        c_compiler_values = config_linux.get_values("c_compiler")
-        assert c_compiler_values is not None
-        assert "gcc" in c_compiler_values
-        assert "clang" not in c_compiler_values
-        assert "vs2019" not in c_compiler_values
+    c_compiler_values = config_linux.get_values("c_compiler")
+    assert c_compiler_values is not None
+    assert "gcc" in c_compiler_values
+    assert "clang" not in c_compiler_values
+    assert "vs2019" not in c_compiler_values
 
-        # Load with macOS context
-        platform_config = PlatformConfig(target_platform="osx-64")
+    # Load with macOS context
+    platform_config = PlatformConfig(target_platform="osx-64")
 
-        jinja_config_osx = JinjaConfig(platform=platform_config)
-        config_osx = VariantConfig.from_conda_build_config(temp_path, jinja_config_osx)
+    jinja_config_osx = JinjaConfig(platform=platform_config)
+    config_osx = VariantConfig.from_conda_build_config(temp_path, jinja_config_osx)
 
-        python_values_osx = config_osx.get_values("python")
-        assert python_values_osx is not None
-        assert len(python_values_osx) == 3  # 3.9, 3.10 (unix), and 3.11 (osx)
+    python_values_osx = config_osx.get_values("python")
+    assert python_values_osx is not None
+    assert len(python_values_osx) == 3  # 3.9, 3.10 (unix), and 3.11 (osx)
 
-        c_compiler_values_osx = config_osx.get_values("c_compiler")
-        assert c_compiler_values_osx is not None
-        assert "clang" in c_compiler_values_osx
-        assert "gcc" not in c_compiler_values_osx
+    c_compiler_values_osx = config_osx.get_values("c_compiler")
+    assert c_compiler_values_osx is not None
+    assert "clang" in c_compiler_values_osx
+    assert "gcc" not in c_compiler_values_osx
 
-        # Load with Windows context
-        platform_config = PlatformConfig(target_platform="win-64")
+    # Load with Windows context
+    platform_config = PlatformConfig(target_platform="win-64")
 
-        jinja_config_win = JinjaConfig(platform=platform_config)
-        config_win = VariantConfig.from_conda_build_config(temp_path, jinja_config_win)
+    jinja_config_win = JinjaConfig(platform=platform_config)
+    config_win = VariantConfig.from_conda_build_config(temp_path, jinja_config_win)
 
-        python_values_win = config_win.get_values("python")
-        assert python_values_win is not None
-        assert len(python_values_win) == 1  # Only 3.9 (no unix/osx selectors match)
+    python_values_win = config_win.get_values("python")
+    assert python_values_win is not None
+    assert len(python_values_win) == 1  # Only 3.9 (no unix/osx selectors match)
 
-        c_compiler_values_win = config_win.get_values("c_compiler")
-        assert c_compiler_values_win is not None
-        assert "vs2019" in c_compiler_values_win
-    finally:
-        # Clean up
-        temp_path.unlink()
+    c_compiler_values_win = config_win.get_values("c_compiler")
+    assert c_compiler_values_win is not None
+    assert "vs2019" in c_compiler_values_win
 
 
 def test_variant_config_multiple_zip_key_groups() -> None:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
+addopts = --basetemp=pytest-temp
+tmp_path_retention_policy = failed
 filterwarnings =
     ignore:.*Use the filter argument to control this behavior.:DeprecationWarning

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -2769,10 +2769,12 @@ about:
     shutil.rmtree(git_dir)
 
     # Verify the cache is now corrupted (git commands should fail)
+    # Set GIT_CEILING_DIRECTORIES so git doesn't walk up into the project repo
     result = subprocess.run(
         ["git", "rev-parse", "--git-dir"],
         cwd=cached_repo,
         capture_output=True,
+        env={**os.environ, "GIT_CEILING_DIRECTORIES": str(cached_repo.parent)},
     )
     assert result.returncode != 0, "Git command should fail on corrupted cache"
 


### PR DESCRIPTION
I've noticed that end-to-end tests actually fail on my machine. This fixes two problems:

- the tests assume powershell is installed -> add it to pixi.toml (unfortunately not available for osx-64)
- the tests fill up the temp directory which causes an out-of-disk error. Put temp dirs in local dir with pytest like we do with pixi