### PR TITLE
fix: crates versioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4949,7 +4949,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_build_core"
-version = "0.58.5"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-once-cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,7 @@ serial_test = "3.4.0"
 
 # Internal rattler-build crates
 rattler_build_allocator = { path = "crates/rattler_build_allocator", version = "=0.1.0" }
-rattler_build_core = { path = "crates/rattler_build_core", version = "=0.58.5", default-features = false }
+rattler_build_core = { path = "crates/rattler_build_core", version = "=0.1.0", default-features = false }
 rattler_build_jinja = { path = "crates/rattler_build_jinja", version = "=0.1.0" }
 rattler_build_networking = { path = "crates/rattler_build_networking", version = "=0.1.0" }
 rattler_build_recipe = { path = "crates/rattler_build_recipe", version = "=0.1.0" }

--- a/crates/rattler_build_core/Cargo.toml
+++ b/crates/rattler_build_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_build_core"
-version = "0.58.5"
+version = "0.1.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/py-rattler-build/rust/Cargo.lock
+++ b/py-rattler-build/rust/Cargo.lock
@@ -4623,7 +4623,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_build_core"
-version = "0.58.5"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-once-cell",


### PR DESCRIPTION
This improves two things about the current crate versioning:

- https://github.com/prefix-dev/rattler-build/commit/ff94d259750725da0dac25a57606eb79d956951b pins the versions. That makes sure the crates are used with synced versions
- https://github.com/prefix-dev/rattler-build/commit/e2bb760c267908ba5c885d275194019ae769323d switches rattler_build_core to 0.10. That way we avoid confusion with the CLI versioning. I already yanked the existing release