### PR TITLE
Update the docs for tests[n].package_contents.lib

### DIFF
--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -1007,8 +1007,9 @@ tests:
       # (default: false)
       strict: true
 
-      # searches for `$PREFIX/lib/libmamba.so` or `$PREFIX/lib/libmamba.dylib` on Linux or macOS,
-      # on Windows for %PREFIX%\Library\lib\mamba.dll & %PREFIX%\Library\bin\mamba.bin
+      # On MacOS, searches for `$PREFIX/lib/libmamba.dylib`
+      # On Linux, searches for `$PREFIX/lib/libmamba.so`
+      # On Windows, searches for both `%PREFIX%\Library\bin\mamba.dll` and %PREFIX%\Library\lib\mamba.lib
       lib:
         - mamba
 


### PR DESCRIPTION
The current instructions are slightly inaccurate. I've updated it based on reading this section:

https://github.com/prefix-dev/rattler-build/blob/d3e2b4b68ed131ab61fa7247b2ec7d01f9dd8a08/crates/rattler_build_core/src/package_test/content_test.rs#L230-L297

I think that further improvements might also be possible, but I didn't want to try anything further without discussion. Using comments in the example make it a bit hard to read as it doesn't wrap across lines. Also there is further subtlety which isn't captured in the examples, like the fact adding `.dll` to the end of the glob will turn off the automatic `.lib` glob etc.