### PR TITLE
ci: merge build into end-to-end and rebuild test

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -75,14 +75,16 @@ jobs:
         if: always()
         run: pixi run sccache --show-stats
 
-  # Build release binary (one per OS)
-  build:
-    name: Build (${{ matrix.os }})
+  # Run end-to-end tests
+  e2e-test:
+    name: End-to-end (${{ matrix.os }})
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    env:
+      RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: "true"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -100,54 +102,18 @@ jobs:
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
       - name: Build release binary
         run: pixi run build-release
-      - name: Upload binary artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: rattler-build-${{ matrix.os }}
-          path: target-pixi/release/rattler-build${{ runner.os == 'Windows' && '.exe' || '' }}
-          retention-days: 7
-      - name: Show sccache stats
-        if: always()
-        run: pixi run sccache --show-stats
-
-  # Run end-to-end tests using the pre-built binary
-  e2e-test:
-    name: End-to-end (${{ matrix.os }})
-    needs: build
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
-    env:
-      RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: "true"
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          submodules: recursive
-          persist-credentials: false
-      - uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
-        with:
-          cache: true
-          cache-write: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-      - name: Download rattler-build binary
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: rattler-build-${{ matrix.os }}
-          path: target-pixi/release/
-      - name: Prepare binary
-        if: runner.os != 'Windows'
-        run: chmod +x target-pixi/release/rattler-build
       - name: Run end-to-end tests
         run: pixi run test-end-to-end-ci
         env:
           PREFIX_DEV_READ_ONLY_TOKEN: ${{ secrets.PREFIX_DEV_READ_ONLY_TOKEN }}
           S3_ACCESS_KEY_ID: ${{ secrets.S3_UPLOAD_ACCESS_KEY_ID }}
           S3_SECRET_ACCESS_KEY: ${{ secrets.S3_UPLOAD_ACCESS_KEY_SECRET }}
+      - name: Show sccache stats
+        if: always()
+        run: pixi run sccache --show-stats
 
   rebuild-test:
     name: Rebuild Test
-    needs: build
     if: contains(github.event.pull_request.labels.*.name, 'needs-rebuild-tests')
     runs-on: ubuntu-latest
     steps:
@@ -156,26 +122,34 @@ jobs:
         with:
           submodules: recursive
           persist-credentials: false
-      - name: Download rattler-build artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
         with:
-          name: rattler-build-ubuntu-latest
-          path: ./
-      - name: Prepare binary
-        run: chmod +x rattler-build
+          cache: true
+          cache-write: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      - name: Configure sccache
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+      - name: Build release binary
+        run: pixi run build-release
       - name: Build rich package
         run: |
           mkdir -p output
-          ./rattler-build build --recipe ./examples/rich
+          ./target-pixi/release/rattler-build build --recipe ./examples/rich
           echo "Built packages:"
           ls -la ./output/noarch/
       - name: Rebuild rich package
         run: |
           PACKAGE=$(find ./output/noarch/rich-*.conda | head -n1)
           echo "Rebuilding package: $PACKAGE"
-          ./rattler-build rebuild --package-file "$PACKAGE"
+          ./target-pixi/release/rattler-build rebuild --package-file "$PACKAGE"
           echo "Rebuild completed successfully"
       - name: Compare original and rebuilt packages
         run: |
           echo "Contents after rebuild:"
           ls -la ./output/noarch/
+      - name: Show sccache stats
+        if: always()
+        run: pixi run sccache --show-stats


### PR DESCRIPTION
This way ubuntu tests don't need to wait for slow windows builds to finish and we get quicker feedback