### PR TITLE
fix: use platform-specific script extensions for test scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5046,6 +5046,7 @@ dependencies = [
  "rattler_shell",
  "serde",
  "serde_yaml",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",

--- a/crates/rattler_build_core/src/package_test/serialize_test.rs
+++ b/crates/rattler_build_core/src/package_test/serialize_test.rs
@@ -4,6 +4,7 @@ use fs_err as fs;
 use rattler_build_recipe::stage1::{TestType, requirements::Dependency, tests::CommandsTest};
 use rattler_build_script::{
     ResolvedScriptContents, ScriptContent, determine_interpreter_from_path,
+    platform_script_extensions,
 };
 use rattler_conda_types::{MatchSpec, PackageNameMatcher};
 
@@ -142,7 +143,7 @@ pub(crate) fn write_test_files(
             let contents = command_test.script.resolve_content(
                 &output.build_configuration.directories.recipe_dir,
                 Some(jinja_renderer),
-                &["sh", "bat"],
+                platform_script_extensions(),
             )?;
 
             // Replace with rendered contents

--- a/crates/rattler_build_core/src/script.rs
+++ b/crates/rattler_build_core/src/script.rs
@@ -12,7 +12,7 @@ use std::{collections::HashMap, collections::HashSet};
 // Re-export from rattler_build_script
 pub use rattler_build_script::{
     ExecutionArgs, InterpreterError, ResolvedScriptContents, SandboxArguments,
-    SandboxConfiguration, Script, ScriptContent,
+    SandboxConfiguration, Script, ScriptContent, platform_script_extensions,
 };
 
 use crate::{
@@ -66,7 +66,7 @@ impl Output {
             script: self.recipe.build().script.resolve_content(
                 &self.build_configuration.directories.recipe_dir,
                 Some(jinja_renderer),
-                if cfg!(windows) { &["bat"] } else { &["sh"] },
+                platform_script_extensions(),
             )?,
             env_vars: env_vars
                 .into_iter()

--- a/crates/rattler_build_script/Cargo.toml
+++ b/crates/rattler_build_script/Cargo.toml
@@ -54,3 +54,4 @@ minijinja = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["rt", "macros", "fs"] }
 insta = { workspace = true, features = ["yaml"] }
 serde_yaml = { workspace = true }
+tempfile = { workspace = true }

--- a/crates/rattler_build_script/src/execution.rs
+++ b/crates/rattler_build_script/src/execution.rs
@@ -136,23 +136,17 @@ impl Script {
     where
         F: Fn(&str) -> Result<String, String>,
     {
-        // Determine the valid script extensions based on the available interpreters.
-        let mut valid_script_extensions = Vec::new();
-        if cfg!(windows) {
-            valid_script_extensions.push("bat");
-            valid_script_extensions.push("ps1");
-        } else {
-            valid_script_extensions.push("sh");
-        }
-
         let env_vars = env_vars
             .into_iter()
             .filter_map(|(k, v)| v.map(|v| (k, v)))
             .chain(self.env().clone().into_iter())
             .collect::<IndexMap<String, String>>();
 
-        let contents =
-            self.resolve_content(recipe_dir, jinja_renderer, &valid_script_extensions)?;
+        let contents = self.resolve_content(
+            recipe_dir,
+            jinja_renderer,
+            crate::platform_script_extensions(),
+        )?;
 
         let secrets = self
             .secrets()
@@ -754,5 +748,58 @@ mod tests {
 
         let resolved_missing = ResolvedScriptContents::Missing;
         assert_eq!(resolved_missing.infer_interpreter(), None);
+    }
+
+    /// Regression test for <https://github.com/prefix-dev/rattler-build/issues/2199>
+    ///
+    /// Extension order in `resolve_content` determines which file is picked
+    /// when both `.sh` and `.bat` exist. `platform_script_extensions()` must
+    /// select the platform-appropriate one.
+    #[test]
+    fn test_script_extension_resolution_respects_order() {
+        use std::path::PathBuf;
+
+        use crate::script::{Script, ScriptContent};
+
+        let dir = tempfile::tempdir().unwrap();
+        fs_err::write(dir.path().join("test-script.sh"), "#!/bin/bash\necho hello").unwrap();
+        fs_err::write(dir.path().join("test-script.bat"), "@echo off\necho hello").unwrap();
+
+        let resolve = |content: ScriptContent, exts: &[&str]| -> PathBuf {
+            let script = Script {
+                content,
+                ..Script::default()
+            };
+            match script
+                .resolve_content(dir.path(), None::<fn(&str) -> Result<String, String>>, exts)
+                .unwrap()
+            {
+                ResolvedScriptContents::Path(path, _) => path,
+                other => panic!("expected Path variant, got {:?}", other),
+            }
+        };
+
+        // Extension list order controls which file wins
+        let path_content = || ScriptContent::Path(PathBuf::from("test-script"));
+        assert_eq!(
+            resolve(path_content(), &["sh", "bat"]).extension().unwrap(),
+            "sh"
+        );
+        assert_eq!(
+            resolve(path_content(), &["bat", "sh"]).extension().unwrap(),
+            "bat"
+        );
+
+        // CommandOrPath variant behaves the same
+        let cop_content = || ScriptContent::CommandOrPath("test-script".into());
+        assert_eq!(resolve(cop_content(), &["sh"]).extension().unwrap(), "sh");
+        assert_eq!(resolve(cop_content(), &["bat"]).extension().unwrap(), "bat");
+
+        // platform_script_extensions() picks the right one for the current platform
+        let ext = resolve(path_content(), crate::platform_script_extensions())
+            .extension()
+            .unwrap()
+            .to_owned();
+        assert_eq!(ext, if cfg!(windows) { "bat" } else { "sh" });
     }
 }

--- a/crates/rattler_build_script/src/lib.rs
+++ b/crates/rattler_build_script/src/lib.rs
@@ -8,7 +8,9 @@ pub mod sandbox;
 mod script;
 
 pub use sandbox::{SandboxArguments, SandboxConfiguration};
-pub use script::{Script, ScriptContent, determine_interpreter_from_path};
+pub use script::{
+    Script, ScriptContent, determine_interpreter_from_path, platform_script_extensions,
+};
 
 #[cfg(feature = "execution")]
 mod execution;

--- a/crates/rattler_build_script/src/script.rs
+++ b/crates/rattler_build_script/src/script.rs
@@ -240,6 +240,20 @@ impl ScriptContent {
     }
 }
 
+/// Returns the platform-appropriate script file extensions, in priority order.
+///
+/// On Windows this returns `&["bat", "ps1"]`, on Unix `&["sh"]`.
+/// Used by both build-time and test-time script resolution so that the
+/// same extension preference is applied consistently everywhere
+/// (see <https://github.com/prefix-dev/rattler-build/issues/2199>).
+pub fn platform_script_extensions() -> &'static [&'static str] {
+    if cfg!(windows) {
+        &["bat", "ps1"]
+    } else {
+        &["sh"]
+    }
+}
+
 /// Helper function to determine interpreter based on file extension
 pub fn determine_interpreter_from_path(path: &Path) -> Option<String> {
     path.extension()


### PR DESCRIPTION
Resolves test.script.file using platform_script_extensions() instead of hardcoded ["sh", "bat"], making test script resolution consistent with build script resolution on Windows.

Closes #2199

Supersedes #2207 since it would have been more work to fix the merge conflicts than simply recreating it.