### PR TITLE
perf: lazily initialize the `BaseClient`

### DIFF
--- a/crates/rattler_build_core/Cargo.toml
+++ b/crates/rattler_build_core/Cargo.toml
@@ -141,7 +141,7 @@ rattler_git = { workspace = true }
 rattler_build_types = { workspace = true }
 rattler_build_jinja = { workspace = true }
 rattler_build_recipe = { workspace = true, features = ["variant-config"] }
-rattler_build_networking = { workspace = true, features = ["middleware"] }
+rattler_build_networking = { workspace = true }
 rattler_build_source_cache = { workspace = true }
 rattler_build_script = { workspace = true, features = ["execution"] }
 

--- a/crates/rattler_build_core/src/tool_configuration.rs
+++ b/crates/rattler_build_core/src/tool_configuration.rs
@@ -10,7 +10,7 @@ use rattler_conda_types::{ChannelConfig, Platform};
 use rattler_networking::s3_middleware;
 use rattler_networking::{
     AuthenticationStorage,
-    authentication_storage::{self, AuthenticationStorageError},
+    authentication_storage::{AuthenticationStorageError, backends::file::FileStorage},
     mirror_middleware,
 };
 use rattler_repodata_gateway::Gateway;
@@ -153,12 +153,10 @@ pub fn get_auth_store(
     match auth_file {
         Some(auth_file) => {
             let mut store = AuthenticationStorage::empty();
-            store.add_backend(Arc::from(
-                authentication_storage::backends::file::FileStorage::from_path(auth_file)?,
-            ));
+            store.add_backend(Arc::from(FileStorage::from_path(auth_file)?));
             Ok(store)
         }
-        None => rattler_networking::AuthenticationStorage::from_env_and_defaults(),
+        None => AuthenticationStorage::from_env_and_defaults(),
     }
 }
 
@@ -175,15 +173,8 @@ pub fn reqwest_client_from_auth_storage(
     let builder = rattler_build_networking::BaseClient::builder()
         .user_agent(APP_USER_AGENT)
         .timeout(5 * 60)
-        .insecure_hosts(allow_insecure_host.unwrap_or_default());
-
-    // Defer auth storage construction (which activates the keyring on
-    // macOS) until the client is actually used. When an auth file is
-    // explicitly provided, validate it eagerly so a bad path errors here.
-    let builder = match auth_file {
-        Some(path) => builder.with_authentication(get_auth_store(Some(path))?),
-        None => builder.with_lazy_authentication(|| get_auth_store(None)),
-    };
+        .insecure_hosts(allow_insecure_host.unwrap_or_default())
+        .with_auth_file(auth_file)?;
     #[cfg(feature = "s3")]
     let builder = builder.with_s3(s3_middleware_config);
     Ok(builder.with_mirrors(mirror_middleware_config).build())

--- a/crates/rattler_build_core/src/tool_configuration.rs
+++ b/crates/rattler_build_core/src/tool_configuration.rs
@@ -172,13 +172,18 @@ pub fn reqwest_client_from_auth_storage(
     mirror_middleware_config: HashMap<Url, Vec<mirror_middleware::Mirror>>,
     allow_insecure_host: Option<Vec<String>>,
 ) -> Result<rattler_build_networking::BaseClient, AuthenticationStorageError> {
-    let auth_storage = get_auth_store(auth_file)?;
-
     let builder = rattler_build_networking::BaseClient::builder()
         .user_agent(APP_USER_AGENT)
         .timeout(5 * 60)
-        .insecure_hosts(allow_insecure_host.unwrap_or_default())
-        .with_authentication(auth_storage);
+        .insecure_hosts(allow_insecure_host.unwrap_or_default());
+
+    // Defer auth storage construction (which activates the keyring on
+    // macOS) until the client is actually used. When an auth file is
+    // explicitly provided, validate it eagerly so a bad path errors here.
+    let builder = match auth_file {
+        Some(path) => builder.with_authentication(get_auth_store(Some(path))?),
+        None => builder.with_lazy_authentication(|| get_auth_store(None)),
+    };
     #[cfg(feature = "s3")]
     let builder = builder.with_s3(s3_middleware_config);
     Ok(builder.with_mirrors(mirror_middleware_config).build())

--- a/crates/rattler_build_networking/Cargo.toml
+++ b/crates/rattler_build_networking/Cargo.toml
@@ -10,21 +10,20 @@ description = "Networking utilities for rattler-build, providing shared HTTP cli
 
 [features]
 default = []
-middleware = ["rattler_networking"]
-s3 = ["rattler_networking?/s3"]
-native-tls = ["reqwest/native-tls", "rattler_networking?/native-tls"]
+s3 = ["rattler_networking/s3"]
+native-tls = ["reqwest/native-tls", "rattler_networking/native-tls"]
 rustls-tls = [
   "reqwest/rustls-tls",
   "reqwest/rustls-tls-native-roots",
   "reqwest-middleware/rustls-tls",
-  "rattler_networking?/rustls-tls",
+  "rattler_networking/rustls-tls",
 ]
 
 [dependencies]
 reqwest = { workspace = true, features = ["multipart"] }
 reqwest-middleware = { workspace = true }
 reqwest-retry = { workspace = true }
-rattler_networking = { workspace = true, optional = true, default-features = false }
+rattler_networking = { workspace = true, default-features = false }
 url = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]

--- a/crates/rattler_build_networking/src/lib.rs
+++ b/crates/rattler_build_networking/src/lib.rs
@@ -3,6 +3,10 @@
 
 use std::sync::{Arc, LazyLock};
 
+use rattler_networking::{
+    AuthenticationStorage, LazyClient,
+    authentication_storage::{AuthenticationStorageError, backends::file::FileStorage},
+};
 use reqwest_middleware::ClientWithMiddleware;
 use reqwest_retry::{RetryTransientMiddleware, policies::ExponentialBackoff};
 use url::Url;
@@ -11,24 +15,11 @@ use url::Url;
 const DEFAULT_USER_AGENT: &str =
     concat!("rattler-build-networking", "/", env!("CARGO_PKG_VERSION"));
 
-/// The pair of (regular, dangerous) clients a [`BaseClient`] resolves to,
-/// constructed lazily on first use so configuring a [`BaseClient`] never
-/// touches the keyring or reads credential files.
-type LazyClients = Arc<LazyLock<(ClientWithMiddleware, ClientWithMiddleware), ClientsInit>>;
-type ClientsInit = Box<dyn FnOnce() -> (ClientWithMiddleware, ClientWithMiddleware) + Send + Sync>;
-#[cfg(feature = "middleware")]
-type AuthFactory = Box<
-    dyn FnOnce() -> Result<
-            rattler_networking::AuthenticationStorage,
-            rattler_networking::authentication_storage::AuthenticationStorageError,
-        > + Send
-        + Sync,
->;
-
-/// A client that can handle both secure and insecure connections
+/// A client that can handle both secure and insecure connections.
 #[derive(Clone)]
 pub struct BaseClient {
-    inner: LazyClients,
+    client: LazyClient,
+    dangerous_client: LazyClient,
     /// List of hosts for which SSL verification should be skipped
     allow_insecure_host: Option<Vec<String>>,
 }
@@ -46,7 +37,8 @@ impl BaseClient {
         allow_insecure_host: Option<Vec<String>>,
     ) -> Self {
         Self {
-            inner: Arc::new(LazyLock::new(Box::new(move || (client, dangerous_client)))),
+            client: client.into(),
+            dangerous_client: dangerous_client.into(),
             allow_insecure_host,
         }
     }
@@ -63,49 +55,6 @@ impl BaseClient {
         Self::builder().timeout(timeout_secs).build()
     }
 
-    fn new_with_config(user_agent: String, timeout_secs: u64) -> Self {
-        Self {
-            inner: Arc::new(LazyLock::new(Box::new(move || {
-                let client = reqwest_middleware::ClientBuilder::new(
-                    reqwest::Client::builder()
-                        .no_gzip()
-                        .pool_max_idle_per_host(20)
-                        .user_agent(&user_agent)
-                        .referer(false)
-                        .read_timeout(std::time::Duration::from_secs(timeout_secs))
-                        .build()
-                        .expect("failed to create client"),
-                )
-                .with(RetryTransientMiddleware::new_with_policy(
-                    ExponentialBackoff::builder().build_with_max_retries(3),
-                ))
-                .build();
-
-                let dangerous_client_inner = reqwest::Client::builder()
-                    .no_gzip()
-                    .pool_max_idle_per_host(20)
-                    .user_agent(&user_agent)
-                    .read_timeout(std::time::Duration::from_secs(timeout_secs));
-                #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
-                let dangerous_client_inner =
-                    dangerous_client_inner.danger_accept_invalid_certs(true);
-                let dangerous_client = reqwest_middleware::ClientBuilder::new(
-                    dangerous_client_inner
-                        .referer(false)
-                        .build()
-                        .expect("failed to create dangerous client"),
-                )
-                .with(RetryTransientMiddleware::new_with_policy(
-                    ExponentialBackoff::builder().build_with_max_retries(3),
-                ))
-                .build();
-
-                (client, dangerous_client)
-            }))),
-            allow_insecure_host: None,
-        }
-    }
-
     /// Create a new BaseClient with insecure hosts
     ///
     /// Deprecated: Use `BaseClient::builder().insecure_hosts(hosts).build()` instead
@@ -114,17 +63,23 @@ impl BaseClient {
         self
     }
 
-    /// Get the default client (with SSL verification enabled)
-    pub fn get_client(&self) -> &ClientWithMiddleware {
-        &self.inner.0
+    /// Get the default lazy client (with SSL verification enabled).
+    ///
+    /// Returns the [`LazyClient`] without forcing it to initialize, so
+    /// passing the result to types that themselves accept a `LazyClient`
+    /// (such as `Gateway::with_client` or
+    /// `Installer::with_download_client`) keeps the underlying reqwest
+    /// client construction deferred.
+    pub fn get_client(&self) -> &LazyClient {
+        &self.client
     }
 
-    /// Selects the appropriate client based on the host's trustworthiness
-    pub fn for_host(&self, url: &Url) -> &ClientWithMiddleware {
+    /// Selects the appropriate lazy client based on the host's trustworthiness.
+    pub fn for_host(&self, url: &Url) -> &LazyClient {
         if self.disable_ssl(url) {
-            &self.inner.1
+            &self.dangerous_client
         } else {
-            &self.inner.0
+            &self.client
         }
     }
 
@@ -150,12 +105,10 @@ pub struct BaseClientBuilder {
     user_agent: Option<String>,
     timeout_secs: u64,
     insecure_hosts: Option<Vec<String>>,
-    #[cfg(feature = "middleware")]
-    auth_storage: Option<AuthFactory>,
-    #[cfg(all(feature = "middleware", feature = "s3"))]
+    auth_file: Option<FileStorage>,
+    #[cfg(feature = "s3")]
     s3_config:
         Option<std::collections::HashMap<String, rattler_networking::s3_middleware::S3Config>>,
-    #[cfg(feature = "middleware")]
     mirror_config: Option<
         std::collections::HashMap<url::Url, Vec<rattler_networking::mirror_middleware::Mirror>>,
     >,
@@ -167,11 +120,9 @@ impl Default for BaseClientBuilder {
             user_agent: None,
             timeout_secs: 5 * 60, // 5 minutes default
             insecure_hosts: None,
-            #[cfg(feature = "middleware")]
-            auth_storage: None,
-            #[cfg(all(feature = "middleware", feature = "s3"))]
+            auth_file: None,
+            #[cfg(feature = "s3")]
             s3_config: None,
-            #[cfg(feature = "middleware")]
             mirror_config: None,
         }
     }
@@ -196,39 +147,20 @@ impl BaseClientBuilder {
         self
     }
 
-    /// Set authentication storage for authenticated requests
-    #[cfg(feature = "middleware")]
-    pub fn with_authentication(
-        mut self,
-        auth_storage: rattler_networking::AuthenticationStorage,
-    ) -> Self {
-        self.auth_storage = Some(Box::new(move || Ok(auth_storage)));
-        self
-    }
-
-    /// Set a factory that produces the authentication storage on first use.
+    /// Add a credential file to consult in addition to the default
+    /// authentication backends.
     ///
-    /// The factory is invoked the first time the client is used to make a
-    /// request, so callers can avoid eagerly running
-    /// `AuthenticationStorage::from_env_and_defaults` (which activates the
-    /// keyring on macOS) for invocations that never end up touching the
-    /// network.
-    #[cfg(feature = "middleware")]
-    pub fn with_lazy_authentication<F>(mut self, factory: F) -> Self
-    where
-        F: FnOnce() -> Result<
-                rattler_networking::AuthenticationStorage,
-                rattler_networking::authentication_storage::AuthenticationStorageError,
-            > + Send
-            + Sync
-            + 'static,
-    {
-        self.auth_storage = Some(Box::new(factory));
-        self
+    /// The file is loaded eagerly so a bad path errors here.
+    pub fn with_auth_file(
+        mut self,
+        auth_file: Option<std::path::PathBuf>,
+    ) -> Result<Self, AuthenticationStorageError> {
+        self.auth_file = auth_file.map(FileStorage::from_path).transpose()?;
+        Ok(self)
     }
 
     /// Set S3 s3 configuration
-    #[cfg(all(feature = "middleware", feature = "s3"))]
+    #[cfg(feature = "s3")]
     pub fn with_s3(
         mut self,
         s3_config: std::collections::HashMap<String, rattler_networking::s3_middleware::S3Config>,
@@ -238,7 +170,6 @@ impl BaseClientBuilder {
     }
 
     /// Set mirror middleware configuration
-    #[cfg(feature = "middleware")]
     pub fn with_mirrors(
         mut self,
         mirror_config: std::collections::HashMap<
@@ -252,126 +183,118 @@ impl BaseClientBuilder {
 
     /// Build the BaseClient with the configured settings
     pub fn build(self) -> BaseClient {
-        #[cfg(feature = "middleware")]
-        {
-            let has_middleware = self.auth_storage.is_some()
-                || {
-                    #[cfg(feature = "s3")]
-                    {
-                        self.s3_config.is_some()
-                    }
-                    #[cfg(not(feature = "s3"))]
-                    {
-                        false
-                    }
-                }
-                || self.mirror_config.is_some();
-            if has_middleware {
-                return self.build_with_middleware();
-            }
-        }
-
-        let user_agent = self
-            .user_agent
-            .unwrap_or_else(|| DEFAULT_USER_AGENT.to_string());
-
-        let mut client = BaseClient::new_with_config(user_agent, self.timeout_secs);
-
-        if let Some(hosts) = self.insecure_hosts {
-            client.allow_insecure_host = Some(hosts);
-        }
-
-        client
-    }
-
-    #[cfg(feature = "middleware")]
-    fn build_with_middleware(self) -> BaseClient {
         let user_agent = self
             .user_agent
             .unwrap_or_else(|| DEFAULT_USER_AGENT.to_string());
         let timeout_secs = self.timeout_secs;
         let insecure_hosts = self.insecure_hosts;
-        let auth_factory = self.auth_storage;
+        let auth_file = self.auth_file;
         let mirror_config = self.mirror_config;
         #[cfg(feature = "s3")]
         let s3_config = self.s3_config;
 
-        BaseClient {
-            inner: Arc::new(LazyLock::new(Box::new(move || {
-                #[cfg(feature = "s3")]
-                use rattler_networking::s3_middleware::S3Middleware;
-                use rattler_networking::{AuthenticationMiddleware, mirror_middleware::MirrorMiddleware};
-
-                let common_settings = |builder: reqwest::ClientBuilder| -> reqwest::ClientBuilder {
-                    builder
-                        .no_gzip()
-                        .pool_max_idle_per_host(20)
-                        .user_agent(&user_agent)
-                        .referer(false)
-                        .read_timeout(std::time::Duration::from_secs(timeout_secs))
-                };
-
-                let auth_storage = auth_factory
-                    .unwrap_or_else(|| {
-                        Box::new(rattler_networking::AuthenticationStorage::from_env_and_defaults)
-                    })()
+        // Lazily build the authentication storage exactly once and share it
+        // between the secure and dangerous clients via Arc<LazyLock>.
+        let shared_auth: Arc<LazyLock<AuthenticationStorage, _>> =
+            Arc::new(LazyLock::new(Box::new(move || {
+                let mut store = AuthenticationStorage::from_env_and_defaults()
                     .expect("Failed to load authentication storage");
+                if let Some(file_storage) = auth_file {
+                    store.add_backend(Arc::from(file_storage));
+                }
+                store
+            })
+                as Box<dyn FnOnce() -> AuthenticationStorage + Send + Sync>));
 
-                // Prepare middlewares once and reuse the same instances (via Arc) for both clients.
-                let mirror_mw = mirror_config.map(|cfg| Arc::new(MirrorMiddleware::from_map(cfg)));
+        let ua_for_secure = user_agent.clone();
+        let auth_for_secure = shared_auth.clone();
+        let mirror_for_secure = mirror_config.clone();
+        #[cfg(feature = "s3")]
+        let s3_for_secure = s3_config.clone();
+        let client = LazyClient::new(move || {
+            build_middleware_client(
+                &ua_for_secure,
+                timeout_secs,
+                false,
+                (*auth_for_secure).clone(),
+                mirror_for_secure,
                 #[cfg(feature = "s3")]
-                let s3_mw =
-                    s3_config.map(|cfg| Arc::new(S3Middleware::new(cfg, auth_storage.clone())));
-                let auth_mw = Arc::new(AuthenticationMiddleware::from_auth_storage(
-                    auth_storage.clone(),
-                ));
-                let retry_mw = Arc::new(RetryTransientMiddleware::new_with_policy(
-                    ExponentialBackoff::builder().build_with_max_retries(3),
-                ));
+                s3_for_secure,
+            )
+        });
 
-                // Build the secure client with the exact middleware chain in a fixed order.
-                let mut client_builder = reqwest_middleware::ClientBuilder::new(
-                    common_settings(reqwest::Client::builder())
-                        .build()
-                        .expect("failed to create client"),
-                );
-                if let Some(mw) = &mirror_mw {
-                    client_builder = client_builder.with_arc(mw.clone());
-                }
+        let dangerous_client = LazyClient::new(move || {
+            build_middleware_client(
+                &user_agent,
+                timeout_secs,
+                true,
+                (*shared_auth).clone(),
+                mirror_config,
                 #[cfg(feature = "s3")]
-                if let Some(mw) = &s3_mw {
-                    client_builder = client_builder.with_arc(mw.clone());
-                }
-                client_builder = client_builder.with_arc(auth_mw.clone());
-                client_builder = client_builder.with_arc(retry_mw.clone());
-                let client = client_builder.build();
+                s3_config,
+            )
+        });
 
-                // Build dangerous client (insecure)
-                let dangerous_inner = common_settings(reqwest::Client::builder());
-                #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
-                let dangerous_inner = dangerous_inner.danger_accept_invalid_certs(true);
-                let mut dangerous_client_builder = reqwest_middleware::ClientBuilder::new(
-                    dangerous_inner
-                        .build()
-                        .expect("failed to create dangerous client"),
-                );
-
-                // Apply the exact same middleware chain and order to the dangerous client.
-                if let Some(mw) = &mirror_mw {
-                    dangerous_client_builder = dangerous_client_builder.with_arc(mw.clone());
-                }
-                #[cfg(feature = "s3")]
-                if let Some(mw) = &s3_mw {
-                    dangerous_client_builder = dangerous_client_builder.with_arc(mw.clone());
-                }
-                dangerous_client_builder = dangerous_client_builder.with_arc(auth_mw);
-                dangerous_client_builder = dangerous_client_builder.with_arc(retry_mw);
-
-                let dangerous_client = dangerous_client_builder.build();
-
-                (client, dangerous_client)
-            }))),
+        BaseClient {
+            client,
+            dangerous_client,
             allow_insecure_host: insecure_hosts,
         }
     }
+}
+
+fn reqwest_client(user_agent: &str, timeout_secs: u64, dangerous: bool) -> reqwest::Client {
+    let builder = reqwest::Client::builder()
+        .no_gzip()
+        .pool_max_idle_per_host(20)
+        .user_agent(user_agent)
+        .referer(false)
+        .read_timeout(std::time::Duration::from_secs(timeout_secs));
+
+    #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+    let builder = if dangerous {
+        builder.danger_accept_invalid_certs(true)
+    } else {
+        builder
+    };
+    #[cfg(not(any(feature = "native-tls", feature = "rustls-tls")))]
+    let _ = dangerous;
+
+    builder.build().expect("failed to create reqwest client")
+}
+
+fn retry_middleware() -> RetryTransientMiddleware<ExponentialBackoff> {
+    RetryTransientMiddleware::new_with_policy(
+        ExponentialBackoff::builder().build_with_max_retries(3),
+    )
+}
+
+fn build_middleware_client(
+    user_agent: &str,
+    timeout_secs: u64,
+    dangerous: bool,
+    auth_storage: AuthenticationStorage,
+    mirror_config: Option<
+        std::collections::HashMap<url::Url, Vec<rattler_networking::mirror_middleware::Mirror>>,
+    >,
+    #[cfg(feature = "s3")] s3_config: Option<
+        std::collections::HashMap<String, rattler_networking::s3_middleware::S3Config>,
+    >,
+) -> ClientWithMiddleware {
+    use rattler_networking::{AuthenticationMiddleware, mirror_middleware::MirrorMiddleware};
+
+    let mut builder =
+        reqwest_middleware::ClientBuilder::new(reqwest_client(user_agent, timeout_secs, dangerous));
+    if let Some(cfg) = mirror_config {
+        builder = builder.with(MirrorMiddleware::from_map(cfg));
+    }
+    #[cfg(feature = "s3")]
+    if let Some(cfg) = s3_config {
+        builder = builder.with(rattler_networking::s3_middleware::S3Middleware::new(
+            cfg,
+            auth_storage.clone(),
+        ));
+    }
+    builder = builder.with(AuthenticationMiddleware::from_auth_storage(auth_storage));
+    builder.with(retry_middleware()).build()
 }

--- a/crates/rattler_build_networking/src/lib.rs
+++ b/crates/rattler_build_networking/src/lib.rs
@@ -1,6 +1,8 @@
 //! Networking utilities for Rattler-Build, providing shared HTTP client functionality
 //! with retry middleware.
 
+use std::sync::{Arc, LazyLock};
+
 use reqwest_middleware::ClientWithMiddleware;
 use reqwest_retry::{RetryTransientMiddleware, policies::ExponentialBackoff};
 use url::Url;
@@ -9,13 +11,24 @@ use url::Url;
 const DEFAULT_USER_AGENT: &str =
     concat!("rattler-build-networking", "/", env!("CARGO_PKG_VERSION"));
 
+/// The pair of (regular, dangerous) clients a [`BaseClient`] resolves to,
+/// constructed lazily on first use so configuring a [`BaseClient`] never
+/// touches the keyring or reads credential files.
+type LazyClients = Arc<LazyLock<(ClientWithMiddleware, ClientWithMiddleware), ClientsInit>>;
+type ClientsInit = Box<dyn FnOnce() -> (ClientWithMiddleware, ClientWithMiddleware) + Send + Sync>;
+#[cfg(feature = "middleware")]
+type AuthFactory = Box<
+    dyn FnOnce() -> Result<
+            rattler_networking::AuthenticationStorage,
+            rattler_networking::authentication_storage::AuthenticationStorageError,
+        > + Send
+        + Sync,
+>;
+
 /// A client that can handle both secure and insecure connections
 #[derive(Clone)]
 pub struct BaseClient {
-    /// The standard client with SSL verification enabled
-    client: ClientWithMiddleware,
-    /// The dangerous client with SSL verification disabled
-    dangerous_client: ClientWithMiddleware,
+    inner: LazyClients,
     /// List of hosts for which SSL verification should be skipped
     allow_insecure_host: Option<Vec<String>>,
 }
@@ -33,8 +46,7 @@ impl BaseClient {
         allow_insecure_host: Option<Vec<String>>,
     ) -> Self {
         Self {
-            client,
-            dangerous_client,
+            inner: Arc::new(LazyLock::new(Box::new(move || (client, dangerous_client)))),
             allow_insecure_host,
         }
     }
@@ -52,42 +64,44 @@ impl BaseClient {
     }
 
     fn new_with_config(user_agent: String, timeout_secs: u64) -> Self {
-        let client = reqwest_middleware::ClientBuilder::new(
-            reqwest::Client::builder()
-                .no_gzip()
-                .pool_max_idle_per_host(20)
-                .user_agent(&user_agent)
-                .referer(false)
-                .read_timeout(std::time::Duration::from_secs(timeout_secs))
-                .build()
-                .expect("failed to create client"),
-        )
-        .with(RetryTransientMiddleware::new_with_policy(
-            ExponentialBackoff::builder().build_with_max_retries(3),
-        ))
-        .build();
-
-        let dangerous_client_inner = reqwest::Client::builder()
-            .no_gzip()
-            .pool_max_idle_per_host(20)
-            .user_agent(&user_agent)
-            .read_timeout(std::time::Duration::from_secs(timeout_secs));
-        #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
-        let dangerous_client_inner = dangerous_client_inner.danger_accept_invalid_certs(true);
-        let dangerous_client = reqwest_middleware::ClientBuilder::new(
-            dangerous_client_inner
-                .referer(false)
-                .build()
-                .expect("failed to create dangerous client"),
-        )
-        .with(RetryTransientMiddleware::new_with_policy(
-            ExponentialBackoff::builder().build_with_max_retries(3),
-        ))
-        .build();
-
         Self {
-            client,
-            dangerous_client,
+            inner: Arc::new(LazyLock::new(Box::new(move || {
+                let client = reqwest_middleware::ClientBuilder::new(
+                    reqwest::Client::builder()
+                        .no_gzip()
+                        .pool_max_idle_per_host(20)
+                        .user_agent(&user_agent)
+                        .referer(false)
+                        .read_timeout(std::time::Duration::from_secs(timeout_secs))
+                        .build()
+                        .expect("failed to create client"),
+                )
+                .with(RetryTransientMiddleware::new_with_policy(
+                    ExponentialBackoff::builder().build_with_max_retries(3),
+                ))
+                .build();
+
+                let dangerous_client_inner = reqwest::Client::builder()
+                    .no_gzip()
+                    .pool_max_idle_per_host(20)
+                    .user_agent(&user_agent)
+                    .read_timeout(std::time::Duration::from_secs(timeout_secs));
+                #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+                let dangerous_client_inner =
+                    dangerous_client_inner.danger_accept_invalid_certs(true);
+                let dangerous_client = reqwest_middleware::ClientBuilder::new(
+                    dangerous_client_inner
+                        .referer(false)
+                        .build()
+                        .expect("failed to create dangerous client"),
+                )
+                .with(RetryTransientMiddleware::new_with_policy(
+                    ExponentialBackoff::builder().build_with_max_retries(3),
+                ))
+                .build();
+
+                (client, dangerous_client)
+            }))),
             allow_insecure_host: None,
         }
     }
@@ -102,15 +116,15 @@ impl BaseClient {
 
     /// Get the default client (with SSL verification enabled)
     pub fn get_client(&self) -> &ClientWithMiddleware {
-        &self.client
+        &self.inner.0
     }
 
     /// Selects the appropriate client based on the host's trustworthiness
     pub fn for_host(&self, url: &Url) -> &ClientWithMiddleware {
         if self.disable_ssl(url) {
-            &self.dangerous_client
+            &self.inner.1
         } else {
-            &self.client
+            &self.inner.0
         }
     }
 
@@ -132,13 +146,12 @@ impl Default for BaseClient {
 }
 
 /// Builder for configuring a BaseClient
-#[derive(Debug, Clone)]
 pub struct BaseClientBuilder {
     user_agent: Option<String>,
     timeout_secs: u64,
     insecure_hosts: Option<Vec<String>>,
     #[cfg(feature = "middleware")]
-    auth_storage: Option<rattler_networking::AuthenticationStorage>,
+    auth_storage: Option<AuthFactory>,
     #[cfg(all(feature = "middleware", feature = "s3"))]
     s3_config:
         Option<std::collections::HashMap<String, rattler_networking::s3_middleware::S3Config>>,
@@ -189,7 +202,28 @@ impl BaseClientBuilder {
         mut self,
         auth_storage: rattler_networking::AuthenticationStorage,
     ) -> Self {
-        self.auth_storage = Some(auth_storage);
+        self.auth_storage = Some(Box::new(move || Ok(auth_storage)));
+        self
+    }
+
+    /// Set a factory that produces the authentication storage on first use.
+    ///
+    /// The factory is invoked the first time the client is used to make a
+    /// request, so callers can avoid eagerly running
+    /// `AuthenticationStorage::from_env_and_defaults` (which activates the
+    /// keyring on macOS) for invocations that never end up touching the
+    /// network.
+    #[cfg(feature = "middleware")]
+    pub fn with_lazy_authentication<F>(mut self, factory: F) -> Self
+    where
+        F: FnOnce() -> Result<
+                rattler_networking::AuthenticationStorage,
+                rattler_networking::authentication_storage::AuthenticationStorageError,
+            > + Send
+            + Sync
+            + 'static,
+    {
+        self.auth_storage = Some(Box::new(factory));
         self
     }
 
@@ -252,90 +286,91 @@ impl BaseClientBuilder {
 
     #[cfg(feature = "middleware")]
     fn build_with_middleware(self) -> BaseClient {
-        #[cfg(feature = "s3")]
-        use rattler_networking::s3_middleware::S3Middleware;
-        use rattler_networking::{AuthenticationMiddleware, mirror_middleware::MirrorMiddleware};
-        use std::sync::Arc;
-
         let user_agent = self
             .user_agent
             .unwrap_or_else(|| DEFAULT_USER_AGENT.to_string());
-
         let timeout_secs = self.timeout_secs;
         let insecure_hosts = self.insecure_hosts;
-
-        let common_settings = |builder: reqwest::ClientBuilder| -> reqwest::ClientBuilder {
-            builder
-                .no_gzip()
-                .pool_max_idle_per_host(20)
-                .user_agent(&user_agent)
-                .referer(false)
-                .read_timeout(std::time::Duration::from_secs(timeout_secs))
-        };
-
-        let auth_storage = self.auth_storage.unwrap_or_else(|| {
-            rattler_networking::AuthenticationStorage::from_env_and_defaults()
-                .expect("Failed to load authentication storage")
-        });
-
-        // Prepare middlewares once and reuse the same instances (via Arc) for both clients.
-        let mirror_mw = self
-            .mirror_config
-            .map(|cfg| Arc::new(MirrorMiddleware::from_map(cfg)));
+        let auth_factory = self.auth_storage;
+        let mirror_config = self.mirror_config;
         #[cfg(feature = "s3")]
-        let s3_mw = self
-            .s3_config
-            .map(|cfg| Arc::new(S3Middleware::new(cfg, auth_storage.clone())));
-        let auth_mw = Arc::new(AuthenticationMiddleware::from_auth_storage(
-            auth_storage.clone(),
-        ));
-        let retry_mw = Arc::new(RetryTransientMiddleware::new_with_policy(
-            ExponentialBackoff::builder().build_with_max_retries(3),
-        ));
-
-        // Build the secure client with the exact middleware chain in a fixed order.
-        let mut client_builder = reqwest_middleware::ClientBuilder::new(
-            common_settings(reqwest::Client::builder())
-                .build()
-                .expect("failed to create client"),
-        );
-        if let Some(mw) = &mirror_mw {
-            client_builder = client_builder.with_arc(mw.clone());
-        }
-        #[cfg(feature = "s3")]
-        if let Some(mw) = &s3_mw {
-            client_builder = client_builder.with_arc(mw.clone());
-        }
-        client_builder = client_builder.with_arc(auth_mw.clone());
-        client_builder = client_builder.with_arc(retry_mw.clone());
-        let client = client_builder.build();
-
-        // Build dangerous client (insecure)
-        let dangerous_inner = common_settings(reqwest::Client::builder());
-        #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
-        let dangerous_inner = dangerous_inner.danger_accept_invalid_certs(true);
-        let mut dangerous_client_builder = reqwest_middleware::ClientBuilder::new(
-            dangerous_inner
-                .build()
-                .expect("failed to create dangerous client"),
-        );
-
-        // Apply the exact same middleware chain and order to the dangerous client.
-        if let Some(mw) = &mirror_mw {
-            dangerous_client_builder = dangerous_client_builder.with_arc(mw.clone());
-        }
-        #[cfg(feature = "s3")]
-        if let Some(mw) = &s3_mw {
-            dangerous_client_builder = dangerous_client_builder.with_arc(mw.clone());
-        }
-        dangerous_client_builder = dangerous_client_builder.with_arc(auth_mw);
-        dangerous_client_builder = dangerous_client_builder.with_arc(retry_mw);
-
-        let dangerous_client = dangerous_client_builder.build();
+        let s3_config = self.s3_config;
 
         BaseClient {
-            client,
-            dangerous_client,
+            inner: Arc::new(LazyLock::new(Box::new(move || {
+                #[cfg(feature = "s3")]
+                use rattler_networking::s3_middleware::S3Middleware;
+                use rattler_networking::{AuthenticationMiddleware, mirror_middleware::MirrorMiddleware};
+
+                let common_settings = |builder: reqwest::ClientBuilder| -> reqwest::ClientBuilder {
+                    builder
+                        .no_gzip()
+                        .pool_max_idle_per_host(20)
+                        .user_agent(&user_agent)
+                        .referer(false)
+                        .read_timeout(std::time::Duration::from_secs(timeout_secs))
+                };
+
+                let auth_storage = auth_factory
+                    .unwrap_or_else(|| {
+                        Box::new(rattler_networking::AuthenticationStorage::from_env_and_defaults)
+                    })()
+                    .expect("Failed to load authentication storage");
+
+                // Prepare middlewares once and reuse the same instances (via Arc) for both clients.
+                let mirror_mw = mirror_config.map(|cfg| Arc::new(MirrorMiddleware::from_map(cfg)));
+                #[cfg(feature = "s3")]
+                let s3_mw =
+                    s3_config.map(|cfg| Arc::new(S3Middleware::new(cfg, auth_storage.clone())));
+                let auth_mw = Arc::new(AuthenticationMiddleware::from_auth_storage(
+                    auth_storage.clone(),
+                ));
+                let retry_mw = Arc::new(RetryTransientMiddleware::new_with_policy(
+                    ExponentialBackoff::builder().build_with_max_retries(3),
+                ));
+
+                // Build the secure client with the exact middleware chain in a fixed order.
+                let mut client_builder = reqwest_middleware::ClientBuilder::new(
+                    common_settings(reqwest::Client::builder())
+                        .build()
+                        .expect("failed to create client"),
+                );
+                if let Some(mw) = &mirror_mw {
+                    client_builder = client_builder.with_arc(mw.clone());
+                }
+                #[cfg(feature = "s3")]
+                if let Some(mw) = &s3_mw {
+                    client_builder = client_builder.with_arc(mw.clone());
+                }
+                client_builder = client_builder.with_arc(auth_mw.clone());
+                client_builder = client_builder.with_arc(retry_mw.clone());
+                let client = client_builder.build();
+
+                // Build dangerous client (insecure)
+                let dangerous_inner = common_settings(reqwest::Client::builder());
+                #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+                let dangerous_inner = dangerous_inner.danger_accept_invalid_certs(true);
+                let mut dangerous_client_builder = reqwest_middleware::ClientBuilder::new(
+                    dangerous_inner
+                        .build()
+                        .expect("failed to create dangerous client"),
+                );
+
+                // Apply the exact same middleware chain and order to the dangerous client.
+                if let Some(mw) = &mirror_mw {
+                    dangerous_client_builder = dangerous_client_builder.with_arc(mw.clone());
+                }
+                #[cfg(feature = "s3")]
+                if let Some(mw) = &s3_mw {
+                    dangerous_client_builder = dangerous_client_builder.with_arc(mw.clone());
+                }
+                dangerous_client_builder = dangerous_client_builder.with_arc(auth_mw);
+                dangerous_client_builder = dangerous_client_builder.with_arc(retry_mw);
+
+                let dangerous_client = dangerous_client_builder.build();
+
+                (client, dangerous_client)
+            }))),
             allow_insecure_host: insecure_hosts,
         }
     }

--- a/crates/rattler_build_source_cache/src/cache.rs
+++ b/crates/rattler_build_source_cache/src/cache.rs
@@ -107,7 +107,7 @@ impl SourceCache {
             .git_resolver
             .fetch(
                 git_url.clone(),
-                self.client.get_client().clone(),
+                self.client.get_client().client().clone(),
                 git_cache,
                 None,
                 checkout_options,
@@ -451,7 +451,13 @@ impl SourceCache {
         }
 
         // Download from HTTP/HTTPS - use the appropriate client based on SSL settings
-        let response = self.client.for_host(url).get(url.clone()).send().await?;
+        let response = self
+            .client
+            .for_host(url)
+            .client()
+            .get(url.clone())
+            .send()
+            .await?;
 
         if !response.status().is_success() {
             return Err(CacheError::Download(

--- a/crates/rattler_build_source_cache/src/sigstore.rs
+++ b/crates/rattler_build_source_cache/src/sigstore.rs
@@ -192,6 +192,7 @@ async fn download_attestation_bundle(
 ) -> Result<String, CacheError> {
     let response = client
         .for_host(url)
+        .client()
         .get(url.clone())
         .send()
         .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -984,6 +984,7 @@ pub async fn rebuild_package_core(
 
             let response = reqwest_client
                 .get_client()
+                .client()
                 .get(url.as_str())
                 .send()
                 .await


### PR DESCRIPTION
This PR makes the initialization of the reqwest client more lazy. This ensure we only pay a startup cost when the client is actually used, and we avoid accessing the keychain until we actually need it. 

The downside is that `rattler_networking` is no longer an optional dependency, but I feel thats fine. 

Also removes a bunch of duplicate code.