### PR TITLE
ci: use GitHub App token for release-plz PRs to trigger CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - release-plz-*
   workflow_dispatch:
   pull_request:
 

--- a/.github/workflows/python-bindings.yml
+++ b/.github/workflows/python-bindings.yml
@@ -2,7 +2,7 @@ name: Python bindings CI
 
 on:
   push:
-    branches: [main, release-plz-*]
+    branches: [main]
   pull_request:
     paths:
       # When we change pyproject.toml, we want to ensure that the maturin builds still work

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -41,10 +41,17 @@ jobs:
       group: release-plz-${{ github.ref }}
       cancel-in-progress: false
     steps:
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
       - name: Install Rust toolchain
         run: rustup show
@@ -53,4 +60,4 @@ jobs:
         with:
           command: release-pr
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [main, release-plz-*]
+    branches: [main]
     tags:
       - "v*.*.*"
   pull_request:


### PR DESCRIPTION
https://github.com/prefix-dev/rattler-build/pull/2275 unfortunately didn't solve the problem that release-plz PRs don't trigger CI

This PR reverts it and uses a GitHub App instead which should not have this limitation