### PR TITLE
fix(py-rattler-build): Append hash string to specified ouput_dir when creating debug session

### DIFF
--- a/py-rattler-build/rust/src/debug.rs
+++ b/py-rattler-build/rust/src/debug.rs
@@ -256,11 +256,10 @@ pub fn create_debug_session_py(
         .map(|tc| tc.inner)
         .unwrap_or_else(|| Configuration::builder().finish());
 
-    let output_dir = output_dir.unwrap_or_else(|| {
-        std::env::temp_dir()
-            .join(format!("rattler_build_{:x}", rand_hash()))
-            .join("output")
-    });
+    let output_dir = output_dir
+        .unwrap_or_else(std::env::temp_dir)
+        .join(format!("rattler_build_{:x}", rand_hash()))
+        .join("output");
 
     // Ensure output directory exists
     fs_err::create_dir_all(&output_dir).map_err(RattlerBuildError::Io)?;


### PR DESCRIPTION
Currently, the randomized string will be included in the temporary directory only if output_dir does not have a value, but we still want to have it included even if it's specified to have a unique directory for each debug attempt.

Note: originally reported in https://github.com/conda/conda-build/pull/5950#issuecomment-4475280119