### PR TITLE
feat: `git.latest_tag_distance`

### DIFF
--- a/crates/rattler_build_jinja/src/git.rs
+++ b/crates/rattler_build_jinja/src/git.rs
@@ -163,12 +163,44 @@ impl Git {
         Ok(Value::from(result))
     }
 
+    fn latest_tag_distance(&self, src: &str) -> Result<Value, minijinja::Error> {
+        if let Some(local_path) = self.resolve_local_path(src) {
+            let result = git_command_in_dir(&local_path, &["describe", "--tags", "--long"])?
+                .trim()
+                .splitn(3, '-')
+                .collect::<Vec<&str>>()[1]
+                .to_string();
+            return Ok(Value::from(result));
+        }
+
+        let tag_rev =
+            get_command_output("git", &["ls-remote", "--tags", "--sort=-v:refname", src])?
+                .lines()
+                .next()
+                .and_then(|s| s.split_ascii_whitespace().nth(0))
+                .ok_or_else(|| {
+                    minijinja::Error::new(
+                        minijinja::ErrorKind::InvalidOperation,
+                        "Failed to get the latest tag".to_string(),
+                    )
+                })?
+                .to_string();
+        let distance = get_command_output(
+            "git",
+            &["rev-list", "--count", &format!("{}..HEAD", tag_rev)],
+        )?
+        .trim()
+        .to_string();
+        Ok(Value::from(distance))
+    }
+
     fn dispatch(&self, name: &str, args: &[Value]) -> Result<Value, minijinja::Error> {
         let (src,) = from_args(args)?;
         match name {
             "head_rev" => self.head_rev(src),
             "latest_tag_rev" => self.latest_tag_rev(src),
             "latest_tag" => self.latest_tag(src),
+            "latest_tag_distance" => self.latest_tag_distance(src),
             name => Err(minijinja::Error::new(
                 minijinja::ErrorKind::UnknownMethod,
                 format!("object has no method named {name}"),

--- a/crates/rattler_build_jinja/src/jinja.rs
+++ b/crates/rattler_build_jinja/src/jinja.rs
@@ -1029,9 +1029,17 @@ mod tests {
                     .unwrap()
             );
             assert_eq!(
+                jinja
+                    .eval(&format!("git.latest_tag_distance({:?})", path))
+                    .expect("test 2")
+                    .as_str()
+                    .unwrap(),
+                "0"
+            );
+            assert_eq!(
                 jinja_wo_experimental
                     .eval(&format!("git.latest_tag({:?})", path))
-                    .expect_err("test 2")
+                    .expect_err("test 3")
                     .to_string(),
                 "invalid operation: Experimental feature: provide the `--experimental` flag to enable this feature (in <expression>:1)",
             );
@@ -1100,6 +1108,16 @@ mod tests {
                 .as_str()
                 .unwrap(),
             head.as_str().unwrap()
+        );
+
+        // Test latest_tag_distance with relative path
+        assert_eq!(
+            jinja
+                .eval("git.latest_tag_distance(\"../repo\")")
+                .expect("relative path latest_tag_distance")
+                .as_str()
+                .unwrap(),
+            "0"
         );
     }
 

--- a/docs/experimental_features.md
+++ b/docs/experimental_features.md
@@ -88,6 +88,9 @@ from a repository.
 
     # latest commit revision(aka, hash of head commit) in the repo
     git.head_rev(<git_repo_url>)
+
+    # latest tag distance(aka, number of commits between latest tag and head) in the repo
+    git.latest_tag_distance(<git_repo_url>)
     ```
 
 #### Usage

--- a/docs/reference/cli/rattler-build/auth/login.md
+++ b/docs/reference/cli/rattler-build/auth/login.md
@@ -16,6 +16,10 @@ rattler-build auth login [OPTIONS] <HOST>
 :  The host to authenticate with (e.g. prefix.dev)
 <br>**required**: `true`
 
+## Options
+- <a id="arg---user-agent" href="#arg---user-agent">`--user-agent <USER_AGENT>`</a>
+:  User-Agent header used for requests
+
 ## OAuth/OIDC Authentication
 - <a id="arg---oauth" href="#arg---oauth">`--oauth`</a>
 :  Use OAuth/OIDC authentication
@@ -31,6 +35,8 @@ rattler-build auth login [OPTIONS] <HOST>
 - <a id="arg---oauth-scope" href="#arg---oauth-scope">`--oauth-scope <OAUTH_SCOPES>`</a>
 :  Additional OAuth scopes to request (repeatable)
 <br>May be provided more than once.
+- <a id="arg---oauth-redirect-uri" href="#arg---oauth-redirect-uri">`--oauth-redirect-uri <OAUTH_REDIRECT_URI>`</a>
+:  OAuth redirect URI (defaults to a random localhost port). Set this when the OAuth client on the `IdP` side is registered with a specific redirect URI such as `http://127.0.0.1:8000/auth/oidc`
 
 ## S3 Authentication
 - <a id="arg---s3-access-key-id" href="#arg---s3-access-key-id">`--s3-access-key-id <S3_ACCESS_KEY_ID>`</a>


### PR DESCRIPTION
Implements the equivalent of [conda-build's `GIT_DESCRIBE_NUMBER`](https://docs.conda.io/projects/conda-build/en/latest/user-guide/environment-variables.html#git-environment-variables)