### PR TITLE
fix: skip unpacking symlinks on Windows instead of failing

### DIFF
--- a/crates/rattler_build_source_cache/src/cache.rs
+++ b/crates/rattler_build_source_cache/src/cache.rs
@@ -717,7 +717,54 @@ pub fn is_tarball(file_name: &str) -> bool {
     .any(|ext| file_name.ends_with(ext))
 }
 
-fn extract_tar(archive: &Path, target: &Path) -> Result<(), CacheError> {
+/// Iterates over the entries of a tar archive and unpacks each one into `target`.
+///
+/// On Windows, symlink entries that fail to unpack are skipped with a warning instead of
+/// aborting the whole extraction. Creating symlinks on Windows requires Developer Mode or
+/// administrator privileges; skipping them gracefully means the rest of the archive is
+/// still extracted and the build can proceed (a missing symlink will surface as a build
+/// error only if it is actually needed).
+fn unpack_tar_entries<R: std::io::Read>(
+    archive: &mut tar::Archive<R>,
+    target: &Path,
+) -> Result<(), CacheError> {
+    let entries = archive.entries().map_err(|e| {
+        CacheError::ExtractionError(format!("Failed to read archive entries: {}", e))
+    })?;
+
+    for entry in entries {
+        let mut entry = entry.map_err(|e| {
+            CacheError::ExtractionError(format!("Failed to read archive entry: {}", e))
+        })?;
+
+        match entry.unpack_in(target) {
+            Ok(_) => {}
+            Err(e) => {
+                // On Windows, creating symlinks requires Developer Mode or admin
+                // privileges. If unpacking a symlink fails, warn and skip the entry
+                // rather than failing the whole extraction.
+                #[cfg(target_os = "windows")]
+                if entry.header().entry_type().is_symlink() {
+                    tracing::warn!(
+                        "skipping symlink in tar archive: {}: {e}",
+                        entry
+                            .path()
+                            .map(|p| p.display().to_string())
+                            .unwrap_or_default()
+                    );
+                    continue;
+                }
+                return Err(CacheError::ExtractionError(format!(
+                    "Failed to unpack archive entry: {e}"
+                )));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) fn extract_tar(archive: &Path, target: &Path) -> Result<(), CacheError> {
     let file = fs_err::File::open(archive)
         .map_err(|e| CacheError::ExtractionError(format!("Failed to open archive: {}", e)))?;
 
@@ -725,32 +772,22 @@ fn extract_tar(archive: &Path, target: &Path) -> Result<(), CacheError> {
 
     if name.ends_with(".tar.gz") || name.ends_with(".tgz") {
         let mut archive = tar::Archive::new(GzDecoder::new(file));
-        archive
-            .unpack(target)
-            .map_err(|e| CacheError::ExtractionError(format!("Failed to extract tar.gz: {}", e)))?;
+        unpack_tar_entries(&mut archive, target)?;
     } else if name.ends_with(".tar.bz2") || name.ends_with(".tbz2") {
         let mut archive = tar::Archive::new(bzip2::read::BzDecoder::new(file));
-        archive.unpack(target).map_err(|e| {
-            CacheError::ExtractionError(format!("Failed to extract tar.bz2: {}", e))
-        })?;
+        unpack_tar_entries(&mut archive, target)?;
     } else if name.ends_with(".tar.xz") || name.ends_with(".txz") {
         let mut archive = tar::Archive::new(lzma_rust2::XzReader::new(file, true));
-        archive
-            .unpack(target)
-            .map_err(|e| CacheError::ExtractionError(format!("Failed to extract tar.xz: {}", e)))?;
+        unpack_tar_entries(&mut archive, target)?;
     } else if name.ends_with(".tar.zst") {
         let decoder = zstd::stream::read::Decoder::new(file).map_err(|e| {
             CacheError::ExtractionError(format!("Failed to create zstd decoder: {}", e))
         })?;
         let mut archive = tar::Archive::new(decoder);
-        archive.unpack(target).map_err(|e| {
-            CacheError::ExtractionError(format!("Failed to extract tar.zst: {}", e))
-        })?;
+        unpack_tar_entries(&mut archive, target)?;
     } else {
         let mut archive = tar::Archive::new(file);
-        archive
-            .unpack(target)
-            .map_err(|e| CacheError::ExtractionError(format!("Failed to extract tar: {}", e)))?;
+        unpack_tar_entries(&mut archive, target)?;
     }
 
     Ok(())

--- a/crates/rattler_build_source_cache/src/cache.rs
+++ b/crates/rattler_build_source_cache/src/cache.rs
@@ -719,49 +719,88 @@ pub fn is_tarball(file_name: &str) -> bool {
 
 /// Iterates over the entries of a tar archive and unpacks each one into `target`.
 ///
-/// On Windows, symlink entries that fail to unpack are skipped with a warning instead of
-/// aborting the whole extraction. Creating symlinks on Windows requires Developer Mode or
-/// administrator privileges; skipping them gracefully means the rest of the archive is
-/// still extracted and the build can proceed (a missing symlink will surface as a build
-/// error only if it is actually needed).
+/// This mirrors [`tar::Archive::unpack`] (canonicalizing the target so Windows long
+/// paths get the `\\?\` prefix, and applying directory entries last in reverse-sorted
+/// order so directory permissions/mtimes do not interfere with descendant extraction),
+/// but adds one behavior: on Windows, symlink entries that fail to unpack are skipped
+/// with a warning instead of aborting the whole extraction. Creating symlinks on Windows
+/// requires Developer Mode or administrator privileges; skipping them gracefully means
+/// the rest of the archive is still extracted and the build can proceed (a missing
+/// symlink will surface as a build error only if it is actually needed).
 fn unpack_tar_entries<R: std::io::Read>(
     archive: &mut tar::Archive<R>,
     target: &Path,
 ) -> Result<(), CacheError> {
+    // Ensure the destination exists, then canonicalize it. On Windows this prepends the
+    // `\\?\` extended-length prefix, which is what lets paths longer than 260 characters be
+    // created. `tar::Archive::unpack` does the same; without it, long paths fail on Windows.
+    if target.symlink_metadata().is_err() {
+        fs_err::create_dir_all(target).map_err(|e| {
+            CacheError::ExtractionError(format!("Failed to create target directory: {}", e))
+        })?;
+    }
+    let canonical_target = target.canonicalize().unwrap_or_else(|_| target.to_path_buf());
+    let target = canonical_target.as_path();
+
     let entries = archive.entries().map_err(|e| {
         CacheError::ExtractionError(format!("Failed to read archive entries: {}", e))
     })?;
 
+    // Delay directory entries until the end so that (potentially restrictive) directory
+    // permissions do not block writing their descendants, and directory mtimes are not
+    // clobbered by files written into them afterwards.
+    let mut directories = Vec::new();
+
     for entry in entries {
-        let mut entry = entry.map_err(|e| {
+        let entry = entry.map_err(|e| {
             CacheError::ExtractionError(format!("Failed to read archive entry: {}", e))
         })?;
 
-        match entry.unpack_in(target) {
-            Ok(_) => {}
-            Err(e) => {
-                // On Windows, creating symlinks requires Developer Mode or admin
-                // privileges. If unpacking a symlink fails, warn and skip the entry
-                // rather than failing the whole extraction.
-                #[cfg(target_os = "windows")]
-                if entry.header().entry_type().is_symlink() {
-                    tracing::warn!(
-                        "skipping symlink in tar archive: {}: {e}",
-                        entry
-                            .path()
-                            .map(|p| p.display().to_string())
-                            .unwrap_or_default()
-                    );
-                    continue;
-                }
-                return Err(CacheError::ExtractionError(format!(
-                    "Failed to unpack archive entry: {e}"
-                )));
-            }
+        if entry.header().entry_type() == tar::EntryType::Directory {
+            directories.push(entry);
+        } else {
+            unpack_entry(entry, target)?;
         }
     }
 
+    // Apply directories in reverse-sorted (topological) order so parents are created
+    // with the correct permissions after their children. Matches `tar::Archive::unpack`.
+    directories.sort_by(|a, b| b.path_bytes().cmp(&a.path_bytes()));
+    for dir in directories {
+        unpack_entry(dir, target)?;
+    }
+
     Ok(())
+}
+
+/// Unpacks a single tar entry into `target`, skipping symlinks that fail to unpack on
+/// Windows (see [`unpack_tar_entries`]).
+fn unpack_entry<R: std::io::Read>(
+    mut entry: tar::Entry<'_, R>,
+    target: &Path,
+) -> Result<(), CacheError> {
+    match entry.unpack_in(target) {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            // On Windows, creating symlinks requires Developer Mode or admin
+            // privileges. If unpacking a symlink fails, warn and skip the entry
+            // rather than failing the whole extraction.
+            #[cfg(target_os = "windows")]
+            if entry.header().entry_type().is_symlink() {
+                tracing::warn!(
+                    "skipping symlink in tar archive: {}: {e}",
+                    entry
+                        .path()
+                        .map(|p| p.display().to_string())
+                        .unwrap_or_default()
+                );
+                return Ok(());
+            }
+            Err(CacheError::ExtractionError(format!(
+                "Failed to unpack archive entry: {e}"
+            )))
+        }
+    }
 }
 
 pub(crate) fn extract_tar(archive: &Path, target: &Path) -> Result<(), CacheError> {

--- a/crates/rattler_build_source_cache/src/tests.rs
+++ b/crates/rattler_build_source_cache/src/tests.rs
@@ -344,6 +344,46 @@ mod source_cache_tests {
         );
     }
 
+    /// Creates a minimal `.tar.gz` at `dest` containing a single symlink entry.
+    #[cfg(target_os = "windows")]
+    fn make_tar_gz_with_symlink(dest: &std::path::Path) {
+        use flate2::{Compression, write::GzEncoder};
+
+        let file = fs_err::File::create(dest).unwrap();
+        let enc = GzEncoder::new(file, Compression::default());
+        let mut builder = tar::Builder::new(enc);
+
+        let mut header = tar::Header::new_gnu();
+        header.set_entry_type(tar::EntryType::Symlink);
+        header.set_size(0);
+        header.set_mode(0o777);
+        header.set_cksum();
+        builder
+            .append_link(&mut header, "link_target", "real_file")
+            .unwrap();
+        builder.finish().unwrap();
+    }
+
+    /// On Windows, extracting a symlink-containing archive should always succeed:
+    /// symlinks that cannot be created are skipped with a warning rather than
+    /// aborting the extraction, regardless of Developer Mode status.
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn test_symlink_extraction_skipped_on_windows() {
+        use crate::cache::extract_tar;
+
+        let dir = TempDir::new().unwrap();
+        let archive = dir.path().join("test.tar.gz");
+        make_tar_gz_with_symlink(&archive);
+
+        let target = dir.path().join("out");
+        fs_err::create_dir_all(&target).unwrap();
+
+        // Symlinks that fail to unpack on Windows are skipped with a warning,
+        // so extraction always succeeds.
+        extract_tar(&archive, &target).unwrap();
+    }
+
     #[test]
     fn test_extract_filename_from_header_strips_path_components() {
         use crate::cache::extract_filename_from_header;


### PR DESCRIPTION
## Problem

Refer - https://github.com/prefix-dev/rattler-build/issues/940#issuecomment-4319905923

When rattler-build tries to extract a source archive (e.g. a `.tar.gz`) that contains symbolic links on Windows **without Developer Mode enabled**, the extraction fails hard with no actionable information:

```
 ╭─ Running build for recipe: podman-desktop-1.26.2-hf0b5a29_0
 │
 │ ╭─ Fetching source code
 │ │ Fetching source from url: https://github.com/podman-desktop/podman-desktop/archive/refs/tags/v1.26.2.tar.gz
 │ │ Downloading from: https://github.com/podman-desktop/podman-desktop/archive/refs/tags/v1.26.2.tar.gz
 │ │ ⚠ warning Failed to fetch from https://github.com/podman-desktop/podman-desktop/archive/refs/tags/v1.26.2.tar.gz: Failed to extract archive: Failed to extract tar
 │ │ ⚠ warning .gz: failed to unpack `\\?\C:\Users\Gagan\staged-recipes\build_artifacts\src_cache\.tmpyweool\podman-desktop-1.26.2\CLAUDE.md`
 │ │
 │ ╰─────────────────── (took 8 seconds)
 │
 ╰─────────────────── (took 8 seconds)
Error:   x Failed to extract archive: Failed to extract tar.gz: failed to unpack `\\?\C:\Users\Gagan\staged-recipes\build_artifacts\src_cache\.tmpyweool\podman-desktop-
  | 1.26.2\CLAUDE.md`
```

## Solution

Instead of failing the entire extraction when a symlink cannot be created, this PR iterates tar entries manually and **skips failing symlink entries with a warning** on Windows. The approach mirrors what rattler/pixi already do for their own extraction path.

1. **`unpack_tar_entries` helper** - replaces the single `archive.unpack(target)` call across all compression formats (`.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tar.zst`, plain `.tar`) with a manual entry loop. On Windows, if unpacking a symlink entry fails, a `tracing::warn!` is emitted and extraction continues. Any other error still propagates as before.

2. **No registry access or new dependencies** - no `winreg`, no `windows-sys`, no `unsafe`. The fix is pure platform-conditional Rust.

3. **Test coverage** - a Windows-only test (`test_symlink_extraction_skipped_on_windows`) creates a minimal `.tar.gz` with a symlink entry and asserts that `extract_tar` succeeds regardless of Developer Mode status.

## Notes

- No behaviour change on Linux/macOS - the `#[cfg(target_os = "windows")]` block is a no-op on other platforms and all other errors still fail extraction.
- A missing symlink will only surface as a build error if the symlink is actually needed, giving users a much clearer failure point.
