### PR TITLE
fix: reset origin URL and sync submodules before update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4694,9 +4694,9 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.40.3"
+version = "0.40.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba7b9c2977ddc74fecb7e68dd6b3f40958416220b9643d94db5b7387fd0cbcd"
+checksum = "d5e004d0371d9671efc0c41c9d5311a21479db551fd68236a3299b7d7b8447f0"
 dependencies = [
  "anyhow",
  "clap",
@@ -5157,9 +5157,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.6.18"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f380851c13b9c14811d0281ce72ddd608b7dd98bc0a3e669247aa75dbac5e3b6"
+checksum = "1b829f276e98d7d670be90df8aebaac4ce92606d766e315c230ee4c1782ec9e4"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5190,9 +5190,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.44.3"
+version = "0.44.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dc7eaa515b50a8ba80753d9902582bc2d62d8452ca61e6afd7bca866b54c85"
+checksum = "251545c07ce023c159c6673e9e5da7f49ae9a5cc791d1f5dbb6067a00612550a"
 dependencies = [
  "ahash",
  "chrono",
@@ -5233,9 +5233,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_config"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c237386638e40597bb4117f6e84edd8bb077fa28cafa0535357f5b304d89c9bd"
+checksum = "04e636e27c327e1cb950c726a44a3507700f92ec8c2acbda1a5bc7a679128588"
 dependencies = [
  "console",
  "fs-err",
@@ -5270,9 +5270,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_git"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3433ae20e2a061b99f8587b497fc2fb0c3f8e63527b047f33aca2d28a949f0"
+checksum = "1225e9333f2930720b5759f70c10a5b6631c580ee67940e6a29fbb8393ccb9cc"
 dependencies = [
  "dashmap",
  "dunce",
@@ -5291,9 +5291,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.27.20"
+version = "0.27.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760870693bdb711c0fade345871e15b5b615cae645bdde66b4855fbfeff34087"
+checksum = "20dfb632a54859867a7b920981951dab376c34397c68527d62f63f38e20898ce"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5339,9 +5339,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.53"
+version = "0.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb53fa7f10330b818ddfafd7c7d407254809ea249597bbc03073c2a3ad2854a"
+checksum = "be28b61681374a243151224f09d8691ef59db158001f075b64ef60f26622cc1a"
 dependencies = [
  "chrono",
  "configparser",
@@ -5370,9 +5370,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.26.6"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67894637c820e2fbdf6ac44fc2b43d5ea38b7196439c4f7525b5c3dc2758e0b5"
+checksum = "6c737c889ed175f55fb86986694a916a58f97bb22cf466169abd9c1dd363712e"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -5402,9 +5402,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.24.6"
+version = "0.24.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54da4bc16291b217181fa9ba07c0d5a796e1fa1e63591fef0f6e6e7e96e211d1"
+checksum = "b9cf2ab39920b58ac3cd41a23ef4ec40ab9fdc4a3645c045f5de6b2677b1398f"
 dependencies = [
  "astral-tokio-tar",
  "astral_async_zip",
@@ -5478,9 +5478,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.27.3"
+version = "0.27.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135ed8236490b3de75e887ea54311e0d7a810187000db71ce7ecaf82c93dd981"
+checksum = "927979192dd8e7644da0d6dcb0a1a98244f1412da7a69f0a9037e185caa01dd1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5541,9 +5541,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_s3"
-version = "0.1.29"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733fc964fdc68b18f7d20e25456ebd97d3f8cc86a93383654bbf892666b63a8e"
+checksum = "bc1756990b91a0ceca2e3ed13875ccf4260968ae22a6cfab980862cf97dfbddf"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -5558,9 +5558,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.26.6"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0304b98dc745f816767dfd46c640c14b178c8327799c651dd10b6e25507cbae"
+checksum = "a39fdc6dab30c7eb958bd3d92c47b9b3e78f85cb0acdaebfa91ad3e3230a7e6b"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -5574,14 +5574,15 @@ dependencies = [
  "sysinfo",
  "tempfile",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "rattler_solve"
-version = "5.1.0"
+version = "5.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804311898940221962582b0fc0f48f122dfb1a85a0169c649121cce143a37f8f"
+checksum = "a71f5f4948fcd822f2612dd21c07de56a358c1404f6373e0ac0b34d97e9aa817"
 dependencies = [
  "chrono",
  "futures",
@@ -5598,9 +5599,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_upload"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d63bfbaf5d72273f0cd8b29a8893c7bd44f793648fdbafcae7e7f7679a1b71"
+checksum = "744df9e3f812863f48c81a2353a99d0348061e22e299b648eaafd0b079f77d05"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -5635,9 +5636,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "2.3.15"
+version = "2.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df69f8439a12f6f06d928ec68b0df2c5958e478e2fb10b5ad939199e6e19d2fb"
+checksum = "8fddfeee1ea50f4f39d2b8750e9f6c5774678108666aa4ff2e0e4d73c733d347"
 dependencies = [
  "archspec",
  "libloading",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,37 +132,37 @@ tracing-test = "0.2.6"
 
 # rattler crates
 # Rattler crates
-rattler_conda_types = { version = "0.44.3", default-features = false }
+rattler_conda_types = { version = "0.44.5", default-features = false }
 rattler_digest = { version = "1.2.3", default-features = false, features = [
   "serde",
 ] }
-rattler_networking = { version = "0.26.6", default-features = false }
-rattler_package_streaming = { version = "0.24.6", default-features = false }
-rattler_shell = { version = "0.26.6", default-features = false, features = [
+rattler_networking = { version = "0.26.8", default-features = false }
+rattler_package_streaming = { version = "0.24.8", default-features = false }
+rattler_shell = { version = "0.26.8", default-features = false, features = [
   "sysinfo",
 ] }
-rattler_git = { version = "0.1.0" }
+rattler_git = { version = "0.1.1" }
 rattler_prefix_guard = { version = "0.1.0" }
 
-rattler_config = { version = "0.3.6" }
-rattler = { version = "0.40.3", default-features = false, features = [
+rattler_config = { version = "0.3.8" }
+rattler = { version = "0.40.5", default-features = false, features = [
   "cli-tools",
   "indicatif",
 ] }
-rattler_cache = { version = "0.6.18", default-features = false }
-rattler_index = { version = "0.27.20", default-features = false }
-rattler_upload = { version = "0.5.3", default-features = false }
-rattler_s3 = { version = "0.1.29" }
+rattler_cache = { version = "0.6.20", default-features = false }
+rattler_index = { version = "0.27.21", default-features = false }
+rattler_upload = { version = "0.5.6", default-features = false }
+rattler_s3 = { version = "0.1.31" }
 rattler_redaction = { version = "0.1.13", default-features = false }
-rattler_repodata_gateway = { version = "0.27.3", default-features = false, features = [
+rattler_repodata_gateway = { version = "0.27.5", default-features = false, features = [
   "gateway",
 ] }
-rattler_solve = { version = "5.0.3", default-features = false, features = [
+rattler_solve = { version = "5.2.1", default-features = false, features = [
   "resolvo",
   "serde",
 ] }
-rattler_virtual_packages = { version = "2.3.15", default-features = false }
-rattler_menuinst = "0.2.53"
+rattler_virtual_packages = { version = "2.3.17", default-features = false }
+rattler_menuinst = "0.2.55"
 
 
 # Internal rattler-build crates

--- a/crates/rattler_build_recipe/src/stage0/evaluate.rs
+++ b/crates/rattler_build_recipe/src/stage0/evaluate.rs
@@ -897,6 +897,7 @@ pub(crate) fn is_free_matchspec(spec: &rattler_conda_types::MatchSpec) -> bool {
         license,
         condition,
         track_features,
+        license_family,
     } = spec;
 
     name.as_exact().is_some()
@@ -912,6 +913,7 @@ pub(crate) fn is_free_matchspec(spec: &rattler_conda_types::MatchSpec) -> bool {
         && extras.is_none()
         && url.is_none()
         && license.is_none()
+        && license_family.is_none()
         && condition.is_none()
         && track_features.is_none()
 }

--- a/crates/rattler_build_source_cache/src/cache.rs
+++ b/crates/rattler_build_source_cache/src/cache.rs
@@ -126,7 +126,7 @@ impl SourceCache {
 
         // Handle submodules if needed (defaults to true)
         if source.submodules {
-            self.git_submodule_update(&repo_path).await?;
+            self.git_submodule_update(&repo_path, &source.url).await?;
         }
 
         // Handle LFS if needed
@@ -163,22 +163,106 @@ impl SourceCache {
     }
 
     /// Initialize and recursively update git submodules
-    async fn git_submodule_update(&self, repo_path: &Path) -> Result<(), CacheError> {
+    async fn git_submodule_update(
+        &self,
+        repo_path: &Path,
+        source_url: &url::Url,
+    ) -> Result<(), CacheError> {
+        // The checkout's origin remote points to the local bare cache
+        // database (set by `git clone --local`). Submodules with relative
+        // URLs would be resolved against that local path and fail.
+        //
+        // We resolve relative submodule URLs against the source URL
+        // and write the absolute URLs into the repo config.
+        self.resolve_submodule_urls(repo_path, source_url).await?;
+
         let output = tokio::process::Command::new("git")
             .current_dir(repo_path)
+            .args(["-c", "protocol.file.allow=always"])
             .arg("submodule")
             .arg("update")
             .arg("--init")
             .arg("--recursive")
             .output()
             .await
-            .map_err(|e| CacheError::Git(format!("Failed to update git submodules: {}", e)))?;
+            .map_err(|e| CacheError::Git(format!("failed to update git submodules: {}", e)))?;
 
         if !output.status.success() {
             return Err(CacheError::Git(format!(
-                "Git submodule update failed: {}",
+                "git submodule update failed: {}",
                 String::from_utf8_lossy(&output.stderr)
             )));
+        }
+
+        Ok(())
+    }
+
+    /// Resolve relative submodule URLs against the Ssource URL.
+    ///
+    /// Reads `.gitmodules`, finds entries with relative URLs (`./` or `../`),
+    /// resolves them against `source_url`, and writes the absolute URL into
+    /// the repo-level git config so that `git submodule update` uses it.
+    async fn resolve_submodule_urls(
+        &self,
+        repo_path: &Path,
+        source_url: &url::Url,
+    ) -> Result<(), CacheError> {
+        let gitmodules_path = repo_path.join(".gitmodules");
+        if !gitmodules_path.exists() {
+            return Ok(());
+        }
+
+        // List all submodule URLs from .gitmodules
+        let output = tokio::process::Command::new("git")
+            .current_dir(repo_path)
+            .args([
+                "config",
+                "--file",
+                ".gitmodules",
+                "--get-regexp",
+                r"submodule\..*\.url",
+            ])
+            .output()
+            .await
+            .map_err(|e| CacheError::Git(format!("failed to read .gitmodules: {}", e)))?;
+
+        if !output.status.success() {
+            // No submodule entries — nothing to resolve
+            return Ok(());
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        for line in stdout.lines() {
+            // Each line is: submodule.<name>.url <url>
+            let Some((key, submodule_url)) = line.split_once(' ') else {
+                continue;
+            };
+
+            if !submodule_url.starts_with("./") && !submodule_url.starts_with("../") {
+                continue;
+            }
+
+            let resolved = resolve_relative_url(source_url, submodule_url)?;
+
+            // Write the resolved URL into the repo config (not .gitmodules).
+            // `git submodule update --init` reads from the repo config,
+            // falling back to .gitmodules only for `submodule init`.
+            let output = tokio::process::Command::new("git")
+                .current_dir(repo_path)
+                .args(["config", key, &resolved])
+                .output()
+                .await
+                .map_err(|e| {
+                    CacheError::Git(format!("failed to set submodule url for {}: {}", key, e))
+                })?;
+
+            if !output.status.success() {
+                return Err(CacheError::Git(format!(
+                    "failed to set submodule url for {}: {}",
+                    key,
+                    String::from_utf8_lossy(&output.stderr)
+                )));
+            }
         }
 
         Ok(())
@@ -675,6 +759,31 @@ pub struct CacheStats {
 
 // Helper functions
 
+/// Resolve a relative submodule URL against a base URL.
+///
+/// This mirrors Cargo's `absolute_submodule_url`: if the base URL is
+/// parseable (http, https, file, ssh, etc.) we use `Url::join` which
+/// handles `../` normalization. The base URL gets a trailing `/`
+/// appended to its path so that `join` resolves relative to the
+/// directory rather than replacing the last path segment.
+fn resolve_relative_url(base: &url::Url, relative: &str) -> Result<String, CacheError> {
+    let mut base = base.clone();
+
+    // Ensure the base path ends with `/` so `join` treats it as a directory.
+    if !base.path().ends_with('/') {
+        base.set_path(&format!("{}/", base.path()));
+    }
+
+    let resolved = base.join(relative).map_err(|e| {
+        CacheError::Git(format!(
+            "failed to resolve submodule url '{}': {}",
+            relative, e
+        ))
+    })?;
+
+    Ok(resolved.to_string())
+}
+
 pub(crate) fn extract_filename_from_header(header_value: &str) -> Option<String> {
     for part in header_value.split(';') {
         let part = part.trim();
@@ -861,5 +970,29 @@ mod tests {
         assert!(is_archive("test.zip"));
         assert!(is_archive("test.7z"));
         assert!(!is_archive("test.txt"));
+    }
+
+    #[test]
+    fn test_resolve_relative_url() {
+        let base = url::Url::parse("https://github.com/org/main.git").unwrap();
+
+        // ../sibling.git resolves to sibling repo in same org
+        assert_eq!(
+            resolve_relative_url(&base, "../sibling.git").unwrap(),
+            "https://github.com/org/sibling.git"
+        );
+
+        // ./child.git resolves relative to the repo
+        assert_eq!(
+            resolve_relative_url(&base, "./child.git").unwrap(),
+            "https://github.com/org/main.git/child.git"
+        );
+
+        // file:// URLs work too
+        let file_base = url::Url::parse("file:///repos/main.git").unwrap();
+        assert_eq!(
+            resolve_relative_url(&file_base, "../sub.git").unwrap(),
+            "file:///repos/sub.git"
+        );
     }
 }

--- a/crates/rattler_build_source_cache/src/cache.rs
+++ b/crates/rattler_build_source_cache/src/cache.rs
@@ -12,6 +12,7 @@ use crate::{
     source::{AttestationVerification, Checksum, GitSource, Source, UrlSource},
 };
 use rattler_build_networking::BaseClient;
+use rattler_git::CheckoutOptions;
 use rattler_git::resolver::GitResolver;
 
 /// Result of fetching a source from the cache
@@ -98,6 +99,10 @@ impl SourceCache {
         let git_cache = self.cache_dir.join("git");
         fs_err::tokio::create_dir_all(&git_cache).await?;
 
+        let checkout_options = CheckoutOptions {
+            update_submodules: source.submodules,
+        };
+
         let fetch_result = self
             .git_resolver
             .fetch(
@@ -105,6 +110,7 @@ impl SourceCache {
                 self.client.get_client().clone(),
                 git_cache,
                 None,
+                checkout_options,
             )
             .await
             .map_err(|e| CacheError::Git(format!("Git fetch failed: {}", e)))?;
@@ -122,11 +128,6 @@ impl SourceCache {
                 });
             }
             tracing::info!("Verified expected commit: {}", expected);
-        }
-
-        // Handle submodules if needed (defaults to true)
-        if source.submodules {
-            self.git_submodule_update(&repo_path, &source.url).await?;
         }
 
         // Handle LFS if needed
@@ -160,112 +161,6 @@ impl SourceCache {
             path: repo_path,
             git_commit: Some(commit_hash),
         })
-    }
-
-    /// Initialize and recursively update git submodules
-    async fn git_submodule_update(
-        &self,
-        repo_path: &Path,
-        source_url: &url::Url,
-    ) -> Result<(), CacheError> {
-        // The checkout's origin remote points to the local bare cache
-        // database (set by `git clone --local`). Submodules with relative
-        // URLs would be resolved against that local path and fail.
-        //
-        // We resolve relative submodule URLs against the source URL
-        // and write the absolute URLs into the repo config.
-        self.resolve_submodule_urls(repo_path, source_url).await?;
-
-        let output = tokio::process::Command::new("git")
-            .current_dir(repo_path)
-            .args(["-c", "protocol.file.allow=always"])
-            .arg("submodule")
-            .arg("update")
-            .arg("--init")
-            .arg("--recursive")
-            .output()
-            .await
-            .map_err(|e| CacheError::Git(format!("failed to update git submodules: {}", e)))?;
-
-        if !output.status.success() {
-            return Err(CacheError::Git(format!(
-                "git submodule update failed: {}",
-                String::from_utf8_lossy(&output.stderr)
-            )));
-        }
-
-        Ok(())
-    }
-
-    /// Resolve relative submodule URLs against the Ssource URL.
-    ///
-    /// Reads `.gitmodules`, finds entries with relative URLs (`./` or `../`),
-    /// resolves them against `source_url`, and writes the absolute URL into
-    /// the repo-level git config so that `git submodule update` uses it.
-    async fn resolve_submodule_urls(
-        &self,
-        repo_path: &Path,
-        source_url: &url::Url,
-    ) -> Result<(), CacheError> {
-        let gitmodules_path = repo_path.join(".gitmodules");
-        if !gitmodules_path.exists() {
-            return Ok(());
-        }
-
-        // List all submodule URLs from .gitmodules
-        let output = tokio::process::Command::new("git")
-            .current_dir(repo_path)
-            .args([
-                "config",
-                "--file",
-                ".gitmodules",
-                "--get-regexp",
-                r"submodule\..*\.url",
-            ])
-            .output()
-            .await
-            .map_err(|e| CacheError::Git(format!("failed to read .gitmodules: {}", e)))?;
-
-        if !output.status.success() {
-            // No submodule entries — nothing to resolve
-            return Ok(());
-        }
-
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        for line in stdout.lines() {
-            // Each line is: submodule.<name>.url <url>
-            let Some((key, submodule_url)) = line.split_once(' ') else {
-                continue;
-            };
-
-            if !submodule_url.starts_with("./") && !submodule_url.starts_with("../") {
-                continue;
-            }
-
-            let resolved = resolve_relative_url(source_url, submodule_url)?;
-
-            // Write the resolved URL into the repo config (not .gitmodules).
-            // `git submodule update --init` reads from the repo config,
-            // falling back to .gitmodules only for `submodule init`.
-            let output = tokio::process::Command::new("git")
-                .current_dir(repo_path)
-                .args(["config", key, &resolved])
-                .output()
-                .await
-                .map_err(|e| {
-                    CacheError::Git(format!("failed to set submodule url for {}: {}", key, e))
-                })?;
-
-            if !output.status.success() {
-                return Err(CacheError::Git(format!(
-                    "failed to set submodule url for {}: {}",
-                    key,
-                    String::from_utf8_lossy(&output.stderr)
-                )));
-            }
-        }
-
-        Ok(())
     }
 
     /// Pull LFS files for a git repository
@@ -759,31 +654,6 @@ pub struct CacheStats {
 
 // Helper functions
 
-/// Resolve a relative submodule URL against a base URL.
-///
-/// This mirrors Cargo's `absolute_submodule_url`: if the base URL is
-/// parseable (http, https, file, ssh, etc.) we use `Url::join` which
-/// handles `../` normalization. The base URL gets a trailing `/`
-/// appended to its path so that `join` resolves relative to the
-/// directory rather than replacing the last path segment.
-fn resolve_relative_url(base: &url::Url, relative: &str) -> Result<String, CacheError> {
-    let mut base = base.clone();
-
-    // Ensure the base path ends with `/` so `join` treats it as a directory.
-    if !base.path().ends_with('/') {
-        base.set_path(&format!("{}/", base.path()));
-    }
-
-    let resolved = base.join(relative).map_err(|e| {
-        CacheError::Git(format!(
-            "failed to resolve submodule url '{}': {}",
-            relative, e
-        ))
-    })?;
-
-    Ok(resolved.to_string())
-}
-
 pub(crate) fn extract_filename_from_header(header_value: &str) -> Option<String> {
     for part in header_value.split(';') {
         let part = part.trim();
@@ -970,29 +840,5 @@ mod tests {
         assert!(is_archive("test.zip"));
         assert!(is_archive("test.7z"));
         assert!(!is_archive("test.txt"));
-    }
-
-    #[test]
-    fn test_resolve_relative_url() {
-        let base = url::Url::parse("https://github.com/org/main.git").unwrap();
-
-        // ../sibling.git resolves to sibling repo in same org
-        assert_eq!(
-            resolve_relative_url(&base, "../sibling.git").unwrap(),
-            "https://github.com/org/sibling.git"
-        );
-
-        // ./child.git resolves relative to the repo
-        assert_eq!(
-            resolve_relative_url(&base, "./child.git").unwrap(),
-            "https://github.com/org/main.git/child.git"
-        );
-
-        // file:// URLs work too
-        let file_base = url::Url::parse("file:///repos/main.git").unwrap();
-        assert_eq!(
-            resolve_relative_url(&file_base, "../sub.git").unwrap(),
-            "file:///repos/sub.git"
-        );
     }
 }

--- a/crates/rattler_build_source_cache/src/tests.rs
+++ b/crates/rattler_build_source_cache/src/tests.rs
@@ -223,6 +223,127 @@ mod source_cache_tests {
         );
     }
 
+    /// Regression test for <https://github.com/prefix-dev/rattler-build/issues/2379>.
+    ///
+    /// Submodules that use relative URLs (e.g. `../sibling.git`) are resolved
+    /// against the origin remote. Because rattler_git creates checkouts with
+    /// `git clone --local`, origin points at the local bare cache database
+    /// instead of the real remote. We resolve relative submodule URLs against
+    /// the real source URL ourselves (similar to Cargo's approach) so that
+    /// `git submodule update` uses the correct absolute URLs.
+    #[tokio::test]
+    async fn test_git_submodule_relative_url() {
+        use crate::GitReference;
+        use crate::source::{GitSource, Source};
+        use std::path::Path;
+        use std::process::Command;
+
+        let tmp = TempDir::new().unwrap();
+        let repos_dir = tmp.path().join("repos");
+        fs_err::create_dir_all(&repos_dir).unwrap();
+
+        // Helper: run git with a fake identity and file protocol allowed.
+        let git = |dir: &Path, args: &[&str]| -> std::process::Output {
+            let out = Command::new("git")
+                .current_dir(dir)
+                .arg("-c")
+                .arg("user.name=test")
+                .arg("-c")
+                .arg("user.email=test@test")
+                .arg("-c")
+                .arg("protocol.file.allow=always")
+                .args(args)
+                .output()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "git {} failed: {}",
+                args.join(" "),
+                String::from_utf8_lossy(&out.stderr),
+            );
+            out
+        };
+
+        // Create a "sub" repo that will serve as the submodule.
+        let sub_repo = repos_dir.join("sub.git");
+        git(&repos_dir, &["init", "--bare", sub_repo.to_str().unwrap()]);
+
+        // Populate it via a temporary worktree.
+        let sub_work = tmp.path().join("sub_work");
+        git(
+            &repos_dir,
+            &[
+                "clone",
+                sub_repo.to_str().unwrap(),
+                sub_work.to_str().unwrap(),
+            ],
+        );
+        fs_err::write(sub_work.join("hello.txt"), "hello from submodule").unwrap();
+        git(&sub_work, &["add", "."]);
+        git(&sub_work, &["commit", "-m", "init sub"]);
+        git(&sub_work, &["push"]);
+
+        // Create a "main" bare repo that references "sub" via a relative URL.
+        let main_repo = repos_dir.join("main.git");
+        git(&repos_dir, &["init", "--bare", main_repo.to_str().unwrap()]);
+        let main_work = tmp.path().join("main_work");
+        git(
+            &repos_dir,
+            &[
+                "clone",
+                main_repo.to_str().unwrap(),
+                main_work.to_str().unwrap(),
+            ],
+        );
+
+        // Add the submodule using a relative URL ("../sub.git").
+        git(&main_work, &["submodule", "add", "../sub.git", "ext/sub"]);
+
+        fs_err::write(main_work.join("README"), "main repo").unwrap();
+        git(&main_work, &["add", "."]);
+        git(&main_work, &["commit", "-m", "init with submodule"]);
+        git(&main_work, &["push"]);
+
+        // Get the commit we just pushed, so we can use it as a tag-like ref.
+        let out = git(&main_work, &["rev-parse", "HEAD"]);
+        let commit = String::from_utf8(out.stdout).unwrap().trim().to_string();
+
+        // Now exercise the source cache against the bare "main.git" repo.
+        let cache_dir = tmp.path().join("cache");
+        let url = url::Url::from_file_path(&main_repo).unwrap();
+
+        let cache = SourceCacheBuilder::new()
+            .cache_dir(&cache_dir)
+            .build()
+            .await
+            .unwrap();
+
+        let source = Source::Git(GitSource::with_expected_commit(
+            url,
+            GitReference::from_rev(commit.clone()),
+            None,
+            false,
+            true,
+            Some(commit),
+        ));
+
+        // This used to fail because git submodule update tried to resolve
+        // "../sub.git" against the local cache bare database path.
+        let result = cache.get_source(&source).await.unwrap();
+
+        // Verify the submodule was actually checked out.
+        let sub_file = result.path.join("ext/sub/hello.txt");
+        assert!(
+            sub_file.exists(),
+            "submodule file should exist at {}",
+            sub_file.display()
+        );
+        assert_eq!(
+            fs_err::read_to_string(&sub_file).unwrap(),
+            "hello from submodule"
+        );
+    }
+
     #[test]
     fn test_extract_filename_from_header_strips_path_components() {
         use crate::cache::extract_filename_from_header;

--- a/py-rattler-build/rust/Cargo.lock
+++ b/py-rattler-build/rust/Cargo.lock
@@ -4593,9 +4593,9 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.40.3"
+version = "0.40.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba7b9c2977ddc74fecb7e68dd6b3f40958416220b9643d94db5b7387fd0cbcd"
+checksum = "d5e004d0371d9671efc0c41c9d5311a21479db551fd68236a3299b7d7b8447f0"
 dependencies = [
  "anyhow",
  "clap",
@@ -5003,9 +5003,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.6.18"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f380851c13b9c14811d0281ce72ddd608b7dd98bc0a3e669247aa75dbac5e3b6"
+checksum = "1b829f276e98d7d670be90df8aebaac4ce92606d766e315c230ee4c1782ec9e4"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5036,9 +5036,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.44.3"
+version = "0.44.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dc7eaa515b50a8ba80753d9902582bc2d62d8452ca61e6afd7bca866b54c85"
+checksum = "251545c07ce023c159c6673e9e5da7f49ae9a5cc791d1f5dbb6067a00612550a"
 dependencies = [
  "ahash",
  "chrono",
@@ -5079,9 +5079,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_config"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c237386638e40597bb4117f6e84edd8bb077fa28cafa0535357f5b304d89c9bd"
+checksum = "04e636e27c327e1cb950c726a44a3507700f92ec8c2acbda1a5bc7a679128588"
 dependencies = [
  "console",
  "fs-err",
@@ -5116,9 +5116,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_git"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3433ae20e2a061b99f8587b497fc2fb0c3f8e63527b047f33aca2d28a949f0"
+checksum = "1225e9333f2930720b5759f70c10a5b6631c580ee67940e6a29fbb8393ccb9cc"
 dependencies = [
  "dashmap",
  "dunce",
@@ -5137,9 +5137,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.27.20"
+version = "0.27.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760870693bdb711c0fade345871e15b5b615cae645bdde66b4855fbfeff34087"
+checksum = "20dfb632a54859867a7b920981951dab376c34397c68527d62f63f38e20898ce"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5185,9 +5185,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.53"
+version = "0.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb53fa7f10330b818ddfafd7c7d407254809ea249597bbc03073c2a3ad2854a"
+checksum = "be28b61681374a243151224f09d8691ef59db158001f075b64ef60f26622cc1a"
 dependencies = [
  "chrono",
  "configparser",
@@ -5216,9 +5216,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.26.6"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67894637c820e2fbdf6ac44fc2b43d5ea38b7196439c4f7525b5c3dc2758e0b5"
+checksum = "6c737c889ed175f55fb86986694a916a58f97bb22cf466169abd9c1dd363712e"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -5248,9 +5248,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.24.6"
+version = "0.24.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54da4bc16291b217181fa9ba07c0d5a796e1fa1e63591fef0f6e6e7e96e211d1"
+checksum = "b9cf2ab39920b58ac3cd41a23ef4ec40ab9fdc4a3645c045f5de6b2677b1398f"
 dependencies = [
  "astral-tokio-tar",
  "astral_async_zip",
@@ -5324,9 +5324,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.27.3"
+version = "0.27.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135ed8236490b3de75e887ea54311e0d7a810187000db71ce7ecaf82c93dd981"
+checksum = "927979192dd8e7644da0d6dcb0a1a98244f1412da7a69f0a9037e185caa01dd1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5387,9 +5387,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_s3"
-version = "0.1.29"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733fc964fdc68b18f7d20e25456ebd97d3f8cc86a93383654bbf892666b63a8e"
+checksum = "bc1756990b91a0ceca2e3ed13875ccf4260968ae22a6cfab980862cf97dfbddf"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -5404,9 +5404,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.26.6"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0304b98dc745f816767dfd46c640c14b178c8327799c651dd10b6e25507cbae"
+checksum = "a39fdc6dab30c7eb958bd3d92c47b9b3e78f85cb0acdaebfa91ad3e3230a7e6b"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -5420,14 +5420,15 @@ dependencies = [
  "sysinfo",
  "tempfile",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "rattler_solve"
-version = "5.0.3"
+version = "5.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93157b38db0d0d54491976b0fcd487817bffb3df41247b3310688ac63e0bea8"
+checksum = "a71f5f4948fcd822f2612dd21c07de56a358c1404f6373e0ac0b34d97e9aa817"
 dependencies = [
  "chrono",
  "futures",
@@ -5444,9 +5445,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_upload"
-version = "0.5.3"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b1d0b2e7e301c3bbd2ab3ba4bd5f27539ec188b3c0437e3bb1771027ff65d9"
+checksum = "744df9e3f812863f48c81a2353a99d0348061e22e299b648eaafd0b079f77d05"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -5481,9 +5482,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "2.3.15"
+version = "2.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df69f8439a12f6f06d928ec68b0df2c5958e478e2fb10b5ad939199e6e19d2fb"
+checksum = "8fddfeee1ea50f4f39d2b8750e9f6c5774678108666aa4ff2e0e4d73c733d347"
 dependencies = [
  "archspec",
  "libloading",

--- a/py-rattler-build/rust/Cargo.toml
+++ b/py-rattler-build/rust/Cargo.toml
@@ -34,16 +34,16 @@ tokio = { version = "1.50.0", features = [
   "rt-multi-thread",
   "process",
 ] }
-rattler_conda_types = "0.44.1"
-rattler_config = "0.3.4"
-rattler_networking = { version = "0.26.4" }
-rattler_solve = "5.0.1"
-rattler_virtual_packages = "2.3.13"
+rattler_conda_types = "0.44.5"
+rattler_config = "0.3.8"
+rattler_networking = { version = "0.26.8" }
+rattler_solve = "5.2.1"
+rattler_virtual_packages = "2.3.17"
 clap = "4.6.0"
 url = "2.5.8"
 chrono = "0.4.44"
-rattler_upload = "0.5.2"
-rattler_package_streaming = { version = "0.24.4", default-features = false }
+rattler_upload = "0.5.6"
+rattler_package_streaming = { version = "0.24.8", default-features = false }
 miette = "7.6.0"
 tempfile = "3.27.0"
 serde_yaml = "0.9"


### PR DESCRIPTION
The local checkout created by `rattler_git` points origin at the bare
cache database. Submodules with relative URLs resolve against origin,
so they fail to clone from non-existent local paths.

Fix by resolving submodule URLs against source URL instead of mutating origin.

Fixes prefix-dev/rattler-build#2379