### PR TITLE
ci: run release-plz PR job after release job

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -33,6 +33,7 @@ jobs:
 
   release-plz-pr:
     name: Release-plz PR
+    needs: release-plz-release
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
This is an attempt to avoid problems like https://github.com/prefix-dev/rattler-build/pull/2284, where release-plz wants to bump crates because of its own release commit