### PR TITLE
Add missing_run_exports_behavior check for shared libraries

### DIFF
--- a/crates/rattler_build_core/src/post_process/checks.rs
+++ b/crates/rattler_build_core/src/post_process/checks.rs
@@ -6,7 +6,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::post_process::{package_nature::PackageNature, relink};
+use crate::post_process::{package_nature::{PackageNature, is_dso}, relink};
 use crate::{
     metadata::Output,
     post_process::{package_nature::PrefixInfo, relink::RelinkError},
@@ -31,6 +31,13 @@ pub enum LinkingCheckError {
 
     #[error("Overdepending against: {package}")]
     Overdepending { package: PathBuf },
+
+    #[error(
+        "Package contains shared libraries without run_exports defined: {libs:?}\n\
+        Add run_exports to ensure that packages linking against these libraries \
+        automatically get this package as a runtime dependency."
+    )]
+    MissingRunExports { libs: Vec<PathBuf> },
 
     #[error("failed to build glob from pattern")]
     GlobError(#[from] globset::Error),
@@ -110,6 +117,54 @@ impl fmt::Display for LinkedPackage {
             }
         }
     }
+}
+
+/// Returns the relative paths of shared libraries in the package that would
+/// typically need run_exports to be defined. This excludes:
+/// - Python extension modules (under `site-packages/` or `.pyd` files)
+/// - R library extensions (under `lib/R/library/`)
+///
+/// These are the files that, if present without run_exports, may cause other
+/// packages that link against them to have unsatisfied runtime dependencies.
+pub fn find_shared_libs_needing_run_exports(
+    new_files: &HashSet<PathBuf>,
+    tmp_prefix: &Path,
+) -> Vec<PathBuf> {
+    let mut libs: Vec<PathBuf> = new_files
+        .iter()
+        .filter_map(|file| {
+            let rel_path = file.strip_prefix(tmp_prefix).unwrap_or(file);
+            if !is_dso(rel_path) {
+                return None;
+            }
+            // Skip Windows Python extension modules
+            if rel_path
+                .extension()
+                .is_some_and(|e| e.eq_ignore_ascii_case("pyd"))
+            {
+                return None;
+            }
+            // Skip Python extension modules under site-packages/
+            if rel_path
+                .components()
+                .any(|c| c.as_os_str() == "site-packages")
+            {
+                return None;
+            }
+            // Skip R library extensions under lib/R/library/
+            let components: Vec<_> = rel_path.components().collect();
+            if components.windows(3).any(|w| {
+                w[0].as_os_str() == "lib"
+                    && w[1].as_os_str() == "R"
+                    && w[2].as_os_str() == "library"
+            }) {
+                return None;
+            }
+            Some(rel_path.to_path_buf())
+        })
+        .collect();
+    libs.sort();
+    libs
 }
 
 /// Returns run dependencies that originated from host run_exports and are DSO
@@ -732,6 +787,34 @@ pub fn perform_linking_checks(
             output.record_warning(&format!("Overdepending against {host_package}"));
         }
     }
+
+    // Check if the package contains shared libraries but has no run_exports defined.
+    // Shared libraries should declare run_exports so that packages linking against
+    // them automatically receive this package as a runtime dependency.
+    let run_exports = &output.recipe.requirements().run_exports;
+    if run_exports.is_empty() {
+        let shared_libs = find_shared_libs_needing_run_exports(new_files, tmp_prefix);
+        if !shared_libs.is_empty() {
+            let lib_list = shared_libs
+                .iter()
+                .map(|p| p.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            let warn_str = format!(
+                "Package contains shared libraries ({lib_list}) but has no run_exports defined. \
+                Consider adding run_exports so that packages linking against these libraries \
+                automatically get this package as a runtime dependency."
+            );
+            if dynamic_linking.missing_run_exports_behavior == LinkingCheckBehavior::Error {
+                tracing::error!("{warn_str}");
+                return Err(LinkingCheckError::MissingRunExports { libs: shared_libs });
+            } else {
+                tracing::warn!("{warn_str}");
+                output.record_warning(&warn_str);
+            }
+        }
+    }
+
     Ok(())
 }
 
@@ -1094,5 +1177,98 @@ mod tests {
         let result = validate_dsolist_files(tmp.path());
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Failed to parse"));
+    }
+
+    #[test]
+    fn test_find_shared_libs_needing_run_exports_dso_in_lib() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut new_files = HashSet::new();
+        new_files.insert(tmp.path().join("lib/libfoo.so.1.0"));
+        new_files.insert(tmp.path().join("lib/libfoo.dylib"));
+        new_files.insert(tmp.path().join("Library/bin/foo.dll"));
+
+        let result = find_shared_libs_needing_run_exports(&new_files, tmp.path());
+        assert_eq!(result.len(), 3, "Expected all 3 DSOs to need run_exports");
+        assert!(result.contains(&PathBuf::from("lib/libfoo.so.1.0")));
+        assert!(result.contains(&PathBuf::from("lib/libfoo.dylib")));
+        assert!(result.contains(&PathBuf::from("Library/bin/foo.dll")));
+    }
+
+    #[test]
+    fn test_find_shared_libs_needing_run_exports_no_dso() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut new_files = HashSet::new();
+        new_files.insert(tmp.path().join("bin/myapp"));
+        new_files.insert(tmp.path().join("lib/python3.10/foo.py"));
+
+        let result = find_shared_libs_needing_run_exports(&new_files, tmp.path());
+        assert!(result.is_empty(), "Executables and scripts should not trigger");
+    }
+
+    #[test]
+    fn test_find_shared_libs_needing_run_exports_skips_site_packages() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut new_files = HashSet::new();
+        // Python extension on Linux under site-packages
+        new_files.insert(
+            tmp.path()
+                .join("lib/python3.10/site-packages/foo.cpython-310-x86_64-linux-gnu.so"),
+        );
+        // Python extension on macOS under site-packages
+        new_files.insert(
+            tmp.path()
+                .join("lib/python3.10/site-packages/bar.cpython-310-darwin.so"),
+        );
+
+        let result = find_shared_libs_needing_run_exports(&new_files, tmp.path());
+        assert!(
+            result.is_empty(),
+            "Python extensions under site-packages should be skipped"
+        );
+    }
+
+    #[test]
+    fn test_find_shared_libs_needing_run_exports_skips_r_library() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut new_files = HashSet::new();
+        new_files.insert(tmp.path().join("lib/R/library/Rcpp/libs/Rcpp.so"));
+
+        let result = find_shared_libs_needing_run_exports(&new_files, tmp.path());
+        assert!(
+            result.is_empty(),
+            "R library extensions should be skipped"
+        );
+    }
+
+    #[test]
+    fn test_find_shared_libs_needing_run_exports_skips_pyd() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut new_files = HashSet::new();
+        // Windows Python extension module
+        new_files.insert(tmp.path().join("Lib/site-packages/foo/bar.pyd"));
+        // Another .pyd outside site-packages (still a Python extension)
+        new_files.insert(tmp.path().join("lib/foo.pyd"));
+
+        let result = find_shared_libs_needing_run_exports(&new_files, tmp.path());
+        assert!(result.is_empty(), ".pyd files should always be skipped");
+    }
+
+    #[test]
+    fn test_find_shared_libs_needing_run_exports_mixed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut new_files = HashSet::new();
+        // A real shared library that should trigger the warning
+        new_files.insert(tmp.path().join("lib/libfoo.so.1"));
+        // A Python extension that should be skipped
+        new_files.insert(
+            tmp.path()
+                .join("lib/python3.10/site-packages/foo/_foo.so"),
+        );
+        // An executable that should be skipped
+        new_files.insert(tmp.path().join("bin/foo"));
+
+        let result = find_shared_libs_needing_run_exports(&new_files, tmp.path());
+        assert_eq!(result.len(), 1, "Only the real DSO should be returned");
+        assert_eq!(result[0], PathBuf::from("lib/libfoo.so.1"));
     }
 }

--- a/crates/rattler_build_recipe/src/stage0/build.rs
+++ b/crates/rattler_build_recipe/src/stage0/build.rs
@@ -146,6 +146,10 @@ pub struct DynamicLinking {
     /// What to do when detecting overlinking
     #[serde(default)]
     pub overlinking_behavior: Option<Value<String>>,
+
+    /// What to do when a package contains shared libraries but no run_exports are defined
+    #[serde(default)]
+    pub missing_run_exports_behavior: Option<Value<String>>,
 }
 
 /// Force file type configuration for prefix detection
@@ -345,6 +349,7 @@ impl Build {
             rpath_allowlist,
             overdepending_behavior,
             overlinking_behavior,
+            missing_run_exports_behavior,
         } = dynamic_linking;
 
         vars.extend(rpaths.used_variables());
@@ -369,6 +374,10 @@ impl Build {
 
         if let Some(overlinking_behavior) = overlinking_behavior {
             vars.extend(overlinking_behavior.used_variables());
+        }
+
+        if let Some(missing_run_exports_behavior) = missing_run_exports_behavior {
+            vars.extend(missing_run_exports_behavior.used_variables());
         }
 
         // Variant

--- a/crates/rattler_build_recipe/src/stage0/evaluate.rs
+++ b/crates/rattler_build_recipe/src/stage0/evaluate.rs
@@ -1984,6 +1984,28 @@ impl Evaluate for Stage0DynamicLinking {
             }
         };
 
+        // Parse missing_run_exports_behavior
+        let missing_run_exports_behavior = match &self.missing_run_exports_behavior {
+            None => LinkingCheckBehavior::Ignore,
+            Some(v) => {
+                let s = evaluate_value_to_string(v, context)?;
+                match s.as_str() {
+                    "ignore" => LinkingCheckBehavior::Ignore,
+                    "error" => LinkingCheckBehavior::Error,
+                    _ => {
+                        return Err(ParseError::invalid_value(
+                            "missing_run_exports_behavior",
+                            format!(
+                                "Invalid missing_run_exports_behavior '{}'. Expected 'ignore' or 'error'",
+                                s
+                            ),
+                            Span::new_blank(),
+                        ));
+                    }
+                }
+            }
+        };
+
         Ok(Stage1DynamicLinking {
             rpaths: Rpaths::new(evaluate_string_list(&self.rpaths, context)?),
             binary_relocation,
@@ -1991,6 +2013,7 @@ impl Evaluate for Stage0DynamicLinking {
             rpath_allowlist,
             overdepending_behavior,
             overlinking_behavior,
+            missing_run_exports_behavior,
         })
     }
 }

--- a/crates/rattler_build_recipe/src/stage0/parser/build.rs
+++ b/crates/rattler_build_recipe/src/stage0/parser/build.rs
@@ -510,10 +510,16 @@ fn parse_dynamic_linking(node: &Node) -> Result<DynamicLinking, ParseError> {
                     value_node
                 ));
             }
+            "missing_run_exports_behavior" => {
+                dynamic_linking.missing_run_exports_behavior = Some(parse_field!(
+                    "dynamic_linking.missing_run_exports_behavior",
+                    value_node
+                ));
+            }
             _ => {
                 return Err(
                     ParseError::invalid_value("dynamic_linking", format!("unknown field '{}'", key), *key_node.span())
-                        .with_suggestion("Valid fields are: rpaths, binary_relocation, missing_dso_allowlist, rpath_allowlist, overdepending_behavior, overlinking_behavior")
+                        .with_suggestion("Valid fields are: rpaths, binary_relocation, missing_dso_allowlist, rpath_allowlist, overdepending_behavior, overlinking_behavior, missing_run_exports_behavior")
                 );
             }
         }

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__complex_recipe_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__complex_recipe_snapshot.snap
@@ -27,6 +27,7 @@ build:
     rpath_allowlist: []
     overdepending_behavior: null
     overlinking_behavior: null
+    missing_run_exports_behavior: null
   variant:
     use_keys: []
     ignore_keys: []

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__conditionals_recipe_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__conditionals_recipe_snapshot.snap
@@ -27,6 +27,7 @@ build:
     rpath_allowlist: []
     overdepending_behavior: null
     overlinking_behavior: null
+    missing_run_exports_behavior: null
   variant:
     use_keys: []
     ignore_keys: []

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__full_recipe_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__full_recipe_snapshot.snap
@@ -27,6 +27,7 @@ build:
     rpath_allowlist: []
     overdepending_behavior: null
     overlinking_behavior: null
+    missing_run_exports_behavior: null
   variant:
     use_keys: []
     ignore_keys: []

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__license_files_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__license_files_snapshot.snap
@@ -27,6 +27,7 @@ build:
     rpath_allowlist: []
     overdepending_behavior: null
     overlinking_behavior: null
+    missing_run_exports_behavior: null
   variant:
     use_keys: []
     ignore_keys: []

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__minimal_recipe_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__minimal_recipe_snapshot.snap
@@ -27,6 +27,7 @@ build:
     rpath_allowlist: []
     overdepending_behavior: null
     overlinking_behavior: null
+    missing_run_exports_behavior: null
   variant:
     use_keys: []
     ignore_keys: []

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__multi_output_conditionals_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__multi_output_conditionals_snapshot.snap
@@ -28,6 +28,7 @@ build:
     rpath_allowlist: []
     overdepending_behavior: null
     overlinking_behavior: null
+    missing_run_exports_behavior: null
   variant:
     use_keys: []
     ignore_keys: []
@@ -106,6 +107,7 @@ outputs:
       rpath_allowlist: []
       overdepending_behavior: null
       overlinking_behavior: null
+      missing_run_exports_behavior: null
     variant:
       use_keys: []
       ignore_keys: []

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__multi_output_full_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__multi_output_full_snapshot.snap
@@ -35,6 +35,7 @@ build:
     rpath_allowlist: []
     overdepending_behavior: null
     overlinking_behavior: null
+    missing_run_exports_behavior: null
   variant:
     use_keys: []
     ignore_keys: []
@@ -123,6 +124,7 @@ outputs:
       rpath_allowlist: []
       overdepending_behavior: null
       overlinking_behavior: null
+      missing_run_exports_behavior: null
     variant:
       use_keys: []
       ignore_keys: []
@@ -176,6 +178,7 @@ outputs:
       rpath_allowlist: []
       overdepending_behavior: null
       overlinking_behavior: null
+      missing_run_exports_behavior: null
     variant:
       use_keys: []
       ignore_keys: []
@@ -231,6 +234,7 @@ outputs:
       rpath_allowlist: []
       overdepending_behavior: null
       overlinking_behavior: null
+      missing_run_exports_behavior: null
     variant:
       use_keys: []
       ignore_keys: []

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__multi_output_minimal_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__multi_output_minimal_snapshot.snap
@@ -32,6 +32,7 @@ build:
     rpath_allowlist: []
     overdepending_behavior: null
     overlinking_behavior: null
+    missing_run_exports_behavior: null
   variant:
     use_keys: []
     ignore_keys: []
@@ -99,6 +100,7 @@ outputs:
       rpath_allowlist: []
       overdepending_behavior: null
       overlinking_behavior: null
+      missing_run_exports_behavior: null
     variant:
       use_keys: []
       ignore_keys: []

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__multi_output_templates_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__multi_output_templates_snapshot.snap
@@ -34,6 +34,7 @@ build:
     rpath_allowlist: []
     overdepending_behavior: null
     overlinking_behavior: null
+    missing_run_exports_behavior: null
   variant:
     use_keys: []
     ignore_keys: []
@@ -103,6 +104,7 @@ outputs:
       rpath_allowlist: []
       overdepending_behavior: null
       overlinking_behavior: null
+      missing_run_exports_behavior: null
     variant:
       use_keys: []
       ignore_keys: []
@@ -151,6 +153,7 @@ outputs:
       rpath_allowlist: []
       overdepending_behavior: null
       overlinking_behavior: null
+      missing_run_exports_behavior: null
     variant:
       use_keys: []
       ignore_keys: []

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__multi_output_top_level_inherit_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__multi_output_top_level_inherit_snapshot.snap
@@ -33,6 +33,7 @@ build:
     rpath_allowlist: []
     overdepending_behavior: null
     overlinking_behavior: null
+    missing_run_exports_behavior: null
   variant:
     use_keys: []
     ignore_keys: []
@@ -83,6 +84,7 @@ outputs:
       rpath_allowlist: []
       overdepending_behavior: null
       overlinking_behavior: null
+      missing_run_exports_behavior: null
     variant:
       use_keys: []
       ignore_keys: []
@@ -136,6 +138,7 @@ outputs:
       rpath_allowlist: []
       overdepending_behavior: null
       overlinking_behavior: null
+      missing_run_exports_behavior: null
     variant:
       use_keys: []
       ignore_keys: []
@@ -190,6 +193,7 @@ outputs:
       rpath_allowlist: []
       overdepending_behavior: null
       overlinking_behavior: null
+      missing_run_exports_behavior: null
     variant:
       use_keys: []
       ignore_keys: []

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__run_exports_recipe_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__run_exports_recipe_snapshot.snap
@@ -27,6 +27,7 @@ build:
     rpath_allowlist: []
     overdepending_behavior: null
     overlinking_behavior: null
+    missing_run_exports_behavior: null
   variant:
     use_keys: []
     ignore_keys: []

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__script_parsing_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__script_parsing_snapshot.snap
@@ -27,6 +27,7 @@ build:
     rpath_allowlist: []
     overdepending_behavior: null
     overlinking_behavior: null
+    missing_run_exports_behavior: null
   variant:
     use_keys: []
     ignore_keys: []

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__single_output_compatibility.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__single_output_compatibility.snap
@@ -27,6 +27,7 @@ build:
     rpath_allowlist: []
     overdepending_behavior: null
     overlinking_behavior: null
+    missing_run_exports_behavior: null
   variant:
     use_keys: []
     ignore_keys: []

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__templates_recipe_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__templates_recipe_snapshot.snap
@@ -27,6 +27,7 @@ build:
     rpath_allowlist: []
     overdepending_behavior: null
     overlinking_behavior: null
+    missing_run_exports_behavior: null
   variant:
     use_keys: []
     ignore_keys: []

--- a/crates/rattler_build_recipe/src/stage0/snapshots/rattler_build_recipe__stage0__test__roundtrip.snap
+++ b/crates/rattler_build_recipe/src/stage0/snapshots/rattler_build_recipe__stage0__test__roundtrip.snap
@@ -27,6 +27,7 @@ build:
     rpath_allowlist: []
     overdepending_behavior: null
     overlinking_behavior: null
+    missing_run_exports_behavior: null
   variant:
     use_keys: []
     ignore_keys: []

--- a/crates/rattler_build_recipe/src/stage1/build.rs
+++ b/crates/rattler_build_recipe/src/stage1/build.rs
@@ -387,6 +387,11 @@ pub struct DynamicLinking {
     /// What to do when detecting overlinking (ignore or error)
     #[serde(default, skip_serializing_if = "LinkingCheckBehavior::is_ignore")]
     pub overlinking_behavior: LinkingCheckBehavior,
+
+    /// What to do when a package contains shared libraries but no run_exports are defined.
+    /// By default this emits a warning; set to "error" to fail the build.
+    #[serde(default, skip_serializing_if = "LinkingCheckBehavior::is_ignore")]
+    pub missing_run_exports_behavior: LinkingCheckBehavior,
 }
 
 impl Default for DynamicLinking {
@@ -398,6 +403,7 @@ impl Default for DynamicLinking {
             rpath_allowlist: GlobVec::default(),
             overdepending_behavior: LinkingCheckBehavior::default(),
             overlinking_behavior: LinkingCheckBehavior::default(),
+            missing_run_exports_behavior: LinkingCheckBehavior::default(),
         }
     }
 }
@@ -411,6 +417,7 @@ impl DynamicLinking {
             && self.rpath_allowlist.is_empty()
             && self.overdepending_behavior.is_ignore()
             && self.overlinking_behavior.is_ignore()
+            && self.missing_run_exports_behavior.is_ignore()
     }
 }
 


### PR DESCRIPTION
## Summary
This PR adds a new linking check to detect when packages contain shared libraries (DSOs) but don't define `run_exports`. This helps ensure that packages linking against these libraries automatically receive the package as a runtime dependency.

## Key Changes

- **New linking check**: Added `find_shared_libs_needing_run_exports()` function that identifies shared libraries requiring `run_exports`, while intelligently excluding:
  - Python extension modules (`.pyd` files and modules under `site-packages/`)
  - R library extensions (under `lib/R/library/`)

- **New error type**: Added `LinkingCheckError::MissingRunExports` variant to report packages with shared libraries but no `run_exports`

- **Configuration option**: Added `missing_run_exports_behavior` field to `DynamicLinking` configuration, allowing users to set the behavior to either:
  - `ignore` (default): Emit a warning
  - `error`: Fail the build

- **Check implementation**: Integrated the check into `perform_linking_checks()` to validate that packages with shared libraries have `run_exports` defined

- **Comprehensive tests**: Added 5 test cases covering:
  - Detection of DSOs in standard library locations
  - Filtering of non-DSO files
  - Proper exclusion of Python extensions under `site-packages/`
  - Proper exclusion of R library extensions
  - Proper exclusion of `.pyd` files
  - Mixed scenarios with multiple file types

## Implementation Details

- The check only runs when `run_exports` is empty, avoiding false positives for packages that already declare exports
- Relative paths are used for clearer error messages
- Results are sorted for consistent output
- The feature integrates seamlessly with existing linking check infrastructure

https://claude.ai/code/session_01Px87wX5kWdDnJwgy21irV4