### PR TITLE
test: add test of channel prefixes for run w/ tests

### DIFF
--- a/test-data/recipes/channel_specific/recipe.yaml
+++ b/test-data/recipes/channel_specific/recipe.yaml
@@ -5,3 +5,9 @@ package:
 requirements:
   host:
     - quantstack::sphinx
+  run:
+    - quantstack::sphinx
+
+tests:
+  - script:
+      - echo "hi!"


### PR DESCRIPTION
I am trying to debug an issue I am finding over in https://github.com/conda-forge/r-nmf-feedstock/pull/27 where rattler-build cannot seem to resolve channel-prefixed run requirements when a package is being tested.