### PR TITLE
fix!: remove `--debug` from CLI and Python API

### DIFF
--- a/crates/rattler_build_core/src/build.rs
+++ b/crates/rattler_build_core/src/build.rs
@@ -183,12 +183,6 @@ pub async fn run_build(
 
     match output.run_build_script().await {
         Ok(_) => {}
-        Err(InterpreterError::Debug(info)) => {
-            tracing::info!("{}", info);
-            return Err(miette::miette!(
-                "Script not executed because debug mode is enabled"
-            ));
-        }
         Err(InterpreterError::ExecutionFailed(_)) => {
             return Err(miette::miette!("Script failed to execute"));
         }

--- a/crates/rattler_build_core/src/metadata.rs
+++ b/crates/rattler_build_core/src/metadata.rs
@@ -1,6 +1,6 @@
 //! All the metadata that makes up a recipe file
 pub use crate::types::{
-    BuildConfiguration, Debug, Output, PlatformWithVirtualPackages, build_reindexed_channels,
+    BuildConfiguration, Output, PlatformWithVirtualPackages, build_reindexed_channels,
 };
 
 #[cfg(test)]

--- a/crates/rattler_build_core/src/package_test/run_test.rs
+++ b/crates/rattler_build_core/src/package_test/run_test.rs
@@ -11,7 +11,7 @@ use rattler_build_recipe::stage1::{
     TestType,
     tests::{CommandsTest, DownstreamTest, PerlTest, PythonTest, PythonVersion, RTest, RubyTest},
 };
-use rattler_build_script::{Debug as ScriptDebug, Script, ScriptContent};
+use rattler_build_script::{Script, ScriptContent};
 use rattler_conda_types::{
     Channel, ChannelUrl, MatchSpec, ParseStrictness, Platform,
     compression_level::CompressionLevel,
@@ -38,11 +38,8 @@ use rattler::package_cache::PackageCache;
 use rattler_cache::validation::ValidationMode;
 
 use crate::{
-    env_vars,
-    metadata::{Debug, PlatformWithVirtualPackages},
-    render::solver::create_environment,
-    source::copy_dir::CopyDir,
-    tool_configuration,
+    env_vars, metadata::PlatformWithVirtualPackages, render::solver::create_environment,
+    source::copy_dir::CopyDir, tool_configuration,
 };
 
 #[allow(missing_docs)]
@@ -201,7 +198,6 @@ impl Tests {
                         None,
                         None::<fn(&str) -> Result<String, String>>,
                         None,
-                        ScriptDebug::new(false),
                     )
                     .await
                     .map_err(|e| TestError::TestFailed(e.to_string()))?;
@@ -222,7 +218,6 @@ impl Tests {
                         None,
                         None::<fn(&str) -> Result<String, String>>,
                         None,
-                        ScriptDebug::new(false),
                     )
                     .await
                     .map_err(|e| TestError::TestFailed(e.to_string()))?;
@@ -291,8 +286,6 @@ pub struct TestConfiguration {
     pub tool_configuration: tool_configuration::Configuration,
     /// The output directory to create the test prefixes in (will be `output_dir/test`)
     pub output_dir: PathBuf,
-    /// Debug mode yes, or no
-    pub debug: Debug,
     /// Exclude packages newer than this date from the solver
     pub exclude_newer: Option<chrono::DateTime<chrono::Utc>>,
 }
@@ -751,7 +744,6 @@ async fn run_python_test_inner(
             None,
             None::<fn(&str) -> Result<String, String>>,
             None,
-            ScriptDebug::new(config.debug.is_enabled()),
         )
         .await
         .map_err(|e| TestError::TestFailed(e.to_string()))?;
@@ -775,7 +767,6 @@ async fn run_python_test_inner(
                 None,
                 None::<fn(&str) -> Result<String, String>>,
                 None,
-                ScriptDebug::new(config.debug.is_enabled()),
             )
             .await
             .map_err(|e| TestError::TestFailed(e.to_string()))?;
@@ -858,7 +849,6 @@ async fn run_perl_test(
             None,
             None::<fn(&str) -> Result<String, String>>,
             None,
-            ScriptDebug::new(config.debug.is_enabled()),
         )
         .await
         .map_err(|e| TestError::TestFailed(e.to_string()))?;
@@ -977,7 +967,6 @@ async fn run_commands_test(
             build_prefix.as_ref(),
             None::<fn(&str) -> Result<String, String>>,
             None,
-            ScriptDebug::new(config.debug.is_enabled()),
         )
         .await
         .map_err(|e| TestError::TestFailed(e.to_string()))?;
@@ -1162,7 +1151,6 @@ async fn run_r_test(
             None,
             None::<fn(&str) -> Result<String, String>>,
             None,
-            ScriptDebug::new(config.debug.is_enabled()),
         )
         .await
         .map_err(|e| TestError::TestFailed(e.to_string()))?;
@@ -1240,7 +1228,6 @@ async fn run_ruby_test(
             None,
             None::<fn(&str) -> Result<String, String>>,
             None,
-            ScriptDebug::new(config.debug.is_enabled()),
         )
         .await
         .map_err(|e| TestError::TestFailed(e.to_string()))?;

--- a/crates/rattler_build_core/src/script.rs
+++ b/crates/rattler_build_core/src/script.rs
@@ -11,8 +11,8 @@ use std::{collections::HashMap, collections::HashSet};
 
 // Re-export from rattler_build_script
 pub use rattler_build_script::{
-    Debug as ScriptDebug, ExecutionArgs, InterpreterError, ResolvedScriptContents,
-    SandboxArguments, SandboxConfiguration, Script, ScriptContent,
+    ExecutionArgs, InterpreterError, ResolvedScriptContents, SandboxArguments,
+    SandboxConfiguration, Script, ScriptContent,
 };
 
 use crate::{
@@ -78,7 +78,6 @@ impl Output {
             execution_platform: Platform::current(),
             work_dir: work_dir.clone(),
             sandbox_config: self.build_configuration.sandbox_config().cloned(),
-            debug: ScriptDebug::new(self.build_configuration.debug.is_enabled()),
         })
     }
 
@@ -135,7 +134,6 @@ impl Output {
                 build_prefix,
                 Some(jinja_renderer),
                 self.build_configuration.sandbox_config(),
-                ScriptDebug::new(self.build_configuration.debug.is_enabled()),
             )
             .await?;
 

--- a/crates/rattler_build_core/src/staging.rs
+++ b/crates/rattler_build_core/src/staging.rs
@@ -14,7 +14,6 @@ use miette::{Context, IntoDiagnostic};
 use minijinja::Value;
 use rattler_build_jinja::{Jinja, Variable};
 use rattler_build_recipe::stage1::{InheritsFrom, StagingCache};
-use rattler_build_script::Debug as ScriptDebug;
 use rattler_build_types::NormalizedKey;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -298,7 +297,6 @@ impl Output {
                 build_prefix,
                 Some(jinja_renderer),
                 self.build_configuration.sandbox_config(),
-                ScriptDebug::new(self.build_configuration.debug.is_enabled()),
             )
             .await
             .into_diagnostic()?;

--- a/crates/rattler_build_core/src/types/build_configuration.rs
+++ b/crates/rattler_build_core/src/types/build_configuration.rs
@@ -9,7 +9,7 @@ use rattler_solve::{ChannelPriority, SolveStrategy};
 use serde::{Deserialize, Serialize};
 
 use crate::types::{
-    Debug, Directories, PackageIdentifier, PackagingSettings, PlatformWithVirtualPackages,
+    Directories, PackageIdentifier, PackagingSettings, PlatformWithVirtualPackages,
 };
 
 use rattler_build_script::SandboxConfiguration;
@@ -59,9 +59,6 @@ pub struct BuildConfiguration {
     /// The configuration for the sandbox
     #[serde(skip_serializing, default)]
     pub sandbox_config: Option<SandboxConfiguration>,
-    /// Whether to enable debug output in build scripts
-    #[serde(skip_serializing, default)]
-    pub debug: Debug,
     /// Exclude packages newer than this date from the solver
     #[serde(skip_serializing, default)]
     pub exclude_newer: Option<chrono::DateTime<chrono::Utc>>,

--- a/crates/rattler_build_core/src/types/mod.rs
+++ b/crates/rattler_build_core/src/types/mod.rs
@@ -114,22 +114,6 @@ impl<'de> Deserialize<'de> for PlatformWithVirtualPackages {
     }
 }
 
-/// A newtype wrapper around a boolean indicating whether debug output is enabled
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Debug(bool);
-
-impl Debug {
-    /// Create a new Debug instance
-    pub fn new(debug: bool) -> Self {
-        Self(debug)
-    }
-
-    /// Returns true if debug output is enabled
-    pub fn is_enabled(&self) -> bool {
-        self.0
-    }
-}
-
 /// A package identifier
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PackageIdentifier {

--- a/crates/rattler_build_script/src/execution.rs
+++ b/crates/rattler_build_script/src/execution.rs
@@ -38,9 +38,6 @@ pub struct ExecutionArgs {
 
     /// The sandbox configuration to use for the script execution
     pub sandbox_config: Option<SandboxConfiguration>,
-
-    /// Whether to enable debug output
-    pub debug: Debug,
 }
 
 impl ExecutionArgs {
@@ -116,28 +113,6 @@ impl ResolvedScriptContents {
     }
 }
 
-/// Debug mode for script execution
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Debug(bool);
-
-impl Debug {
-    /// Create a new Debug mode
-    pub fn new(enabled: bool) -> Self {
-        Self(enabled)
-    }
-
-    /// Check if debug mode is enabled
-    pub fn is_enabled(&self) -> bool {
-        self.0
-    }
-}
-
-impl From<bool> for Debug {
-    fn from(enabled: bool) -> Self {
-        Self(enabled)
-    }
-}
-
 impl Script {
     /// Run the script with the given parameters
     ///
@@ -157,7 +132,6 @@ impl Script {
         build_prefix: Option<&PathBuf>,
         jinja_renderer: Option<F>,
         sandbox_config: Option<&SandboxConfiguration>,
-        debug: Debug,
     ) -> Result<(), crate::InterpreterError>
     where
         F: Fn(&str) -> Result<String, String>,
@@ -226,7 +200,6 @@ impl Script {
             execution_platform: Platform::current(),
             work_dir,
             sandbox_config: sandbox_config.cloned(),
-            debug,
         };
 
         crate::execution::run_script(exec_args, interpreter).await?;

--- a/crates/rattler_build_script/src/interpreter/bash.rs
+++ b/crates/rattler_build_script/src/interpreter/bash.rs
@@ -12,11 +12,7 @@ pub struct BashInterpreter;
 fn print_debug_info(args: &ExecutionArgs) -> String {
     let mut output = String::new();
 
-    if args.debug.is_enabled() {
-        output.push_str("\nDebug mode enabled - not executing the script.\n\n");
-    } else {
-        output.push_str("\nScript execution failed.\n\n");
-    }
+    output.push_str("\nScript execution failed.\n\n");
 
     output.push_str(&format!("  Work directory: {}\n", args.work_dir.display()));
     output.push_str(&format!("  Prefix: {}\n", args.run_prefix.display()));
@@ -57,15 +53,7 @@ impl Interpreter for BashInterpreter {
         }
 
         let build_script_path_str = build_script_path.to_string_lossy().to_string();
-        let mut cmd_args = vec!["bash"];
-        if args.debug.is_enabled() {
-            cmd_args.push("-x");
-        }
-        cmd_args.push(&build_script_path_str);
-
-        if args.debug.is_enabled() {
-            return Err(InterpreterError::Debug(print_debug_info(&args)));
-        }
+        let cmd_args = vec!["bash", &build_script_path_str];
 
         let output = run_process_with_replacements(
             &cmd_args,

--- a/crates/rattler_build_script/src/interpreter/cmd_exe.rs
+++ b/crates/rattler_build_script/src/interpreter/cmd_exe.rs
@@ -9,11 +9,8 @@ use super::{CMDEXE_PREAMBLE, Interpreter, InterpreterError, find_interpreter};
 
 fn print_debug_info(args: &ExecutionArgs) -> String {
     let mut output = String::new();
-    if args.debug.is_enabled() {
-        output.push_str("\nDebug mode enabled - not executing the script.\n\n");
-    } else {
-        output.push_str("\nScript execution failed.\n\n")
-    }
+
+    output.push_str("\nScript execution failed.\n\n");
 
     output.push_str(&format!("  Work directory: {}\n", args.work_dir.display()));
     output.push_str(&format!("  Prefix: {}\n", args.run_prefix.display()));
@@ -59,10 +56,6 @@ impl Interpreter for CmdExeInterpreter {
 
         let build_script_path_str = build_script_path.to_string_lossy().to_string();
         let cmd_args = ["cmd.exe", "/d", "/c", &build_script_path_str];
-
-        if args.debug.is_enabled() {
-            return Err(InterpreterError::Debug(print_debug_info(&args)));
-        }
 
         let output = run_process_with_replacements(
             &cmd_args,

--- a/crates/rattler_build_script/src/interpreter/mod.rs
+++ b/crates/rattler_build_script/src/interpreter/mod.rs
@@ -34,10 +34,6 @@ use crate::execution::ExecutionArgs;
 /// The error type for the interpreter
 #[derive(Debug, thiserror::Error)]
 pub enum InterpreterError {
-    /// This error is returned when running in debug mode
-    #[error("Debugging information: {0}")]
-    Debug(String),
-
     /// This error is returned when the script execution fails or the
     /// interpreter is not found
     #[error("IO Error: {0}")]

--- a/crates/rattler_build_script/src/lib.rs
+++ b/crates/rattler_build_script/src/lib.rs
@@ -17,8 +17,8 @@ mod interpreter;
 
 #[cfg(feature = "execution")]
 pub use execution::{
-    Debug, ExecutionArgs, ResolvedScriptContents, create_build_script,
-    run_process_with_replacements, run_script,
+    ExecutionArgs, ResolvedScriptContents, create_build_script, run_process_with_replacements,
+    run_script,
 };
 #[cfg(feature = "execution")]
 pub use interpreter::InterpreterError;

--- a/docs/reference/cli/rattler-build/build.md
+++ b/docs/reference/cli/rattler-build/build.md
@@ -86,8 +86,6 @@ e.g. `tar-bz2:<number>` (from 1 to 9) or `conda:<number>` (from -7 to
 <br>**options**: `none`, `local`, `all`
 - <a id="arg---noarch-build-platform" href="#arg---noarch-build-platform">`--noarch-build-platform <NOARCH_BUILD_PLATFORM>`</a>
 :  Define a "noarch platform" for which the noarch packages will be built for. The noarch builds will be skipped on the other platforms
-- <a id="arg---debug" href="#arg---debug">`--debug`</a>
-:  Enable debug output in build scripts
 - <a id="arg---markdown-summary" href="#arg---markdown-summary">`--markdown-summary <MARKDOWN_SUMMARY>`</a>
 :  Write a markdown summary to the specified file (appends to the file). Useful for generating PR comments or custom reports
 - <a id="arg---error-prefix-in-binary" href="#arg---error-prefix-in-binary">`--error-prefix-in-binary`</a>

--- a/docs/reference/cli/rattler-build/publish.md
+++ b/docs/reference/cli/rattler-build/publish.md
@@ -92,8 +92,6 @@ e.g. `tar-bz2:<number>` (from 1 to 9) or `conda:<number>` (from -7 to
 <br>**options**: `none`, `local`, `all`
 - <a id="arg---noarch-build-platform" href="#arg---noarch-build-platform">`--noarch-build-platform <NOARCH_BUILD_PLATFORM>`</a>
 :  Define a "noarch platform" for which the noarch packages will be built for. The noarch builds will be skipped on the other platforms
-- <a id="arg---debug" href="#arg---debug">`--debug`</a>
-:  Enable debug output in build scripts
 - <a id="arg---markdown-summary" href="#arg---markdown-summary">`--markdown-summary <MARKDOWN_SUMMARY>`</a>
 :  Write a markdown summary to the specified file (appends to the file). Useful for generating PR comments or custom reports
 - <a id="arg---error-prefix-in-binary" href="#arg---error-prefix-in-binary">`--error-prefix-in-binary`</a>

--- a/docs/reference/cli/rattler-build/test.md
+++ b/docs/reference/cli/rattler-build/test.md
@@ -23,8 +23,6 @@ rattler-build test [OPTIONS] --package-file <PACKAGE_FILE>
 <br>**env**: `RATTLER_COMPRESSION_THREADS`
 - <a id="arg---test-index" href="#arg---test-index">`--test-index <TEST_INDEX>`</a>
 :  The index of the test to run. This is used to run a specific test from the package
-- <a id="arg---debug" href="#arg---debug">`--debug`</a>
-:  Build test environment and output debug information for manual debugging
 - <a id="arg---experimental" href="#arg---experimental">`--experimental`</a>
 :  Enable experimental features
 <br>**env**: `RATTLER_BUILD_EXPERIMENTAL`

--- a/py-rattler-build/rust/src/build.rs
+++ b/py-rattler-build/rust/src/build.rs
@@ -91,7 +91,6 @@ pub fn build_rendered_variant_py(
     no_build_id: bool,
     package_format: Option<String>,
     no_include_recipe: bool,
-    debug: bool,
     exclude_newer: Option<chrono::DateTime<chrono::Utc>>,
 ) -> PyResult<BuildResultPy> {
     let tool_config = tool_config.inner;
@@ -218,7 +217,6 @@ pub fn build_rendered_variant_py(
             store_recipe: !effective_no_include_recipe,
             force_colors: false, // Set to false for Python API
             sandbox_config: None,
-            debug: ::rattler_build::metadata::Debug::new(debug),
             exclude_newer,
         },
         finalized_dependencies: None,

--- a/py-rattler-build/rust/src/cli_api.rs
+++ b/py-rattler-build/rust/src/cli_api.rs
@@ -6,7 +6,6 @@ use std::{collections::HashMap, path::PathBuf, str::FromStr};
 
 use ::rattler_build::{
     build_recipes,
-    metadata::Debug,
     opt::{BuildData, ChannelPriorityWrapper, CommonData, TestData},
     run_test,
     tool_configuration::{ContinueOnFailure, SkipExisting, TestStrategy},
@@ -20,7 +19,7 @@ use crate::error::RattlerBuildError;
 use crate::run_async_task;
 
 #[pyfunction]
-#[pyo3(signature = (recipes, up_to, build_platform, target_platform, host_platform, channel, variant_config, variant_overrides=None, ignore_recipe_variants=false, render_only=false, with_solve=false, keep_build=false, no_build_id=false, package_format=None, compression_threads=None, io_concurrency_limit=None, no_include_recipe=false, test=None, output_dir=None, auth_file=None, channel_priority=None, skip_existing=None, noarch_build_platform=None, allow_insecure_host=None, continue_on_failure=false, debug=false, error_prefix_in_binary=false, allow_symlinks_on_windows=false, allow_absolute_license_paths=false, exclude_newer=None, build_num=None, use_bz2=true, use_zstd=true, use_sharded=true))]
+#[pyo3(signature = (recipes, up_to, build_platform, target_platform, host_platform, channel, variant_config, variant_overrides=None, ignore_recipe_variants=false, render_only=false, with_solve=false, keep_build=false, no_build_id=false, package_format=None, compression_threads=None, io_concurrency_limit=None, no_include_recipe=false, test=None, output_dir=None, auth_file=None, channel_priority=None, skip_existing=None, noarch_build_platform=None, allow_insecure_host=None, continue_on_failure=false, error_prefix_in_binary=false, allow_symlinks_on_windows=false, allow_absolute_license_paths=false, exclude_newer=None, build_num=None, use_bz2=true, use_zstd=true, use_sharded=true))]
 #[allow(clippy::too_many_arguments)]
 pub fn build_recipes_py(
     recipes: Vec<PathBuf>,
@@ -48,7 +47,6 @@ pub fn build_recipes_py(
     noarch_build_platform: Option<String>,
     allow_insecure_host: Option<Vec<String>>,
     continue_on_failure: bool,
-    debug: bool,
     error_prefix_in_binary: bool,
     allow_symlinks_on_windows: bool,
     allow_absolute_license_paths: bool,
@@ -134,7 +132,6 @@ pub fn build_recipes_py(
         noarch_build_platform,
         None, // extra meta
         None, // sandbox configuration
-        Debug::new(debug),
         ContinueOnFailure::from(continue_on_failure),
         error_prefix_in_binary,
         allow_symlinks_on_windows,
@@ -152,7 +149,7 @@ pub fn build_recipes_py(
 
 #[allow(clippy::too_many_arguments)]
 #[pyfunction]
-#[pyo3(signature = (package_file, channel, compression_threads, auth_file, channel_priority, allow_insecure_host=None, debug=false, test_index=None, use_bz2=true, use_zstd=true, use_sharded=true))]
+#[pyo3(signature = (package_file, channel, compression_threads, auth_file, channel_priority, allow_insecure_host=None, test_index=None, use_bz2=true, use_zstd=true, use_sharded=true))]
 pub fn test_package_py(
     package_file: PathBuf,
     channel: Option<Vec<String>>,
@@ -160,7 +157,6 @@ pub fn test_package_py(
     auth_file: Option<PathBuf>,
     channel_priority: Option<String>,
     allow_insecure_host: Option<Vec<String>>,
-    debug: bool,
     test_index: Option<usize>,
     use_bz2: bool,
     use_zstd: bool,
@@ -199,7 +195,6 @@ pub fn test_package_py(
         package_file,
         channel,
         compression_threads,
-        Debug::new(debug),
         test_index,
         common,
     );

--- a/py-rattler-build/rust/src/package.rs
+++ b/py-rattler-build/rust/src/package.rs
@@ -269,14 +269,13 @@ impl PyPackage {
     }
 
     /// Run a specific test by index
-    #[pyo3(signature = (index, channel=None, channel_priority=None, debug=false, auth_file=None, allow_insecure_host=None, compression_threads=None, use_bz2=true, use_zstd=true, use_sharded=true))]
+    #[pyo3(signature = (index, channel=None, channel_priority=None, auth_file=None, allow_insecure_host=None, compression_threads=None, use_bz2=true, use_zstd=true, use_sharded=true))]
     #[allow(clippy::too_many_arguments)]
     fn run_test(
         &self,
         index: usize,
         channel: Option<Vec<String>>,
         channel_priority: Option<String>,
-        debug: bool,
         auth_file: Option<PathBuf>,
         allow_insecure_host: Option<Vec<String>>,
         compression_threads: Option<u32>,
@@ -288,7 +287,6 @@ impl PyPackage {
             Some(index),
             channel,
             channel_priority,
-            debug,
             auth_file,
             allow_insecure_host,
             compression_threads,
@@ -300,13 +298,12 @@ impl PyPackage {
     }
 
     /// Run all tests in the package
-    #[pyo3(signature = (channel=None, channel_priority=None, debug=false, auth_file=None, allow_insecure_host=None, compression_threads=None, use_bz2=true, use_zstd=true, use_sharded=true))]
+    #[pyo3(signature = (channel=None, channel_priority=None, auth_file=None, allow_insecure_host=None, compression_threads=None, use_bz2=true, use_zstd=true, use_sharded=true))]
     #[allow(clippy::too_many_arguments)]
     fn run_tests(
         &self,
         channel: Option<Vec<String>>,
         channel_priority: Option<String>,
-        debug: bool,
         auth_file: Option<PathBuf>,
         allow_insecure_host: Option<Vec<String>>,
         compression_threads: Option<u32>,
@@ -318,7 +315,6 @@ impl PyPackage {
             None,
             channel,
             channel_priority,
-            debug,
             auth_file,
             allow_insecure_host,
             compression_threads,
@@ -486,7 +482,6 @@ impl PyPackage {
         test_index: Option<usize>,
         channel: Option<Vec<String>>,
         channel_priority: Option<String>,
-        debug: bool,
         auth_file: Option<PathBuf>,
         allow_insecure_host: Option<Vec<String>>,
         compression_threads: Option<u32>,
@@ -495,7 +490,6 @@ impl PyPackage {
         use_sharded: bool,
     ) -> PyResult<Vec<PyTestResult>> {
         use ::rattler_build::{
-            metadata::Debug,
             opt::{ChannelPriorityWrapper, CommonData, TestData},
             run_test,
         };
@@ -552,7 +546,6 @@ impl PyPackage {
             self.path.clone(),
             channel,
             compression_threads,
-            Debug::new(debug),
             test_index,
             common,
         );

--- a/py-rattler-build/src/rattler_build/cli_api.py
+++ b/py-rattler-build/src/rattler_build/cli_api.py
@@ -35,7 +35,6 @@ def build_recipes(
     noarch_build_platform: str | None = None,
     allow_insecure_host: list[str] | None = None,
     continue_on_failure: bool = False,
-    debug: bool = False,
     error_prefix_in_binary: bool = False,
     allow_symlinks_on_windows: bool = False,
     allow_absolute_license_paths: bool = False,
@@ -77,7 +76,6 @@ def build_recipes(
         noarch_build_platform: Define a "noarch platform" for which the noarch packages will be built for. The noarch builds will be skipped on the other platforms.
         allow_insecure_host: Allow insecure hosts for the build.
         continue_on_failure: Continue building other recipes even if one fails. (default: False)
-        debug: Enable or disable debug mode. (default: False)
         error_prefix_in_binary: Do not allow the $PREFIX to appear in binary files. (default: False)
         allow_symlinks_on_windows: Allow symlinks on Windows and `noarch` packages. (default: False)
         allow_absolute_license_paths: Allow absolute paths in license files. (default: False)
@@ -122,7 +120,6 @@ def build_recipes(
         noarch_build_platform,
         allow_insecure_host,
         continue_on_failure,
-        debug,
         error_prefix_in_binary,
         allow_symlinks_on_windows,
         allow_absolute_license_paths,
@@ -142,7 +139,6 @@ def test_package(
     auth_file: str | Path | None = None,
     channel_priority: str | None = None,
     allow_insecure_host: list[str] | None = None,
-    debug: bool = False,
     test_index: int | None = None,
     use_bz2: bool = True,
     use_zstd: bool = True,
@@ -161,7 +157,6 @@ def test_package(
         auth_file: The authentication file.
         channel_priority: The channel priority.
         allow_insecure_host: Allow insecure hosts for the build.
-        debug: Enable or disable debug mode. (default: False)
         test_index: The test to run, selected by index. (default: None - run all tests)
         use_bz2: Allow the use of bzip2 compression when downloading repodata. (default: True)
         use_zstd: Allow the use of zstd compression when downloading repodata. (default: True)
@@ -182,7 +177,6 @@ def test_package(
         auth_file,
         channel_priority,
         allow_insecure_host,
-        debug,
         test_index,
         use_bz2,
         use_zstd,

--- a/py-rattler-build/src/rattler_build/package.py
+++ b/py-rattler-build/src/rattler_build/package.py
@@ -223,7 +223,6 @@ class Package:
         *,
         channel: "Sequence[str] | None" = None,
         channel_priority: Literal["disabled", "strict", "flexible"] | None = None,
-        debug: bool = False,
         auth_file: str | Path | None = None,
         allow_insecure_host: "Sequence[str] | None" = None,
         compression_threads: int | None = None,
@@ -237,7 +236,6 @@ class Package:
             index: Index of the test to run (0-based)
             channel: List of channels to use for dependencies
             channel_priority: Channel priority ("disabled", "strict", or "flexible")
-            debug: Enable debug mode (keeps test environment)
             auth_file: Path to authentication file
             allow_insecure_host: List of hosts to allow insecure connections
             compression_threads: Number of compression threads
@@ -263,7 +261,6 @@ class Package:
                 index,
                 channel=list(channel) if channel else None,
                 channel_priority=channel_priority,
-                debug=debug,
                 auth_file=str(auth_file) if auth_file else None,
                 allow_insecure_host=list(allow_insecure_host) if allow_insecure_host else None,
                 compression_threads=compression_threads,
@@ -278,7 +275,6 @@ class Package:
         *,
         channel: "Sequence[str] | None" = None,
         channel_priority: Literal["disabled", "strict", "flexible"] | None = None,
-        debug: bool = False,
         auth_file: str | Path | None = None,
         allow_insecure_host: "Sequence[str] | None" = None,
         compression_threads: int | None = None,
@@ -291,7 +287,6 @@ class Package:
         Args:
             channel: List of channels to use for dependencies
             channel_priority: Channel priority ("disabled", "strict", or "flexible")
-            debug: Enable debug mode (keeps test environment)
             auth_file: Path to authentication file
             allow_insecure_host: List of hosts to allow insecure connections
             compression_threads: Number of compression threads
@@ -315,7 +310,6 @@ class Package:
             for r in self._inner.run_tests(
                 channel=list(channel) if channel else None,
                 channel_priority=channel_priority,
-                debug=debug,
                 auth_file=str(auth_file) if auth_file else None,
                 allow_insecure_host=list(allow_insecure_host) if allow_insecure_host else None,
                 compression_threads=compression_threads,

--- a/py-rattler-build/src/rattler_build/render.py
+++ b/py-rattler-build/src/rattler_build/render.py
@@ -328,7 +328,6 @@ class RenderedVariant:
         no_build_id: bool = False,
         package_format: str | None = None,
         no_include_recipe: bool = False,
-        debug: bool = False,
         exclude_newer: datetime | None = None,
     ) -> BuildResult:
         """Build this rendered variant.
@@ -346,7 +345,6 @@ class RenderedVariant:
             no_build_id: Don't include build ID in output directory.
             package_format: Package format ("conda" or "tar.bz2").
             no_include_recipe: Don't include recipe in the output package.
-            debug: Enable debug mode.
             exclude_newer: Exclude packages newer than this timestamp.
 
         Returns:
@@ -384,7 +382,6 @@ class RenderedVariant:
             no_build_id=no_build_id,
             package_format=package_format,
             no_include_recipe=no_include_recipe,
-            debug=debug,
             exclude_newer=exclude_newer,
         )
 
@@ -405,7 +402,6 @@ def build_rendered_variants(
     no_build_id: bool = False,
     package_format: str | None = None,
     no_include_recipe: bool = False,
-    debug: bool = False,
     exclude_newer: datetime | None = None,
 ) -> list[BuildResult]:
     """Build multiple rendered variants.
@@ -425,7 +421,6 @@ def build_rendered_variants(
         no_build_id: Don't include build ID in output directory.
         package_format: Package format ("conda" or "tar.bz2").
         no_include_recipe: Don't include recipe in the output package.
-        debug: Enable debug mode.
         exclude_newer: Exclude packages newer than this timestamp.
 
     Returns:
@@ -465,7 +460,6 @@ def build_rendered_variants(
             no_build_id=no_build_id,
             package_format=package_format,
             no_include_recipe=no_include_recipe,
-            debug=debug,
             exclude_newer=exclude_newer,
         )
         results.append(result)

--- a/py-rattler-build/src/rattler_build/stage0.py
+++ b/py-rattler-build/src/rattler_build/stage0.py
@@ -264,7 +264,6 @@ class Stage0Recipe(ABC):
         no_build_id: bool = False,
         package_format: str | None = None,
         no_include_recipe: bool = False,
-        debug: bool = False,
         exclude_newer: datetime | None = None,
     ) -> list[BuildResult]:
         """Build this recipe.
@@ -283,7 +282,6 @@ class Stage0Recipe(ABC):
             no_build_id: Don't include build ID in output directory.
             package_format: Package format ("conda" or "tar.bz2").
             no_include_recipe: Don't include recipe in the output package.
-            debug: Enable debug mode.
             exclude_newer: Exclude packages newer than this timestamp.
 
         Returns:
@@ -319,7 +317,6 @@ class Stage0Recipe(ABC):
                 no_build_id=no_build_id,
                 package_format=package_format,
                 no_include_recipe=no_include_recipe,
-                debug=debug,
                 exclude_newer=exclude_newer,
             )
             results.append(result)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ use types::{
     build_reindexed_channels,
 };
 
-use crate::metadata::{Debug, Output, PlatformWithVirtualPackages};
+use crate::metadata::{Output, PlatformWithVirtualPackages};
 use crate::publish::{
     BuildNumberOverride, PublishConfig, apply_build_number_override, fetch_highest_build_numbers,
     upload_and_index_channel,
@@ -556,7 +556,6 @@ pub async fn get_build_output(
                 store_recipe: !build_data.no_include_recipe,
                 force_colors: build_data.color_build_log && console::colors_enabled(),
                 sandbox_config: build_data.sandbox_configuration.clone(),
-                debug: build_data.debug,
                 exclude_newer: build_data.exclude_newer,
             },
             finalized_dependencies: None,
@@ -795,7 +794,6 @@ pub async fn run_build_from_args(
                         tool_configuration: tool_configuration.clone(),
                         test_index: None,
                         output_dir: output.build_configuration.directories.output_dir.clone(),
-                        debug: output.build_configuration.debug,
                         exclude_newer: output.build_configuration.exclude_newer,
                     },
                     None,
@@ -957,7 +955,6 @@ pub async fn run_test(
         solve_strategy: SolveStrategy::Highest,
         tool_configuration: tool_config,
         output_dir: test_data.common.output_dir,
-        debug: test_data.debug,
         exclude_newer: None,
     };
 
@@ -1552,7 +1549,6 @@ pub async fn debug_recipe(
         channels: debug_data.channels,
         common: debug_data.common,
         keep_build: true,
-        debug: Debug::new(true),
         test: TestStrategy::Skip,
         up_to: None,
         variant_config: debug_data.variant_config,

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -23,7 +23,6 @@ use url::Url;
 
 use crate::{
     console_utils::{Color, LogStyle},
-    metadata::Debug,
     tool_configuration::{ContinueOnFailure, SkipExisting, TestStrategy},
 };
 #[cfg(feature = "recipe-generation")]
@@ -677,10 +676,6 @@ pub struct BuildOpts {
     #[clap(flatten)]
     pub sandbox_arguments: SandboxArguments,
 
-    /// Enable debug output in build scripts
-    #[arg(long, help_heading = "Modifying result")]
-    pub debug: bool,
-
     /// Write a markdown summary to the specified file (appends to the file).
     /// Useful for generating PR comments or custom reports.
     #[arg(long, help_heading = "Modifying result")]
@@ -884,7 +879,6 @@ pub struct BuildData {
     pub noarch_build_platform: Option<Platform>,
     pub extra_meta: Option<Vec<(String, Value)>>,
     pub sandbox_configuration: Option<SandboxConfiguration>,
-    pub debug: Debug,
     pub continue_on_failure: ContinueOnFailure,
     pub error_prefix_in_binary: bool,
     pub allow_symlinks_on_windows: bool,
@@ -921,7 +915,6 @@ impl BuildData {
         noarch_build_platform: Option<Platform>,
         extra_meta: Option<Vec<(String, Value)>>,
         sandbox_configuration: Option<SandboxConfiguration>,
-        debug: Debug,
         continue_on_failure: ContinueOnFailure,
         error_prefix_in_binary: bool,
         allow_symlinks_on_windows: bool,
@@ -962,7 +955,6 @@ impl BuildData {
             noarch_build_platform,
             extra_meta,
             sandbox_configuration,
-            debug,
             continue_on_failure,
             error_prefix_in_binary,
             allow_symlinks_on_windows,
@@ -1014,7 +1006,6 @@ impl BuildData {
             opts.noarch_build_platform,
             opts.extra_meta,
             opts.sandbox_arguments.into(),
-            Debug::new(opts.debug),
             opts.continue_on_failure.into(),
             opts.error_prefix_in_binary,
             opts.allow_symlinks_on_windows,
@@ -1088,10 +1079,6 @@ pub struct TestOpts {
     #[clap(long)]
     pub test_index: Option<usize>,
 
-    /// Build test environment and output debug information for manual debugging.
-    #[arg(long)]
-    pub debug: bool,
-
     /// Common options.
     #[clap(flatten)]
     pub common: CommonOpts,
@@ -1105,7 +1092,6 @@ pub struct TestData {
     pub compression_threads: Option<u32>,
     pub common: CommonData,
     pub test_index: Option<usize>,
-    pub debug: Debug,
 }
 
 impl TestData {
@@ -1116,7 +1102,6 @@ impl TestData {
             value.package_file,
             value.channels,
             value.compression_threads,
-            Debug::new(value.debug),
             value.test_index,
             CommonData::from_opts_and_config(value.common, config.unwrap_or_default()),
         )
@@ -1127,7 +1112,6 @@ impl TestData {
         package_file: PathBuf,
         channels: Option<Vec<NamedChannelOrUrl>>,
         compression_threads: Option<u32>,
-        debug: Debug,
         test_index: Option<usize>,
         common: CommonData,
     ) -> Self {
@@ -1136,7 +1120,6 @@ impl TestData {
             channels,
             compression_threads,
             test_index,
-            debug,
             common,
         }
     }


### PR DESCRIPTION
It is a bit weird since it always fails with an error. Also we have a more suitable API at `debug setup` now.