### PR TITLE
fix: honor run-export ignore from staging output

### DIFF
--- a/crates/rattler_build_core/src/render/resolved_dependencies.rs
+++ b/crates/rattler_build_core/src/render/resolved_dependencies.rs
@@ -22,7 +22,7 @@ use crate::{
     metadata::{BuildConfiguration, Output, build_reindexed_channels},
     package_cache_reporter::PackageCacheReporter,
     render::{
-        run_exports::filter_run_exports,
+        run_exports::{filter_inherited_run_exports, filter_run_exports},
         solver::{install_packages, solve_environment},
     },
     tool_configuration::{self, Configuration},
@@ -1001,20 +1001,21 @@ pub(crate) async fn resolve_dependencies(
             .map(|i| i.inherit_run_exports)
             .unwrap_or(true);
 
-        // Add dependencies from cache, but filter out RunExports if inherit_run_exports is false
-        depends = depends
-            .iter()
-            .chain(finalized_cache.run.depends.iter().filter(|dep| {
-                // Include non-RunExport dependencies always
-                // Include RunExport dependencies only if inherit_run_exports is true
-                if matches!(dep, DependencyInfo::RunExport(_)) {
-                    should_inherit_run_exports
-                } else {
-                    true
-                }
-            }))
-            .cloned()
-            .collect();
+        // Add dependencies from cache, but filter out RunExports if inherit_run_exports is
+        // false. Also apply the current output's ignore_run_exports filters to
+        // any inherited run exports.
+        let inherited_deps: Vec<_> = if should_inherit_run_exports {
+            filter_inherited_run_exports(&ignore_run_exports, &finalized_cache.run.depends)
+        } else {
+            finalized_cache
+                .run
+                .depends
+                .iter()
+                .filter(|dep| !matches!(dep, DependencyInfo::RunExport(_)))
+                .cloned()
+                .collect()
+        };
+        depends.extend(inherited_deps);
 
         constraints = constraints
             .iter()

--- a/crates/rattler_build_core/src/render/run_exports.rs
+++ b/crates/rattler_build_core/src/render/run_exports.rs
@@ -2,7 +2,8 @@ use std::collections::HashMap;
 
 use rattler_build_recipe::stage1::requirements::IgnoreRunExports;
 use rattler_conda_types::{
-    MatchSpec, PackageName, ParseMatchSpecError, ParseStrictness, package::RunExportsJson,
+    MatchSpec, PackageName, PackageNameMatcher, ParseMatchSpecError, ParseStrictness,
+    package::RunExportsJson,
 };
 
 use super::resolved_dependencies::{DependencyInfo, RunExportDependency};
@@ -29,7 +30,6 @@ pub fn filter_run_exports(
     let mut filtered_run_exports = FilteredRunExports::default();
 
     let to_specs = |strings: &Vec<String>| -> Result<Vec<MatchSpec>, ParseMatchSpecError> {
-        use rattler_conda_types::PackageNameMatcher;
         strings
             .iter()
             // We have to parse these as lenient as they come from packages
@@ -92,4 +92,144 @@ pub fn filter_run_exports(
     }
 
     Ok(filtered_run_exports)
+}
+
+/// Filter already-resolved run export dependencies (e.g. inherited from a
+/// staging cache) using `ignore_run_exports` rules.
+pub fn filter_inherited_run_exports(
+    ignore_run_exports: &IgnoreRunExports,
+    deps: &[DependencyInfo],
+) -> Vec<DependencyInfo> {
+    deps.iter()
+        .filter(|dep| {
+            if let DependencyInfo::RunExport(re) = dep {
+                // Check from_package: ignore all run exports originating from
+                // a listed source package.
+                if ignore_run_exports
+                    .from_package
+                    .iter()
+                    .any(|p| p.as_normalized() == re.source_package)
+                {
+                    return false;
+                }
+
+                // Check by_name: ignore run exports whose dependency name
+                // matches one of the listed names.
+                if let Some(PackageNameMatcher::Exact(name)) = re.spec.name.as_ref()
+                    && ignore_run_exports.by_name.contains(name)
+                {
+                    return false;
+                }
+            }
+            true
+        })
+        .cloned()
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use rattler_build_recipe::stage1::requirements::IgnoreRunExports;
+    use rattler_conda_types::{MatchSpec, PackageName, ParseStrictness};
+
+    use super::*;
+    use crate::render::resolved_dependencies::{
+        DependencyInfo, RunExportDependency, SourceDependency,
+    };
+
+    fn make_run_export(spec_str: &str, source: &str) -> DependencyInfo {
+        DependencyInfo::RunExport(RunExportDependency {
+            spec: MatchSpec::from_str(spec_str, ParseStrictness::Lenient).unwrap(),
+            from: "host".to_string(),
+            source_package: source.to_string(),
+        })
+    }
+
+    fn make_source_dep(spec_str: &str) -> DependencyInfo {
+        DependencyInfo::Source(SourceDependency {
+            spec: MatchSpec::from_str(spec_str, ParseStrictness::Lenient).unwrap(),
+        })
+    }
+
+    #[test]
+    fn test_filter_inherited_by_name() {
+        let deps = vec![
+            make_run_export("numpy >=1.23,<3", "numpy"),
+            make_run_export("python_abi 3.13.* *_cp313", "python"),
+            make_run_export("libfoo >=1.0", "libfoo"),
+            make_source_dep("some-dep >=2.0"),
+        ];
+
+        let ignore = IgnoreRunExports {
+            by_name: vec![
+                "numpy".parse::<PackageName>().unwrap(),
+                "python_abi".parse::<PackageName>().unwrap(),
+            ],
+            from_package: vec![],
+        };
+
+        let filtered = filter_inherited_run_exports(&ignore, &deps);
+        assert_eq!(filtered.len(), 2);
+        // libfoo run export and the source dep should remain
+        assert!(
+            matches!(&filtered[0], DependencyInfo::RunExport(re) if re.source_package == "libfoo")
+        );
+        assert!(matches!(&filtered[1], DependencyInfo::Source(_)));
+    }
+
+    #[test]
+    fn test_filter_inherited_from_package() {
+        let deps = vec![
+            make_run_export("numpy >=1.23,<3", "numpy"),
+            make_run_export("python_abi 3.13.* *_cp313", "python"),
+            make_run_export("libfoo >=1.0", "libfoo"),
+        ];
+
+        let ignore = IgnoreRunExports {
+            by_name: vec![],
+            from_package: vec!["python".parse::<PackageName>().unwrap()],
+        };
+
+        let filtered = filter_inherited_run_exports(&ignore, &deps);
+        assert_eq!(filtered.len(), 2);
+        assert!(
+            matches!(&filtered[0], DependencyInfo::RunExport(re) if re.source_package == "numpy")
+        );
+        assert!(
+            matches!(&filtered[1], DependencyInfo::RunExport(re) if re.source_package == "libfoo")
+        );
+    }
+
+    #[test]
+    fn test_filter_inherited_combined() {
+        let deps = vec![
+            make_run_export("numpy >=1.23,<3", "numpy"),
+            make_run_export("python_abi 3.13.* *_cp313", "python"),
+            make_run_export("libbar >=2.0", "libfoo"),
+        ];
+
+        let ignore = IgnoreRunExports {
+            by_name: vec!["numpy".parse::<PackageName>().unwrap()],
+            from_package: vec!["libfoo".parse::<PackageName>().unwrap()],
+        };
+
+        let filtered = filter_inherited_run_exports(&ignore, &deps);
+        // numpy filtered by name, libbar filtered by from_package (libfoo)
+        assert_eq!(filtered.len(), 1);
+        assert!(
+            matches!(&filtered[0], DependencyInfo::RunExport(re) if re.source_package == "python")
+        );
+    }
+
+    #[test]
+    fn test_filter_inherited_no_filters() {
+        let deps = vec![
+            make_run_export("numpy >=1.23", "numpy"),
+            make_source_dep("foo >=1.0"),
+        ];
+
+        let ignore = IgnoreRunExports::default();
+        let filtered = filter_inherited_run_exports(&ignore, &deps);
+        assert_eq!(filtered.len(), 2);
+    }
 }


### PR DESCRIPTION
Now we honor `run-export-ignore` from staging output. 

Fixes #2278