### PR TITLE
test: add case: specific channel specification under requirements, w/ channel_sources and tests specified

### DIFF
--- a/test-data/recipes/channel_specific_with_sources/conda_build_config.yaml
+++ b/test-data/recipes/channel_specific_with_sources/conda_build_config.yaml
@@ -1,0 +1,2 @@
+channel_sources:
+  - conda-forge,bioconda

--- a/test-data/recipes/channel_specific_with_sources/recipe.yaml
+++ b/test-data/recipes/channel_specific_with_sources/recipe.yaml
@@ -1,0 +1,11 @@
+package:
+  name: channel_specific_with_sources
+  version: 1.0.0
+
+requirements:
+  run:
+    - bioconda::r-dwls
+
+tests:
+  - script:
+      - R -e "library('DWLS')"

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -1298,7 +1298,9 @@ def test_channel_specific(rattler_build: RattlerBuild, recipes: Path, tmp_path: 
             assert d["channel"] == "https://conda.anaconda.org/quantstack/"
 
 
-def test_channel_specific_with_sources(rattler_build: RattlerBuild, recipes: Path, tmp_path: Path):
+def test_channel_specific_with_sources(
+    rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
+):
     rattler_build.build(
         recipes / "channel_specific_with_sources/recipe.yaml",
         tmp_path,

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -1298,6 +1298,25 @@ def test_channel_specific(rattler_build: RattlerBuild, recipes: Path, tmp_path: 
             assert d["channel"] == "https://conda.anaconda.org/quantstack/"
 
 
+def test_channel_specific_with_sources(rattler_build: RattlerBuild, recipes: Path, tmp_path: Path):
+    rattler_build.build(
+        recipes / "channel_specific_with_sources/recipe.yaml",
+        tmp_path,
+    )
+    pkg = get_extracted_package(tmp_path, "channel_specific_with_sources")
+
+    assert (pkg / "info/recipe/rendered_recipe.yaml").exists()
+    # load yaml
+    text = (pkg / "info/recipe/rendered_recipe.yaml").read_text()
+    rendered_recipe = yaml.safe_load(text)
+    print(text)
+    deps = rendered_recipe["finalized_dependencies"]["host"]["resolved"]
+
+    for d in deps:
+        if d["name"] == "r-dwls":
+            assert d["channel"] == "https://conda.anaconda.org/bioconda/"
+
+
 def test_run_exports_from(
     rattler_build: RattlerBuild, recipes: Path, tmp_path: Path, snapshot_json
 ):


### PR DESCRIPTION
This comes from [an attempt to build a `conda-forge` package that references dependencies from the `bioconda` channel](https://github.com/conda-forge/r-nmf-feedstock/pull/27). The syntax seems to work for building, but the channel then isn't found during testing. Thus, this test case includes a `tests:` section.

Generally, if this channel specification works out with both building and testing, we can use this to consistently fix a number of `conda-forge` packages that added `bioconda` package dependencies at some point (usually `r-` packages from `CRAN` that added `bioconductor-` package dependencies).