### PR TITLE
feat: add warn when repodata unsupported

### DIFF
--- a/crates/rattler_build_core/src/render/reporters.rs
+++ b/crates/rattler_build_core/src/render/reporters.rs
@@ -5,7 +5,7 @@ use std::{
 
 use indicatif::{MultiProgress, ProgressBar, ProgressFinish, ProgressStyle};
 use rattler::install::Placement;
-use rattler_repodata_gateway::{DownloadReporter, Reporter};
+use rattler_repodata_gateway::{DownloadReporter, Reporter, UnsupportedRepodataRevision};
 use url::Url;
 
 /// Reporter used for tracking download progress via `MultiProgress`.
@@ -94,6 +94,10 @@ impl DownloadReporter for GatewayReporter {
 impl Reporter for GatewayReporter {
     fn download_reporter(&self) -> Option<&dyn DownloadReporter> {
         Some(self)
+    }
+
+    fn on_unsupported_repodata_revision(&self, message: &UnsupportedRepodataRevision) {
+        tracing::warn!("{}", message);
     }
 }
 


### PR DESCRIPTION
When a `v4` repodata drops in the future, we'll log a warning.