### PR TITLE
fix: fetch and reset release branch before syncing Cargo.lock

### DIFF
--- a/scripts/release_plz_pr.py
+++ b/scripts/release_plz_pr.py
@@ -66,7 +66,9 @@ def sync_py_cargo_lock(git_token: str, repo_url: str, branch: str) -> None:
         )
         return
 
+    run(["git", "fetch", "origin", branch])
     run(["git", "checkout", branch])
+    run(["git", "reset", "--hard", f"origin/{branch}"])
     run(["cargo", "update", "--workspace", "--manifest-path", str(PY_MANIFEST)])
 
     diff = subprocess.run(


### PR DESCRIPTION
The release-plz tool pushes commits to the remote PR branch, but the local checkout doesn't have those commits. This causes the subsequent push to be rejected because the remote is ahead. Fetch and reset the local branch to match the remote before making changes.