### PR TITLE
fix: expected commit usage

### DIFF
--- a/crates/rattler_build_core/src/source/mod.rs
+++ b/crates/rattler_build_core/src/source/mod.rs
@@ -169,12 +169,13 @@ pub(crate) fn convert_git_source(
         GitRev::Head => RattlerGitReference::DefaultBranch,
     };
 
-    Ok(CacheGitSource::new(
+    Ok(CacheGitSource::with_expected_commit(
         url,
         reference,
         git_src.depth,
         git_src.lfs,
         git_src.submodules,
+        git_src.expected_commit.clone(),
     ))
 }
 


### PR DESCRIPTION
This is a left over from the refactor. Should use the right function to get errors when the commit hash does not match.