### PR TITLE
fix: add support for @loader_path and @executable_path in macOS dylib relinking

### DIFF
--- a/crates/rattler_build_core/src/macos/link.rs
+++ b/crates/rattler_build_core/src/macos/link.rs
@@ -156,8 +156,7 @@ impl Relinker for Dylib {
                 let exec_dir = encoded_prefix.join("bin");
                 let resolved = to_lexical_absolute(lib_without_exec, &exec_dir);
                 if resolved.exists() {
-                    let resolved_library_path =
-                        Some(resolved.canonicalize().unwrap_or(resolved));
+                    let resolved_library_path = Some(resolved.canonicalize().unwrap_or(resolved));
                     resolved_libraries.insert(lib.clone(), resolved_library_path);
                 }
             } else if lib.is_absolute() {


### PR DESCRIPTION
This PR extends the macOS dylib relinking logic to properly resolve `@loader_path` and `@executable_path` references, which are common in macOS binaries for specifying library locations relative to the loading binary or executable.