### PR TITLE
feat: add timestamp option to build command

### DIFF
--- a/py-rattler-build/rust/src/cli_api.rs
+++ b/py-rattler-build/rust/src/cli_api.rs
@@ -142,6 +142,7 @@ pub fn build_recipes_py(
         exclude_newer,
         build_num,
         None, // markdown_summary
+        None, // timestamp
     );
 
     run_async_task(async {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -444,7 +444,7 @@ pub async fn get_build_output(
         .or_else(|| outputs_and_variants.first().map(|o| o.name.clone()))
         .unwrap_or_else(|| "build".to_string());
 
-    let timestamp = chrono::Utc::now();
+    let timestamp = build_data.timestamp.unwrap_or_else(chrono::Utc::now);
 
     for discovered_output in outputs_and_variants {
         let recipe = &discovered_output.recipe;
@@ -1581,6 +1581,7 @@ pub async fn debug_recipe(
         exclude_newer: None,
         build_num_override: None,
         markdown_summary: None,
+        timestamp: None,
     };
 
     let tool_config = get_tool_config(&build_data, log_handler)?;

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -710,6 +710,12 @@ pub struct BuildOpts {
     /// Override the build number for all outputs (defaults to the build number in the recipe)
     #[arg(long, help_heading = "Modifying result")]
     pub build_num: Option<u64>,
+
+    /// Set the timestamp for the build. This is used as SOURCE_DATE_EPOCH and for the build
+    /// directory name. Accepts either a Unix epoch in seconds (e.g. 1700000000) or an RFC3339
+    /// timestamp (e.g. 2024-03-15T12:00:00Z). Defaults to the current time.
+    #[arg(long, help_heading = "Modifying result", value_parser = parse_timestamp)]
+    pub timestamp: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 /// Publish options for the `publish` command.
@@ -892,6 +898,7 @@ pub struct BuildData {
     pub exclude_newer: Option<chrono::DateTime<chrono::Utc>>,
     pub build_num_override: Option<u64>,
     pub markdown_summary: Option<PathBuf>,
+    pub timestamp: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 impl BuildData {
@@ -929,6 +936,7 @@ impl BuildData {
         exclude_newer: Option<chrono::DateTime<chrono::Utc>>,
         build_num_override: Option<u64>,
         markdown_summary: Option<PathBuf>,
+        timestamp: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Self {
         Self {
             up_to,
@@ -970,6 +978,7 @@ impl BuildData {
             exclude_newer,
             build_num_override,
             markdown_summary,
+            timestamp,
         }
     }
 }
@@ -1022,6 +1031,7 @@ impl BuildData {
             opts.exclude_newer,
             opts.build_num,
             opts.markdown_summary,
+            opts.timestamp,
         )
     }
 }
@@ -1067,6 +1077,16 @@ fn parse_datetime(s: &str) -> Result<chrono::DateTime<chrono::Utc>, String> {
                 s, e
             )
         })
+}
+
+fn parse_timestamp(s: &str) -> Result<chrono::DateTime<chrono::Utc>, String> {
+    // First try parsing as a Unix epoch (integer seconds)
+    if let Ok(epoch) = s.parse::<i64>() {
+        return chrono::DateTime::from_timestamp(epoch, 0)
+            .ok_or_else(|| format!("Invalid Unix epoch timestamp: {s}"));
+    }
+    // Fall back to RFC3339
+    parse_datetime(s)
 }
 
 /// Test options.


### PR DESCRIPTION
## Summary
This PR adds a new `--timestamp` option to the build command that allows users to set a custom timestamp for the build. This timestamp is used as `SOURCE_DATE_EPOCH` and for the build directory name, enabling reproducible builds with consistent timestamps.