### PR TITLE
docs: Outdated variants examples

### DIFF
--- a/py-rattler-build/src/rattler_build/variant_config.py
+++ b/py-rattler-build/src/rattler_build/variant_config.py
@@ -115,9 +115,10 @@ class VariantConfig:
 
         Example:
             ```python
-            from rattler_build import JinjaConfig
+            from rattler_build import JinjaConfig, PlatformConfig
 
-            jinja_config = JinjaConfig(target_platform="linux-64")
+            platform_config = PlatformConfig(target_platform="linux-64")
+            jinja_config = JinjaConfig(platform=platform_config)
             config = VariantConfig.from_file_with_context("variants.yaml", jinja_config)
             ```
         """
@@ -142,9 +143,10 @@ class VariantConfig:
 
         Example:
             ```python
-            from rattler_build import JinjaConfig
+            from rattler_build import JinjaConfig, PlatformConfig
 
-            jinja_config = JinjaConfig(target_platform="linux-64")
+            platform_config = PlatformConfig(target_platform="linux-64")
+            jinja_config = JinjaConfig(platform=platform_config)
             config = VariantConfig.from_conda_build_config("conda_build_config.yaml", jinja_config)
             ```
         """
@@ -197,9 +199,10 @@ class VariantConfig:
 
         Example:
             ```python
-            from rattler_build import JinjaConfig
+            from rattler_build import JinjaConfig, PlatformConfig
 
-            jinja_config = JinjaConfig(target_platform="linux-64")
+            platform_config = PlatformConfig(target_platform="linux-64")
+            jinja_config = JinjaConfig(platform=platform_config)
             config = VariantConfig.from_files_with_context(
                 ["base_variants.yaml", "conda_build_config.yaml"],
                 jinja_config,
@@ -280,7 +283,7 @@ class VariantConfig:
 
         Example:
             ```python
-            from rattler_build import JinjaConfig
+            from rattler_build import JinjaConfig, PlatformConfig
 
             yaml_str = '''
             c_compiler:
@@ -289,7 +292,8 @@ class VariantConfig:
               - if: win
                 then: msvc
             '''
-            jinja_config = JinjaConfig(target_platform="linux-64")
+            platform_config = PlatformConfig(target_platform="linux-64")
+            jinja_config = JinjaConfig(platform=platform_config)
             config = VariantConfig.from_yaml_with_context(yaml_str, jinja_config)
             ```
         """


### PR DESCRIPTION
I noticed this inconsistency in the documentation online: https://rattler-build.prefix.dev/latest/py-rattler-build/reference/rendering/#rendering

Namely, `JinjaConfig()` no longer appears to take a `target_platform` string directly. Instead it and the other `*Config` classes appear to take a `PlatformConfig` instance.

I'm not sure if there are other similar instances of this, but I _think_ these changes are correct? Feel free to close the PR if I'm wrong or missed something. Thanks!