### PR TITLE
docs: use Rattler-Build for program name in doc comments and docstrings

### DIFF
--- a/crates/rattler_build_core/src/lib.rs
+++ b/crates/rattler_build_core/src/lib.rs
@@ -1,6 +1,6 @@
 #![deny(missing_docs)]
 
-//! The core engine of rattler-build, providing recipe rendering, source fetching,
+//! The core engine of Rattler-Build, providing recipe rendering, source fetching,
 //! script execution, package building, testing, and publishing.
 
 pub mod build;

--- a/crates/rattler_build_core/src/package_test/run_test.rs
+++ b/crates/rattler_build_core/src/package_test/run_test.rs
@@ -1,4 +1,4 @@
-//! Testing a package produced by rattler-build (or conda-build)
+//! Testing a package produced by Rattler-Build (or conda-build)
 //!
 //! Tests are part of the final package (under the `info/test` directory).
 //! There are multiple test types:

--- a/crates/rattler_build_core/src/script.rs
+++ b/crates/rattler_build_core/src/script.rs
@@ -1,6 +1,6 @@
 //! Module for running scripts in different interpreters.
 //!
-//! This module provides integration between rattler-build and the rattler_build_script crate,
+//! This module provides integration between Rattler-Build and the rattler_build_script crate,
 //! specifically handling the execution of build scripts within the Output context.
 
 use indexmap::IndexMap;

--- a/crates/rattler_build_core/src/tool_configuration.rs
+++ b/crates/rattler_build_core/src/tool_configuration.rs
@@ -1,5 +1,5 @@
-//! Configuration for the rattler-build tool
-//! This is useful when using rattler-build as a library
+//! Configuration for the Rattler-Build tool
+//! This is useful when using Rattler-Build as a library
 
 use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
@@ -141,7 +141,7 @@ pub struct Configuration {
     pub allow_absolute_license_paths: bool,
 
     /// Whether the environments are externally managed (e.g. by `pixi-build`).
-    /// This is only useful for other libraries that build their own environments and only use rattler-build
+    /// This is only useful for other libraries that build their own environments and only use Rattler-Build
     /// to execute scripts / bundle up files.
     pub environments_externally_managed: bool,
 }

--- a/crates/rattler_build_core/src/types/mod.rs
+++ b/crates/rattler_build_core/src/types/mod.rs
@@ -1,4 +1,4 @@
-//! Common types used throughout rattler-build
+//! Common types used throughout Rattler-Build
 //! All the metadata that makes up a recipe file
 use std::{iter, path::PathBuf, str::FromStr};
 

--- a/crates/rattler_build_docs/src/main.rs
+++ b/crates/rattler_build_docs/src/main.rs
@@ -12,7 +12,7 @@ use itertools::Itertools;
 
 const MD_EXTENSION: &str = ".md";
 
-/// Generates documentation for the rattler-build CLI by:
+/// Generates documentation for the Rattler-Build CLI by:
 /// - Loading the clap command from the rattler-build crate
 /// - Creating markdown files for each command
 /// - Organizing commands into a directory structure

--- a/crates/rattler_build_jinja/src/ast_variables.rs
+++ b/crates/rattler_build_jinja/src/ast_variables.rs
@@ -244,7 +244,7 @@ fn collect_variables_from_ast(
 }
 
 /// Collect variables from a Call expression
-/// Special handling for rattler-build Jinja functions that expand to variant variables
+/// Special handling for Rattler-Build Jinja functions that expand to variant variables
 fn collect_variables_from_call(
     call: &minijinja::machinery::ast::Call,
     variables: &mut BTreeSet<String>,

--- a/crates/rattler_build_jinja/src/jinja.rs
+++ b/crates/rattler_build_jinja/src/jinja.rs
@@ -46,7 +46,7 @@ const KNOWN_FUNCTIONS: &[&str] = &[
     "hash",
 ];
 
-/// Configuration for Jinja template rendering in rattler-build
+/// Configuration for Jinja template rendering in Rattler-Build
 #[derive(Debug, Clone)]
 pub struct JinjaConfig {
     /// The target platform for the build
@@ -643,7 +643,7 @@ fn parse_platform(platform: &str) -> Result<Platform, minijinja::Error> {
 }
 
 lazy_static::lazy_static! {
-    /// The syntax config for MiniJinja / rattler-build
+    /// The syntax config for MiniJinja / Rattler-Build
     pub static ref SYNTAX_CONFIG: SyntaxConfig = SyntaxConfig::builder()
         .block_delimiters("{%", "%}")
         .variable_delimiters("${{", "}}")

--- a/crates/rattler_build_networking/src/lib.rs
+++ b/crates/rattler_build_networking/src/lib.rs
@@ -1,4 +1,4 @@
-//! Networking utilities for rattler-build, providing shared HTTP client functionality
+//! Networking utilities for Rattler-Build, providing shared HTTP client functionality
 //! with retry middleware.
 
 use reqwest_middleware::ClientWithMiddleware;

--- a/crates/rattler_build_recipe/tests/test_real_world_tests_yaml.rs
+++ b/crates/rattler_build_recipe/tests/test_real_world_tests_yaml.rs
@@ -1,4 +1,4 @@
-/// End-to-end test using a real tests.yaml file rendered by old rattler-build
+/// End-to-end test using a real tests.yaml file rendered by old Rattler-Build
 /// This ensures our parsing is backwards compatible with existing packages
 #[cfg(test)]
 mod test {

--- a/crates/rattler_build_recipe_generator/src/cpan.rs
+++ b/crates/rattler_build_recipe_generator/src/cpan.rs
@@ -473,7 +473,7 @@ async fn fetch_cpan_metadata(
 
 /// Construct a `Recipe` from resolved CPAN metadata without performing I/O.
 ///
-/// This function converts MetaCPAN release information into a rattler-build
+/// This function converts MetaCPAN release information into a Rattler-Build
 /// `Recipe`, populating package metadata, sources, requirements, and basic
 /// tests. The provided `opts` are currently reserved for future use.
 ///

--- a/crates/rattler_build_recipe_generator/src/luarocks/mod.rs
+++ b/crates/rattler_build_recipe_generator/src/luarocks/mod.rs
@@ -1,4 +1,4 @@
-//! Implements logic to generate a rattler-build recipe from a LuaRocks rockspec
+//! Implements logic to generate a Rattler-Build recipe from a LuaRocks rockspec
 //! file.
 
 use std::{collections::BTreeMap, io::Write, path::PathBuf};

--- a/crates/rattler_build_script/src/lib.rs
+++ b/crates/rattler_build_script/src/lib.rs
@@ -1,8 +1,8 @@
-//! Script execution and sandbox configuration for rattler-build, supporting bash, cmd,
+//! Script execution and sandbox configuration for Rattler-Build, supporting bash, cmd,
 //! python, and other interpreters.
 //!
 //! This crate provides functionality for defining, parsing, and executing build scripts
-//! in various interpreters as part of the rattler-build process.
+//! in various interpreters as part of the Rattler-Build process.
 
 pub mod sandbox;
 mod script;

--- a/crates/rattler_build_source_cache/src/lib.rs
+++ b/crates/rattler_build_source_cache/src/lib.rs
@@ -1,6 +1,6 @@
 //! # Rattler Build Source Cache
 //!
-//! This crate provides a unified source cache for rattler-build, handling Git repositories,
+//! This crate provides a unified source cache for Rattler-Build, handling Git repositories,
 //! URL downloads, and local paths with proper caching, extraction, and concurrent access control.
 
 pub mod builder;

--- a/crates/rattler_build_yaml_parser/src/lib.rs
+++ b/crates/rattler_build_yaml_parser/src/lib.rs
@@ -1,4 +1,4 @@
-//! YAML parser with Jinja2 template support for rattler-build, providing shared parsing
+//! YAML parser with Jinja2 template support for Rattler-Build, providing shared parsing
 //! infrastructure for conditional structures and template values.
 //!
 //! # Core Types

--- a/py-rattler-build/src/rattler_build/__init__.py
+++ b/py-rattler-build/src/rattler_build/__init__.py
@@ -128,5 +128,5 @@ __all__ = [
 
 
 def rattler_build_version() -> str:
-    """Get the version of the rattler-build package"""
+    """Get the version of the Rattler-Build package"""
     return get_rattler_build_version_py()

--- a/py-rattler-build/src/rattler_build/build_result.py
+++ b/py-rattler-build/src/rattler_build/build_result.py
@@ -1,4 +1,4 @@
-"""Build result types for rattler-build."""
+"""Build result types for Rattler-Build."""
 
 from __future__ import annotations
 

--- a/py-rattler-build/src/rattler_build/package.py
+++ b/py-rattler-build/src/rattler_build/package.py
@@ -1,4 +1,4 @@
-"""Package inspection and testing API for rattler-build.
+"""Package inspection and testing API for Rattler-Build.
 
 This module provides functionality to load and inspect conda packages (.conda or .tar.bz2),
 examine their metadata and embedded tests, and run tests against them.

--- a/py-rattler-build/src/rattler_build/package_assembler.py
+++ b/py-rattler-build/src/rattler_build/package_assembler.py
@@ -1,4 +1,4 @@
-"""Package builder API for rattler-build.
+"""Package builder API for Rattler-Build.
 
 This module provides a Pythonic API for creating conda packages programmatically,
 without needing a recipe file. Use this when you have files staged and want to

--- a/py-rattler-build/src/rattler_build/progress.py
+++ b/py-rattler-build/src/rattler_build/progress.py
@@ -1,5 +1,5 @@
 """
-Progress reporting and callbacks for rattler-build.
+Progress reporting and callbacks for Rattler-Build.
 
 This module provides base classes and implementations for progress reporting
 during recipe rendering and building. You can use the built-in implementations

--- a/py-rattler-build/src/rattler_build/stage0.py
+++ b/py-rattler-build/src/rattler_build/stage0.py
@@ -1,7 +1,7 @@
 """
 Stage0 - Parsed recipe types before evaluation.
 
-This module provides Python bindings for rattler-build's stage0 types,
+This module provides Python bindings for Rattler-Build's stage0 types,
 which represent the parsed YAML recipe before Jinja template evaluation
 and conditional resolution.
 """

--- a/py-rattler-build/src/rattler_build/stage1.py
+++ b/py-rattler-build/src/rattler_build/stage1.py
@@ -1,7 +1,7 @@
 """
 Stage1 - Evaluated recipe types ready for building.
 
-This module provides Python bindings for rattler-build's stage1 types,
+This module provides Python bindings for Rattler-Build's stage1 types,
 which represent the fully evaluated recipe with all Jinja templates resolved
 and conditionals evaluated.
 """

--- a/py-rattler-build/src/rattler_build/tool_config.py
+++ b/py-rattler-build/src/rattler_build/tool_config.py
@@ -1,5 +1,5 @@
 """
-Tool configuration for rattler-build.
+Tool configuration for Rattler-Build.
 
 This module provides a Pythonic API for configuring the build tool.
 """
@@ -65,7 +65,7 @@ class PlatformConfig:
 
 
 class ToolConfiguration:
-    """Configuration for the rattler-build tool.
+    """Configuration for the Rattler-Build tool.
 
     Args:
         keep_build: Whether to keep the build directory after the build is done

--- a/py-rattler-build/src/rattler_build/variant_config.py
+++ b/py-rattler-build/src/rattler_build/variant_config.py
@@ -1,7 +1,7 @@
 """
 VariantConfig - Manage variant configuration for recipe builds.
 
-This module provides Python bindings for rattler-build's VariantConfig,
+This module provides Python bindings for Rattler-Build's VariantConfig,
 which manages variant matrices for building packages with different configurations.
 """
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![deny(missing_docs)]
 
-//! rattler-build library.
+//! Rattler-Build library.
 
 // Re-export all core modules from rattler_build_core
 pub use rattler_build_core::build;
@@ -1218,12 +1218,12 @@ pub async fn rebuild(
     Ok(())
 }
 
-/// Get the version of rattler-build.
+/// Get the version of Rattler-Build.
 pub fn get_rattler_build_version() -> &'static str {
     env!("CARGO_PKG_VERSION")
 }
 
-/// Build rattler-build recipes
+/// Build Rattler-Build recipes
 pub async fn build_recipes(
     recipe_paths: Vec<std::path::PathBuf>,
     build_data: BuildData,

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -348,11 +348,11 @@ pub struct App {
     )]
     pub wrap_log_lines: Option<bool>,
 
-    /// The rattler-build configuration file to use
+    /// The Rattler-Build configuration file to use
     #[arg(long, global = true)]
     pub config_file: Option<PathBuf>,
 
-    /// Enable or disable colored output from rattler-build.
+    /// Enable or disable colored output from Rattler-Build.
     /// Also honors the `CLICOLOR` and `CLICOLOR_FORCE` environment variable.
     #[clap(
         long,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,4 +1,4 @@
-//! Terminal user interface for rattler-build.
+//! Terminal user interface for Rattler-Build.
 
 pub mod event;
 pub mod logger;


### PR DESCRIPTION
This only concerns comments in code files