### PR TITLE
fix(release): use renamed `rustls` feature in build_options.py

### DIFF
--- a/scripts/build_options.py
+++ b/scripts/build_options.py
@@ -1,7 +1,7 @@
 """Determine cargo build/test options for a given target and write to GITHUB_OUTPUT.
 
 Outputs:
-    cargo-build-options - extra flags for cargo build (e.g. --no-default-features --features rustls-tls)
+    cargo-build-options - extra flags for cargo build (e.g. --no-default-features --features rustls)
     cargo-test-options  - extra flags for cargo test (e.g. --lib --bin rattler-build)
 
 Usage:
@@ -23,7 +23,7 @@ def main() -> None:
 
     # musl targets need rustls instead of native TLS
     if "-musl" in target:
-        build_options = "--no-default-features --features rustls-tls"
+        build_options = "--no-default-features --features rustls"
     else:
         build_options = ""
 


### PR DESCRIPTION
## Summary

PR #2493 (reqwest 0.13 migration) renamed the workspace TLS feature `rustls-tls` → `rustls` in the root `Cargo.toml`, but missed updating `scripts/build_options.py`, which still emits `--features rustls-tls` for musl targets. That call site is exercised only by the release workflow, so the bug stayed latent until today's 0.65.0 release attempt, where the `Build x86_64-unknown-linux-musl` and `Build aarch64-unknown-linux-musl` jobs both failed with:

```
error: the package 'rattler-build' does not contain this feature: rustls-tls
```

(Run: https://github.com/prefix-dev/rattler-build/actions/runs/26166908338)

This PR updates the script to emit `--features rustls` for musl targets and refreshes the docstring example to match.

## Test plan

- [x] `python3 scripts/build_options.py --target x86_64-unknown-linux-musl` → `--no-default-features --features rustls`
- [x] `python3 scripts/build_options.py --target x86_64-unknown-linux-gnu` → no build options (unchanged)
- [x] `cargo check --no-default-features --features rustls,recipe-generation,s3,sigstore` succeeds locally
- [ ] Release workflow re-run is green after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)