### PR TITLE
feat(py): add progress_callback to run_tests

### DIFF
--- a/crates/rattler_build_script/src/interpreter/bash.rs
+++ b/crates/rattler_build_script/src/interpreter/bash.rs
@@ -65,10 +65,11 @@ impl Interpreter for BashInterpreter {
 
         if !output.status.success() {
             let status_code = output.status.code().unwrap_or(1);
+            let debug_info = print_debug_info(&args);
             tracing::error!("Script failed with status {}", status_code);
-            tracing::error!("{}", print_debug_info(&args));
+            tracing::error!("{}", debug_info);
             return Err(InterpreterError::ExecutionFailed(std::io::Error::other(
-                "Script failed".to_string(),
+                format!("Script failed with status {}{}", status_code, debug_info),
             )));
         }
 

--- a/crates/rattler_build_script/src/interpreter/cmd_exe.rs
+++ b/crates/rattler_build_script/src/interpreter/cmd_exe.rs
@@ -67,10 +67,11 @@ impl Interpreter for CmdExeInterpreter {
 
         if !output.status.success() {
             let status_code = output.status.code().unwrap_or(1);
+            let debug_info = print_debug_info(&args);
             tracing::error!("Script failed with status {}", status_code);
-            tracing::error!("{}", print_debug_info(&args));
+            tracing::error!("{}", debug_info);
             return Err(InterpreterError::ExecutionFailed(std::io::Error::other(
-                "Script failed".to_string(),
+                format!("Script failed with status {}{}", status_code, debug_info),
             )));
         }
 

--- a/crates/rattler_build_script/src/interpreter/nushell.rs
+++ b/crates/rattler_build_script/src/interpreter/nushell.rs
@@ -133,7 +133,11 @@ impl Interpreter for NuShellInterpreter {
             tracing::error!("Script failed with status {}", status_code);
             tracing::error!("Work directory: '{}'", args.work_dir.display());
             return Err(InterpreterError::ExecutionFailed(std::io::Error::other(
-                "Script failed".to_string(),
+                format!(
+                    "Script failed with status {}\n\n  Work directory: {}",
+                    status_code,
+                    args.work_dir.display()
+                ),
             )));
         }
 

--- a/py-rattler-build/examples/test_with_progress.py
+++ b/py-rattler-build/examples/test_with_progress.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""
+Example: Running package tests with streaming progress output.
+
+This example demonstrates how to use rattler-build's progress reporting
+when running tests on a built package, so you can see test output in
+real-time instead of only after completion.
+
+Usage:
+    python test_with_progress.py path/to/package.conda
+"""
+
+import sys
+from pathlib import Path
+
+from rattler_build import Package
+from rattler_build.progress import SimpleProgressCallback
+
+
+def test_package_with_progress(package_path: Path) -> None:
+    """Run tests on a package with streaming progress output.
+
+    Args:
+        package_path: Path to a .conda or .tar.bz2 package file
+    """
+    print(f"Loading package: {package_path}")
+    pkg = Package.from_file(package_path)
+    print(f"  {pkg.name} {pkg.version} ({pkg.archive_type})")
+    print(f"  Tests: {pkg.test_count}")
+
+    if pkg.test_count == 0:
+        print("No tests found in package.")
+        return
+
+    # Run all tests with a progress callback for real-time output
+    callback = SimpleProgressCallback()
+    print("\nRunning tests with streaming output:\n")
+    results = pkg.run_tests(progress_callback=callback)
+
+    # Print summary
+    print("\n" + "=" * 60)
+    print("Test Summary:")
+    print("=" * 60)
+    for r in results:
+        status = "PASS" if r.success else "FAIL"
+        print(f"  Test {r.test_index}: {status}")
+        if not r.success:
+            print("  Output:")
+            for line in r.output:
+                print(f"    {line}")
+
+    passed = sum(1 for r in results if r.success)
+    total = len(results)
+    print(f"\n{passed}/{total} tests passed.")
+
+
+def main() -> None:
+    """Main entry point."""
+    if len(sys.argv) < 2:
+        print("Usage: python test_with_progress.py <package.conda>")
+        print("\nExamples:")
+        print("  python test_with_progress.py output/noarch/mypackage-1.0-py_0.conda")
+        sys.exit(1)
+
+    package_path = Path(sys.argv[1])
+    if not package_path.exists():
+        print(f"Error: Package file not found: {package_path}")
+        sys.exit(1)
+
+    try:
+        test_package_with_progress(package_path)
+    except Exception as e:
+        print(f"Error: {e}")
+        import traceback
+
+        traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/py-rattler-build/rust/src/package.rs
+++ b/py-rattler-build/rust/src/package.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use crate::error::RattlerBuildError;
+use crate::tracing_subscriber;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use rattler_build_recipe::stage1::tests::{
@@ -269,7 +270,7 @@ impl PyPackage {
     }
 
     /// Run a specific test by index
-    #[pyo3(signature = (index, channel=None, channel_priority=None, auth_file=None, allow_insecure_host=None, compression_threads=None, use_bz2=true, use_zstd=true, use_sharded=true))]
+    #[pyo3(signature = (index, channel=None, channel_priority=None, auth_file=None, allow_insecure_host=None, compression_threads=None, use_bz2=true, use_zstd=true, use_sharded=true, progress_callback=None))]
     #[allow(clippy::too_many_arguments)]
     fn run_test(
         &self,
@@ -282,6 +283,7 @@ impl PyPackage {
         use_bz2: bool,
         use_zstd: bool,
         use_sharded: bool,
+        progress_callback: Option<Py<PyAny>>,
     ) -> PyResult<PyTestResult> {
         self.run_test_internal(
             Some(index),
@@ -293,12 +295,13 @@ impl PyPackage {
             use_bz2,
             use_zstd,
             use_sharded,
+            progress_callback,
         )
         .map(|results| results.into_iter().next().unwrap())
     }
 
     /// Run all tests in the package
-    #[pyo3(signature = (channel=None, channel_priority=None, auth_file=None, allow_insecure_host=None, compression_threads=None, use_bz2=true, use_zstd=true, use_sharded=true))]
+    #[pyo3(signature = (channel=None, channel_priority=None, auth_file=None, allow_insecure_host=None, compression_threads=None, use_bz2=true, use_zstd=true, use_sharded=true, progress_callback=None))]
     #[allow(clippy::too_many_arguments)]
     fn run_tests(
         &self,
@@ -310,6 +313,7 @@ impl PyPackage {
         use_bz2: bool,
         use_zstd: bool,
         use_sharded: bool,
+        progress_callback: Option<Py<PyAny>>,
     ) -> PyResult<Vec<PyTestResult>> {
         self.run_test_internal(
             None,
@@ -321,6 +325,7 @@ impl PyPackage {
             use_bz2,
             use_zstd,
             use_sharded,
+            progress_callback,
         )
     }
 
@@ -488,6 +493,7 @@ impl PyPackage {
         use_bz2: bool,
         use_zstd: bool,
         use_sharded: bool,
+        progress_callback: Option<Py<PyAny>>,
     ) -> PyResult<Vec<PyTestResult>> {
         use ::rattler_build::{
             opt::{ChannelPriorityWrapper, CommonData, TestData},
@@ -550,8 +556,15 @@ impl PyPackage {
             common,
         );
 
-        // Run the test(s)
-        let result = run_async_task(async { run_test(test_data, None).await });
+        // Run the test(s) with log capture and optional streaming callback
+        let (result, log_buffer) = tracing_subscriber::with_log_capture(progress_callback, || {
+            run_async_task(async { run_test(test_data, None).await })
+        });
+
+        let captured_logs = log_buffer
+            .lock()
+            .map(|buffer| buffer.clone())
+            .unwrap_or_default();
 
         match result {
             Ok(()) => {
@@ -559,14 +572,14 @@ impl PyPackage {
                 let results = if let Some(idx) = test_index {
                     vec![PyTestResult {
                         success: true,
-                        output: Vec::new(),
+                        output: captured_logs,
                         test_index: idx,
                     }]
                 } else {
                     (0..test_count)
                         .map(|idx| PyTestResult {
                             success: true,
-                            output: Vec::new(),
+                            output: captured_logs.clone(),
                             test_index: idx,
                         })
                         .collect()
@@ -574,20 +587,21 @@ impl PyPackage {
                 Ok(results)
             }
             Err(e) => {
-                // Test failed
-                let error_msg = e.to_string();
+                // Test failed — include both captured logs and the error message
+                let mut output = captured_logs;
+                output.push(e.to_string());
+
                 if let Some(idx) = test_index {
                     Ok(vec![PyTestResult {
                         success: false,
-                        output: vec![error_msg],
+                        output,
                         test_index: idx,
                     }])
                 } else {
                     // When running all tests and one fails, we don't know which one
-                    // Return a single result indicating failure
                     Ok(vec![PyTestResult {
                         success: false,
-                        output: vec![error_msg],
+                        output,
                         test_index: 0,
                     }])
                 }

--- a/py-rattler-build/src/rattler_build/package.py
+++ b/py-rattler-build/src/rattler_build/package.py
@@ -40,6 +40,8 @@ from rattler_build._rattler_build import _package
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from rattler_build.progress import ProgressCallback
+
 # Type alias for test union
 PackageTestType = Union[
     "PythonTest",
@@ -229,6 +231,7 @@ class Package:
         use_bz2: bool = True,
         use_zstd: bool = True,
         use_sharded: bool = True,
+        progress_callback: "ProgressCallback | None" = None,
     ) -> "TestResult":
         """Run a specific test by index.
 
@@ -242,6 +245,7 @@ class Package:
             use_bz2: Enable bz2 repodata
             use_zstd: Enable zstd repodata
             use_sharded: Enable sharded repodata
+            progress_callback: Optional callback for streaming log output in real-time
 
         Returns:
             TestResult with success status and output
@@ -267,6 +271,7 @@ class Package:
                 use_bz2=use_bz2,
                 use_zstd=use_zstd,
                 use_sharded=use_sharded,
+                progress_callback=progress_callback,
             )
         )
 
@@ -281,6 +286,7 @@ class Package:
         use_bz2: bool = True,
         use_zstd: bool = True,
         use_sharded: bool = True,
+        progress_callback: "ProgressCallback | None" = None,
     ) -> list["TestResult"]:
         """Run all tests in the package.
 
@@ -293,6 +299,7 @@ class Package:
             use_bz2: Enable bz2 repodata
             use_zstd: Enable zstd repodata
             use_sharded: Enable sharded repodata
+            progress_callback: Optional callback for streaming log output in real-time
 
         Returns:
             List of TestResult objects, one per test
@@ -303,6 +310,13 @@ class Package:
             for r in results:
                 status = "PASS" if r.success else "FAIL"
                 print(f"Test {r.test_index}: {status}")
+
+            # With streaming output:
+            from rattler_build.progress import SimpleProgressCallback
+            results = pkg.run_tests(
+                channel=["conda-forge"],
+                progress_callback=SimpleProgressCallback(),
+            )
             ```
         """
         return [
@@ -316,6 +330,7 @@ class Package:
                 use_bz2=use_bz2,
                 use_zstd=use_zstd,
                 use_sharded=use_sharded,
+                progress_callback=progress_callback,
             )
         ]
 

--- a/py-rattler-build/src/rattler_build/progress.py
+++ b/py-rattler-build/src/rattler_build/progress.py
@@ -128,7 +128,7 @@ class ProgressCallback(Protocol):
         ...
 
 
-class SimpleProgressCallback:
+class SimpleProgressCallback(ProgressCallback):
     """Simple console-based progress callback.
 
     Prints progress updates to the console with simple formatting.
@@ -179,7 +179,7 @@ class SimpleProgressCallback:
         print(f"{prefix}{span_str} {event.message}")
 
 
-class RichProgressCallback:
+class RichProgressCallback(ProgressCallback):
     """Rich-based progress callback with beautiful terminal output.
 
     Automatically creates progress bars for long-running operations by parsing


### PR DESCRIPTION
Fixes #2355

This is the output of the example using `SimpleCallback` on the `rich` conda package. Not exactly gorgeous, but I expect people to use their own callback anyway (or ask us to provide nicer ones)

<img width="500" height="302" alt="image" src="https://github.com/user-attachments/assets/a36959f2-c0d9-41d9-ae31-43d66fcbe80b" />
