### PR TITLE
fix(jinja): exhaustively handle CallArg variants in used-variable collection

### DIFF
--- a/crates/rattler_build_jinja/src/ast_variables.rs
+++ b/crates/rattler_build_jinja/src/ast_variables.rs
@@ -284,20 +284,17 @@ fn collect_variables_from_call(
                 // pin_subpackage(name) expands to the name variable (unless it's a string literal)
                 // pin_subpackage("literal") doesn't expand
                 for arg in &call.args {
-                    if let minijinja::machinery::ast::CallArg::Pos(expr) = arg {
-                        // Don't add string literals as variables
-                        if !matches!(expr, Expr::Const(_)) {
-                            collect_variables_from_expr(expr, variables);
-                        }
+                    let expr = call_arg_expr(arg);
+                    if !matches!(expr, Expr::Const(_)) {
+                        collect_variables_from_expr(expr, variables);
                     }
                 }
             }
             "pin_compatible" => {
                 // pin_compatible(name) expands to the name variable (unless it's a string literal)
                 for arg in &call.args {
-                    if let minijinja::machinery::ast::CallArg::Pos(expr) = arg
-                        && !matches!(expr, Expr::Const(_))
-                    {
+                    let expr = call_arg_expr(arg);
+                    if !matches!(expr, Expr::Const(_)) {
                         collect_variables_from_expr(expr, variables);
                     }
                 }
@@ -305,10 +302,7 @@ fn collect_variables_from_call(
             "match" => {
                 // match(var, spec) - first arg is a variable, second is a string
                 for arg in &call.args {
-                    if let minijinja::machinery::ast::CallArg::Pos(expr) = arg {
-                        // Both arguments could be variables
-                        collect_variables_from_expr(expr, variables);
-                    }
+                    collect_variables_from_expr(call_arg_expr(arg), variables);
                 }
             }
             "cdt" => {
@@ -345,22 +339,28 @@ fn extract_first_string_arg(args: &[minijinja::machinery::ast::CallArg]) -> Opti
     None
 }
 
+/// Return the inner expression of any CallArg variant.
+///
+/// Exhaustive on purpose: if minijinja adds a new CallArg variant, this fails
+/// to compile rather than silently dropping variables passed via that form.
+fn call_arg_expr<'a, 'b>(
+    arg: &'a minijinja::machinery::ast::CallArg<'b>,
+) -> &'a minijinja::machinery::ast::Expr<'b> {
+    use minijinja::machinery::ast::CallArg;
+    match arg {
+        CallArg::Pos(expr)
+        | CallArg::Kwarg(_, expr)
+        | CallArg::PosSplat(expr)
+        | CallArg::KwargSplat(expr) => expr,
+    }
+}
+
 /// Collect variables from a CallArg
 fn collect_variables_from_call_arg(
     arg: &minijinja::machinery::ast::CallArg,
     variables: &mut BTreeSet<String>,
 ) {
-    use minijinja::machinery::ast::CallArg;
-
-    // Match based on the CallArg variants available
-    match arg {
-        CallArg::Pos(expr) => {
-            collect_variables_from_expr(expr, variables);
-        }
-        _ => {
-            // Handle other CallArg variants if they exist
-        }
-    }
+    collect_variables_from_expr(call_arg_expr(arg), variables);
 }
 
 /// Recursively collect variable names from expressions
@@ -551,5 +551,33 @@ mod tests {
         let mut vars = template.used_variables().to_vec();
         vars.sort();
         assert_eq!(vars, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn test_template_with_chained_comparison() {
+        // Chained comparison `a < b < c` parses to a single Expr::Compare node
+        // in minijinja 2.20+ (previously two BinOps). Regression guard for the
+        // Expr enum gaining new variants.
+        let template = JinjaTemplate::new("${{ lo <= n < hi }}".to_string()).unwrap();
+        let mut vars = template.used_variables().to_vec();
+        vars.sort();
+        assert_eq!(vars, vec!["hi", "lo", "n"]);
+    }
+
+    #[test]
+    fn test_pin_subpackage_kwarg_form() {
+        let template =
+            JinjaTemplate::new("${{ pin_subpackage(name=somevar) }}".to_string()).unwrap();
+        assert_eq!(template.used_variables(), &["somevar"]);
+    }
+
+    #[test]
+    fn test_generic_call_with_kwarg_and_splat() {
+        // Kwarg and splat args must contribute their inner variables.
+        let template =
+            JinjaTemplate::new("${{ my_fn(foo, bar=baz, *args, **kwargs) }}".to_string()).unwrap();
+        let mut vars = template.used_variables().to_vec();
+        vars.sort();
+        assert_eq!(vars, vec!["args", "baz", "foo", "kwargs", "my_fn"]);
     }
 }


### PR DESCRIPTION
## Summary

While fixing the minijinja 2.20 build break (PR #2427, `Expr::Compare`), I audited the rest of the AST walker in `rattler_build_jinja/src/ast_variables.rs` and found a pre-existing gap: `collect_variables_from_call_arg` matches only `CallArg::Pos` and uses `_ => {}` to swallow the other three variants. The same Pos-only filter is duplicated in the `pin_subpackage`, `pin_compatible`, and `match` special-function arms.

Result: templates using kwarg or splat call forms lose variables for variant tracking. E.g.

```jinja
${{ pin_subpackage(name=somevar) }}    # somevar dropped
${{ my_fn(**kwargs) }}                 # kwargs dropped
```

In conda-build idioms these are always positional, so existing recipes are unlikely to hit this — but user-written macros that pass kwargs or splats would silently lose variant detection.

This PR:

- Adds `call_arg_expr` — a small helper that exhaustively destructures every `CallArg` variant (`Pos | Kwarg | PosSplat | KwargSplat`) into its inner `Expr`. **No wildcard arm**, so a future minijinja release that adds a new variant will fail to compile here instead of silently losing variables — same property that just saved us for `Expr::Compare`.
- Routes `collect_variables_from_call_arg` and the three special-function arms through the helper.
- Adds three regression tests: chained comparison (`Expr::Compare`), `pin_subpackage` kwarg form, and a generic call covering all four `CallArg` variants.

This is stacked on top of #2427 so the new chained-comparison test compiles. Once #2427 merges to main, GitHub will auto-rebase this diff down to just the audit changes.

## Test plan

- [x] `cargo test -p rattler_build_jinja` — 48/48 pass (up from 45)
- [x] `cargo check --workspace` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)