### PR TITLE
fix: inherit build number for cache outputs

### DIFF
--- a/crates/rattler_build_recipe/src/stage0/evaluate.rs
+++ b/crates/rattler_build_recipe/src/stage0/evaluate.rs
@@ -2859,6 +2859,12 @@ fn evaluate_package_output_to_recipe(
         if output_build.variant.is_default() {
             output_build.variant = toplevel_build.variant;
         }
+        if matches!(output_build.string, BuildString::Default) {
+            output_build.string = toplevel_build.string;
+        }
+        if output_build.number.is_none() {
+            output_build.number = toplevel_build.number;
+        }
         if output_build.noarch.is_none() {
             output_build.noarch = toplevel_build.noarch;
         }

--- a/crates/rattler_build_recipe/src/variant_render.rs
+++ b/crates/rattler_build_recipe/src/variant_render.rs
@@ -1553,6 +1553,51 @@ outputs:
     }
 
     #[test]
+    fn test_cache_inherited_output_inherits_top_level_build_number_before_build_string() {
+        let recipe_yaml = r#"
+schema_version: 1
+
+recipe:
+  name: multi-pkg
+  version: "1.0.0"
+
+build:
+  number: 1
+
+outputs:
+  - staging:
+      name: build-cache
+    build:
+      script: build
+
+  - package:
+      name: runtime
+    inherit: build-cache
+    build:
+      script: install
+"#;
+
+        let stage0_recipe = stage0::parse_recipe_or_multi_from_source(recipe_yaml).unwrap();
+        let variant_config = VariantConfig::from_yaml_str("{}").unwrap();
+
+        let rendered =
+            render_recipe_with_variant_config(&stage0_recipe, &variant_config, RenderConfig::new())
+                .unwrap();
+
+        assert_eq!(rendered.len(), 1);
+
+        let output = &rendered[0].recipe;
+        assert_eq!(output.package.name.as_normalized(), "runtime");
+        assert_eq!(output.build.number, Some(1));
+
+        let build_string = output.build.string.as_resolved().unwrap();
+        assert!(
+            build_string.ends_with("_1"),
+            "cache-inherited output should resolve its build string with the inherited build number, got {build_string}"
+        );
+    }
+
+    #[test]
     fn test_render_multi_output_with_pin_subpackage() {
         let recipe_yaml = r#"
 schema_version: 1


### PR DESCRIPTION
## Summary

Fix cache-inherited package outputs so they inherit top-level `build.number` and `build.string` during stage0 evaluation, before the build string is finalized.

This preserves the existing behavior where cache-inherited outputs do not inherit the top-level build script, while ensuring recipes shaped like conda-forge/glib-feedstock#239 render package outputs with the correct build number before build execution.

## Validation

- `cargo test -p rattler_build_recipe test_cache_inherited_output_inherits_top_level_build_number_before_build_string`
- `cargo test -p rattler_build_recipe --lib`
- `git diff --check`

Note: `cargo test -p rattler_build_recipe` was not clean in this checkout because an unrelated untracked `test-data/recipes/prefix_license/recipe.yaml` is discovered by the integration test and fails to parse.