### PR TITLE
fix: use force directory removal to handle Windows file locks

### DIFF
--- a/crates/rattler_build_core/src/staging.rs
+++ b/crates/rattler_build_core/src/staging.rs
@@ -27,6 +27,7 @@ use crate::{
         FinalizedDependencies, RunExportsDownload, install_environments, resolve_dependencies,
     },
     source::{copy_dir::CopyDir, fetch_sources},
+    utils::remove_dir_all_force,
 };
 
 /// Error type for staging cache operations
@@ -195,7 +196,7 @@ impl Output {
                                 e
                             );
                             // Remove corrupted cache and rebuild
-                            fs::remove_dir_all(&cache_dir).into_diagnostic()?;
+                            remove_dir_all_force(&cache_dir).into_diagnostic()?;
                         }
                     },
                     Err(e) => {
@@ -204,7 +205,7 @@ impl Output {
                             metadata_path.display(),
                             e
                         );
-                        fs::remove_dir_all(&cache_dir).into_diagnostic()?;
+                        remove_dir_all_force(&cache_dir).into_diagnostic()?;
                     }
                 }
             }
@@ -430,16 +431,20 @@ impl Output {
         let work_dir_cache = cache_dir.join("work_dir");
 
         // IMPORTANT: Clean the prefix directory before restoring from cache
-        // The prefix may already have files from dependency installation or previous builds
+        // The prefix may already have files from dependency installation or previous builds.
+        // Use `remove_dir_all_force` so Windows can rename-before-delete when a
+        // lingering handle (antivirus, indexer, build tool) would otherwise
+        // cause `remove_dir_all` to fail with "Access is denied" (os error 5).
         if self.prefix().exists() {
             tracing::debug!("Removing existing prefix before cache restoration");
-            fs::remove_dir_all(self.prefix()).into_diagnostic()?;
+            remove_dir_all_force(self.prefix()).into_diagnostic()?;
         }
 
         // Clean the work directory as well
         if self.build_configuration.directories.work_dir.exists() {
             tracing::debug!("Removing existing work directory before cache restoration");
-            fs::remove_dir_all(&self.build_configuration.directories.work_dir).into_diagnostic()?;
+            remove_dir_all_force(&self.build_configuration.directories.work_dir)
+                .into_diagnostic()?;
         }
 
         // Restore prefix files


### PR DESCRIPTION
## Summary
Replace standard `fs::remove_dir_all` calls with a new `remove_dir_all_force` utility function to handle Windows file locking issues during directory cleanup operations.

## Key Changes
- Import new `remove_dir_all_force` utility from `utils` module
- Replace 4 instances of `fs::remove_dir_all` with `remove_dir_all_force` in the staging module:
  - Two calls in cache corruption/error handling paths
  - Two calls in prefix and work directory cleanup before cache restoration
- Add detailed comment explaining the Windows-specific rationale: the force removal allows rename-before-delete semantics to work around "Access is denied" errors caused by lingering file handles from antivirus, indexers, or build tools

## Implementation Details
The `remove_dir_all_force` function provides more robust directory removal on Windows by using a rename-before-delete strategy when standard removal fails, preventing build failures due to transient file locks that would otherwise cause "os error 5" (Access is denied).

https://claude.ai/code/session_017q622zzbYvMWsWRCmyPJky