### PR TITLE
fix: respect run dependencies on sibling outputs for build ordering

### DIFF
--- a/crates/rattler_build_recipe/src/variant_render.rs
+++ b/crates/rattler_build_recipe/src/variant_render.rs
@@ -429,7 +429,8 @@ fn build_recipe_graph(
     for (idx, recipe) in recipes.iter().enumerate() {
         let current_name = &recipe.package.name;
 
-        for dep_name in extract_dependency_names(recipe) {
+        for dep_name in extract_dependency_names_with_sibling_context(recipe, Some(name_to_indices))
+        {
             if &dep_name == current_name {
                 continue;
             }
@@ -612,8 +613,11 @@ fn stable_topological_sort(
             let current_name = &variants[idx].recipe.package.name;
             let current_combination = &variants[idx].full_combination;
 
-            // Check all dependencies in requirements
-            for dep_name in extract_dependency_names(&variants[idx].recipe) {
+            // Check all dependencies in requirements (including run deps on sibling outputs)
+            for dep_name in extract_dependency_names_with_sibling_context(
+                &variants[idx].recipe,
+                Some(name_to_indices),
+            ) {
                 // Skip self-dependencies
                 if &dep_name == current_name {
                     continue;
@@ -1079,15 +1083,17 @@ fn finalize_build_string_single(
     Ok(())
 }
 
-/// Helper function to extract all dependency package names from a recipe.
+/// Extract dependency names, optionally including plain run dependencies that reference
+/// sibling outputs in the same recipe.
 ///
-/// This collects:
-/// - All named dependencies from build/host/run requirements
-/// - All pin_subpackage references from run_exports (these reference other outputs
-///   and create build-order dependencies even though they're not direct build deps)
-///
-/// Note: May contain duplicates, which is acceptable for dependency graph construction.
-fn extract_dependency_names(recipe: &Stage1Recipe) -> Vec<rattler_conda_types::PackageName> {
+/// When `sibling_names` is provided, plain run/run_constraints dependencies whose names
+/// match sibling output names are included as build-order dependencies. This ensures that
+/// when output B has a run dependency on output A (e.g., `polars` depends on
+/// `polars-runtime-32`), A is built before B so that B's test environment can install A.
+fn extract_dependency_names_with_sibling_context(
+    recipe: &Stage1Recipe,
+    sibling_names: Option<&BTreeMap<rattler_conda_types::PackageName, Vec<usize>>>,
+) -> Vec<rattler_conda_types::PackageName> {
     let requirements = recipe.requirements();
 
     // Collect names from build/host dependencies (needed at build time)
@@ -1115,9 +1121,29 @@ fn extract_dependency_names(recipe: &Stage1Recipe) -> Vec<rattler_conda_types::P
             _ => None,
         });
 
+    // Collect plain run/run_constraints dependencies that reference sibling outputs.
+    // These create build-order dependencies: if output B has a run dep on sibling output A,
+    // then A must be built before B (e.g., so B's test environment can install A).
+    let run_sibling_deps: Vec<rattler_conda_types::PackageName> =
+        if let Some(sibling_names) = sibling_names {
+            requirements
+                .run
+                .iter()
+                .chain(requirements.run_constraints.iter())
+                .filter_map(|dep| match dep {
+                    Dependency::Spec(_) => dep.name().cloned(),
+                    _ => None, // pin_subpackage already handled above
+                })
+                .filter(|name| sibling_names.contains_key(name))
+                .collect()
+        } else {
+            Vec::new()
+        };
+
     build_host
         .chain(run_pin_subpackages)
         .chain(run_export_pins)
+        .chain(run_sibling_deps)
         .collect()
 }
 
@@ -3329,6 +3355,164 @@ package:
         assert!(
             bs_override.ends_with("_7"),
             "overridden build string should end with '_7', got '{bs_override}'"
+        );
+    }
+
+    /// Test that build order respects run dependencies between sibling outputs.
+    /// This is the "polars build order" bug: when output B has a plain run dependency
+    /// on output A (not pin_subpackage), A must be built before B.
+    #[test]
+    fn test_build_order_respects_run_deps_on_sibling_outputs() {
+        // This mimics the polars feedstock structure:
+        // - polars-runtime: the Rust extension
+        // - polars: the noarch Python wrapper that depends on polars-runtime at runtime
+        let recipe_yaml = r#"
+schema_version: 1
+
+context:
+  version: "1.0.0"
+
+recipe:
+  name: polars
+  version: ${{ version }}
+
+build:
+  number: 0
+
+outputs:
+  - package:
+      name: polars
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python >=3.10
+        - pip
+      run:
+        - polars-runtime ==${{ version }}
+        - python >=3.10
+
+  - package:
+      name: polars-runtime
+    requirements:
+      build:
+        - ${{ compiler('c') }}
+      host:
+        - python
+"#;
+
+        let variant_yaml = r#"
+python:
+  - "3.10.*"
+"#;
+
+        let stage0_recipe = stage0::parse_recipe_or_multi_from_source(recipe_yaml).unwrap();
+        let variant_config = VariantConfig::from_yaml_str(variant_yaml).unwrap();
+
+        let rendered =
+            render_recipe_with_variant_config(&stage0_recipe, &variant_config, RenderConfig::new())
+                .unwrap_or_else(|e| panic!("Failed to render: {:?}", e));
+
+        assert_eq!(rendered.len(), 2);
+
+        // polars-runtime should come BEFORE polars because polars depends on it at runtime
+        let names: Vec<String> = rendered
+            .iter()
+            .map(|r| r.recipe.package.name.as_normalized().to_string())
+            .collect();
+
+        let runtime_idx = names
+            .iter()
+            .position(|n| n == "polars-runtime")
+            .expect("polars-runtime not found");
+        let polars_idx = names
+            .iter()
+            .position(|n| n == "polars")
+            .expect("polars not found");
+
+        assert!(
+            runtime_idx < polars_idx,
+            "polars-runtime (idx={}) should be built before polars (idx={}). Order: {:?}",
+            runtime_idx,
+            polars_idx,
+            names
+        );
+    }
+
+    /// Test that build order is correct even when the dependent output is listed first
+    /// in the recipe (reversed order from what's needed).
+    #[test]
+    fn test_build_order_reversed_recipe_order() {
+        // The wrapper output is listed first, but depends on runtime via run dep.
+        // The topological sort should reorder them so runtime comes first.
+        let recipe_yaml = r#"
+schema_version: 1
+
+context:
+  version: "1.0.0"
+
+recipe:
+  name: my-pkg
+  version: ${{ version }}
+
+build:
+  number: 0
+
+outputs:
+  - package:
+      name: my-wrapper
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python >=3.10
+        - pip
+      run:
+        - my-runtime ==${{ version }}
+        - python >=3.10
+
+  - package:
+      name: my-runtime
+    requirements:
+      build:
+        - ${{ compiler('c') }}
+      host:
+        - python
+"#;
+
+        let variant_yaml = r#"
+python:
+  - "3.10.*"
+"#;
+
+        let stage0_recipe = stage0::parse_recipe_or_multi_from_source(recipe_yaml).unwrap();
+        let variant_config = VariantConfig::from_yaml_str(variant_yaml).unwrap();
+
+        let rendered =
+            render_recipe_with_variant_config(&stage0_recipe, &variant_config, RenderConfig::new())
+                .unwrap_or_else(|e| panic!("Failed to render: {:?}", e));
+
+        let names: Vec<String> = rendered
+            .iter()
+            .map(|r| r.recipe.package.name.as_normalized().to_string())
+            .collect();
+
+        let runtime_idx = names
+            .iter()
+            .position(|n| n == "my-runtime")
+            .expect("my-runtime not found");
+        let wrapper_idx = names
+            .iter()
+            .position(|n| n == "my-wrapper")
+            .expect("my-wrapper not found");
+
+        assert!(
+            runtime_idx < wrapper_idx,
+            "my-runtime (idx={}) should be built before my-wrapper (idx={}) \
+             even though my-wrapper is listed first in the recipe. Order: {:?}",
+            runtime_idx,
+            wrapper_idx,
+            names
         );
     }
 }

--- a/crates/rattler_build_recipe/src/variant_render.rs
+++ b/crates/rattler_build_recipe/src/variant_render.rs
@@ -429,8 +429,7 @@ fn build_recipe_graph(
     for (idx, recipe) in recipes.iter().enumerate() {
         let current_name = &recipe.package.name;
 
-        for dep_name in extract_dependency_names_with_sibling_context(recipe, Some(name_to_indices))
-        {
+        for dep_name in extract_dependency_names_with_sibling_context(recipe, name_to_indices) {
             if &dep_name == current_name {
                 continue;
             }
@@ -616,7 +615,7 @@ fn stable_topological_sort(
             // Check all dependencies in requirements (including run deps on sibling outputs)
             for dep_name in extract_dependency_names_with_sibling_context(
                 &variants[idx].recipe,
-                Some(name_to_indices),
+                name_to_indices,
             ) {
                 // Skip self-dependencies
                 if &dep_name == current_name {
@@ -1083,16 +1082,16 @@ fn finalize_build_string_single(
     Ok(())
 }
 
-/// Extract dependency names, optionally including plain run dependencies that reference
-/// sibling outputs in the same recipe.
+/// Extract dependency names, including plain run dependencies that reference sibling
+/// outputs in the same recipe.
 ///
-/// When `sibling_names` is provided, plain run/run_constraints dependencies whose names
-/// match sibling output names are included as build-order dependencies. This ensures that
-/// when output B has a run dependency on output A (e.g., `polars` depends on
-/// `polars-runtime-32`), A is built before B so that B's test environment can install A.
+/// Plain run/run_constraints dependencies whose names match sibling output names are
+/// included as build-order dependencies. This ensures that when output B has a run
+/// dependency on output A (e.g., `polars` depends on `polars-runtime-32`), A is built
+/// before B so that B's test environment can install A.
 fn extract_dependency_names_with_sibling_context(
     recipe: &Stage1Recipe,
-    sibling_names: Option<&BTreeMap<rattler_conda_types::PackageName, Vec<usize>>>,
+    sibling_names: &BTreeMap<rattler_conda_types::PackageName, Vec<usize>>,
 ) -> Vec<rattler_conda_types::PackageName> {
     let requirements = recipe.requirements();
 
@@ -1124,21 +1123,15 @@ fn extract_dependency_names_with_sibling_context(
     // Collect plain run/run_constraints dependencies that reference sibling outputs.
     // These create build-order dependencies: if output B has a run dep on sibling output A,
     // then A must be built before B (e.g., so B's test environment can install A).
-    let run_sibling_deps: Vec<rattler_conda_types::PackageName> =
-        if let Some(sibling_names) = sibling_names {
-            requirements
-                .run
-                .iter()
-                .chain(requirements.run_constraints.iter())
-                .filter_map(|dep| match dep {
-                    Dependency::Spec(_) => dep.name().cloned(),
-                    _ => None, // pin_subpackage already handled above
-                })
-                .filter(|name| sibling_names.contains_key(name))
-                .collect()
-        } else {
-            Vec::new()
-        };
+    let run_sibling_deps = requirements
+        .run
+        .iter()
+        .chain(requirements.run_constraints.iter())
+        .filter_map(|dep| match dep {
+            Dependency::Spec(_) => dep.name().cloned(),
+            _ => None, // pin_subpackage already handled above
+        })
+        .filter(|name| sibling_names.contains_key(name));
 
     build_host
         .chain(run_pin_subpackages)

--- a/crates/rattler_build_recipe/src/variant_render.rs
+++ b/crates/rattler_build_recipe/src/variant_render.rs
@@ -432,8 +432,7 @@ fn build_recipe_graph(
     for (idx, recipe) in recipes.iter().enumerate() {
         let current_name = &recipe.package.name;
 
-        for dep_name in extract_dependency_names_with_sibling_context(recipe, Some(name_to_indices))
-        {
+        for dep_name in extract_dependency_names_with_sibling_context(recipe, name_to_indices) {
             if &dep_name == current_name {
                 continue;
             }
@@ -619,7 +618,7 @@ fn stable_topological_sort(
             // Check all dependencies in requirements (including run deps on sibling outputs)
             for dep_name in extract_dependency_names_with_sibling_context(
                 &variants[idx].recipe,
-                Some(name_to_indices),
+                name_to_indices,
             ) {
                 // Skip self-dependencies
                 if &dep_name == current_name {
@@ -1089,8 +1088,8 @@ fn finalize_build_string_single(
     Ok(())
 }
 
-/// Extract dependency names, optionally including plain run dependencies that reference
-/// sibling outputs in the same recipe.
+/// Extract dependency names, including plain run dependencies that reference sibling
+/// outputs in the same recipe.
 ///
 /// Collects build/host deps, pin_subpackage refs from run/run_exports, and
 /// *exact* pin_subpackage refs from run_constraints (non-exact constraints only
@@ -1099,7 +1098,7 @@ fn finalize_build_string_single(
 /// May contain duplicates, which is fine for graph construction.
 fn extract_dependency_names_with_sibling_context(
     recipe: &Stage1Recipe,
-    sibling_names: Option<&BTreeMap<rattler_conda_types::PackageName, Vec<usize>>>,
+    sibling_names: &BTreeMap<rattler_conda_types::PackageName, Vec<usize>>,
 ) -> Vec<rattler_conda_types::PackageName> {
     let requirements = recipe.requirements();
 
@@ -1138,21 +1137,15 @@ fn extract_dependency_names_with_sibling_context(
     // Collect plain run/run_constraints dependencies that reference sibling outputs.
     // These create build-order dependencies: if output B has a run dep on sibling output A,
     // then A must be built before B (e.g., so B's test environment can install A).
-    let run_sibling_deps: Vec<rattler_conda_types::PackageName> =
-        if let Some(sibling_names) = sibling_names {
-            requirements
-                .run
-                .iter()
-                .chain(requirements.run_constraints.iter())
-                .filter_map(|dep| match dep {
-                    Dependency::Spec(_) => dep.name().cloned(),
-                    _ => None, // pin_subpackage already handled above
-                })
-                .filter(|name| sibling_names.contains_key(name))
-                .collect()
-        } else {
-            Vec::new()
-        };
+    let run_sibling_deps = requirements
+        .run
+        .iter()
+        .chain(requirements.run_constraints.iter())
+        .filter_map(|dep| match dep {
+            Dependency::Spec(_) => dep.name().cloned(),
+            _ => None, // pin_subpackage already handled above
+        })
+        .filter(|name| sibling_names.contains_key(name));
 
     build_host
         .chain(run_pin_subpackages)

--- a/crates/rattler_build_recipe/src/variant_render.rs
+++ b/crates/rattler_build_recipe/src/variant_render.rs
@@ -432,7 +432,8 @@ fn build_recipe_graph(
     for (idx, recipe) in recipes.iter().enumerate() {
         let current_name = &recipe.package.name;
 
-        for dep_name in extract_dependency_names(recipe) {
+        for dep_name in extract_dependency_names_with_sibling_context(recipe, Some(name_to_indices))
+        {
             if &dep_name == current_name {
                 continue;
             }
@@ -615,8 +616,11 @@ fn stable_topological_sort(
             let current_name = &variants[idx].recipe.package.name;
             let current_combination = &variants[idx].full_combination;
 
-            // Check all dependencies in requirements
-            for dep_name in extract_dependency_names(&variants[idx].recipe) {
+            // Check all dependencies in requirements (including run deps on sibling outputs)
+            for dep_name in extract_dependency_names_with_sibling_context(
+                &variants[idx].recipe,
+                Some(name_to_indices),
+            ) {
                 // Skip self-dependencies
                 if &dep_name == current_name {
                     continue;
@@ -1085,14 +1089,18 @@ fn finalize_build_string_single(
     Ok(())
 }
 
-/// Extract the package names a recipe must be built after.
+/// Extract dependency names, optionally including plain run dependencies that reference
+/// sibling outputs in the same recipe.
 ///
 /// Collects build/host deps, pin_subpackage refs from run/run_exports, and
 /// *exact* pin_subpackage refs from run_constraints (non-exact constraints only
 /// pin a version, so they impose no build-order edge; see issue #2531).
 ///
 /// May contain duplicates, which is fine for graph construction.
-fn extract_dependency_names(recipe: &Stage1Recipe) -> Vec<rattler_conda_types::PackageName> {
+fn extract_dependency_names_with_sibling_context(
+    recipe: &Stage1Recipe,
+    sibling_names: Option<&BTreeMap<rattler_conda_types::PackageName, Vec<usize>>>,
+) -> Vec<rattler_conda_types::PackageName> {
     let requirements = recipe.requirements();
 
     // Collect names from build/host dependencies (needed at build time)
@@ -1127,9 +1135,29 @@ fn extract_dependency_names(recipe: &Stage1Recipe) -> Vec<rattler_conda_types::P
                 _ => None,
             });
 
+    // Collect plain run/run_constraints dependencies that reference sibling outputs.
+    // These create build-order dependencies: if output B has a run dep on sibling output A,
+    // then A must be built before B (e.g., so B's test environment can install A).
+    let run_sibling_deps: Vec<rattler_conda_types::PackageName> =
+        if let Some(sibling_names) = sibling_names {
+            requirements
+                .run
+                .iter()
+                .chain(requirements.run_constraints.iter())
+                .filter_map(|dep| match dep {
+                    Dependency::Spec(_) => dep.name().cloned(),
+                    _ => None, // pin_subpackage already handled above
+                })
+                .filter(|name| sibling_names.contains_key(name))
+                .collect()
+        } else {
+            Vec::new()
+        };
+
     build_host
         .chain(run_pin_subpackages)
         .chain(run_constraint_pin_subpackages)
+        .chain(run_sibling_deps)
         .collect()
 }
 
@@ -3552,6 +3580,164 @@ package:
         assert!(
             bs_override.ends_with("_7"),
             "overridden build string should end with '_7', got '{bs_override}'"
+        );
+    }
+
+    /// Test that build order respects run dependencies between sibling outputs.
+    /// This is the "polars build order" bug: when output B has a plain run dependency
+    /// on output A (not pin_subpackage), A must be built before B.
+    #[test]
+    fn test_build_order_respects_run_deps_on_sibling_outputs() {
+        // This mimics the polars feedstock structure:
+        // - polars-runtime: the Rust extension
+        // - polars: the noarch Python wrapper that depends on polars-runtime at runtime
+        let recipe_yaml = r#"
+schema_version: 1
+
+context:
+  version: "1.0.0"
+
+recipe:
+  name: polars
+  version: ${{ version }}
+
+build:
+  number: 0
+
+outputs:
+  - package:
+      name: polars
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python >=3.10
+        - pip
+      run:
+        - polars-runtime ==${{ version }}
+        - python >=3.10
+
+  - package:
+      name: polars-runtime
+    requirements:
+      build:
+        - ${{ compiler('c') }}
+      host:
+        - python
+"#;
+
+        let variant_yaml = r#"
+python:
+  - "3.10.*"
+"#;
+
+        let stage0_recipe = stage0::parse_recipe_or_multi_from_source(recipe_yaml).unwrap();
+        let variant_config = VariantConfig::from_yaml_str(variant_yaml).unwrap();
+
+        let rendered =
+            render_recipe_with_variant_config(&stage0_recipe, &variant_config, RenderConfig::new())
+                .unwrap_or_else(|e| panic!("Failed to render: {:?}", e));
+
+        assert_eq!(rendered.len(), 2);
+
+        // polars-runtime should come BEFORE polars because polars depends on it at runtime
+        let names: Vec<String> = rendered
+            .iter()
+            .map(|r| r.recipe.package.name.as_normalized().to_string())
+            .collect();
+
+        let runtime_idx = names
+            .iter()
+            .position(|n| n == "polars-runtime")
+            .expect("polars-runtime not found");
+        let polars_idx = names
+            .iter()
+            .position(|n| n == "polars")
+            .expect("polars not found");
+
+        assert!(
+            runtime_idx < polars_idx,
+            "polars-runtime (idx={}) should be built before polars (idx={}). Order: {:?}",
+            runtime_idx,
+            polars_idx,
+            names
+        );
+    }
+
+    /// Test that build order is correct even when the dependent output is listed first
+    /// in the recipe (reversed order from what's needed).
+    #[test]
+    fn test_build_order_reversed_recipe_order() {
+        // The wrapper output is listed first, but depends on runtime via run dep.
+        // The topological sort should reorder them so runtime comes first.
+        let recipe_yaml = r#"
+schema_version: 1
+
+context:
+  version: "1.0.0"
+
+recipe:
+  name: my-pkg
+  version: ${{ version }}
+
+build:
+  number: 0
+
+outputs:
+  - package:
+      name: my-wrapper
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python >=3.10
+        - pip
+      run:
+        - my-runtime ==${{ version }}
+        - python >=3.10
+
+  - package:
+      name: my-runtime
+    requirements:
+      build:
+        - ${{ compiler('c') }}
+      host:
+        - python
+"#;
+
+        let variant_yaml = r#"
+python:
+  - "3.10.*"
+"#;
+
+        let stage0_recipe = stage0::parse_recipe_or_multi_from_source(recipe_yaml).unwrap();
+        let variant_config = VariantConfig::from_yaml_str(variant_yaml).unwrap();
+
+        let rendered =
+            render_recipe_with_variant_config(&stage0_recipe, &variant_config, RenderConfig::new())
+                .unwrap_or_else(|e| panic!("Failed to render: {:?}", e));
+
+        let names: Vec<String> = rendered
+            .iter()
+            .map(|r| r.recipe.package.name.as_normalized().to_string())
+            .collect();
+
+        let runtime_idx = names
+            .iter()
+            .position(|n| n == "my-runtime")
+            .expect("my-runtime not found");
+        let wrapper_idx = names
+            .iter()
+            .position(|n| n == "my-wrapper")
+            .expect("my-wrapper not found");
+
+        assert!(
+            runtime_idx < wrapper_idx,
+            "my-runtime (idx={}) should be built before my-wrapper (idx={}) \
+             even though my-wrapper is listed first in the recipe. Order: {:?}",
+            runtime_idx,
+            wrapper_idx,
+            names
         );
     }
 }


### PR DESCRIPTION
This PR fixes a regression in the topological sort that was introduced during the v0.58.0 refactor. When multiple recipes are built together, the dependency graph used for ordering builds only considered `pin_subpackage` references from run dependencies, but ignored plain `run:` specs. This caused solver failures when a package needed a plain runtime dependency that hadn't been built yet.

The fix `replaces extract_dependency_names` with `extract_dependency_names_with_sibling_context`, which also collects plain run/run_constraints dependencies whose names match other outputs in the build set.

This issue is causing ROS Humble to fail a full rebuild for the RoboStack project https://github.com/RoboStack/ros-humble/issues/400 (`ros-humble-uncrustify-vendor` which is a plain run dependency was scheduled to build after its consumer `ros-humble-ament-uncrustify`), with this fix I was able to do a full rebuild of ROS Humble.

I found this fix as part of an existing Claude session https://github.com/prefix-dev/rattler-build/commit/780ce8023c33a15463b06c62656f2a51025d0e97, I don't know what's the policy regarding AI-generated contributions, so I kept the author (Claude) and removed the skip filtering test as it's not part of this fix, but part of https://github.com/prefix-dev/rattler-build/commit/8f5cb03c9d43fa236c951d36a50374587176498c