### PR TITLE
docs: use Rattler-Build instead of `rattler-build`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@
 
 </h1>
 
-# rattler-build: a fast conda-package builder
+# Rattler-Build: a fast conda-package builder
 
-The `rattler-build` tooling and library creates cross-platform relocatable
+The Rattler-Build tooling and library creates cross-platform relocatable
 binaries / packages from a simple recipe format. The recipe format is heavily
 inspired by `conda-build` and `boa`, and the output of a regular `rattler-build`
 run is a package that can be installed using [`pixi`](https://github.com/prefix-dev/pixi), [`mamba`](https://github.com/mamba-org/mamba), or [`conda`](https://conda.org).
 
-`rattler-build` is a standalone binary written from scratch in Rust, and does not have any dependencies on `conda-build` or Python.
+Rattler-Build is a standalone binary written from scratch in Rust, and does not have any dependencies on `conda-build` or Python.
 
 ![](https://github.com/prefix-dev/rattler-build/assets/885054/98377399-aae4-45a5-a4e9-982a3c7b2d50)
 
@@ -59,7 +59,7 @@ brew install rattler-build
 
 #### Arch Linux
 
-`rattler-build` is available on Arch Linux in the [extra repository](https://archlinux.org/packages/extra/x86_64/rattler-build/):
+Rattler-Build is available on Arch Linux in the [extra repository](https://archlinux.org/packages/extra/x86_64/rattler-build/):
 
 ```
 pacman -S rattler-build
@@ -67,7 +67,7 @@ pacman -S rattler-build
 
 #### Alpine Linux
 
-`rattler-build` is available for [Alpine Edge](https://pkgs.alpinelinux.org/packages?name=rattler-build&branch=edge). It can be installed via [apk](https://wiki.alpinelinux.org/wiki/Alpine_Package_Keeper) after enabling the [testing repository](https://wiki.alpinelinux.org/wiki/Repositories).
+Rattler-Build is available for [Alpine Edge](https://pkgs.alpinelinux.org/packages?name=rattler-build&branch=edge). It can be installed via [apk](https://wiki.alpinelinux.org/wiki/Alpine_Package_Keeper) after enabling the [testing repository](https://wiki.alpinelinux.org/wiki/Repositories).
 
 ```shell
 apk add rattler-build
@@ -75,9 +75,9 @@ apk add rattler-build
 
 #### Dependencies
 
-Currently `rattler-build` needs some dependencies on the host system which are
+Currently Rattler-Build needs some dependencies on the host system which are
 executed as subprocess. We plan to reduce the number of external dependencies
-over time by writing what we need in Rust to make `rattler-build` fully
+over time by writing what we need in Rust to make Rattler-Build fully
 self-contained.
 
 * `install_name_tool` is necessary on macOS to rewrite the `rpath` of shared
@@ -90,16 +90,16 @@ self-contained.
 
 ### Documentation
 
-We have extensive documentation for `rattler-build`. You can find the [book
+We have extensive documentation for Rattler-Build. You can find the [book
 here](https://prefix-dev.github.io/rattler-build).
 
 ### GitHub Action
 
-There is a GitHub Action for `rattler-build`. It can be used to install `rattler-build` in CI/CD workflows and run a build command. Please check out the [GitHub Action documentation](https://github.com/prefix-dev/rattler-build-action) for more information.
+There is a GitHub Action for Rattler-Build. It can be used to install `rattler-build` in CI/CD workflows and run a build command. Please check out the [GitHub Action documentation](https://github.com/prefix-dev/rattler-build-action) for more information.
 
 ### Usage
 
-`rattler-build` comes with two commands: `build` and `test`.
+Rattler-Build comes with two commands: `build` and `test`.
 
 The `build` command takes a `--recipe recipe.yaml` as input and produces a
 package as output. The `test` subcommand can be used to test existing packages
@@ -109,7 +109,7 @@ There is also a [terminal user interface (TUI)](https://prefix-dev.github.io/rat
 
 ### Playground
 
-Want to try `rattler-build` recipes without installing anything? The [online playground](https://playground.rattler.build/) lets you edit recipes, tweak variant configurations, and see evaluated output — all in the browser.
+Want to try Rattler-Build recipes without installing anything? The [online playground](https://playground.rattler.build/) lets you edit recipes, tweak variant configurations, and see evaluated output — all in the browser.
 
 ### The recipe format
 

--- a/crates/rattler_build_source_cache/README.md
+++ b/crates/rattler_build_source_cache/README.md
@@ -1,6 +1,6 @@
 # Rattler Build Source Cache
 
-A unified source cache for rattler-build that handles Git repositories, URL downloads, and local paths with proper caching, extraction, and concurrent access control.
+A unified source cache for Rattler-Build that handles Git repositories, URL downloads, and local paths with proper caching, extraction, and concurrent access control.
 
 ## Features
 

--- a/docs/authentication_and_upload.md
+++ b/docs/authentication_and_upload.md
@@ -28,7 +28,7 @@ rattler-build auth login s3://my-bucket --s3-access-key-id <key> --s3-secret-acc
 rattler-build auth logout prefix.dev
 ```
 
-Once logged in, `rattler-build` will automatically use these credentials when accessing
+Once logged in, Rattler-Build will automatically use these credentials when accessing
 the corresponding hosts.
 
 ### Using `RATTLER_AUTH_FILE` (ephemeral)
@@ -74,7 +74,7 @@ The following known authentication methods are supported:
 
 ## Uploading packages
 
-If you want to upload packages, then rattler-build comes with a built-in
+If you want to upload packages, then Rattler-Build comes with a built-in
 `upload` command. There are the following options:
 
 - `prefix.dev`: you can create public or private channels on the prefix.dev
@@ -97,8 +97,8 @@ authenticate with the server.
 
 #### Trusted publishing via OIDC
 
-`rattler-build` supports authentication with <https://prefix.dev> through OIDC with GitHub Actions.
-An API key is no longer required, rattler-build can manage the complete authentication workflow for you.
+Rattler-Build supports authentication with <https://prefix.dev> through OIDC with GitHub Actions.
+An API key is no longer required, Rattler-Build can manage the complete authentication workflow for you.
 You only have to set up a specific repository and workflow under "Trusted Publishers" on prefix.dev.
 
 ![Trusted Publisher](assets/trusted_publisher.png)

--- a/docs/build_options.md
+++ b/docs/build_options.md
@@ -186,7 +186,7 @@ build:
 
 ## Dynamic linking configuration
 
-After the package is built, rattler-build performs some "post-processing" on the
+After the package is built, Rattler-Build performs some "post-processing" on the
 binaries and libraries.
 
 This entails making the shared libraries relocatable and checking that all
@@ -202,11 +202,11 @@ locations outside of the environment. This is useful if you want to link against
 libraries that are not part of the conda environment (e.g. proprietary
 software).
 
-If you want to stop `rattler-build` from relocating the binaries, you can set
+If you want to stop Rattler-Build from relocating the binaries, you can set
 `binary_relocation` to `false`. If you want to only relocate some binaries, you
 can select the relevant ones with a glob pattern.
 
-To read more about `rpath`s and how rattler-build creates relocatable binary
+To read more about `rpath`s and how Rattler-Build creates relocatable binary
 packages, see the [internals](internals.md) docs.
 
 If you link against some libraries (possibly even outside of the prefix, in a
@@ -214,7 +214,7 @@ system location), then you can use the `missing_dso_allowlist` to allow linking
 against these and suppress any warnings. This list is pre-populated with a list
 of known system libraries on the different operating systems.
 
-As part of the post-processing, `rattler-build` checks for overlinking and
+As part of the post-processing, Rattler-Build checks for overlinking and
 overdepending. "Overlinking" is when a binary links against a library that is
 not specified in the run requirements. This is usually a mistake because the
 library would not be present in the environment when the package is installed.
@@ -222,9 +222,9 @@ library would not be present in the environment when the package is installed.
 Conversely, "overdepending" is when a library is part of the run requirements,
 but is not actually used by any of the binaries/libraries in the package.
 
-In addition to handling binary dependencies, `rattler-build` also ensures that
+In addition to handling binary dependencies, Rattler-Build also ensures that
 packages containing hardcoded paths into the environment are relocatable when
-installed outside the of the build environment. To do this, `rattler-build`
+installed outside the of the build environment. To do this, Rattler-Build
 constructs a host environment with a 255 character name of the form
 `host_env_placehold[_placehold[_placehold[...]]]` (for details, see the
 [internals](internals.md) docs). At install time, conda will find these paths
@@ -346,7 +346,7 @@ different Python versions within each platform.
 
 ## Post processing of the package contents (experimental)
 
-rattler-build allows you to post-process the package contents with `regex`
+Rattler-Build allows you to post-process the package contents with `regex`
 replacements after the build has finished. This is only useful in very specific
 cases when you cannot easily identify new files and want to run post-processing
 only on new files.

--- a/docs/build_script.md
+++ b/docs/build_script.md
@@ -68,7 +68,7 @@ build:
 
 ## Alternative script interpreters
 
-With `rattler-build` and the new recipe syntax you can select an `interpreter`
+With Rattler-Build and the new recipe syntax you can select an `interpreter`
 for your script.
 
 So far, the following interpreters are supported:
@@ -82,7 +82,7 @@ So far, the following interpreters are supported:
 - `ruby`
 - `node` or `nodejs` (for NodeJS scripts)
 
-`rattler-build` automatically detects the interpreter based on the file extension
+Rattler-Build automatically detects the interpreter based on the file extension
 (`.sh`, `.bat`, `.nu`, `.py`, `.pl`, `.r`, `.rb`, `.js`) or you can specify it in the
 `interpreter` key in the `script` section of your recipe.
 
@@ -318,7 +318,7 @@ defined only on Windows.
 | `LIBRARY_PREFIX` | `<build prefix>\Library`.         |
 | `SCRIPTS`        | `<build prefix>\Scripts`.         |
 
-Not yet supported in `rattler-build`:
+Not yet supported in Rattler-Build:
 
 - `CYGWIN_PREFIX`
 - `VS_MAJOR`

--- a/docs/bump_recipe.md
+++ b/docs/bump_recipe.md
@@ -1,6 +1,6 @@
 # Bumping recipe versions
 
-When maintaining conda recipes, you often need to update packages to newer versions. This involves changing the version number in your recipe and updating the SHA256 checksum for the new source archive. `rattler-build` provides the `bump-recipe` command to automate this process.
+When maintaining conda recipes, you often need to update packages to newer versions. This involves changing the version number in your recipe and updating the SHA256 checksum for the new source archive. Rattler-Build provides the `bump-recipe` command to automate this process.
 
 ## How it works
 

--- a/docs/compilers.md
+++ b/docs/compilers.md
@@ -33,7 +33,7 @@ variant config.
 
 ## Cross-compilation
 
-Cross-compilation is supported by `rattler-build` and the compiler template
+Cross-compilation is supported by Rattler-Build and the compiler template
 function is part of what makes it possible. When you want to cross-compile from
 `linux-64` to `linux-aarch64` (i.e. intel to ARM), you can pass `--target-platform
 linux-aarch64` to the `rattler-build` command. This will cause the compiler
@@ -52,7 +52,7 @@ those are packages that we want to link against.
 
 ```yaml
 # packages that need to run at build time (cmake, gcc, autotools, etc.)
-# in the platform that rattler-build is executed on (the build_platform)
+# in the platform that Rattler-Build is executed on (the build_platform)
 build:
   - cmake
   - ${{ compiler('c') }}

--- a/docs/conda_forge.md
+++ b/docs/conda_forge.md
@@ -21,12 +21,12 @@ flowchart LR
 Before submitting to conda-forge:
 
 - Your package should be publicly available (GitHub, PyPI, crates.io, etc.)
-- You have a working `recipe.yaml` that builds successfully with `rattler-build`
+- You have a working `recipe.yaml` that builds successfully with Rattler-Build
 - The package has an OSI-approved open source license
 
 ## Step 1: Prepare your recipe
 
-conda-forge uses the same recipe format as `rattler-build`. If you've already built your
+conda-forge uses the same recipe format as Rattler-Build. If you've already built your
 package locally, you're most of the way there.
 
 ### Recipe location

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,6 +1,6 @@
-# Rattler-build configuration
+# Rattler-Build configuration
 
-`rattler-build` can be configured by specifying `--config-file ~/.pixi/config.toml`.
+Rattler-Build can be configured by specifying `--config-file ~/.pixi/config.toml`.
 The config file is of the same format as pixi's [global configuration file](https://pixi.sh/latest/reference/pixi_configuration/).
 
 ## Channels
@@ -24,7 +24,7 @@ package-format = "conda:22"
 
 ## Mirror configuration
 
-By specifying the `mirrors` section, you can instruct rattler-build to use mirrors when building.
+By specifying the `mirrors` section, you can instruct Rattler-Build to use mirrors when building.
 For more information, see [pixi's documentation](https://pixi.sh/latest/reference/pixi_configuration/#mirror-configuration).
 
 ```toml title="config.toml"

--- a/docs/converting_from_conda_build.md
+++ b/docs/converting_from_conda_build.md
@@ -1,8 +1,8 @@
 # Converting a recipe from conda-build
 
-The recipe format of `rattler-build` differs in some aspects from `conda-build`.
+The recipe format of Rattler-Build differs in some aspects from `conda-build`.
 This document aims to help you convert a recipe from `conda-build` to
-`rattler-build`.
+Rattler-Build.
 
 ## Automatic conversion
 
@@ -76,7 +76,7 @@ source:
 `conda-build` has a line based "selector" system, to e.g. disable certain fields
 on Windows vs. Unix.
 
-In rattler-build we use two different syntaxes: an `if/else/then` map or a
+In Rattler-Build we use two different syntaxes: an `if/else/then` map or a
 inline jinja expression.
 
 A typical selector in `conda-build` looks something like this:
@@ -87,7 +87,7 @@ requirements:
     - pywin32  # [win]
 ```
 
-To convert this to `rattler-build` syntax, you can use one of the following two
+To convert this to Rattler-Build syntax, you can use one of the following two
 syntaxes:
 
 ```yaml title="recipe.yaml"
@@ -183,7 +183,7 @@ environment.
 
 # Automatic feedstock conversion
 
-Use the tool [`feedrattler`](https://github.com/hadim/feedrattler) by [hadim](https://github.com/hadim) to go directly from an existing conda-forge v0 recipe feedstock to the new v1 recipe used by rattler-build.
+Use the tool [`feedrattler`](https://github.com/hadim/feedrattler) by [hadim](https://github.com/hadim) to go directly from an existing conda-forge v0 recipe feedstock to the new v1 recipe used by Rattler-Build.
 
 You can install and use it directly by running `pixi exec`:
 ```

--- a/docs/create_patch.md
+++ b/docs/create_patch.md
@@ -2,7 +2,7 @@
 
 When packaging software, you often need to make small source code changes – fixing a typo, applying a bug fix, or adapting build scripts. Instead of maintaining a fork of the upstream project, you can create patch files that are applied during the build process.
 
-`rattler-build` provides a streamlined workflow for creating patches using the `debug` and `create-patch` commands.
+Rattler-Build provides a streamlined workflow for creating patches using the `debug` and `create-patch` commands.
 
 ## How it works
 

--- a/docs/debugging_builds.md
+++ b/docs/debugging_builds.md
@@ -1,6 +1,6 @@
 # Debugging Builds
 
-This guide covers how to debug conda package builds with rattler-build when
+This guide covers how to debug conda package builds with Rattler-Build when
 things go wrong. It's designed for both humans and AI agents working with
 recipes.
 
@@ -157,6 +157,7 @@ build for the first time.
 
 The `rattler-build package` subcommand provides utilities for inspecting and extracting built packages, which is useful for debugging package contents.
 
+
 ### Inspecting Packages
 
 Use `package inspect` to view package metadata without extracting:
@@ -198,7 +199,7 @@ Both `.conda` and `.tar.bz2` package formats are supported.
 
 ## Build Directory Structure
 
-When rattler-build builds a package, it creates:
+When Rattler-Build builds a package, it creates:
 
 ```txt
 output/
@@ -350,7 +351,7 @@ The last line of `output/rattler-build-log.txt` is JSON:
 
 ## Understanding Relocatability
 
-rattler-build makes packages relocatable through:
+Rattler-Build makes packages relocatable through:
 
 1. **RPATH patching** - Changes `.dylib` and `.so` files to use relative paths (`$ORIGIN`, `@loader_path`) using `patchelf` or `install_name_tool`
 

--- a/docs/experimental_features.md
+++ b/docs/experimental_features.md
@@ -1,7 +1,7 @@
 # Experimental features
 
 !!! warning
-    These are experimental features of `rattler-build` and may change or go away completely.
+    These are experimental features of Rattler-Build and may change or go away completely.
 
 
 Currently only the `build` and `rebuild` commands support the following experimental features.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,6 +1,6 @@
 # Getting started
 
-This tutorial walks you through building and publishing your first conda package with `rattler-build`.
+This tutorial walks you through building and publishing your first conda package with Rattler-Build.
 
 ## Creating a recipe
 
@@ -290,7 +290,7 @@ jobs:
 | `build-args` | Additional arguments for `rattler-build build` | |
 | `upload-artifact` | Upload built packages as artifacts | `true` |
 | `artifact-name` | Name for the artifact (use with matrix builds) | `package` |
-| `rattler-build-version` | Version of rattler-build to use | latest |
+| `rattler-build-version` | Version of Rattler-Build to use | latest |
 
 ## Next steps
 

--- a/docs/highlevel.md
+++ b/docs/highlevel.md
@@ -1,16 +1,16 @@
-# What is `rattler-build`?
+# What is Rattler-Build?
 
-`rattler-build` is a tool to build and package software so that it can be
+Rattler-Build is a tool to build and package software so that it can be
 installed on any operating system – with any compatible package manager such as
-`mamba`, `conda`, or `rattler`. We are also intending for `rattler-build` to be
+`mamba`, `conda`, or `rattler`. We are also intending for Rattler-Build to be
 used as a library to drive builds of packages from any other recipe format in
 the future.
 
-### How does `rattler-build` work?
+### How does Rattler-Build work?
 
 Building of packages consists of several steps. It all begins with a
 `recipe.yaml` file that specifies how the package is to be built and what the
-dependencies are. From the recipe file, `rattler-build` executes several steps:
+dependencies are. From the recipe file, Rattler-Build executes several steps:
 
 1. **Rendering**:
 Parse the recipe file and evaluate conditionals, Jinja expressions, and

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,22 +1,22 @@
-## A fast conda package builder: `rattler-build`
+## A fast conda package builder: Rattler-Build
 
-The `rattler-build` tool creates cross-platform relocatable packages from a simple recipe format. 
+The Rattler-Build tool creates cross-platform relocatable packages from a simple recipe format.
 The recipe format is heavily inspired by `conda-build` and `boa`, and the output of `rattler-build`
-is a standard "conda" package that can be installed using [`pixi`](https://pixi.sh), 
+is a standard "conda" package that can be installed using [`pixi`](https://pixi.sh),
 [`mamba`](https://github.com/mamba-org/mamba) or [`conda`](https://docs.conda.io).
 
-`rattler-build` is implemented in Rust, does not have any dependencies on `conda-build` or Python and works as a standalone binary.
+Rattler-Build is implemented in Rust, does not have any dependencies on `conda-build` or Python and works as a standalone binary.
 
-You can use `rattler-build` to publish packages to prefix.dev, anaconda.org, JFrog Artifactory, S3 buckets, or Quetz Servers.
+You can use Rattler-Build to publish packages to prefix.dev, anaconda.org, JFrog Artifactory, S3 buckets, or Quetz Servers.
 
-**Try it out!** You can experiment with rattler-build directly in your browser using our [online playground](https://playground.rattler.build/).
+**Try it out!** You can experiment with Rattler-Build directly in your browser using our [online playground](https://playground.rattler.build/).
 
 ![](https://user-images.githubusercontent.com/885054/244683824-fd1b3896-84c7-498c-b406-40ab2a9e450c.svg)
 
 ## Installation
 
 The recommended way of installing `rattler-build`, being a conda-package builder, is through a conda package manager.
-Next to `rattler-build` we are also building [`pixi`](https://pixi.sh).
+Next to Rattler-Build we are also building [`pixi`](https://pixi.sh).
 
 With `pixi` you can install `rattler-build` globally:
 
@@ -105,9 +105,9 @@ Other options are:
 
 ### Dependencies
 
-Currently `rattler-build` needs some dependencies on the host system which are
+Currently Rattler-Build needs some dependencies on the host system which are
 executed as subprocess. We plan to reduce the number of external dependencies
-over time by writing what we need in Rust to make `rattler-build` fully
+over time by writing what we need in Rust to make Rattler-Build fully
 self-contained.
 
 * `install_name_tool` is necessary on macOS to rewrite the `rpath` of shared
@@ -121,7 +121,7 @@ self-contained.
 
 ### GitHub Action
 
-There is a GitHub Action for `rattler-build`. It can be used to install `rattler-build` in CI/CD workflows and run a build command. Please check out the [GitHub Action documentation](https://github.com/prefix-dev/rattler-build-action) for more information.
+There is a GitHub Action for Rattler-Build. It can be used to install `rattler-build` in CI/CD workflows and run a build command. Please check out the [GitHub Action documentation](https://github.com/prefix-dev/rattler-build-action) for more information.
 
 ## The Recipe Format
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -1,6 +1,6 @@
-# What does `rattler-build` do to build a package?
+# What does Rattler-Build do to build a package?
 
-`rattler-build` creates conda packages which are relocatable packages.
+Rattler-Build creates conda packages which are relocatable packages.
 These packages are built up with some rules and conventions in mind.
 
 ## What goes into a package?
@@ -56,15 +56,15 @@ which aids in making the package relocatable:
 - On Windows, a warning is issued since symlink creation requires administrator
   privileges.
 
-## Making Packages Relocatable with `rattler-build`
+## Making Packages Relocatable with Rattler-Build
 
-Often, the most challenging aspect of building a package using `rattler-build`
+Often, the most challenging aspect of building a package using Rattler-Build
 is making it relocatable. A relocatable package can be installed into any
 prefix, allowing it to be used outside the environment in which it was built.
 This is in contrast to a non-relocatable package, which can only be utilized
 within its original build environment.
 
-`rattler-build` automatically performs the following actions to make packages
+Rattler-Build automatically performs the following actions to make packages
 relocatable:
 
 1. **Binary object file conversion**: Binary object files are converted to use
@@ -81,7 +81,7 @@ their build prefix replaced with the install prefix at install time. This works
 by padding the install prefix with null terminators, such that the length of the
 binary file remains the same. The build prefix must be long enough to
 accommodate any reasonable installation prefix. On macOS and Linux,
-`rattler-build` pads the build prefix to 255 characters by appending
+Rattler-Build pads the build prefix to 255 characters by appending
 `_placehold` to the end of the build directory name.
 <!--4. **Prefix replacement for specific binary files**: There may be cases where a
    file is identified as binary but requires the build prefix to be replaced as

--- a/docs/multiple_output_cache.md
+++ b/docs/multiple_output_cache.md
@@ -2,7 +2,7 @@
 
 !!!note
 
-    Staging outputs are different from a compilation cache. If you look for tips and tricks on how to use `sccache` or `ccache` with `rattler-build`, please refer to the [tips and tricks section](tips_and_tricks.md#using-sccache-or-ccache-with-rattler-build).
+    Staging outputs are different from a compilation cache. If you look for tips and tricks on how to use `sccache` or `ccache` with Rattler-Build, please refer to the [tips and tricks section](tips_and_tricks.md#using-sccache-or-ccache-with-rattler-build).
 
 Sometimes you build a package and want to split the contents into multiple sub-packages.
 For example, when building a C/C++ package, you might want to create multiple packages for the

--- a/docs/package_spec.md
+++ b/docs/package_spec.md
@@ -1,6 +1,6 @@
 # Package specification
 
-`rattler-build` produces "conda" packages. These packages work with the `mamba`
+Rattler-Build produces "conda" packages. These packages work with the `mamba`
 and `conda` package managers, and they work cross-platform on Windows, Linux and
 macOS.
 

--- a/docs/publish.md
+++ b/docs/publish.md
@@ -1,6 +1,6 @@
 # Publishing packages to your own channel
 
-Rattler-build comes with an intuitive `publish` subcommand, that will publish a package to a channel.
+Rattler-Build comes with an intuitive `publish` subcommand, that will publish a package to a channel.
 
 You can either point to an already built package, or to a recipe and `publish` them into your channel.
 The channel can be either on prefix.dev, anaconda.org, an S3 bucket, a local filesystem folder (or network mount), or a Quetz or Artifactory instance.
@@ -56,17 +56,17 @@ If the recipe does specify a build number, you have to manually trigger an overr
 
 ## Authentication
 
-Rattler-build uses the same authentication as other tools in the prefix family. It's easiest to login using the `auth` subcommand: `rattler-build auth login`. Note: if you are already logged in with `pixi`, you are also logged in with `rattler-build` - they share credentials.
+Rattler-Build uses the same authentication as other tools in the prefix family. It's easiest to login using the `auth` subcommand: `rattler-build auth login`. Note: if you are already logged in with `pixi`, you are also logged in with Rattler-Build - they share credentials.
 
 Otherwise you can also use the same options as with `upload`, and supply tokens as environment variables or CLI arguments.
 
 ## Channel Initialization
 
-When publishing to local filesystem or S3 channels, rattler-build automatically handles channel initialization:
+When publishing to local filesystem or S3 channels, Rattler-Build automatically handles channel initialization:
 
 ### New channels
 
-If the target channel doesn't exist yet, rattler-build will:
+If the target channel doesn't exist yet, Rattler-Build will:
 
 1. Create the channel directory (for filesystem channels)
 2. Initialize it with an empty `noarch/repodata.json`
@@ -83,16 +83,16 @@ rattler-build publish ./my-package.conda --to s3://my-bucket/channel
 
 ### Existing channels
 
-If the channel directory exists but is not properly initialized (missing `noarch/repodata.json`), rattler-build will fail with a helpful error message. This prevents accidentally treating a random directory as a conda channel.
+If the channel directory exists but is not properly initialized (missing `noarch/repodata.json`), Rattler-Build will fail with a helpful error message. This prevents accidentally treating a random directory as a conda channel.
 
 To initialize an existing directory as a channel, you can either:
 
-- Let rattler-build create it fresh (remove the directory first)
+- Let Rattler-Build create it fresh (remove the directory first)
 - Manually create `noarch/repodata.json` with content `{"packages": {}, "packages.conda": {}}`
 
 ## Indexing S3 and Filesystem channels
 
-Since S3 and Filesystem channels don't know anything about "indexing" (producing repodata.json), rattler-build will internally use `rattler-index` to run the indexing step after a successful upload. This will ensure that the repodata in the channel is up to date and users can start downloading the new packages.
+Since S3 and Filesystem channels don't know anything about "indexing" (producing repodata.json), Rattler-Build will internally use `rattler-index` to run the indexing step after a successful upload. This will ensure that the repodata in the channel is up to date and users can start downloading the new packages.
 
 ## Sigstore attestations
 

--- a/docs/py-rattler-build/reference/exceptions.md
+++ b/docs/py-rattler-build/reference/exceptions.md
@@ -1,8 +1,8 @@
 # Exceptions
 
-Exception classes raised by rattler-build operations.
+Exception classes raised by Rattler-Build operations.
 
-All exceptions inherit from `RattlerBuildError`, so you can catch all rattler-build
+All exceptions inherit from `RattlerBuildError`, so you can catch all Rattler-Build
 errors with a single except clause:
 
 ```python
@@ -56,7 +56,7 @@ RattlerBuildError (base)
 
 ## `RattlerBuildError`
 
-Base exception for all rattler-build errors. Catch this to handle any error from the library.
+Base exception for all Rattler-Build errors. Catch this to handle any error from the library.
 
 ## `AuthError`
 

--- a/docs/py-rattler-build/reference/index.md
+++ b/docs/py-rattler-build/reference/index.md
@@ -2,12 +2,12 @@
 
 Here's the reference documentation for the `rattler_build` Python bindings API.
 
-If you want to **learn how to use** rattler-build's Python API, check out the
+If you want to **learn how to use** Rattler-Build's Python API, check out the
 [Tutorials](../tutorials/recipe_rendering_basics.md).
 
 ## Version
 
-Get the version of rattler-build:
+Get the version of Rattler-Build:
 
 ```python
 from rattler_build import rattler_build_version
@@ -36,4 +36,4 @@ print(rattler_build_version())
 
 ## Exceptions
 
-- **[Exceptions](exceptions.md)** - Error types raised by rattler-build
+- **[Exceptions](exceptions.md)** - Error types raised by Rattler-Build

--- a/docs/py-rattler-build/reference/recipe.md
+++ b/docs/py-rattler-build/reference/recipe.md
@@ -2,7 +2,7 @@
 
 Recipe classes for parsing and working with conda recipes.
 
-rattler-build uses a two-stage recipe system:
+Rattler-Build uses a two-stage recipe system:
 
 1. **Stage0** - Parsed YAML recipes before Jinja template evaluation
 2. **Stage1** - Fully evaluated recipes ready for building

--- a/docs/recipe_generation.md
+++ b/docs/recipe_generation.md
@@ -1,6 +1,6 @@
 # Generating recipes for different ecosystems
 
-Rattler-build has some builtin functionality to generate recipes for different (existing) ecosystems.
+Rattler-Build has some builtin functionality to generate recipes for different (existing) ecosystems.
 
 Currently we support the following ecosystems:
 
@@ -59,4 +59,4 @@ R packages will be prefixed with `r-` to avoid name conflicts with Python packag
 
 !!!tip
 
-    You can use the generated recipes to build your own "forge" with `rattler-build`. Read more about it in the [Building your own forge](./tips_and_tricks.md#building-your-own-forge) section.
+    You can use the generated recipes to build your own "forge" with Rattler-Build. Read more about it in the [Building your own forge](./tips_and_tricks.md#building-your-own-forge) section.

--- a/docs/reference/jinja.md
+++ b/docs/reference/jinja.md
@@ -1,6 +1,6 @@
 # Jinja
 
-`rattler-build` comes with a couple of useful [Jinja](https://jinja.palletsprojects.com)
+Rattler-Build comes with a couple of useful [Jinja](https://jinja.palletsprojects.com)
 functions and filters that can be used in the recipe.
 
 ## Functions
@@ -42,7 +42,7 @@ Note that the final output will still contain the `target_platform`, so that the
 full compiler will read `clang_linux-64 9.0` when compiling with
 `--target-platform linux-64`.
 
-`rattler-build` defines some default compilers for the following languages
+Rattler-Build defines some default compilers for the following languages
 (inherited from `conda-build`):
 
 - `c`: `gcc` on Linux, `clang` on `osx` and `vs2017` on Windows

--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -1,6 +1,6 @@
 # The recipe spec
 
-`rattler-build` implements a new recipe spec, different from the traditional
+Rattler-Build implements a new recipe spec, different from the traditional
 "`meta.yaml`" file used in `conda-build`. A recipe has to be stored as a
 `recipe.yaml` file.
 
@@ -18,7 +18,7 @@ The reason for a new spec are:
   and more)
 - remove any need for recursive parsing & solving
 - finally, the initial implementation in `boa` relied on `conda-build`;
-  `rattler-build` removes any dependency on Python or `conda-build` and
+  Rattler-Build removes any dependency on Python or `conda-build` and
   reimplements everything in Rust
 
 ## Major differences from `conda-build`
@@ -221,7 +221,7 @@ source:
   lfs: true # note: defaults to false
 ```
 
-By default, rattler-build will recursively initialize and update all git
+By default, Rattler-Build will recursively initialize and update all git
 submodules. For repositories with large or numerous submodules that aren't needed
 for the build, you can disable this by setting `submodules: false`:
 
@@ -264,7 +264,7 @@ source is copied to the work directory before building.
 ```
 
 By default, all files in the local path that are ignored by `git` are also ignored
-by `rattler-build`. You can disable this behavior by setting `use_gitignore` to
+by Rattler-Build. You can disable this behavior by setting `use_gitignore` to
 `false`.
 
 #### Patches
@@ -282,8 +282,8 @@ Patches may optionally be applied to the source.
 
 #### Destination path
 
-Within `rattler-build`'s work directory, you may specify a particular folder to
-place the source into. `rattler-build` will always drop you into the same folder
+Within Rattler-Build's work directory, you may specify a particular folder to
+place the source into. Rattler-Build will always drop you into the same folder
 (`[build folder]/work`), but it's up to you whether you want your source extracted
 into that folder, or nested deeper. This feature is particularly useful when dealing
 with multiple sources, but can apply to recipes with single sources as well.
@@ -386,7 +386,7 @@ Recursive globbing using `**` is also supported.
 
 The build number should be incremented for new builds of the same version. The
 number defaults to `0`. The build string cannot contain "`-`". The string defaults
-to the default `rattler-build` build string plus the build number.
+to the default Rattler-Build build string plus the build number.
 
 ```yaml
 build:
@@ -406,7 +406,7 @@ build:
 
 ### Script
 
-By default, `rattler-build` uses a `build.sh` file on Unix (macOS and Linux) and a
+By default, Rattler-Build uses a `build.sh` file on Unix (macOS and Linux) and a
 `build.bat` file on Windows, if they exist in the same folder as the `recipe.yaml`
 file. With the script parameter you can either supply a different filename or
 write out short build scripts. You may need to use selectors to use different
@@ -431,7 +431,7 @@ Please see [Build script](../build_script.md) for more information.
 
 ### Skipping builds
 
-Lists conditions under which `rattler-build` should skip the build of this recipe.
+Lists conditions under which Rattler-Build should skip the build of this recipe.
 Particularly useful for defining recipes that are platform-specific. By default,
 a build is never skipped.
 
@@ -520,7 +520,7 @@ build:
 
 #### Version independent (ABI3) packages
 
-Since rattler-build 0.35.0 and [CEP 20](https://github.com/conda/ceps/blob/main/cep-0020.md)
+Since Rattler-Build 0.35.0 and [CEP 20](https://github.com/conda/ceps/blob/main/cep-0020.md)
 you can create version-independent Python packages that still contain compiled code.
 
 ABI3 packages support building a native Python extension using a specific Python
@@ -804,7 +804,7 @@ Using a runtime dependency name:
 
 ## Tests section
 
-`rattler-build` supports four different types of tests. The "script test" installs
+Rattler-Build supports four different types of tests. The "script test" installs
 the package and runs a list of commands. The "Python test" attempts to import a
 list of Python modules and runs `pip check`. The "downstream test" runs the tests
 of a downstream package that reverse depends on the package being built. And lastly,
@@ -1314,7 +1314,7 @@ form.
 
 ## Templating with Jinja
 
-`rattler-build` supports limited Jinja templating in the `recipe.yaml` file.
+Rattler-Build supports limited Jinja templating in the `recipe.yaml` file.
 
 You can set up Jinja variables in the `context` section:
 
@@ -1346,7 +1346,7 @@ tests:
 
 Jinja has built-in support for some common string manipulations.
 
-In rattler-build, complex Jinja is completely disallowed as we try to produce
+In Rattler-Build, complex Jinja is completely disallowed as we try to produce
 YAML that is valid at all times. So you should not use any `{% if ... %}` or
 similar Jinja constructs that produce invalid YAML. Furthermore, instead of
 plain double curly brackets Jinja statements need to be prefixed by `$`, e.g.
@@ -1367,10 +1367,10 @@ Jinja templates are evaluated during the build process.
 To retrieve a fully rendered `recipe.yaml`, use the `` command.
 -->
 
-#### Additional Jinja2 functionality in rattler-build
+#### Additional Jinja2 functionality in Rattler-Build
 
 Besides the default Jinja2 functionality, additional Jinja functions are
-available during the `rattler-build` process: `pin_compatible`, `pin_subpackage`,
+available during the Rattler-Build process: `pin_compatible`, `pin_subpackage`,
 and `compiler`.
 
 The compiler function takes `c`, `cxx`, `fortran` and other values as argument
@@ -1389,7 +1389,7 @@ specified rules.
 
 #### Pin expressions
 
-`rattler-build` knows pin expressions. A pin expression can have a `lower_bound`,
+Rattler-Build knows pin expressions. A pin expression can have a `lower_bound`,
 `upper_bound` and `exact` value. A `upper_bound` and `lower_bound` are specified with a
 string containing only `x` and `.`, e.g. `upper_bound="x.x.x"` would signify to pin
 the given package to `<1.2.3` (if the package version is `1.2.2`, for example).
@@ -1574,7 +1574,7 @@ tests:
 ## Experimental features
 
 !!! warning
-    These are experimental features of `rattler-build` and may change or go away completely.
+    These are experimental features of Rattler-Build and may change or go away completely.
 
 ### Jinja functions
 

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -4,7 +4,7 @@
     The sandbox feature is experimental and may not work as expected. The options might
     change in future releases.
 
-Since the 0.34.0 release, `rattler-build` has a new experimental feature called
+Since the 0.34.0 release, Rattler-Build has a new experimental feature called
 `sandbox`. With the sandbox feature enabled (via `--sandbox`), the build process
 has much more restricted access to system resources on macOS and Linux.
 As the sandbox feature is experimental it is disabled by default.

--- a/docs/selectors.md
+++ b/docs/selectors.md
@@ -144,7 +144,7 @@ variant, and thus the `match` condition always evaluates to `true`.
 
 ### Selector evaluation
 
-Except for the rattler-build specific selectors, the selectors are evaluated using the `minijinja` engine. This means
+Except for the Rattler-Build specific selectors, the selectors are evaluated using the `minijinja` engine. This means
 that the selectors are evaluated by [`minijinja`][minijinja] thus Python like expressions.
 Some notable options are:
 

--- a/docs/sigstore.md
+++ b/docs/sigstore.md
@@ -2,7 +2,7 @@
 
 Sigstore is a way to cryptographically sign packages (or any binary artifacts). It was pioneered in the container space, but has been adopted by many packaging ecosystems: PyPI, Python releases, Rust crates, Homebrew, and Rubygems.
 
-Rattler-build supports creating Sigstore attestations for conda packages, allowing you to cryptographically sign your packages and provide verifiable provenance information.
+Rattler-Build supports creating Sigstore attestations for conda packages, allowing you to cryptographically sign your packages and provide verifiable provenance information.
 
 ## What does a Sigstore attestation provide?
 
@@ -118,7 +118,7 @@ This approach gives you full control over the attestation creation and allows yo
 !!! note "Experimental"
     This feature requires the `--experimental` flag: `rattler-build build --experimental -r recipe.yaml`
 
-In addition to signing built packages, rattler-build can also **verify** the attestations of source archives during the build. This lets you ensure that the source code you're building from was produced by a trusted publisher (e.g., a specific GitHub Actions workflow).
+In addition to signing built packages, Rattler-Build can also **verify** the attestations of source archives during the build. This lets you ensure that the source code you're building from was produced by a trusted publisher (e.g., a specific GitHub Actions workflow).
 
 ### How it works
 
@@ -133,7 +133,7 @@ source:
       - github:pallets/flask
 ```
 
-When rattler-build downloads the source, it will:
+When Rattler-Build downloads the source, it will:
 
 1. Fetch the Sigstore attestation bundle (automatically derived for PyPI packages, or from `bundle_url`)
 2. Verify the bundle signature against the Sigstore transparency log

--- a/docs/special_files.md
+++ b/docs/special_files.md
@@ -164,7 +164,7 @@ This means:
 
 ## Post-link and pre-unlink scripts
 
-The `post-link` and `pre-unlink` scripts are executed when the package is installed or uninstalled. They are both heavily discouraged but implemented for compatibility with conda in `rattler-build` since version 0.17.
+The `post-link` and `pre-unlink` scripts are executed when the package is installed or uninstalled. They are both heavily discouraged but implemented for compatibility with conda in Rattler-Build since version 0.17.
 
 For a `post-link` script to be executed when a package is installed, the built package needs to have a `.<package_name>-post-link.{sh/bat}` in its `bin/` folder. The same is applicable for `pre-unlink` scripts, just with the name `.<package_name>-pre-unlink.{sh/bat}` (note the leading period). For example, for a package `mypkg`, you would need to have a `.mypkg-post-link.sh` in its `bin/` folder.
 

--- a/docs/tips_and_tricks.md
+++ b/docs/tips_and_tricks.md
@@ -1,8 +1,8 @@
-# Tips and tricks for rattler-build
+# Tips and tricks for Rattler-Build
 
-This section contains some tips and tricks for using `rattler-build`.
+This section contains some tips and tricks for using Rattler-Build.
 
-## Using sccache or ccache with `rattler-build`
+## Using sccache or ccache with Rattler-Build
 
 When debugging a recipe it can help a lot to use `sccache` or `ccache`. You can
 install both tools e.g. with `pixi global install sccache`.
@@ -20,7 +20,7 @@ export CXX="sccache $CXX"
 ```
 
 However, both `ccache` and `sccache` are sensitive to changes in the build
-location. Since `rattler-build`, by default, always creates a new build
+location. Since Rattler-Build, by default, always creates a new build
 directory with the timestamp, you need to use the `--no-build-id` flag. This
 will disable the time stamp in the build directory and allow `ccache` and
 `sccache` to cache the build.
@@ -35,7 +35,7 @@ You might want to publish your own software packages to a channel you control.
 These might be packages that are not available in the main conda-forge channel,
 or proprietary packages, or packages that you have modified in some way.
 
-Doing so is pretty straightforward with `rattler-build` and a CI provider of
+Doing so is pretty straightforward with Rattler-Build and a CI provider of
 your choice. We have a number of example repositories for "custom" forges:
 
 - [rust-forge](https://github.com/wolfv/rust-forge): This repository builds a
@@ -47,7 +47,7 @@ your choice. We have a number of example repositories for "custom" forges:
 
 To create your own forge, you should create a number of sub-directories where
 each sub-directory should contain at most one recipe. With the `--recipe-dir`
-flag of rattler-build, the program will go and collect all recipes it finds in
+flag of Rattler-Build, the program will go and collect all recipes it finds in
 the given directory or sub-directories.
 
 We can combine this with the `--skip-existing=all` flag which will skip all
@@ -68,8 +68,8 @@ rebuilding should be rebuilt.
 ### CI setup
 
 As an example, the following is the CI setup for `rust-forge`. The workflow uses
-`rattler-build` to build and upload packages to a custom channel on
-[https://prefix.dev](https://prefix.dev) – but you can also use `rattler-build`
+Rattler-Build to build and upload packages to a custom channel on
+[https://prefix.dev](https://prefix.dev) – but you can also use Rattler-Build
 to upload to your own `quetz` instance, or a channel on `anaconda.org`.
 
 ??? tip "Example CI setup for `rust-forge`"

--- a/docs/tutorials/cpp.md
+++ b/docs/tutorials/cpp.md
@@ -1,6 +1,6 @@
 # Packaging a C++ package
 
-This tutorial will guide you though making a C++ package with `rattler-build`.
+This tutorial will guide you though making a C++ package with Rattler-Build.
 
 ## Building a Header-only Library
 
@@ -121,7 +121,7 @@ ninja install
 
 ## Parsing the `rattler-build build` Output
 
-When running the `rattler-build` command, you might notice some interesting information in the output.
+When running the `rattler-build build` command, you might notice some interesting information in the output.
 Our package will have some `run` dependencies, even if we didn't specify any.
 
 These come from the `run-exports` of the packages listed in the `host` section of the recipe.
@@ -168,7 +168,7 @@ You can also see "linking" information in the output, for example on macOS:
  └─ @rpath/libcairo.2.dylib
 ```
 
-`rattler-build` ensures that:
+Rattler-Build ensures that:
 
 1. All shared libraries linked against are present in the run dependencies.
 Missing libraries trigger an `overlinking` warning.

--- a/docs/tutorials/go.md
+++ b/docs/tutorials/go.md
@@ -1,6 +1,6 @@
 # Packaging a Go package
 
-This tutorial will guide you through making a Go package with `rattler-build`.
+This tutorial will guide you through making a Go package with Rattler-Build.
 
 When building a recipe for Go, most Go dependencies are linked statically. That
 means, we should collect their licenses and add them in the package. The

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,6 +1,6 @@
 # Examples
 
-This section contains examples for packaging software in different languages with `rattler-build`. Each example walks you through creating a recipe for a specific language ecosystem.
+This section contains examples for packaging software in different languages with Rattler-Build. Each example walks you through creating a recipe for a specific language ecosystem.
 
 | Example | Description |
 |---------|-------------|
@@ -12,4 +12,4 @@ This section contains examples for packaging software in different languages wit
 | [Perl](perl.md) | Build Perl packages from CPAN with `noarch: generic` support |
 | [R](r.md) | Package R libraries from CRAN |
 | [Repackaging](repackaging.md) | Repackage existing pre-built binaries for distribution |
-| [Converting from conda-build](../converting_from_conda_build.md) | Migrate existing `meta.yaml` recipes to the `rattler-build` format |
+| [Converting from conda-build](../converting_from_conda_build.md) | Migrate existing `meta.yaml` recipes to the Rattler-Build format |

--- a/docs/tutorials/javascript.md
+++ b/docs/tutorials/javascript.md
@@ -1,13 +1,13 @@
 # Packaging a Javascript (NPM/NodeJS) package
 
 This tutorial will guide you though making a NodeJS package with
-`rattler-build`. Please note that, while packaging executable applications is
+Rattler-Build. Please note that, while packaging executable applications is
 possible, the conda ecosystem is not ideal for NPM libraries. NPM supports a
 number of features that cannot easily be modeled in the conda ecosystem, such as
 peer dependencies, optional dependencies, and the ability to install multiple
 versions of the same package.
 
-However, if you need to package a NodeJS application, `rattler-build` can help!
+However, if you need to package a NodeJS application, Rattler-Build can help!
 
 ## Building a NodeJS Package
 

--- a/docs/tutorials/python.md
+++ b/docs/tutorials/python.md
@@ -5,7 +5,7 @@ In the second example we will build a package for `numpy` which contains compile
 
 ## Generating a starter recipe
 
-Rattler-build provides a command to generate a recipe for a package from PyPI.
+Rattler-Build provides a command to generate a recipe for a package from PyPI.
 The generated recipe can be used as a starting point for your recipe.
 The recipe generator will fetch the metadata from PyPI and generate a recipe that will build the package from the `sdist` source distribution.
 
@@ -27,7 +27,7 @@ Additionally, `noarch: python` packages work with a range of Python versions (co
 --8<-- "docs/snippets/recipes/ipywidgets.yaml"
 ```
 
-1. The `noarch: python` line tells `rattler-build` that this package is pure
+1. The `noarch: python` line tells Rattler-Build that this package is pure
    Python and can be one-size-fits-all. `noarch` packages can be installed on any
    platform without modification which is very handy.
 2. The `imports` section in the tests is used to check that the package is
@@ -101,7 +101,7 @@ Running this recipe with the variant config file will build a total of 2 `numpy`
 rattler-build build --recipe ./numpy
 ```
 
-At the beginning of the build process, `rattler-build` will print the following message to show you the variants it found:
+At the beginning of the build process, Rattler-Build will print the following message to show you the variants it found:
 
 ```txt
 Found variants:

--- a/docs/tutorials/r.md
+++ b/docs/tutorials/r.md
@@ -4,7 +4,7 @@ Packaging a R package is similar to packaging a Python package!
 
 ## Generating a starting point
 
-You can use rattler-build to generate a starting point for your recipe from the metadata on CRAN.
+You can use Rattler-Build to generate a starting point for your recipe from the metadata on CRAN.
 
 ```bash
 rattler-build generate-recipe cran r-knitr

--- a/docs/tutorials/repackaging.md
+++ b/docs/tutorials/repackaging.md
@@ -1,6 +1,6 @@
 # Repackaging existing software
 
-It's totally possible to repackage existing software using rattler-build, and make it easy to install
+It's totally possible to repackage existing software using Rattler-Build, and make it easy to install
 with conda, mamba or pixi.
 
 Repackaging existing binaries is not recommended on `conda-forge`, but totally acceptable for your own channels / repositories.

--- a/docs/tutorials/rust.md
+++ b/docs/tutorials/rust.md
@@ -1,6 +1,6 @@
 # Building a Rust package
 
-We're using `rattler-build` to build a Rust package for the `cargo-edit` utility.
+We're using Rattler-Build to build a Rust package for the `cargo-edit` utility.
 This utility manages Cargo dependencies from the command line.
 
 ```yaml title="recipe.yaml"

--- a/docs/understanding_terminal_output.md
+++ b/docs/understanding_terminal_output.md
@@ -1,6 +1,6 @@
 # Understanding the terminal output
 
-When you build a recipe with rattler-build, a lot of information is printed on the terminal. Some of that information uses short codes that we are explaining here.
+When you build a recipe with Rattler-Build, a lot of information is printed on the terminal. Some of that information uses short codes that we are explaining here.
 
 Let's look at the logs together!
 

--- a/docs/variants.md
+++ b/docs/variants.md
@@ -1,6 +1,6 @@
 # Variant configuration
 
-`rattler-build` can automatically build multiple _variants_ of a given package.
+Rattler-Build can automatically build multiple _variants_ of a given package.
 For example, a Python package might need multiple variants per Python version
 (especially if it is a binary package such as `numpy`).
 
@@ -59,7 +59,7 @@ would be ignored.
 
 ## Automatic Discovery
 
-`rattler-build` automatically discovers and includes variant configurations from
+Rattler-Build automatically discovers and includes variant configurations from
 either:
 
 - `variants.yaml` file located next to the recipe
@@ -87,7 +87,7 @@ When multiple variant configuration files are merged, the following rules apply:
 
 ### `conda-build` Compatibility
 
-Since version 0.35.0, rattler-build supports `conda_build_config.yaml` files,
+Since version 0.35.0, Rattler-Build supports `conda_build_config.yaml` files,
 parsing a subset of conda-build's configuration syntax. The filename must match
 exactly to be recognized as a conda-build config file.
 

--- a/docs/windows_quirks.md
+++ b/docs/windows_quirks.md
@@ -44,7 +44,7 @@ To make this easier, certain shortcut env vars are available on Windows: `%LIBRA
 
 The _default interpreter_ for build scripts on Windows is `cmd.exe` which has a quite clunky syntax and execution model.
 
-It will, for example, skip over errors if you do not manually insert `if %ERRORLEVEL% neq 0 exit 1` after each statement. If the build script is a list of commands, then rattler-build will automatically inject this after each list item. If you pass in a complete build script or file, you will have to do this manually to recognize issues in command execution early on.
+It will, for example, skip over errors if you do not manually insert `if %ERRORLEVEL% neq 0 exit 1` after each statement. If the build script is a list of commands, then Rattler-Build will automatically inject this after each list item. If you pass in a complete build script or file, you will have to do this manually to recognize issues in command execution early on.
 
 ### Using Powershell
 
@@ -57,18 +57,18 @@ build:
     script: ...
 ```
 
-Or save your build script as `build.ps1` (which will automatically use powershell based on the file ending), rattler-build will choose it automatically on Windows if `build.bat` is absent.
+Or save your build script as `build.ps1` (which will automatically use powershell based on the file ending), Rattler-Build will choose it automatically on Windows if `build.bat` is absent.
 
-rattler-build relies on `$PSNativeCommandUseErrorActionPreference`, which is only available in PowerShell 7.4+. If your PowerShell is not new enough, it will skip over errors from native
+Rattler-Build relies on `$PSNativeCommandUseErrorActionPreference`, which is only available in PowerShell 7.4+. If your PowerShell is not new enough, it will skip over errors from native
 command and you have to check `$?` or `$LASTEXITCODE` manually like in `cmd.exe`.
 
-rattler-build also creates normal variable copies of environment variables, you can use them if you feel `Env:` prefix is tedious, so you can write
+Rattler-Build also creates normal variable copies of environment variables, you can use them if you feel `Env:` prefix is tedious, so you can write
 
 ```ps1 title="build.ps1"
 cmake -S . B build -DCMAKE_INSTALL_PREFIX=$LIBRARY_PREFIX # same as $Env:LIBRARY_PREFIX
 ```
 
-All these variables are strings, because rattler-build just copies them, so variables with value `'True'` will not be `$true` in current implementation.
+All these variables are strings, because Rattler-Build just copies them, so variables with value `'True'` will not be `$true` in current implementation.
 
 ### Using `Bash` on Windows
 

--- a/py-rattler-build/README.md
+++ b/py-rattler-build/README.md
@@ -1,6 +1,6 @@
 # py-rattler-build
 
-Python bindings for [rattler-build](https://github.com/prefix-dev/rattler-build), the fast conda package builder.
+Python bindings for [Rattler-Build](https://github.com/prefix-dev/rattler-build), the fast conda package builder.
 
 `py-rattler-build` lets you build, inspect, test, and upload conda packages
 directly from Python — no subprocess calls needed.


### PR DESCRIPTION
This only concerns markdown files