### PR TITLE
ci: preserve Unix permissions (executable bit) in zip archive for macOS

### DIFF
--- a/scripts/package_binary.py
+++ b/scripts/package_binary.py
@@ -70,7 +70,11 @@ def main() -> None:
     else:
         with zipfile.ZipFile(archive_path, "w", zipfile.ZIP_DEFLATED) as zf:
             for item in sorted(archive_dir.iterdir()):
-                zf.write(item, f"{pkg_basename}/{item.name}")
+                zi = zipfile.ZipInfo(f"{pkg_basename}/{item.name}")
+                zi.compress_type = zipfile.ZIP_DEFLATED
+                # Preserve Unix permissions (including executable bit) in ZIP external attrs
+                zi.external_attr = item.stat().st_mode << 16
+                zf.writestr(zi, item.read_bytes())
 
     # Stage everything flat for upload
     staging = ROOT / "staging"


### PR DESCRIPTION
Fixes #2328

When creating the macOS zip archive, `zipfile.ZipFile.write()` silently drops Unix metadata including the executable bit. This replaces it with a `ZipInfo`-based approach that reads `st_mode` from each file on disk and stores it in `external_attr` (upper 16 bits, the standard ZIP convention for Unix attributes).

- The binary gets its actual permissions (e.g. `0o755`) → executable bit preserved
- README/LICENSE get their actual permissions (e.g. `0o644`) → unchanged
