### PR TITLE
feat: Allow build scripts to override package contents

### DIFF
--- a/crates/rattler_build_core/src/consts.rs
+++ b/crates/rattler_build_core/src/consts.rs
@@ -10,3 +10,13 @@ pub const GITHUB_ACTIONS: &str = "GITHUB_ACTIONS";
 
 /// This env var determines whether GitHub integration is enabled
 pub const RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: &str = "RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION";
+
+/// Environment variable pointing to a file where the build script can write
+/// the paths of files that should end up in the final package, one per line.
+/// If the file is non-empty after the build, those paths are used as the
+/// package contents instead of the default "new files in `$PREFIX`" diff.
+pub const RATTLER_BUILD_PACKAGE_FILES: &str = "RATTLER_BUILD_PACKAGE_FILES";
+
+/// File name used (under the build directory) for the package files override
+/// list pointed at by [`RATTLER_BUILD_PACKAGE_FILES`].
+pub const PACKAGE_FILES_LIST_NAME: &str = "package_files.txt";

--- a/crates/rattler_build_core/src/consts.rs
+++ b/crates/rattler_build_core/src/consts.rs
@@ -18,5 +18,7 @@ pub const RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: &str = "RATTLER_BUILD_ENABLE_
 pub const RATTLER_BUILD_PACKAGE_FILES: &str = "RATTLER_BUILD_PACKAGE_FILES";
 
 /// File name used (under the build directory) for the package files override
-/// list pointed at by [`RATTLER_BUILD_PACKAGE_FILES`].
-pub const PACKAGE_FILES_LIST_NAME: &str = "package_files.txt";
+/// list pointed at by [`RATTLER_BUILD_PACKAGE_FILES`]. The name is dot-prefixed
+/// and namespaced so that build scripts are extremely unlikely to clobber it
+/// by accident.
+pub const PACKAGE_FILES_LIST_NAME: &str = ".rattler-build-package-files";

--- a/crates/rattler_build_core/src/env_vars.rs
+++ b/crates/rattler_build_core/src/env_vars.rs
@@ -9,6 +9,7 @@ use rattler_build_types::NormalizedKey;
 use rattler_conda_types::{Platform, RepoDataRecord};
 use std::collections::BTreeMap;
 
+use crate::consts;
 use crate::linux;
 use crate::macos;
 use crate::metadata::Output;
@@ -335,6 +336,11 @@ pub fn vars(output: &Output, build_state: &str) -> HashMap<String, Option<String
     insert!(vars, "RECIPE_DIR", directories.recipe_dir.to_string_lossy());
     insert!(vars, "SRC_DIR", directories.work_dir.to_string_lossy());
     insert!(vars, "BUILD_DIR", directories.build_dir.to_string_lossy());
+    insert!(
+        vars,
+        consts::RATTLER_BUILD_PACKAGE_FILES,
+        directories.package_files_list_path().to_string_lossy()
+    );
 
     // python variables
     // hard-code this because we never want pip's build isolation

--- a/crates/rattler_build_core/src/packaging.rs
+++ b/crates/rattler_build_core/src/packaging.rs
@@ -22,7 +22,7 @@ use unicode_normalization::UnicodeNormalization;
 mod file_finder;
 mod file_mapper;
 mod metadata;
-pub use file_finder::{Files, TempFiles, content_type, record_files};
+pub use file_finder::{Files, TempFiles, content_type, read_package_files_list, record_files};
 pub use metadata::{contains_prefix_binary, contains_prefix_text, create_prefix_placeholder};
 use tempfile::NamedTempFile;
 
@@ -865,12 +865,29 @@ impl Output {
     ) -> Result<(PathBuf, PathsJson), PackagingError> {
         let span = tracing::info_span!("Packaging new files");
         let _enter = span.enter();
-        let files_after = Files::from_prefix(
-            &self.build_configuration.directories.host_prefix,
-            &self.recipe.build().always_include_files,
-            &self.recipe.build().files,
-            post_install_files,
-        )?;
+
+        let host_prefix = &self.build_configuration.directories.host_prefix;
+        let package_files_list = self
+            .build_configuration
+            .directories
+            .package_files_list_path();
+
+        let files_after = match read_package_files_list(&package_files_list)? {
+            Some(paths) => {
+                tracing::info!(
+                    "Using {} explicit package file(s) from {}",
+                    paths.len(),
+                    package_files_list.display()
+                );
+                Files::from_paths(host_prefix, paths)?
+            }
+            None => Files::from_prefix(
+                host_prefix,
+                &self.recipe.build().always_include_files,
+                &self.recipe.build().files,
+                post_install_files,
+            )?,
+        };
 
         package_conda(self, tool_configuration, &files_after)
     }

--- a/crates/rattler_build_core/src/packaging.rs
+++ b/crates/rattler_build_core/src/packaging.rs
@@ -93,6 +93,12 @@ pub enum PackagingError {
 
     #[error("Invalid MenuInst schema file: {0} - {1}")]
     InvalidMenuInstSchema(PathBuf, serde_json::Error),
+
+    #[error("Package file `{0}` listed in $RATTLER_BUILD_PACKAGE_FILES is not inside the prefix")]
+    PackageFileOutsidePrefix(PathBuf),
+
+    #[error("Package file `{0}` listed in $RATTLER_BUILD_PACKAGE_FILES does not exist")]
+    PackageFileMissing(PathBuf),
 }
 
 /// This function copies the license files to the info/licenses folder.
@@ -879,7 +885,12 @@ impl Output {
                     paths.len(),
                     package_files_list.display()
                 );
-                Files::from_paths(host_prefix, paths)?
+                Files::from_paths(
+                    host_prefix,
+                    paths,
+                    &self.recipe.build().always_include_files,
+                    &self.recipe.build().files,
+                )?
             }
             None => Files::from_prefix(
                 host_prefix,

--- a/crates/rattler_build_core/src/packaging/file_finder.rs
+++ b/crates/rattler_build_core/src/packaging/file_finder.rs
@@ -26,11 +26,12 @@ use rattler_build_recipe::stage1::GlobVec;
 /// `echo path >> $RATTLER_BUILD_PACKAGE_FILES` and similar shell idioms work
 /// reliably.
 pub fn read_package_files_list(path: &Path) -> Result<Option<Vec<PathBuf>>, io::Error> {
-    if !path.exists() {
-        return Ok(None);
-    }
+    let contents = match fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err),
+    };
 
-    let contents = fs::read_to_string(path)?;
     let paths: Vec<PathBuf> = contents
         .lines()
         .map(|line| line.trim())
@@ -198,16 +199,17 @@ impl Files {
     /// inside `prefix`, or a relative path that will be resolved against
     /// `prefix`.
     ///
-    /// Paths that do not exist on disk, that escape the prefix, or that resolve
-    /// to a directory are skipped (with a warning) so that the caller can keep
-    /// the input file format simple. The set of "old files" (i.e. files
-    /// contributed by the installed host environment) is still computed so
-    /// that downstream packaging logic that depends on it (e.g. the `pyc`
-    /// filter) keeps working.
+    /// Paths that escape the prefix or do not exist on disk cause the build to
+    /// fail. The `files` and `always_include` globs are applied on top of the
+    /// explicit list, mirroring the behaviour of [`Files::from_prefix`]: the
+    /// `files` glob filters the explicit list down, and `always_include`
+    /// scans the prefix to force-include matching files.
     pub fn from_paths(
         prefix: &Path,
         paths: impl IntoIterator<Item = PathBuf>,
-    ) -> Result<Self, io::Error> {
+        always_include: &GlobVec,
+        files: &GlobVec,
+    ) -> Result<Self, PackagingError> {
         let old_files = collect_previous_files(prefix)?;
 
         let mut new_files = HashSet::new();
@@ -218,25 +220,32 @@ impl Files {
                 prefix.join(path)
             };
 
-            // Make sure the path is inside the prefix.
             if resolved.strip_prefix(prefix).is_err() {
-                tracing::warn!(
-                    "Ignoring package file `{}`: not inside the prefix `{}`",
-                    resolved.display(),
-                    prefix.display()
-                );
-                continue;
+                return Err(PackagingError::PackageFileOutsidePrefix(resolved));
             }
 
             if !resolved.exists() {
-                tracing::warn!(
-                    "Ignoring package file `{}`: file does not exist",
-                    resolved.display()
-                );
-                continue;
+                return Err(PackagingError::PackageFileMissing(resolved));
             }
 
             new_files.insert(resolved);
+        }
+
+        if !files.is_empty() {
+            new_files.retain(|f| {
+                files.is_match(f.strip_prefix(prefix).expect("File should be in prefix"))
+            });
+        }
+
+        if !always_include.is_empty() {
+            for file in record_files(prefix)? {
+                let file_without_prefix =
+                    file.strip_prefix(prefix).expect("File should be in prefix");
+                if always_include.is_match(file_without_prefix) {
+                    tracing::info!("Forcing inclusion of file: {:?}", file_without_prefix);
+                    new_files.insert(file);
+                }
+            }
         }
 
         Ok(Files {
@@ -439,7 +448,7 @@ mod test {
     fn test_read_package_files_list_empty() {
         let tempdir = tempfile::TempDir::new().unwrap();
         let path = tempdir.path().join("package_files.txt");
-        std::fs::write(&path, "\n   \n\n").unwrap();
+        fs_err::write(&path, "\n   \n\n").unwrap();
         assert!(read_package_files_list(&path).unwrap().is_none());
     }
 
@@ -447,7 +456,7 @@ mod test {
     fn test_read_package_files_list_paths() {
         let tempdir = tempfile::TempDir::new().unwrap();
         let path = tempdir.path().join("package_files.txt");
-        std::fs::write(&path, "  bin/foo\n\nbin/bar\n/abs/path  \n").unwrap();
+        fs_err::write(&path, "  bin/foo\n\nbin/bar\n/abs/path  \n").unwrap();
         let parsed = read_package_files_list(&path).unwrap().unwrap();
         assert_eq!(
             parsed,
@@ -460,39 +469,112 @@ mod test {
     }
 
     #[test]
-    fn test_files_from_paths_resolves_and_filters() {
+    fn test_files_from_paths_resolves_paths() {
         let tempdir = tempfile::TempDir::new().unwrap();
         let prefix = tempdir.path();
 
-        // Create some files inside the prefix
-        std::fs::create_dir_all(prefix.join("bin")).unwrap();
-        std::fs::write(prefix.join("bin/foo"), b"foo").unwrap();
-        std::fs::write(prefix.join("bin/bar"), b"bar").unwrap();
+        fs_err::create_dir_all(prefix.join("bin")).unwrap();
+        fs_err::write(prefix.join("bin/foo"), b"foo").unwrap();
+        fs_err::write(prefix.join("bin/bar"), b"bar").unwrap();
 
-        // And one outside the prefix
-        let outside = tempfile::TempDir::new().unwrap();
-        let outside_file = outside.path().join("escape.txt");
-        std::fs::write(&outside_file, b"nope").unwrap();
+        let inputs = vec![PathBuf::from("bin/foo"), prefix.join("bin/bar")];
 
-        let inputs = vec![
-            // relative path -> should resolve against prefix
-            PathBuf::from("bin/foo"),
-            // absolute path inside prefix
-            prefix.join("bin/bar"),
-            // path outside the prefix should be skipped
-            outside_file.clone(),
-            // missing path should be skipped
-            prefix.join("bin/missing"),
-        ];
-
-        let files = Files::from_paths(prefix, inputs).unwrap();
+        let files =
+            Files::from_paths(prefix, inputs, &Default::default(), &Default::default()).unwrap();
         let new_files: HashSet<PathBuf> = files.new_files.iter().cloned().collect();
 
         assert_eq!(new_files.len(), 2);
         assert!(new_files.contains(&prefix.join("bin/foo")));
         assert!(new_files.contains(&prefix.join("bin/bar")));
-        assert!(!new_files.contains(&outside_file));
-        assert!(!new_files.contains(&prefix.join("bin/missing")));
         assert_eq!(files.prefix, prefix);
+    }
+
+    #[test]
+    fn test_files_from_paths_outside_prefix_errors() {
+        let tempdir = tempfile::TempDir::new().unwrap();
+        let prefix = tempdir.path();
+
+        let outside = tempfile::TempDir::new().unwrap();
+        let outside_file = outside.path().join("escape.txt");
+        fs_err::write(&outside_file, b"nope").unwrap();
+
+        let err = Files::from_paths(
+            prefix,
+            vec![outside_file],
+            &Default::default(),
+            &Default::default(),
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            crate::packaging::PackagingError::PackageFileOutsidePrefix(_)
+        ));
+    }
+
+    #[test]
+    fn test_files_from_paths_missing_errors() {
+        let tempdir = tempfile::TempDir::new().unwrap();
+        let prefix = tempdir.path();
+
+        let err = Files::from_paths(
+            prefix,
+            vec![PathBuf::from("bin/missing")],
+            &Default::default(),
+            &Default::default(),
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            crate::packaging::PackagingError::PackageFileMissing(_)
+        ));
+    }
+
+    #[test]
+    fn test_files_from_paths_applies_files_glob() {
+        use rattler_build_recipe::stage1::GlobVec;
+
+        let tempdir = tempfile::TempDir::new().unwrap();
+        let prefix = tempdir.path();
+        fs_err::create_dir_all(prefix.join("bin")).unwrap();
+        fs_err::write(prefix.join("bin/foo"), b"foo").unwrap();
+        fs_err::write(prefix.join("bin/bar"), b"bar").unwrap();
+
+        let only_foo: GlobVec = serde_yaml::from_str("- bin/foo").unwrap();
+
+        let files = Files::from_paths(
+            prefix,
+            vec![PathBuf::from("bin/foo"), PathBuf::from("bin/bar")],
+            &Default::default(),
+            &only_foo,
+        )
+        .unwrap();
+
+        assert_eq!(files.new_files.len(), 1);
+        assert!(files.new_files.contains(&prefix.join("bin/foo")));
+    }
+
+    #[test]
+    fn test_files_from_paths_applies_always_include_glob() {
+        use rattler_build_recipe::stage1::GlobVec;
+
+        let tempdir = tempfile::TempDir::new().unwrap();
+        let prefix = tempdir.path();
+        fs_err::create_dir_all(prefix.join("bin")).unwrap();
+        fs_err::write(prefix.join("bin/foo"), b"foo").unwrap();
+        fs_err::write(prefix.join("bin/extra"), b"extra").unwrap();
+
+        let always: GlobVec = serde_yaml::from_str("- bin/extra").unwrap();
+
+        let files = Files::from_paths(
+            prefix,
+            vec![PathBuf::from("bin/foo")],
+            &always,
+            &Default::default(),
+        )
+        .unwrap();
+
+        assert_eq!(files.new_files.len(), 2);
+        assert!(files.new_files.contains(&prefix.join("bin/foo")));
+        assert!(files.new_files.contains(&prefix.join("bin/extra")));
     }
 }

--- a/crates/rattler_build_core/src/packaging/file_finder.rs
+++ b/crates/rattler_build_core/src/packaging/file_finder.rs
@@ -14,6 +14,37 @@ use crate::metadata::Output;
 use super::{PackagingError, file_mapper, normalize_path_for_comparison};
 use rattler_build_recipe::stage1::GlobVec;
 
+/// Read the list of paths written by the build script into the file pointed at
+/// by the `RATTLER_BUILD_PACKAGE_FILES` environment variable.
+///
+/// Returns `Ok(None)` if the file does not exist or contains no non-empty
+/// lines (in which case the caller should fall back to the default file
+/// discovery mechanism). Returns `Ok(Some(paths))` if the file exists and
+/// contains at least one path.
+///
+/// Lines are trimmed of whitespace; empty lines are skipped to make
+/// `echo path >> $RATTLER_BUILD_PACKAGE_FILES` and similar shell idioms work
+/// reliably.
+pub fn read_package_files_list(path: &Path) -> Result<Option<Vec<PathBuf>>, io::Error> {
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let contents = fs::read_to_string(path)?;
+    let paths: Vec<PathBuf> = contents
+        .lines()
+        .map(|line| line.trim())
+        .filter(|line| !line.is_empty())
+        .map(PathBuf::from)
+        .collect();
+
+    if paths.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(paths))
+    }
+}
+
 /// A wrapper around PathBuf that implements case-insensitive hashing and equality
 /// when the filesystem is case-insensitive
 #[derive(Debug, Clone)]
@@ -87,6 +118,27 @@ pub fn content_type(path: &Path) -> Result<Option<ContentType>, io::Error> {
     Ok(Some(content_inspector::inspect(buffer)))
 }
 
+/// Collect the set of files contributed by packages already installed in the
+/// given prefix. These are the files that should be considered "old" and that
+/// would normally be excluded from the package contents.
+fn collect_previous_files(prefix: &Path) -> Result<HashSet<PathBuf>, io::Error> {
+    if !prefix.exists() || !prefix.join("conda-meta").exists() {
+        return Ok(HashSet::new());
+    }
+
+    let prefix_records: Vec<PrefixRecord> = PrefixRecord::collect_from_prefix(prefix)?;
+    let mut previous_files = prefix_records
+        .into_iter()
+        .fold(HashSet::new(), |mut acc, record| {
+            acc.extend(record.files.iter().map(|f| prefix.join(f)));
+            acc
+        });
+
+    // Also include the existing conda-meta (PrefixRecord) files themselves
+    previous_files.extend(record_files(&prefix.join("conda-meta"))?);
+    Ok(previous_files)
+}
+
 /// This function returns a HashSet of (recursively) all the files in the given directory.
 pub fn record_files(directory: &Path) -> Result<HashSet<PathBuf>, io::Error> {
     let mut res = HashSet::new();
@@ -141,6 +193,59 @@ fn find_new_files(
 }
 
 impl Files {
+    /// Build a [`Files`] struct from an explicit list of paths that should end
+    /// up in the package. Each entry must be either an absolute path that lives
+    /// inside `prefix`, or a relative path that will be resolved against
+    /// `prefix`.
+    ///
+    /// Paths that do not exist on disk, that escape the prefix, or that resolve
+    /// to a directory are skipped (with a warning) so that the caller can keep
+    /// the input file format simple. The set of "old files" (i.e. files
+    /// contributed by the installed host environment) is still computed so
+    /// that downstream packaging logic that depends on it (e.g. the `pyc`
+    /// filter) keeps working.
+    pub fn from_paths(
+        prefix: &Path,
+        paths: impl IntoIterator<Item = PathBuf>,
+    ) -> Result<Self, io::Error> {
+        let old_files = collect_previous_files(prefix)?;
+
+        let mut new_files = HashSet::new();
+        for path in paths {
+            let resolved = if path.is_absolute() {
+                path
+            } else {
+                prefix.join(path)
+            };
+
+            // Make sure the path is inside the prefix.
+            if resolved.strip_prefix(prefix).is_err() {
+                tracing::warn!(
+                    "Ignoring package file `{}`: not inside the prefix `{}`",
+                    resolved.display(),
+                    prefix.display()
+                );
+                continue;
+            }
+
+            if !resolved.exists() {
+                tracing::warn!(
+                    "Ignoring package file `{}`: file does not exist",
+                    resolved.display()
+                );
+                continue;
+            }
+
+            new_files.insert(resolved);
+        }
+
+        Ok(Files {
+            new_files,
+            old_files,
+            prefix: prefix.to_owned(),
+        })
+    }
+
     /// Find all files in the given (host) prefix and remove all previously installed files (based on the PrefixRecord
     /// of the conda environment). If always_include is Some, then all files matching the glob pattern will be included
     /// in the new_files set.
@@ -160,22 +265,7 @@ impl Files {
 
         let fs_is_case_sensitive = check_is_case_sensitive()?;
 
-        let mut previous_files = if prefix.join("conda-meta").exists() {
-            let prefix_records: Vec<PrefixRecord> = PrefixRecord::collect_from_prefix(prefix)?;
-            let mut previous_files =
-                prefix_records
-                    .into_iter()
-                    .fold(HashSet::new(), |mut acc, record| {
-                        acc.extend(record.files.iter().map(|f| prefix.join(f)));
-                        acc
-                    });
-
-            // Also include the existing conda-meta (PrefixRecord) files themselves
-            previous_files.extend(record_files(&prefix.join("conda-meta"))?);
-            previous_files
-        } else {
-            HashSet::new()
-        };
+        let mut previous_files = collect_previous_files(prefix)?;
 
         // If we have a snapshot of files taken after dependency installation,
         // treat those as "already existing" so that post-link script artifacts
@@ -269,7 +359,9 @@ impl TempFiles {
 mod test {
     use std::{collections::HashSet, path::PathBuf};
 
-    use crate::packaging::file_finder::{check_is_case_sensitive, find_new_files};
+    use crate::packaging::file_finder::{
+        Files, check_is_case_sensitive, find_new_files, read_package_files_list,
+    };
 
     #[test]
     fn test_find_new_files_case_sensitive() {
@@ -334,5 +426,73 @@ mod test {
         // We can't assert the specific value since it depends on the filesystem,
         // but we can verify the function doesn't panic and returns a boolean
         let _is_case_sensitive = result.unwrap();
+    }
+
+    #[test]
+    fn test_read_package_files_list_missing() {
+        let tempdir = tempfile::TempDir::new().unwrap();
+        let path = tempdir.path().join("does_not_exist.txt");
+        assert!(read_package_files_list(&path).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_read_package_files_list_empty() {
+        let tempdir = tempfile::TempDir::new().unwrap();
+        let path = tempdir.path().join("package_files.txt");
+        std::fs::write(&path, "\n   \n\n").unwrap();
+        assert!(read_package_files_list(&path).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_read_package_files_list_paths() {
+        let tempdir = tempfile::TempDir::new().unwrap();
+        let path = tempdir.path().join("package_files.txt");
+        std::fs::write(&path, "  bin/foo\n\nbin/bar\n/abs/path  \n").unwrap();
+        let parsed = read_package_files_list(&path).unwrap().unwrap();
+        assert_eq!(
+            parsed,
+            vec![
+                PathBuf::from("bin/foo"),
+                PathBuf::from("bin/bar"),
+                PathBuf::from("/abs/path"),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_files_from_paths_resolves_and_filters() {
+        let tempdir = tempfile::TempDir::new().unwrap();
+        let prefix = tempdir.path();
+
+        // Create some files inside the prefix
+        std::fs::create_dir_all(prefix.join("bin")).unwrap();
+        std::fs::write(prefix.join("bin/foo"), b"foo").unwrap();
+        std::fs::write(prefix.join("bin/bar"), b"bar").unwrap();
+
+        // And one outside the prefix
+        let outside = tempfile::TempDir::new().unwrap();
+        let outside_file = outside.path().join("escape.txt");
+        std::fs::write(&outside_file, b"nope").unwrap();
+
+        let inputs = vec![
+            // relative path -> should resolve against prefix
+            PathBuf::from("bin/foo"),
+            // absolute path inside prefix
+            prefix.join("bin/bar"),
+            // path outside the prefix should be skipped
+            outside_file.clone(),
+            // missing path should be skipped
+            prefix.join("bin/missing"),
+        ];
+
+        let files = Files::from_paths(prefix, inputs).unwrap();
+        let new_files: HashSet<PathBuf> = files.new_files.iter().cloned().collect();
+
+        assert_eq!(new_files.len(), 2);
+        assert!(new_files.contains(&prefix.join("bin/foo")));
+        assert!(new_files.contains(&prefix.join("bin/bar")));
+        assert!(!new_files.contains(&outside_file));
+        assert!(!new_files.contains(&prefix.join("bin/missing")));
+        assert_eq!(files.prefix, prefix);
     }
 }

--- a/crates/rattler_build_core/src/script.rs
+++ b/crates/rattler_build_core/src/script.rs
@@ -86,6 +86,19 @@ impl Output {
         let span = tracing::info_span!("Running build script");
         let _enter = span.enter();
 
+        // Reset the package files override list before running the build
+        // script. This ensures that we do not pick up paths from a previous
+        // run if the script does not write to the file this time.
+        let package_files_path = self
+            .build_configuration
+            .directories
+            .package_files_list_path();
+        match fs_err::remove_file(&package_files_path) {
+            Ok(()) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => return Err(err.into()),
+        }
+
         let exec_args = self.prepare_build_script().await?;
         let build_prefix = if self.recipe.build().merge_build_and_host_envs {
             None

--- a/crates/rattler_build_core/src/types/directories.rs
+++ b/crates/rattler_build_core/src/types/directories.rs
@@ -206,6 +206,14 @@ impl Directories {
         Ok(directories)
     }
 
+    /// Path to the file pointed at by the `RATTLER_BUILD_PACKAGE_FILES`
+    /// environment variable. Build scripts may write paths to this file (one
+    /// per line) to override the default mechanism that determines which files
+    /// end up in the final package.
+    pub fn package_files_list_path(&self) -> PathBuf {
+        self.build_dir.join(crate::consts::PACKAGE_FILES_LIST_NAME)
+    }
+
     /// Remove all directories except for the cache directory
     pub fn clean(&self) -> Result<(), std::io::Error> {
         if self.build_dir.exists() {

--- a/docs/build_options.md
+++ b/docs/build_options.md
@@ -98,6 +98,51 @@ build:
   always_copy_files: list of globs
 ```
 
+## Override package contents from the build script
+
+By default, the package contents are determined by diffing the host prefix
+before and after the build script runs: every newly created file in `$PREFIX`
+that does not come from an installed host dependency is included.
+
+If you need full control, the build script can write an explicit list of paths
+to the file pointed at by the `$RATTLER_BUILD_PACKAGE_FILES` environment
+variable. When this file is non-empty after the build, its entries are used
+verbatim as the package contents and the default diff is skipped entirely.
+Globs in `build.files` and `build.always_include_files` are not applied in
+this mode, since the script has already declared exactly which files belong to
+the package.
+
+Each line must reference a file rooted in `$PREFIX`:
+
+- an absolute path under `$PREFIX`, or
+- a relative path that is resolved against `$PREFIX`.
+
+Empty lines are ignored, and paths that escape the prefix or do not exist on
+disk are skipped with a warning. The file is appendable, so
+`echo path >> $RATTLER_BUILD_PACKAGE_FILES` works correctly across multiple
+script invocations. If the file is empty or never created, rattler-build
+falls back to the default behavior.
+
+```bash title="build.sh"
+mkdir -p $PREFIX/bin
+echo "hello" > $PREFIX/bin/included.sh
+echo "hello" > $PREFIX/bin/excluded.sh
+
+# Only `included.sh` will end up in the package.
+echo "$PREFIX/bin/included.sh" >> $RATTLER_BUILD_PACKAGE_FILES
+# Relative paths are also supported (resolved against $PREFIX):
+# echo "bin/included.sh" >> $RATTLER_BUILD_PACKAGE_FILES
+```
+
+```batch title="build.bat"
+mkdir %PREFIX%\bin
+echo hello > %PREFIX%\bin\included.txt
+echo hello > %PREFIX%\bin\excluded.txt
+
+@rem Only `included.txt` will end up in the package.
+echo %PREFIX%\bin\included.txt >> %RATTLER_BUILD_PACKAGE_FILES%
+```
+
 ## Merge build and host environments
 
 In very rare cases you might want to merge the build and host environments to

--- a/docs/build_options.md
+++ b/docs/build_options.md
@@ -100,25 +100,25 @@ build:
 
 ## Override package contents from the build script
 
-By default, the package contents are determined by diffing the host prefix
-before and after the build script runs: every newly created file in `$PREFIX`
-that does not come from an installed host dependency is included.
+By default, the package contents are determined by walking `$PREFIX` and
+removing every file that is recorded as belonging to an installed host
+dependency (read from the `conda-meta` records in the prefix). Whatever
+remains is what ends up in the package.
 
 If you need full control, the build script can write an explicit list of paths
 to the file pointed at by the `$RATTLER_BUILD_PACKAGE_FILES` environment
 variable. When this file is non-empty after the build, its entries are used
-verbatim as the package contents and the default diff is skipped entirely.
-Globs in `build.files` and `build.always_include_files` are not applied in
-this mode, since the script has already declared exactly which files belong to
-the package.
+as the package contents instead of the conda-meta diff. The `build.files` and
+`build.always_include_files` globs still apply on top of that list, so you can
+combine an explicit selection with the usual filtering.
 
 Each line must reference a file rooted in `$PREFIX`:
 
 - an absolute path under `$PREFIX`, or
 - a relative path that is resolved against `$PREFIX`.
 
-Empty lines are ignored, and paths that escape the prefix or do not exist on
-disk are skipped with a warning. The file is appendable, so
+Empty lines are ignored. Paths that escape the prefix or do not exist on disk
+cause the build to fail. The file is appendable, so
 `echo path >> $RATTLER_BUILD_PACKAGE_FILES` works correctly across multiple
 script invocations. If the file is empty or never created, rattler-build
 falls back to the default behavior.

--- a/docs/build_script.md
+++ b/docs/build_script.md
@@ -312,6 +312,20 @@ noted, no variables are inherited from the shell environment in which you invoke
 : The subdirectory describing the platform that the resulting package will
   run on. Equivalent to `SUBDIR`.
 
+`RATTLER_BUILD_PACKAGE_FILES`
+
+: Path to a writable file. If the build script writes any paths to this file
+  (one per line), those paths are used as the package contents instead of the
+  default "new files in `$PREFIX`" diff. Each line must be either an absolute
+  path under `$PREFIX` or a relative path resolved against `$PREFIX`. The file
+  is appendable across multiple invocations, so
+  `echo path >> $RATTLER_BUILD_PACKAGE_FILES` works as expected. If the file
+  is empty or absent, rattler-build falls back to the default behavior. See
+  [Override package contents from the build script][override-package-contents]
+  in the build options for more details.
+
+  [override-package-contents]: ./build_options.md#override-package-contents-from-the-build-script
+
 `PKG_BUILDNUM`
 
 : Indicates the build number of the package currently being built.

--- a/test-data/recipes/package_files_override/recipe.yaml
+++ b/test-data/recipes/package_files_override/recipe.yaml
@@ -1,0 +1,29 @@
+package:
+  name: package_files_override
+  version: 1.0.0
+
+build:
+  # Even though many files would be included by default, the build script
+  # writes an explicit list to $RATTLER_BUILD_PACKAGE_FILES, which then
+  # determines the package contents.
+  script:
+    - if: unix
+      then:
+        - mkdir -p $PREFIX/bin $PREFIX/share/doc
+        - echo "kept" > $PREFIX/bin/keep.sh
+        - echo "also kept" > $PREFIX/bin/also-keep.sh
+        - echo "skipped" > $PREFIX/bin/skip.sh
+        - echo "skipped doc" > $PREFIX/share/doc/skip.txt
+        # Write absolute and relative paths to exercise both forms,
+        # using `>>` across multiple invocations.
+        - echo "$PREFIX/bin/keep.sh" >> $RATTLER_BUILD_PACKAGE_FILES
+        - echo "bin/also-keep.sh" >> $RATTLER_BUILD_PACKAGE_FILES
+      else:
+        - mkdir %PREFIX%\bin
+        - mkdir %PREFIX%\share\doc
+        - echo kept > %PREFIX%\bin\keep.txt
+        - echo also kept > %PREFIX%\bin\also-keep.txt
+        - echo skipped > %PREFIX%\bin\skip.txt
+        - echo skipped doc > %PREFIX%\share\doc\skip.txt
+        - echo %PREFIX%\bin\keep.txt >> %RATTLER_BUILD_PACKAGE_FILES%
+        - echo bin\also-keep.txt >> %RATTLER_BUILD_PACKAGE_FILES%

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -668,6 +668,30 @@ def test_always_include_files(
     assert "Force include new file" in (pkg_force / "hello.txt").read_text()
 
 
+@pytest.mark.skipif(
+    os.name == "nt", reason="recipe does not support execution on windows"
+)
+def test_package_files_override(
+    rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
+):
+    """The build script writes an explicit list of paths to
+    $RATTLER_BUILD_PACKAGE_FILES; only those should end up in the package."""
+    rattler_build.build(
+        recipes / "package_files_override/recipe.yaml",
+        tmp_path,
+    )
+
+    pkg = get_extracted_package(tmp_path, "package_files_override")
+    paths = json.loads((pkg / "info/paths.json").read_text())
+    listed = sorted(p["_path"] for p in paths["paths"])
+
+    assert listed == ["bin/also-keep.sh", "bin/keep.sh"]
+    assert (pkg / "bin/keep.sh").exists()
+    assert (pkg / "bin/also-keep.sh").exists()
+    assert not (pkg / "bin/skip.sh").exists()
+    assert not (pkg / "share/doc/skip.txt").exists()
+
+
 def test_script_env_in_recipe(
     rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
 ):


### PR DESCRIPTION
## Summary

This PR adds support for build scripts to explicitly specify which files should be included in the final package by writing paths to a file pointed at by the `RATTLER_BUILD_PACKAGE_FILES` environment variable. This provides an alternative to the default mechanism that determines package contents by diffing the prefix against conda-meta records.

## Key Changes

- **New `read_package_files_list()` function**: Reads and parses the package files override list from disk, handling missing files and empty lines gracefully
- **New `Files::from_paths()` method**: Constructs a `Files` struct from an explicit list of paths, with validation that paths exist and stay within the prefix, plus support for applying `files` and `always_include` globs on top
- **New `collect_previous_files()` helper**: Extracted common logic for collecting previously installed files from conda-meta records
- **Build script integration**: 
  - Resets the package files list before running the build script to avoid stale data
  - Sets `RATTLER_BUILD_PACKAGE_FILES` environment variable pointing to the override file
  - Falls back to default behavior if the file is empty or missing
- **Error handling**: Added `PackageFileOutsidePrefix` and `PackageFileMissing` error variants for validation
- **Documentation**: Added comprehensive docs explaining the feature, including examples for both bash and batch scripts
- **Tests**: Added unit tests for path reading, validation, and glob filtering, plus integration tests

## Implementation Details

- The override file is stored at `.rattler-build-package-files` in the build directory to avoid accidental clobbering by build scripts
- Paths can be absolute (under `$PREFIX`) or relative (resolved against `$PREFIX`)
- Empty lines are skipped to support shell idioms like `echo path >> $RATTLER_BUILD_PACKAGE_FILES`
- The `files` and `always_include` globs still apply on top of the explicit list, allowing combined filtering
- The feature is fully backward compatible—if the file is empty or missing, the default behavior is used