### PR TITLE
test: remove anaconda upload test

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -142,7 +142,6 @@ jobs:
         run: pixi run test-end-to-end-ci
         env:
           PREFIX_DEV_READ_ONLY_TOKEN: ${{ secrets.PREFIX_DEV_READ_ONLY_TOKEN }}
-          ANACONDA_ORG_TEST_TOKEN: ${{ secrets.ANACONDA_ORG_TEST_TOKEN }}
           S3_ACCESS_KEY_ID: ${{ secrets.S3_UPLOAD_ACCESS_KEY_ID }}
           S3_SECRET_ACCESS_KEY: ${{ secrets.S3_UPLOAD_ACCESS_KEY_SECRET }}
 

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -13,7 +13,6 @@ from typing import Iterator
 
 import boto3
 import pytest
-import requests
 import yaml
 from helpers import (
     RattlerBuild,
@@ -462,63 +461,6 @@ def test_auth_file(
         tmp_path,
         custom_channels=["conda-forge", "https://repo.prefix.dev/setup-pixi-test"],
     )
-
-
-@pytest.mark.skipif(
-    not os.environ.get("ANACONDA_ORG_TEST_TOKEN", ""),
-    reason="requires ANACONDA_ORG_TEST_TOKEN",
-)
-def test_anaconda_upload(
-    rattler_build: RattlerBuild, recipes: Path, tmp_path: Path, monkeypatch
-):
-    URL = "https://api.anaconda.org/package/rattler-build-testpackages/globtest"
-
-    # Make sure the package doesn't exist
-    requests.delete(
-        URL, headers={"Authorization": f"token {os.environ['ANACONDA_ORG_TEST_TOKEN']}"}
-    )
-
-    assert requests.get(URL).status_code == 404
-
-    monkeypatch.setenv("ANACONDA_API_KEY", os.environ["ANACONDA_ORG_TEST_TOKEN"])
-
-    rattler_build.build(recipes / "globtest", tmp_path)
-
-    rattler_build(
-        "upload",
-        "-vvv",
-        "anaconda",
-        "--owner",
-        "rattler-build-testpackages",
-        str(get_package(tmp_path, "globtest")),
-    )
-
-    # Make sure the package exists
-    assert requests.get(URL).status_code == 200
-
-    # Make sure the package attempted overwrites fail without --force
-    with pytest.raises(CalledProcessError):
-        rattler_build(
-            "upload",
-            "-vvv",
-            "anaconda",
-            "--owner",
-            "rattler-build-testpackages",
-            str(get_package(tmp_path, "globtest")),
-        )
-
-    # Make sure the package attempted overwrites succeed with --force
-    rattler_build(
-        "upload",
-        "-vvv",
-        "anaconda",
-        "--owner",
-        "rattler-build-testpackages",
-        "--force",
-        str(get_package(tmp_path, "globtest")),
-    )
-
-    assert requests.get(URL).status_code == 200
 
 
 @dataclass


### PR DESCRIPTION
This test is now causing problems for a while and I added corresponding tests to `rattler_upload` in the meantime