### PR TITLE
fix: prevent stacking of pending-rm suffixes on Windows cleanup

### DIFF
--- a/crates/rattler_build_core/src/build.rs
+++ b/crates/rattler_build_core/src/build.rs
@@ -228,10 +228,6 @@ pub async fn run_build(
         }
     }
 
-    if !tool_configuration.no_clean {
-        directories.clean().into_diagnostic()?;
-    }
-
     drop(enter);
 
     if !tool_configuration.no_clean {

--- a/crates/rattler_build_core/src/types/directories.rs
+++ b/crates/rattler_build_core/src/types/directories.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use dunce::canonicalize;
 
-use crate::utils::remove_dir_all_force;
+use crate::utils::{is_pending_removal, remove_dir_all_force};
 
 /// Builder for creating [`Directories`] with a fluent API.
 #[derive(Debug, Clone)]
@@ -209,16 +209,31 @@ impl Directories {
     /// Remove all directories except for the cache directory
     pub fn clean(&self) -> Result<(), std::io::Error> {
         if self.build_dir.exists() {
-            let folders = self.build_dir.read_dir()?;
+            // Snapshot entries before iterating: on Windows the rename-before-
+            // delete path in `remove_dir_all_force` creates new sibling trash
+            // dirs (`.{name}.pending-rm-{nanos}`), and we don't want the
+            // iterator to pick them up and process them recursively.
+            let folders: Vec<_> = self
+                .build_dir
+                .read_dir()?
+                .collect::<Result<_, _>>()?;
             for folder in folders {
-                let folder = folder?;
+                let path = folder.path();
 
-                if folder.path() == self.cache_dir {
+                if path == self.cache_dir {
+                    continue;
+                }
+
+                // Leave pending-rm trash dirs (from this or a previous run)
+                // alone. Re-cleaning them stacks `.pending-rm-*` suffixes and
+                // can blow past Windows' MAX_PATH, and the underlying files
+                // are still locked by whatever blocked removal originally.
+                if is_pending_removal(&path) {
                     continue;
                 }
 
                 if folder.file_type()?.is_dir() {
-                    remove_dir_all_force(&folder.path())?;
+                    remove_dir_all_force(&path)?;
                 }
             }
         }
@@ -311,6 +326,39 @@ mod tests {
         let f2 = p2.file_name().unwrap();
         let epoch = timestamp.timestamp();
         assert!(f2.eq(format!("rattler-build_name_{epoch}").as_str()));
+    }
+
+    #[test]
+    fn test_clean_skips_pending_rm_dirs() {
+        let tempdir = tempfile::tempdir().unwrap();
+
+        let directories = Directories::builder(
+            "name",
+            &tempdir.path().join("recipe"),
+            &tempdir.path().join("output"),
+            &chrono::Utc::now(),
+        )
+        .build()
+        .unwrap();
+        directories.recreate_directories().unwrap();
+
+        // Simulate a leftover trash dir from a previous rename-before-delete
+        // attempt. `clean()` must leave it alone — attempting to remove it
+        // would stack another `.pending-rm-*` suffix on Windows and waste
+        // retries on files the OS still holds open.
+        let trash = directories
+            .build_dir
+            .join(".work.pending-rm-1776529982099702900");
+        fs::create_dir_all(&trash).unwrap();
+        fs::write(trash.join("locked.txt"), b"content").unwrap();
+
+        directories.clean().unwrap();
+
+        assert!(trash.exists(), "pending-rm trash dir must be preserved");
+        assert!(
+            !directories.work_dir.exists(),
+            "regular work dir should still be cleaned"
+        );
     }
 
     #[test]

--- a/crates/rattler_build_core/src/types/directories.rs
+++ b/crates/rattler_build_core/src/types/directories.rs
@@ -213,10 +213,7 @@ impl Directories {
             // delete path in `remove_dir_all_force` creates new sibling trash
             // dirs (`.{name}.pending-rm-{nanos}`), and we don't want the
             // iterator to pick them up and process them recursively.
-            let folders: Vec<_> = self
-                .build_dir
-                .read_dir()?
-                .collect::<Result<_, _>>()?;
+            let folders: Vec<_> = self.build_dir.read_dir()?.collect::<Result<_, _>>()?;
             for folder in folders {
                 let path = folder.path();
 

--- a/crates/rattler_build_core/src/utils.rs
+++ b/crates/rattler_build_core/src/utils.rs
@@ -238,8 +238,9 @@ fn pending_removal_path(path: &Path) -> PathBuf {
     parent.join(format!(".{base}.pending-rm-{unique}"))
 }
 
-/// Strip any `.pending-rm-{digits}` suffixes and a single leading `.` that
-/// `pending_removal_path` may have added on a previous attempt.
+/// Strip any `.pending-rm-{digits}` suffixes and the matching leading `.`
+/// that `pending_removal_path` prepended alongside each suffix on previous
+/// attempts, so repeated renames don't drift the recovered base name.
 #[cfg(windows)]
 fn strip_pending_rm(name: &str) -> &str {
     const MARKER: &str = ".pending-rm-";
@@ -248,11 +249,12 @@ fn strip_pending_rm(name: &str) -> &str {
         let tail = &stripped[idx + MARKER.len()..];
         if !tail.is_empty() && tail.bytes().all(|b| b.is_ascii_digit()) {
             stripped = &stripped[..idx];
+            stripped = stripped.strip_prefix('.').unwrap_or(stripped);
         } else {
             break;
         }
     }
-    stripped.strip_prefix('.').unwrap_or(stripped)
+    stripped
 }
 
 /// Make the path and any children writable by adjusting permissions.

--- a/crates/rattler_build_core/src/utils.rs
+++ b/crates/rattler_build_core/src/utils.rs
@@ -337,7 +337,7 @@ mod tests {
         );
         assert_eq!(
             strip_pending_rm(".work.pending-rm-123.pending-rm-notdigits"),
-            "work.pending-rm-123.pending-rm-notdigits"
+            ".work.pending-rm-123.pending-rm-notdigits"
         );
     }
 

--- a/crates/rattler_build_core/src/utils.rs
+++ b/crates/rattler_build_core/src/utils.rs
@@ -209,16 +209,50 @@ fn try_remove_with_retry(path: &Path, last_err: Option<std::io::Error>) -> std::
     }
 }
 
+/// Whether a path has been marked for deferred removal by
+/// `remove_dir_all_force` on Windows (a `.{name}.pending-rm-{nanos}` sibling).
+///
+/// Callers that iterate a parent directory (e.g. `Directories::clean`) should
+/// skip such entries: re-processing them just stacks more suffixes and burns
+/// retries on files the OS still holds open.
+pub fn is_pending_removal(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .is_some_and(|n| n.starts_with('.') && n.contains(".pending-rm-"))
+}
+
 /// Generate a unique sibling path for rename-before-delete.
+///
+/// If `path` is already a pending-rm sibling, the original base name is
+/// recovered so repeated attempts don't accumulate names like
+/// `..work.pending-rm-A.pending-rm-B`.
 #[cfg(windows)]
 fn pending_removal_path(path: &Path) -> PathBuf {
     let parent = path.parent().unwrap_or(Path::new("."));
-    let name = path.file_name().unwrap_or_default().to_string_lossy();
+    let raw = path.file_name().unwrap_or_default().to_string_lossy();
+    let base = strip_pending_rm(&raw);
     let unique = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    parent.join(format!(".{name}.pending-rm-{unique}"))
+    parent.join(format!(".{base}.pending-rm-{unique}"))
+}
+
+/// Strip any `.pending-rm-{digits}` suffixes and a single leading `.` that
+/// `pending_removal_path` may have added on a previous attempt.
+#[cfg(windows)]
+fn strip_pending_rm(name: &str) -> &str {
+    const MARKER: &str = ".pending-rm-";
+    let mut stripped = name;
+    while let Some(idx) = stripped.rfind(MARKER) {
+        let tail = &stripped[idx + MARKER.len()..];
+        if !tail.is_empty() && tail.bytes().all(|b| b.is_ascii_digit()) {
+            stripped = &stripped[..idx];
+        } else {
+            break;
+        }
+    }
+    stripped.strip_prefix('.').unwrap_or(stripped)
 }
 
 /// Make the path and any children writable by adjusting permissions.
@@ -272,6 +306,56 @@ mod tests {
             let forward_slash = to_forward_slash_lossy(path);
             assert_eq!(forward_slash, "/foo/bar/baz");
         }
+    }
+
+    #[test]
+    fn test_is_pending_removal() {
+        assert!(is_pending_removal(Path::new(".work.pending-rm-123")));
+        assert!(is_pending_removal(Path::new(
+            "/tmp/build/.work.pending-rm-1776529982099702900"
+        )));
+        assert!(is_pending_removal(Path::new(
+            "..work.pending-rm-1.pending-rm-2"
+        )));
+
+        assert!(!is_pending_removal(Path::new("work")));
+        assert!(!is_pending_removal(Path::new(".hidden")));
+        assert!(!is_pending_removal(Path::new("pending-rm-123")));
+        assert!(!is_pending_removal(Path::new(".work")));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_strip_pending_rm() {
+        assert_eq!(strip_pending_rm("work"), "work");
+        assert_eq!(strip_pending_rm(".work.pending-rm-123"), "work");
+        assert_eq!(
+            strip_pending_rm("..work.pending-rm-123.pending-rm-456"),
+            "work"
+        );
+        assert_eq!(
+            strip_pending_rm(".work.pending-rm-123.pending-rm-notdigits"),
+            "work.pending-rm-123.pending-rm-notdigits"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_pending_removal_path_does_not_stack() {
+        use std::path::PathBuf;
+
+        let base = PathBuf::from(r"C:\bld\rattler-build_pkg\work");
+        let first = pending_removal_path(&base);
+        let first_name = first.file_name().unwrap().to_string_lossy().into_owned();
+        assert!(first_name.starts_with(".work.pending-rm-"));
+        assert_eq!(first_name.matches(".pending-rm-").count(), 1);
+
+        // Re-renaming the trash path must not nest suffixes.
+        let second = pending_removal_path(&first);
+        let second_name = second.file_name().unwrap().to_string_lossy().into_owned();
+        assert!(second_name.starts_with(".work.pending-rm-"));
+        assert_eq!(second_name.matches(".pending-rm-").count(), 1);
+        assert!(!second_name.starts_with(".."));
     }
 
     #[cfg(windows)]


### PR DESCRIPTION
## Summary
This PR fixes a Windows-specific issue where repeated cleanup attempts could accumulate multiple `.pending-rm-*` suffixes on directory names, potentially exceeding MAX_PATH limits and wasting retry attempts on locked files.

## Key Changes
- **Added `is_pending_removal()` utility**: Identifies directories marked for deferred removal (those with `.pending-rm-{nanos}` suffixes) so they can be skipped during cleanup iterations.

- **Added `strip_pending_rm()` function**: Recovers the original base name from paths that already have pending-rm suffixes, preventing suffix stacking when `pending_removal_path()` is called multiple times on the same path.

- **Updated `pending_removal_path()`**: Now uses `strip_pending_rm()` to ensure that re-renaming a trash path doesn't accumulate nested suffixes like `.work.pending-rm-A.pending-rm-B`.

- **Modified `Directories::clean()`**: 
  - Snapshots directory entries before iteration to avoid processing newly-created trash directories
  - Skips entries identified as pending removal to prevent re-processing locked files
  - Avoids recursive cleanup of trash directories that the OS still holds open

- **Removed duplicate cleanup call**: Eliminated a redundant `directories.clean()` call in `run_build()` that was executing before the conditional check.

## Implementation Details
- The `strip_pending_rm()` function iteratively removes `.pending-rm-{digits}` suffixes from the right, then strips a leading dot, recovering the original filename.
- Directory iteration is now collected into a `Vec` before processing to create a stable snapshot, preventing the iterator from picking up newly-created trash directories on Windows.
- Comprehensive test coverage added for the new utility functions and the cleanup behavior.

https://claude.ai/code/session_01E8Psngzhc72iTNYGZRBTki