### PR TITLE
test: speed up end-to-end tests by merging redundant builds

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -99,8 +99,6 @@ syrupy = "4.6.*"
 boto3 = "*"
 
 
-
-
 [feature.lint.dependencies]
 actionlint = ">=1.7.4,<2"
 cargo-deny = ">=0.18.3,<0.19"

--- a/test/end-to-end/__snapshots__/test_simple.ambr
+++ b/test/end-to-end/__snapshots__/test_simple.ambr
@@ -1,4 +1,12 @@
 # serializer version: 1
+# name: test_r_interpreter
+  '''
+  - r:
+      libraries:
+      - ggplot2
+  
+  '''
+# ---
 # name: test_noarch_flask
   '''
   - python:

--- a/test/end-to-end/__snapshots__/test_tests.ambr
+++ b/test/end-to-end/__snapshots__/test_tests.ambr
@@ -14,14 +14,6 @@
   
   '''
 # ---
-# name: test_r_tests
-  '''
-  - r:
-      libraries:
-      - ggplot2
-  
-  '''
-# ---
 # name: test_win_errorlevel_injection
   '''
   - script:

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -1994,7 +1994,9 @@ def test_line_breaks(rattler_build: RattlerBuild, recipes: Path, tmp_path: Path)
     assert any("done" in line for line in output_lines)
 
 
-def test_r_interpreter(rattler_build: RattlerBuild, recipes: Path, tmp_path: Path):
+def test_r_interpreter(
+    rattler_build: RattlerBuild, recipes: Path, tmp_path: Path, snapshot
+):
     rattler_build.build(recipes / "r-test", tmp_path)
     pkg = get_extracted_package(tmp_path, "r-test")
 
@@ -2008,6 +2010,10 @@ def test_r_interpreter(rattler_build: RattlerBuild, recipes: Path, tmp_path: Pat
     assert "PREFIX:" in output_content
     assert (pkg / "info/recipe/recipe.yaml").exists()
     assert (pkg / "info/tests/tests.yaml").exists()
+
+    # Verify tests.yaml content (was test_r_tests in test_tests.py)
+    tests_content = (pkg / "info/tests/tests.yaml").read_text()
+    assert snapshot == tests_content
 
     # Verify index.json exists before running test
     assert (pkg / "info/index.json").exists(), "index.json file missing from package"
@@ -2168,30 +2174,6 @@ def test_interpreter_detection(
         expected_output = f"Hello from {interpreter.upper()}!"
 
     assert expected_output in test_output
-    assert "all tests passed!" in test_output
-
-
-def test_interpreter_detection_all_tests(
-    rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
-):
-    """
-    Tests that rattler-build can run multiple test scripts requiring
-    different interpreters within the same test phase.
-    """
-    recipe_dir = recipes / "interpreter-detection"
-    pkg_name = "test-interpreter-all"
-
-    rattler_build.build(recipe_dir, tmp_path)
-    pkg_file = get_package(tmp_path, pkg_name)
-    assert pkg_file.exists()
-
-    test_output = rattler_build.test(pkg_file)
-
-    assert "Hello from Python!" in test_output
-    assert "Hello from Perl!" in test_output
-    assert "Hello from R!" in test_output
-    assert "Hello from Nushell!" in test_output
-    assert "Hello from PowerShell!" in test_output
     assert "all tests passed!" in test_output
 
 
@@ -2513,76 +2495,40 @@ def test_caseinsensitive(rattler_build: RattlerBuild, recipes: Path, tmp_path: P
         assert "test.txt" in paths
 
 
-def test_ruby_test(rattler_build: RattlerBuild, recipes: Path, tmp_path: Path):
-    rattler_build.build(
-        recipes / "ruby-test/recipe.yaml",
-        tmp_path,
-    )
-    pkg = get_extracted_package(tmp_path, "ruby-test")
+def test_ruby(rattler_build: RattlerBuild, recipes: Path, tmp_path: Path):
+    """Test Ruby recipes (ruby-test, ruby-extension-test, ruby-imports-test).
 
+    Builds all three in the same tmp_path to share the conda package cache.
+    """
+    rattler_build.build(recipes / "ruby-test/recipe.yaml", tmp_path)
+    pkg = get_extracted_package(tmp_path, "ruby-test")
     assert (pkg / "info/index.json").exists()
     assert (pkg / "info/tests/tests.yaml").exists()
 
+    rattler_build.build(recipes / "ruby-extension-test/recipe.yaml", tmp_path)
+    pkg_ext = get_extracted_package(tmp_path, "ruby-extension-test")
+    assert (pkg_ext / "info/index.json").exists()
 
-def test_simple_ruby_test(rattler_build: RattlerBuild, recipes: Path, tmp_path: Path):
-    rattler_build.build(
-        recipes / "simple-ruby-test/recipe.yaml",
-        tmp_path,
-    )
-    pkg = get_extracted_package(tmp_path, "simple-ruby-test")
-
-    assert (pkg / "info/index.json").exists()
-
-
-def test_ruby_extension_test(
-    rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
-):
-    rattler_build.build(
-        recipes / "ruby-extension-test/recipe.yaml",
-        tmp_path,
-    )
-    pkg = get_extracted_package(tmp_path, "ruby-extension-test")
-
-    assert (pkg / "info/index.json").exists()
-
-
-def test_ruby_imports_test(rattler_build: RattlerBuild, recipes: Path, tmp_path: Path):
-    rattler_build.build(
-        recipes / "ruby-imports-test/recipe.yaml",
-        tmp_path,
-    )
-    pkg = get_extracted_package(tmp_path, "ruby-imports-test")
-
-    assert (pkg / "info/index.json").exists()
-
-
-def test_simple_nodejs_test(rattler_build: RattlerBuild, recipes: Path, tmp_path: Path):
-    rattler_build.build(
-        recipes / "simple-nodejs-test/recipe.yaml",
-        tmp_path,
-    )
-    pkg = get_extracted_package(tmp_path, "simple-nodejs-test")
-
-    assert (pkg / "info/index.json").exists()
-
-
-def test_nodejs_extension(rattler_build: RattlerBuild, recipes: Path, tmp_path: Path):
-    rattler_build.build(
-        recipes / "nodejs-extension-test/recipe.yaml",
-        tmp_path,
-    )
-    pkg = get_extracted_package(tmp_path, "nodejs-extension-test")
-
-    assert (pkg / "info/index.json").exists()
+    rattler_build.build(recipes / "ruby-imports-test/recipe.yaml", tmp_path)
+    pkg_imp = get_extracted_package(tmp_path, "ruby-imports-test")
+    assert (pkg_imp / "info/index.json").exists()
 
 
 def test_nodejs(rattler_build: RattlerBuild, recipes: Path, tmp_path: Path):
-    rattler_build.build(
-        recipes / "nodejs-test/recipe.yaml",
-        tmp_path,
-    )
-    pkg = get_extracted_package(tmp_path, "nodejs-test")
+    """Test NodeJS recipes (simple-nodejs-test, nodejs-extension-test, nodejs-test).
 
+    Builds all three in the same tmp_path to share the conda package cache.
+    """
+    rattler_build.build(recipes / "simple-nodejs-test/recipe.yaml", tmp_path)
+    pkg_simple = get_extracted_package(tmp_path, "simple-nodejs-test")
+    assert (pkg_simple / "info/index.json").exists()
+
+    rattler_build.build(recipes / "nodejs-extension-test/recipe.yaml", tmp_path)
+    pkg_ext = get_extracted_package(tmp_path, "nodejs-extension-test")
+    assert (pkg_ext / "info/index.json").exists()
+
+    rattler_build.build(recipes / "nodejs-test/recipe.yaml", tmp_path)
+    pkg = get_extracted_package(tmp_path, "nodejs-test")
     assert (pkg / "info/index.json").exists()
 
 
@@ -3169,10 +3115,12 @@ def test_render_only_cross_platform(
     )
 
 
-def test_script_content_scalar_with_jinja(rattler_build: RattlerBuild, tmp_path: Path):
-    recipe_dir = tmp_path / "recipe"
-    recipe_dir.mkdir()
-    (recipe_dir / "recipe.yaml").write_text(
+def test_script_content_with_jinja(rattler_build: RattlerBuild, tmp_path: Path):
+    """Test script content with Jinja templating (both scalar and sequence forms)."""
+    # Scalar form
+    scalar_dir = tmp_path / "recipe-scalar"
+    scalar_dir.mkdir()
+    (scalar_dir / "recipe.yaml").write_text(
         """\
 package:
   name: hellopackage
@@ -3185,15 +3133,12 @@ requirements:
     - python
 """
     )
-    rattler_build.build(recipe_dir, tmp_path / "output")
+    rattler_build.build(scalar_dir, tmp_path / "output-scalar")
 
-
-def test_script_content_sequence_with_jinja(
-    rattler_build: RattlerBuild, tmp_path: Path
-):
-    recipe_dir = tmp_path / "recipe"
-    recipe_dir.mkdir()
-    (recipe_dir / "recipe.yaml").write_text(
+    # Sequence form
+    seq_dir = tmp_path / "recipe-seq"
+    seq_dir.mkdir()
+    (seq_dir / "recipe.yaml").write_text(
         """\
 package:
   name: hellopackage
@@ -3207,7 +3152,7 @@ requirements:
     - python
 """
     )
-    rattler_build.build(recipe_dir, tmp_path / "output")
+    rattler_build.build(seq_dir, tmp_path / "output-seq")
 
 
 @pytest.mark.skipif(os.name == "nt", reason="Uses Unix /tmp paths")

--- a/test/end-to-end/test_staging.py
+++ b/test/end-to-end/test_staging.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from subprocess import CalledProcessError
 
 import pytest
+import yaml
 from helpers import (
     RattlerBuild,
     get_extracted_package,
@@ -151,6 +152,10 @@ def test_staging_with_deps(rattler_build: RattlerBuild, recipes: Path, tmp_path:
     assert (pkg1 / "info/index.json").exists()
     assert (pkg2 / "info/index.json").exists()
 
+    # -- Build number propagation (was test_staging_build_number_propagation) --
+    index = json.loads((pkg1 / "info/index.json").read_text())
+    assert index["build_number"] == 0
+
 
 def test_staging_run_exports(
     rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
@@ -250,7 +255,11 @@ def test_staging_with_variants(
 def test_multiple_staging_caches(
     rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
 ):
-    """Test multiple independent staging outputs in one recipe."""
+    """Test multiple independent staging outputs in one recipe.
+
+    Also verifies metadata preservation, file selection, source handling,
+    and about propagation (previously separate tests).
+    """
     rattler_build.build(
         recipes / "staging/multiple-staging-caches.yaml",
         tmp_path,
@@ -280,6 +289,41 @@ def test_multiple_staging_caches(
         assert not (pkg_dev / "lib/libcore.dll").exists()
     else:
         assert not (pkg_dev / "lib/libcore.so").exists()
+
+    # -- Metadata preservation (was test_staging_metadata_preserved) --
+    assert (pkg_core / "info/recipe/rendered_recipe.yaml").exists()
+
+    rendered = yaml.safe_load(
+        (pkg_core / "info/recipe/rendered_recipe.yaml").read_text()
+    )
+    recipe = rendered["recipe"]
+    assert "staging_caches" in recipe
+    assert len(recipe["staging_caches"]) >= 1
+    assert "inherits_from" in recipe
+    assert recipe["inherits_from"]["cache_name"] == "core-build"
+
+    # -- File selection (was test_staging_files_selection) --
+    paths_core = json.loads((pkg_core / "info/paths.json").read_text())
+    core_files = [p["_path"] for p in paths_core["paths"]]
+    if platform.system() == "Windows":
+        assert any("lib/libcore.dll" in f for f in core_files)
+    else:
+        assert any("lib/libcore.so" in f for f in core_files)
+    assert any("include/core.h" in f for f in core_files)
+
+    paths_dev = json.loads((pkg_dev / "info/paths.json").read_text())
+    dev_files = [p["_path"] for p in paths_dev["paths"]]
+    assert not any("lib/" in f for f in dev_files)
+    assert any("include/" in f for f in dev_files)
+
+    # -- Source handling (was test_staging_source_handling) --
+    if "finalized_sources" in rendered:
+        assert isinstance(rendered["finalized_sources"], list)
+
+    # -- About propagation (was test_staging_about_propagation) --
+    about = json.loads((pkg_core / "info/about.json").read_text())
+    assert about["summary"] == "Core library"
+    assert about["license"] == "MIT"
 
 
 def test_staging_with_top_level_inherit(
@@ -468,37 +512,6 @@ def test_staging_with_tests(rattler_build: RattlerBuild, recipes: Path, tmp_path
     assert (pkg2 / "info/index.json").exists()
 
 
-def test_staging_metadata_preserved(
-    rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
-):
-    """Test that staging metadata is preserved in package outputs."""
-    rattler_build.build(
-        recipes / "staging/multiple-staging-caches.yaml",
-        tmp_path,
-        extra_args=["--experimental"],
-    )
-
-    pkg = get_extracted_package(tmp_path, "libcore")
-
-    # Check that the rendered recipe includes staging information
-    assert (pkg / "info/recipe/rendered_recipe.yaml").exists()
-
-    import yaml
-
-    rendered = yaml.safe_load((pkg / "info/recipe/rendered_recipe.yaml").read_text())
-
-    # The staging_caches and inherits_from are in the recipe section
-    recipe = rendered["recipe"]
-
-    # The recipe should have staging_caches
-    assert "staging_caches" in recipe
-    assert len(recipe["staging_caches"]) >= 1
-
-    # Should have inherits_from
-    assert "inherits_from" in recipe
-    assert recipe["inherits_from"]["cache_name"] == "core-build"
-
-
 def test_staging_error_invalid_inherit(
     rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
 ):
@@ -509,94 +522,6 @@ def test_staging_error_invalid_inherit(
             tmp_path,
             extra_args=["--experimental"],
         )
-
-
-def test_staging_files_selection(
-    rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
-):
-    """Test that file selection works correctly with staging inheritance."""
-    rattler_build.build(
-        recipes / "staging/multiple-staging-caches.yaml",
-        tmp_path,
-        extra_args=["--experimental"],
-    )
-
-    # libcore should have both lib and include
-    pkg_core = get_extracted_package(tmp_path, "libcore")
-    paths_core = json.loads((pkg_core / "info/paths.json").read_text())
-    core_files = [p["_path"] for p in paths_core["paths"]]
-    if platform.system() == "Windows":
-        assert any("lib/libcore.dll" in f for f in core_files)
-    else:
-        assert any("lib/libcore.so" in f for f in core_files)
-    assert any("include/core.h" in f for f in core_files)
-
-    # core-headers should only have include
-    pkg_dev = get_extracted_package(tmp_path, "core-headers")
-    paths_dev = json.loads((pkg_dev / "info/paths.json").read_text())
-    dev_files = [p["_path"] for p in paths_dev["paths"]]
-    assert not any("lib/" in f for f in dev_files)
-    assert any("include/" in f for f in dev_files)
-
-
-def test_staging_source_handling(
-    rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
-):
-    """Test that sources are properly handled in staging outputs."""
-    # The staging recipes reference sources, ensure they're fetched correctly
-    rattler_build.build(
-        recipes / "staging/multiple-staging-caches.yaml",
-        tmp_path,
-        extra_args=["--experimental"],
-    )
-
-    pkg = get_extracted_package(tmp_path, "libcore")
-
-    # Check finalized sources in rendered recipe
-    assert (pkg / "info/recipe/rendered_recipe.yaml").exists()
-
-    import yaml
-
-    rendered = yaml.safe_load((pkg / "info/recipe/rendered_recipe.yaml").read_text())
-
-    # Should have finalized sources (even if they're dummy URLs in test)
-    if "finalized_sources" in rendered:
-        assert isinstance(rendered["finalized_sources"], list)
-
-
-def test_staging_build_number_propagation(
-    rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
-):
-    """Test that build numbers are properly handled with staging."""
-    rattler_build.build(
-        recipes / "staging/staging-with-deps.yaml",
-        tmp_path,
-        extra_args=["--experimental"],
-    )
-
-    pkg = get_extracted_package(tmp_path, "check-1")
-    index = json.loads((pkg / "info/index.json").read_text())
-
-    # Build number should be 0 as specified in context
-    assert index["build_number"] == 0
-
-
-def test_staging_about_propagation(
-    rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
-):
-    """Test that about metadata is properly set in package outputs."""
-    rattler_build.build(
-        recipes / "staging/multiple-staging-caches.yaml",
-        tmp_path,
-        extra_args=["--experimental"],
-    )
-
-    pkg = get_extracted_package(tmp_path, "libcore")
-    about = json.loads((pkg / "info/about.json").read_text())
-
-    # About information should be present
-    assert about["summary"] == "Core library"
-    assert about["license"] == "MIT"
 
 
 @pytest.mark.skipif(os.name == "nt", reason="symlinks not fully supported on Windows")

--- a/test/end-to-end/test_tests.py
+++ b/test/end-to-end/test_tests.py
@@ -20,16 +20,6 @@ def test_perl_tests(
     assert snapshot == content
 
 
-def test_r_tests(rattler_build: RattlerBuild, recipes: Path, tmp_path: Path, snapshot):
-    rattler_build.build(recipes / "r-test", tmp_path)
-    pkg = get_extracted_package(tmp_path, "r-test")
-
-    assert (pkg / "info" / "tests" / "tests.yaml").exists()
-    content = (pkg / "info" / "tests" / "tests.yaml").read_text()
-
-    assert snapshot == content
-
-
 def test_source_files_copied_to_test(
     rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
 ):


### PR DESCRIPTION
Merge tests that build the same recipe into single tests to avoid redundant conda dependency solving and downloading. Delete tests that are strict subsets of other tests.

- Delete test_interpreter_detection_all_tests (covered by parametrized tests)
- Merge 4 staging tests into test_multiple_staging_caches (same recipe)
- Merge test_staging_build_number_propagation into test_staging_with_deps
- Merge test_r_tests into test_r_interpreter (same r-test recipe)
- Merge 4 Ruby tests into one test_ruby sharing conda cache
- Merge 3 NodeJS tests into one test_nodejs sharing conda cache
- Merge 2 Jinja script content tests into one test_script_content_with_jinja