### PR TITLE
ci: remove windows-gnu job

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -65,8 +65,6 @@ jobs:
             os: macos-latest
           - target: aarch64-apple-darwin
             os: macos-latest
-          - target: x86_64-pc-windows-gnu
-            os: windows-2022
           - target: x86_64-pc-windows-msvc
             os: windows-2022
           - target: aarch64-pc-windows-msvc
@@ -195,7 +193,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - target: x86_64-pc-windows-gnu
           - target: x86_64-pc-windows-msvc
           - target: aarch64-pc-windows-msvc
     steps:


### PR DESCRIPTION
This has been always been there, it at least been there since the last big CI refactor three years ago.

Let's remove it and see if people complain