### PR TITLE
fix: allow git push in tag-release job by keeping checkout credentials

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -268,8 +268,6 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
       - uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e # v0.9.4
         with:
           environments: release

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -3,3 +3,5 @@ rules:
     ignore:
       # docs workflow needs git credentials for mike deploy --push
       - docs.yml
+      # tag-release job needs git credentials to push tags
+      - release-artifacts.yml


### PR DESCRIPTION
See https://github.com/prefix-dev/rattler-build/actions/runs/23013915326/job/66835673952