### PR TITLE
fix: point release-plz to cliff.toml for changelog generation

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,4 +1,5 @@
 [workspace]
+changelog_config = "cliff.toml"
 allow_dirty = true
 changelog_update = true
 dependencies_update = true


### PR DESCRIPTION
Before every message in the changelog was categorized as "Other"