### PR TITLE
ci: trigger CI on release-plz PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release-plz-*
   workflow_dispatch:
   pull_request:
 

--- a/.github/workflows/python-bindings.yml
+++ b/.github/workflows/python-bindings.yml
@@ -2,7 +2,7 @@ name: Python bindings CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, release-plz-*]
   pull_request:
     paths:
       # When we change pyproject.toml, we want to ensure that the maturin builds still work

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [main]
+    branches: [main, release-plz-*]
     tags:
       - "v*.*.*"
   pull_request:

--- a/py-rattler-build/rust/Cargo.lock
+++ b/py-rattler-build/rust/Cargo.lock
@@ -4623,7 +4623,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_build_core"
-version = "0.58.4"
+version = "0.58.5"
 dependencies = [
  "anyhow",
  "async-once-cell",


### PR DESCRIPTION
That works around the problem that CI doesn't trigger on PRs opened by the github bot