### PR TITLE
fix: remove PKG_* environment variables in staging cache, set variant values

### DIFF
--- a/crates/rattler_build_core/src/staging.rs
+++ b/crates/rattler_build_core/src/staging.rs
@@ -281,9 +281,12 @@ impl Output {
         ));
         env_vars.extend(env_vars::env_vars_from_variant(self.variant()));
 
-        // Override PKG_NAME with the staging cache name so the script sees the
-        // staging cache identity rather than the inheriting output's name.
-        env_vars.insert("PKG_NAME".to_string(), Some(staging.name.clone()));
+        // A staging cache does not produce a package, so the PKG_* vars
+        // (which would otherwise carry the inheriting output's identity) are
+        // misleading here.
+        for key in ["PKG_NAME", "PKG_VERSION", "PKG_BUILDNUM", "PKG_BUILD_STRING", "PKG_HASH"] {
+            env_vars.remove(key);
+        }
 
         // Create Jinja context
         let selector_config = self.build_configuration.selector_config();

--- a/crates/rattler_build_core/src/staging.rs
+++ b/crates/rattler_build_core/src/staging.rs
@@ -279,6 +279,11 @@ impl Output {
             self.build_configuration.env_isolation,
             &self.build_configuration.directories.work_dir,
         ));
+        env_vars.extend(env_vars::env_vars_from_variant(self.variant()));
+
+        // Override PKG_NAME with the staging cache name so the script sees the
+        // staging cache identity rather than the inheriting output's name.
+        env_vars.insert("PKG_NAME".to_string(), Some(staging.name.clone()));
 
         // Create Jinja context
         let selector_config = self.build_configuration.selector_config();

--- a/crates/rattler_build_core/src/staging.rs
+++ b/crates/rattler_build_core/src/staging.rs
@@ -284,7 +284,13 @@ impl Output {
         // A staging cache does not produce a package, so the PKG_* vars
         // (which would otherwise carry the inheriting output's identity) are
         // misleading here.
-        for key in ["PKG_NAME", "PKG_VERSION", "PKG_BUILDNUM", "PKG_BUILD_STRING", "PKG_HASH"] {
+        for key in [
+            "PKG_NAME",
+            "PKG_VERSION",
+            "PKG_BUILDNUM",
+            "PKG_BUILD_STRING",
+            "PKG_HASH",
+        ] {
             env_vars.remove(key);
         }
 


### PR DESCRIPTION
## Summary
This change fixes environment variable handling in staging cache contexts by removing misleading PKG_* variables that would otherwise inherit from the parent output's identity.

## Key Changes
- Added variant-specific environment variables to the staging cache environment setup
- Removed PKG_NAME, PKG_VERSION, PKG_BUILDNUM, PKG_BUILD_STRING, and PKG_HASH from the environment since staging caches don't produce packages and these variables would be misleading in that context

## Implementation Details
The fix ensures that when setting up environment variables for a staging cache, we:
1. First extend with variant-specific environment variables
2. Then explicitly remove the PKG_* variables that carry package identity information, since a staging cache is not a package output and shouldn't inherit these values from the parent output

https://claude.ai/code/session_01Jy4Cz8QvigYixpjzvwzHLK