### PR TITLE
Replace chrono with jiff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "apple-native-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7be2f067ccd8d4b4d4a66ddafe0f32a5dff31732f32dbff85fefc40929b1f72"
+dependencies = [
+ "keyring-core",
+ "log",
+ "security-framework",
+]
+
+[[package]]
 name = "archspec"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,7 +195,7 @@ checksum = "35d7a19757bfe3658d5a95bf25a0492f29ebb21933549bdbfa4075c895510124"
 dependencies = [
  "goblin",
  "scroll",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
 ]
 
@@ -275,30 +286,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-broadcast"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-channel"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "async-compression"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,20 +296,6 @@ dependencies = [
  "futures-io",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "pin-project-lite",
- "slab",
 ]
 
 [[package]]
@@ -341,68 +314,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-fs"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
-dependencies = [
- "async-lock",
- "blocking",
- "futures-lite",
-]
-
-[[package]]
-name = "async-io"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
-dependencies = [
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite",
- "parking",
- "polling",
- "rustix 1.1.4",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
 name = "async-once-cell"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288f83726785267c6f2ef073a3d83dc3f9b81464e9f99898240cced85fce35a"
-
-[[package]]
-name = "async-process"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
-dependencies = [
- "async-channel",
- "async-io",
- "async-lock",
- "async-signal",
- "async-task",
- "blocking",
- "cfg-if",
- "event-listener",
- "futures-lite",
- "rustix 1.1.4",
-]
 
 [[package]]
 name = "async-recursion"
@@ -416,24 +331,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-signal"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
-dependencies = [
- "async-io",
- "async-lock",
- "atomic-waker",
- "cfg-if",
- "futures-core",
- "futures-io",
- "rustix 1.1.4",
- "signal-hook-registry",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "async-spooled-tempfile"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,12 +339,6 @@ dependencies = [
  "tempfile",
  "tokio",
 ]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -499,7 +390,7 @@ dependencies = [
  "p256 0.13.2",
  "rand 0.8.6",
  "ring",
- "sha2",
+ "sha2 0.10.9",
  "time",
  "tokio",
  "tracing",
@@ -600,7 +491,7 @@ dependencies = [
  "lru",
  "percent-encoding",
  "regex-lite",
- "sha2",
+ "sha2 0.10.9",
  "tracing",
  "url",
 ]
@@ -723,7 +614,7 @@ dependencies = [
  "p256 0.11.1",
  "percent-encoding",
  "ring",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "time",
  "tracing",
@@ -755,10 +646,10 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "md-5",
+ "md-5 0.10.6",
  "pin-project-lite",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "tracing",
 ]
 
@@ -1048,11 +939,11 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.10.6"
+version = "0.11.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+checksum = "061f1a09225e328e1ffbb378d2d49923c0ca5fee19fb5ac1cc9c1e9d52b93690"
 dependencies = [
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1065,25 +956,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "blocking"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
-dependencies = [
- "async-channel",
- "async-task",
- "futures-io",
- "futures-lite",
- "piper",
 ]
 
 [[package]]
@@ -1172,7 +1059,7 @@ dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 1.3.0",
 ]
 
 [[package]]
@@ -1245,7 +1132,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -1329,6 +1216,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
 name = "cmpv2"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1346,7 +1239,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b77c319abfd5219629c45c34c89ba945ed3c5e49fcde9d16b6c3885f118a730"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "der 0.7.10",
  "spki 0.7.3",
  "x509-cert",
@@ -1355,8 +1248,7 @@ dependencies = [
 [[package]]
 name = "coalesced_map"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fe09392885c9af28aed39c6ddd06e41b43dbe98a850ccf0abe3f88d7cc75de"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "dashmap",
  "tokio",
@@ -1441,6 +1333,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const-random"
@@ -1537,7 +1435,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd92aca2c6001b1bf5ba0ff84ee74ec8501b52bbef0cac80bf25a6c1d87a83d"
 dependencies = [
  "crc",
- "digest",
+ "digest 0.10.7",
  "rustversion",
  "spin 0.10.0",
 ]
@@ -1696,6 +1594,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1704,7 +1620,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -1795,8 +1711,19 @@ dependencies = [
  "hkdf",
  "num",
  "once_cell",
- "sha2",
+ "openssl",
+ "sha2 0.10.9",
  "zeroize",
+]
+
+[[package]]
+name = "dbus-secret-service-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21d8f54da401bb5eb2a4d873ac4b359f4a599df2ca8634bb5b8c045e5ee78757"
+dependencies = [
+ "dbus-secret-service",
+ "keyring-core",
 ]
 
 [[package]]
@@ -1805,7 +1732,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
 ]
 
@@ -1815,7 +1742,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "der_derive",
  "flagset",
  "pem-rfc7468",
@@ -1867,10 +1794,22 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1900,7 +1839,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1969,7 +1908,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der 0.7.10",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve 0.13.8",
  "rfc6979 0.4.0",
  "signature 2.2.0",
@@ -1995,7 +1934,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -2015,7 +1954,7 @@ dependencies = [
  "base16ct 0.1.1",
  "crypto-bigint 0.4.9",
  "der 0.6.1",
- "digest",
+ "digest 0.10.7",
  "ff 0.12.1",
  "generic-array",
  "group 0.12.1",
@@ -2034,7 +1973,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct 0.2.0",
  "crypto-bigint 0.5.5",
- "digest",
+ "digest 0.10.7",
  "ff 0.13.1",
  "generic-array",
  "group 0.13.0",
@@ -2072,12 +2011,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "endi"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
-
-[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2096,27 +2029,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
 dependencies = [
  "once_cell",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "enumflags2"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
-dependencies = [
- "enumflags2_derive",
- "serde",
-]
-
-[[package]]
-name = "enumflags2_derive"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
-dependencies = [
  "proc-macro2",
  "quote",
  "syn",
@@ -2146,7 +2058,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2161,20 +2073,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener-strategy"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
-dependencies = [
- "event-listener",
- "pin-project-lite",
-]
-
-[[package]]
 name = "fancy-regex"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -2216,8 +2118,7 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 [[package]]
 name = "file_url"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d8c8b9119e366c1b4103d3ca9b5e09cc5684ae14f1265d1472d0a7fbc61747"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "itertools 0.14.0",
  "percent-encoding",
@@ -2680,6 +2581,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -2726,7 +2632,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2835,6 +2741,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2910,7 +2825,7 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry 0.6.1",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2925,7 +2840,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -3213,7 +3128,7 @@ dependencies = [
  "portable-atomic-util",
  "serde_core",
  "wasm-bindgen",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3336,20 +3251,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "keyring"
-version = "3.6.3"
+name = "keyring-core"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
 dependencies = [
- "byteorder",
- "dbus-secret-service",
  "log",
- "secret-service",
- "security-framework 2.11.1",
- "security-framework 3.7.0",
- "windows-sys 0.60.2",
- "zbus",
- "zeroize",
 ]
 
 [[package]]
@@ -3358,7 +3265,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3417,6 +3324,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
 dependencies = [
+ "cc",
  "pkg-config",
 ]
 
@@ -3526,7 +3434,7 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47bb1e988e6fb779cf720ad431242d3f03167c1b3f2b1aae7f1a94b2495b36ae"
 dependencies = [
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3556,7 +3464,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3588,15 +3506,6 @@ name = "memo-map"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "miette"
@@ -3697,7 +3606,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework 3.7.0",
+ "security-framework",
  "security-framework-sys",
  "tempfile",
 ]
@@ -3707,19 +3616,6 @@ name = "netrc-rs"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2970fbbc8c785e8246234a7bd004ed66cd1ed1a35ec73669a92545e419b836"
-
-[[package]]
-name = "nix"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
-dependencies = [
- "bitflags",
- "cfg-if",
- "cfg_aliases",
- "libc",
- "memoffset",
-]
 
 [[package]]
 name = "nix"
@@ -3752,21 +3648,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "ntapi"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3881,7 +3768,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.21.7",
  "chrono",
  "getrandom 0.2.17",
  "http 1.4.0",
@@ -3889,7 +3776,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "url",
 ]
@@ -3902,25 +3789,6 @@ checksum = "234fb5c965bbce983ee5de636a7a51d6a3223da8067ea02f9ab2d2d78ac08be2"
 dependencies = [
  "oauth2",
  "reqwest 0.13.3",
-]
-
-[[package]]
-name = "objc2-core-foundation"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "objc2-io-kit"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
-dependencies = [
- "libc",
- "objc2-core-foundation",
 ]
 
 [[package]]
@@ -3998,7 +3866,7 @@ dependencies = [
  "http-body 1.0.1",
  "jiff",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "mea",
  "percent-encoding",
  "quick-xml 0.38.4",
@@ -4048,7 +3916,7 @@ dependencies = [
  "crc32c",
  "http 1.4.0",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "opendal-core",
  "quick-xml 0.38.4",
  "reqsign-aws-v4",
@@ -4083,7 +3951,7 @@ dependencies = [
  "serde_path_to_error",
  "serde_plain",
  "serde_with",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "thiserror 1.0.69",
  "url",
@@ -4121,6 +3989,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.0+3.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4128,6 +4005,7 @@ checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -4158,16 +4036,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered-stream"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
-dependencies = [
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4187,7 +4055,7 @@ checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
 dependencies = [
  "ecdsa 0.14.8",
  "elliptic-curve 0.12.3",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4199,7 +4067,7 @@ dependencies = [
  "ecdsa 0.16.9",
  "elliptic-curve 0.13.8",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4211,7 +4079,7 @@ dependencies = [
  "ecdsa 0.16.9",
  "elliptic-curve 0.13.8",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4256,8 +4124,7 @@ dependencies = [
 [[package]]
 name = "path_resolver"
 version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a9f07f388f2a58768a34000c2b956bbc44f51630aa39d84f1d362c6785075a1"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "ahash",
  "fs-err",
@@ -4344,17 +4211,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "piper"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
-dependencies = [
- "atomic-waker",
- "fastrand",
- "futures-io",
-]
-
-[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4436,20 +4292,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
-]
-
-[[package]]
-name = "polling"
-version = "3.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi",
- "pin-project-lite",
- "rustix 1.1.4",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4663,7 +4505,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4781,22 +4623,24 @@ dependencies = [
 [[package]]
 name = "rattler"
 version = "0.43.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "188a5ce39ea764f92fb4868ac74a722e27d33a52f3aba18be8ec705fba911cbd"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
+ "base64 0.22.1",
  "clap",
  "console",
- "digest",
+ "digest 0.11.3",
  "dirs",
  "filetime",
  "fs-err",
  "futures",
+ "hex",
  "humantime",
  "indexmap 2.14.0",
  "indicatif",
  "itertools 0.14.0",
+ "jiff",
  "memchr",
  "memmap2",
  "oauth2-reqwest",
@@ -4838,7 +4682,6 @@ dependencies = [
  "astral_async_http_range_reader",
  "astral_async_zip",
  "async-compression",
- "chrono",
  "clap",
  "clap-verbosity-flag",
  "clap_complete",
@@ -4851,10 +4694,12 @@ dependencies = [
  "fs-err",
  "futures",
  "globset",
+ "hex",
  "http 1.4.0",
  "ignore",
  "indexmap 2.14.0",
  "insta",
+ "jiff",
  "memmap2",
  "miette",
  "minijinja",
@@ -4884,7 +4729,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "serial_test",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "tokio",
  "tokio-util",
@@ -4912,7 +4757,6 @@ dependencies = [
  "astral-reqwest-middleware",
  "async-once-cell",
  "async-recursion",
- "chrono",
  "clap",
  "clap-verbosity-flag",
  "comfy-table",
@@ -4930,6 +4774,7 @@ dependencies = [
  "indicatif",
  "insta",
  "itertools 0.14.0",
+ "jiff",
  "line-ending",
  "memchr",
  "memmap2",
@@ -4974,7 +4819,7 @@ dependencies = [
  "serde_with",
  "serde_yaml",
  "serial_test",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "terminal_size",
  "text-stub-library",
@@ -5022,7 +4867,7 @@ dependencies = [
  "strum",
  "tempfile",
  "thiserror 2.0.18",
- "toml 1.1.2+spec-1.1.0",
+ "toml",
 ]
 
 [[package]]
@@ -5041,12 +4886,12 @@ dependencies = [
 name = "rattler_build_package"
 version = "0.1.7"
 dependencies = [
- "chrono",
  "content_inspector",
  "fs-err",
  "globset",
  "indicatif",
  "insta",
+ "jiff",
  "memchr",
  "memmap2",
  "pathdiff",
@@ -5060,7 +4905,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
@@ -5075,6 +4920,7 @@ dependencies = [
  "clap",
  "fs-err",
  "globset",
+ "hex",
  "indexmap 2.14.0",
  "insta",
  "itertools 0.14.0",
@@ -5112,6 +4958,7 @@ dependencies = [
  "clap",
  "flate2",
  "fs-err",
+ "hex",
  "indexmap 2.14.0",
  "insta",
  "itertools 0.14.0",
@@ -5124,11 +4971,11 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serde_yaml",
- "sha2",
+ "sha2 0.10.9",
  "tar",
  "tempfile",
  "tokio",
- "toml 1.1.2+spec-1.1.0",
+ "toml",
  "tracing",
  "url",
  "zip",
@@ -5167,15 +5014,15 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bzip2",
- "chrono",
  "dunce",
  "flate2",
  "fs-err",
  "futures",
  "hex",
  "indicatif",
+ "jiff",
  "lzma-rust2",
- "md-5",
+ "md-5 0.10.6",
  "rattler_build_networking",
  "rattler_git",
  "rattler_prefix_guard",
@@ -5183,9 +5030,9 @@ dependencies = [
  "serde",
  "serde_json",
  "sevenz-rust2",
- "sha2",
- "sigstore-trust-root 0.7.0",
- "sigstore-types 0.7.0",
+ "sha2 0.10.9",
+ "sigstore-trust-root",
+ "sigstore-types",
  "sigstore-verify",
  "tar",
  "tempfile",
@@ -5251,18 +5098,18 @@ dependencies = [
 [[package]]
 name = "rattler_cache"
 version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2aa78ff1be938e28fdcdb9837f90da858d090ec1147a00a2aab8490c077f557"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "ahash",
  "anyhow",
  "astral-reqwest-middleware",
  "dashmap",
- "digest",
+ "digest 0.11.3",
  "dirs",
  "fs-err",
  "fs4",
  "futures",
+ "hex",
  "itertools 0.14.0",
  "parking_lot",
  "rattler_conda_types",
@@ -5284,11 +5131,9 @@ dependencies = [
 [[package]]
 name = "rattler_conda_types"
 version = "0.46.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6018a34d7edb8a6b97c971ba935e59d217a0986376d14f4d515fb238b28bdf02"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "ahash",
- "chrono",
  "core-foundation 0.10.1",
  "dirs",
  "fancy-regex",
@@ -5298,6 +5143,7 @@ dependencies = [
  "hex",
  "indexmap 2.14.0",
  "itertools 0.14.0",
+ "jiff",
  "lazy-regex",
  "memmap2",
  "nom",
@@ -5327,8 +5173,7 @@ dependencies = [
 [[package]]
 name = "rattler_config"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e61e6eba72c2e8cc59f8fe7bd120eee4f0d34ed141ae1985ac5bd8c107261ecd"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "console",
  "fs-err",
@@ -5337,7 +5182,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
  "tracing",
  "url",
 ]
@@ -5345,19 +5190,18 @@ dependencies = [
 [[package]]
 name = "rattler_digest"
 version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c44304c9353802e910fac1dbdf6e16df44c341d07b1850bc1fd8b03912cbaab"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "blake2",
- "digest",
+ "digest 0.11.3",
  "generic-array",
  "hex",
- "md-5",
+ "md-5 0.11.0",
  "serde",
  "serde-untagged",
  "serde_bytes",
  "serde_with",
- "sha2",
+ "sha2 0.11.0",
  "tokio",
  "url",
 ]
@@ -5365,8 +5209,7 @@ dependencies = [
 [[package]]
 name = "rattler_git"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373265099ab8b2b816b30e0f8db4cddb6b8364be0a04bc9bdaa21c5ad3fe8943"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "astral-reqwest-middleware",
  "dashmap",
@@ -5386,20 +5229,20 @@ dependencies = [
 [[package]]
 name = "rattler_index"
 version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a8bafd1bc5ad33a81d97a57fee3668406ad37b5f526a3658b019b34b72aa8ca"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "ahash",
  "anyhow",
  "bytes",
- "chrono",
  "clap",
  "clap-verbosity-flag",
  "console",
  "fs-err",
  "futures",
+ "hex",
  "indexmap 2.14.0",
  "indicatif",
+ "jiff",
  "opendal",
  "rattler_conda_types",
  "rattler_config",
@@ -5412,7 +5255,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "tar",
  "thiserror 2.0.18",
  "tokio",
@@ -5425,8 +5268,7 @@ dependencies = [
 [[package]]
 name = "rattler_macros"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d44a87a904057524e32dc8beeb50197016cec467d487bce9d64e044adbcaeb5"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "quote",
  "syn",
@@ -5435,13 +5277,12 @@ dependencies = [
 [[package]]
 name = "rattler_menuinst"
 version = "0.2.62"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ac99b44fac7a9e6cb4bd65cee12c3ec281db52284f6c85fc929b1d1b775cea8"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
- "chrono",
  "configparser",
  "dirs",
  "fs-err",
+ "hex",
  "indexmap 2.14.0",
  "known-folders",
  "once_cell",
@@ -5452,25 +5293,25 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2",
- "shlex",
+ "sha2 0.11.0",
+ "shlex 2.0.1",
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
  "unicode-normalization",
  "which",
  "windows 0.61.3",
- "windows-registry 0.5.3",
+ "windows-registry",
 ]
 
 [[package]]
 name = "rattler_networking"
 version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19984b40494bdbaf785525ba36fdb1fa487fe44a36b4214851af4428c69ecf27"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "ambient-id",
  "anyhow",
+ "apple-native-keyring-store",
  "astral-reqwest-middleware",
  "async-once-cell",
  "async-trait",
@@ -5478,12 +5319,13 @@ dependencies = [
  "aws-sdk-s3",
  "aws-smithy-http-client",
  "base64 0.22.1",
+ "dbus-secret-service-keyring-store",
  "dirs",
  "fs-err",
  "getrandom 0.4.2",
  "http 1.4.0",
  "itertools 0.14.0",
- "keyring",
+ "keyring-core",
  "netrc-rs",
  "rattler_config",
  "reqwest 0.13.3",
@@ -5494,13 +5336,13 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "url",
+ "windows-native-keyring-store",
 ]
 
 [[package]]
 name = "rattler_package_streaming"
 version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eefa295dc7b49aa0b67d125400561d2b45b754c66c0f7a19e8fc375b1056bfa9"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-tokio-tar",
@@ -5509,13 +5351,14 @@ dependencies = [
  "async-compression",
  "async-spooled-tempfile",
  "bzip2",
- "chrono",
  "fs-err",
  "futures",
  "futures-util",
  "getrandom 0.2.17",
  "getrandom 0.4.2",
+ "hex",
  "http 1.4.0",
+ "jiff",
  "num_cpus",
  "rattler_conda_types",
  "rattler_digest",
@@ -5538,8 +5381,7 @@ dependencies = [
 [[package]]
 name = "rattler_prefix_guard"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d083796e99a8dbe46fdd5dbde5c853ce532d43419959f3c51578f9f59ada860d"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "fs-err",
  "libc",
@@ -5552,11 +5394,10 @@ dependencies = [
 [[package]]
 name = "rattler_pty"
 version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30f42171f331905af5752aeba3bd1a539b73a35d0754b7db9f7d06a314ad913e"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "libc",
- "nix 0.30.1",
+ "nix",
  "signal-hook",
  "tokio",
 ]
@@ -5564,8 +5405,7 @@ dependencies = [
 [[package]]
 name = "rattler_redaction"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1893dff3da09d778304797291869b17287e35a785cd8bc58fb9cd4760ef51b"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "astral-reqwest-middleware",
  "reqwest 0.13.3",
@@ -5575,8 +5415,7 @@ dependencies = [
 [[package]]
 name = "rattler_repodata_gateway"
 version = "0.29.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d033dc7d25fedc1918719b6d084983436d1cea15621ab5f4c8d722c9020376"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5588,7 +5427,6 @@ dependencies = [
  "bytes",
  "cache_control",
  "cfg-if",
- "chrono",
  "coalesced_map",
  "dashmap",
  "dirs",
@@ -5596,13 +5434,14 @@ dependencies = [
  "fs-err",
  "fslock",
  "futures",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "hex",
  "http 1.4.0",
  "http-cache-semantics",
  "humansize",
  "humantime",
  "itertools 0.14.0",
+ "jiff",
  "json-patch",
  "libc",
  "memmap2",
@@ -5638,8 +5477,7 @@ dependencies = [
 [[package]]
 name = "rattler_s3"
 version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58be09fc22d312cce5ac8158dd94950bb6ba080b23b352b4aa6d53a8dbec8fd4"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -5655,8 +5493,7 @@ dependencies = [
 [[package]]
 name = "rattler_shell"
 version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b57f7b11f6e6d0ef88e5d93b3ba5ea1c0cedeaa58195ec4e75680b465f38dc43"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -5666,8 +5503,7 @@ dependencies = [
  "rattler_conda_types",
  "rattler_pty",
  "serde_json",
- "shlex",
- "sysinfo",
+ "shlex 2.0.1",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -5677,13 +5513,12 @@ dependencies = [
 [[package]]
 name = "rattler_solve"
 version = "7.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eef2142527283596cad4f0b89f4fa0c87a2e20831bf8ef51422d72c9fc6bc316"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
- "chrono",
  "futures",
- "humantime",
+ "hex",
  "itertools 0.14.0",
+ "jiff",
  "rattler_conda_types",
  "rattler_digest",
  "resolvo",
@@ -5696,8 +5531,7 @@ dependencies = [
 [[package]]
 name = "rattler_upload"
 version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca99035497a581f847c76847bac53b18a9ce682daeef01e404f3a61faaf2d58"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-reqwest-retry",
@@ -5705,6 +5539,7 @@ dependencies = [
  "clap",
  "fs-err",
  "futures",
+ "hex",
  "indicatif",
  "miette",
  "opendal",
@@ -5720,8 +5555,9 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.11.0",
  "sigstore-sign",
+ "sigstore-trust-root",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -5733,8 +5569,7 @@ dependencies = [
 [[package]]
 name = "rattler_virtual_packages"
 version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0820759e1171d6ef08237cc7683181cb7aa954d3586b24142333ffe8c7efb5b"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "archspec",
  "libloading",
@@ -5901,7 +5736,7 @@ dependencies = [
  "log",
  "percent-encoding",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "windows-sys 0.61.2",
 ]
 
@@ -6091,8 +5926,8 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -6188,7 +6023,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6216,7 +6051,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.7.0",
+ "security-framework",
 ]
 
 [[package]]
@@ -6244,10 +6079,10 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.13",
- "security-framework 3.7.0",
+ "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6428,38 +6263,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
  "zeroize",
-]
-
-[[package]]
-name = "secret-service"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4d35ad99a181be0a60ffcbe85d680d98f87bdc4d7644ade319b87076b9dbfd4"
-dependencies = [
- "aes",
- "cbc",
- "futures-util",
- "generic-array",
- "hkdf",
- "num",
- "once_cell",
- "rand 0.8.6",
- "serde",
- "sha2",
- "zbus",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
 ]
 
 [[package]]
@@ -6721,7 +6524,7 @@ dependencies = [
  "js-sys",
  "lzma-rust2",
  "ppmd-rust",
- "sha2",
+ "sha2 0.10.9",
  "wasm-bindgen",
 ]
 
@@ -6733,7 +6536,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -6744,8 +6547,19 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
  "sha2-asm",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -6779,6 +6593,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6804,7 +6624,7 @@ version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -6814,26 +6634,8 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "sigstore-bundle"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7dc53c8a941858d01479622dbb7650aaa2ee0ca1fb58fb6cdddbfc3064abbb"
-dependencies = [
- "base64 0.22.1",
- "hex",
- "serde",
- "serde_json",
- "sigstore-crypto 0.6.6",
- "sigstore-merkle 0.6.6",
- "sigstore-rekor 0.6.6",
- "sigstore-tsa 0.6.6",
- "sigstore-types 0.6.6",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6846,34 +6648,12 @@ dependencies = [
  "hex",
  "serde",
  "serde_json",
- "sigstore-crypto 0.7.0",
- "sigstore-merkle 0.7.0",
- "sigstore-rekor 0.7.0",
- "sigstore-tsa 0.7.0",
- "sigstore-types 0.7.0",
+ "sigstore-crypto",
+ "sigstore-merkle",
+ "sigstore-rekor",
+ "sigstore-tsa",
+ "sigstore-types",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "sigstore-crypto"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da90c3d9af638898a5fdc347479b18f950bb0dde11ecf2244f94cd28135da53b"
-dependencies = [
- "aws-lc-rs",
- "base64 0.22.1",
- "const-oid",
- "der 0.7.10",
- "digest",
- "pem",
- "rand_core 0.10.1",
- "sha2",
- "signature 2.2.0",
- "sigstore-types 0.6.6",
- "spki 0.7.3",
- "thiserror 2.0.18",
- "tracing",
- "x509-cert",
 ]
 
 [[package]]
@@ -6884,14 +6664,14 @@ checksum = "ac7172898e15789d69d12469bb3d33397aab0771fb4f8d32cd56972e97808bf3"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
- "const-oid",
+ "const-oid 0.9.6",
  "der 0.7.10",
- "digest",
+ "digest 0.10.7",
  "pem",
  "rand_core 0.9.5",
- "sha2",
+ "sha2 0.10.9",
  "signature 2.2.0",
- "sigstore-types 0.7.0",
+ "sigstore-types",
  "spki 0.7.3",
  "thiserror 2.0.18",
  "tracing",
@@ -6900,32 +6680,19 @@ dependencies = [
 
 [[package]]
 name = "sigstore-fulcio"
-version = "0.6.6"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c60b95ecc87b2e279705e4a617cfb2d668bb9dfb15b3a99322524b6f44a4201b"
+checksum = "a3dd9d2e96569798c7a6959a8712261d0c8048fe1a86604019eb19618b48cf00"
 dependencies = [
  "base64 0.22.1",
  "reqwest 0.13.3",
  "serde",
  "serde_json",
- "sigstore-crypto 0.6.6",
+ "sigstore-crypto",
  "sigstore-oidc",
- "sigstore-types 0.6.6",
+ "sigstore-types",
  "thiserror 2.0.18",
  "url",
-]
-
-[[package]]
-name = "sigstore-merkle"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c0d53558825c77716855c13794306fff766854c1bf92948e77d7890da3f2455"
-dependencies = [
- "base64 0.22.1",
- "hex",
- "sigstore-crypto 0.6.6",
- "sigstore-types 0.6.6",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6936,45 +6703,27 @@ checksum = "5e86ee272adfcfa21a2248b2fbf05a79b6e39a1fb699ef70c578c814af16e4db"
 dependencies = [
  "base64 0.22.1",
  "hex",
- "sigstore-crypto 0.7.0",
- "sigstore-types 0.7.0",
+ "sigstore-crypto",
+ "sigstore-types",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "sigstore-oidc"
-version = "0.6.6"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cff865c405b9bcc2d8f684245307880c282c87edcd34b0039babfde9ae301ba"
+checksum = "587e216497808f23de607ea7966b3ca312a48afa3babaf54fdef9b2518106070"
 dependencies = [
  "ambient-id",
  "base64 0.22.1",
- "rand 0.10.1",
+ "rand 0.9.4",
  "reqwest 0.13.3",
  "serde",
  "serde_json",
- "sigstore-crypto 0.6.6",
- "sigstore-types 0.6.6",
+ "sigstore-crypto",
+ "sigstore-types",
  "thiserror 2.0.18",
  "tokio",
- "url",
-]
-
-[[package]]
-name = "sigstore-rekor"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "641fdaaa40d0cd6e249cf1671c2240beff1a3ece578062cf43e750779e8db2b3"
-dependencies = [
- "base64 0.22.1",
- "hex",
- "reqwest 0.13.3",
- "serde",
- "serde_json",
- "sigstore-crypto 0.6.6",
- "sigstore-merkle 0.6.6",
- "sigstore-types 0.6.6",
- "thiserror 2.0.18",
  "url",
 ]
 
@@ -6989,47 +6738,29 @@ dependencies = [
  "reqwest 0.13.3",
  "serde",
  "serde_json",
- "sigstore-crypto 0.7.0",
- "sigstore-merkle 0.7.0",
- "sigstore-types 0.7.0",
+ "sigstore-crypto",
+ "sigstore-merkle",
+ "sigstore-types",
  "thiserror 2.0.18",
  "url",
 ]
 
 [[package]]
 name = "sigstore-sign"
-version = "0.6.6"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ae2a8b1e76abe552de2ba89c85013d09753beeebc76b5c50bfdff4abc689a1"
+checksum = "a6fea3ac015830222b4083a9905681030430e079683aaf74e1ec6e75ab3b4b9e"
 dependencies = [
  "base64 0.22.1",
  "serde_json",
- "sigstore-bundle 0.6.6",
- "sigstore-crypto 0.6.6",
+ "sigstore-bundle",
+ "sigstore-crypto",
  "sigstore-fulcio",
  "sigstore-oidc",
- "sigstore-rekor 0.6.6",
- "sigstore-trust-root 0.6.6",
- "sigstore-tsa 0.6.6",
- "sigstore-types 0.6.6",
- "thiserror 2.0.18",
- "x509-cert",
-]
-
-[[package]]
-name = "sigstore-trust-root"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6b0d2550f05c096400066e858db13d91f9de3b750a7541fb1291c1dc80ca290"
-dependencies = [
- "base64 0.22.1",
- "chrono",
- "hex",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "sigstore-crypto 0.6.6",
- "sigstore-types 0.6.6",
+ "sigstore-rekor",
+ "sigstore-trust-root",
+ "sigstore-tsa",
+ "sigstore-types",
  "thiserror 2.0.18",
  "x509-cert",
 ]
@@ -7049,40 +6780,14 @@ dependencies = [
  "rustls-pki-types",
  "serde",
  "serde_json",
- "sigstore-crypto 0.7.0",
- "sigstore-types 0.7.0",
+ "sigstore-crypto",
+ "sigstore-types",
  "thiserror 2.0.18",
  "tokio",
  "tough",
  "tracing",
  "url",
  "x509-cert",
-]
-
-[[package]]
-name = "sigstore-tsa"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bc86c8abc1ece6832236e7e34e9baebb5d4d40490c0332b814a0d8624ca7255"
-dependencies = [
- "aws-lc-rs",
- "base64 0.22.1",
- "chrono",
- "cmpv2",
- "cms",
- "const-oid",
- "der 0.7.10",
- "hex",
- "rand 0.10.1",
- "reqwest 0.13.3",
- "rustls-pki-types",
- "rustls-webpki 0.103.13",
- "sigstore-crypto 0.6.6",
- "sigstore-types 0.6.6",
- "thiserror 2.0.18",
- "tracing",
- "x509-cert",
- "x509-tsp",
 ]
 
 [[package]]
@@ -7096,34 +6801,19 @@ dependencies = [
  "chrono",
  "cmpv2",
  "cms",
- "const-oid",
+ "const-oid 0.9.6",
  "der 0.7.10",
  "hex",
  "rand 0.9.4",
  "reqwest 0.13.3",
  "rustls-pki-types",
  "rustls-webpki 0.102.8",
- "sigstore-crypto 0.7.0",
- "sigstore-types 0.7.0",
+ "sigstore-crypto",
+ "sigstore-types",
  "thiserror 2.0.18",
  "tracing",
  "x509-cert",
  "x509-tsp",
-]
-
-[[package]]
-name = "sigstore-types"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8d870c9bcfdf83396ac2bd2d6a23c5d09ec02cc9fda50fa1cbb3dd71a9bee53"
-dependencies = [
- "base64 0.22.1",
- "chrono",
- "hex",
- "pem",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7150,7 +6840,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "cms",
- "const-oid",
+ "const-oid 0.9.6",
  "hex",
  "pem",
  "rustls-pki-types",
@@ -7158,13 +6848,13 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_canonicalizer",
- "sigstore-bundle 0.7.0",
- "sigstore-crypto 0.7.0",
- "sigstore-merkle 0.7.0",
- "sigstore-rekor 0.7.0",
- "sigstore-trust-root 0.7.0",
- "sigstore-tsa 0.7.0",
- "sigstore-types 0.7.0",
+ "sigstore-bundle",
+ "sigstore-crypto",
+ "sigstore-merkle",
+ "sigstore-rekor",
+ "sigstore-trust-root",
+ "sigstore-tsa",
+ "sigstore-types",
  "thiserror 2.0.18",
  "tls_codec",
  "tracing",
@@ -7216,8 +6906,7 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 [[package]]
 name = "simple_spawn_blocking"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55c0b0b683828aa9d4f5c0e59b0c856a12c30a65b5f1ca4292664734d76fa9c2"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "tokio",
 ]
@@ -7316,12 +7005,6 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -7429,20 +7112,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sysinfo"
-version = "0.38.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
-dependencies = [
- "libc",
- "memchr",
- "ntapi",
- "objc2-core-foundation",
- "objc2-io-kit",
- "windows 0.62.2",
-]
-
-[[package]]
 name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7490,7 +7159,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7500,7 +7169,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7766,21 +7435,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.12+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
-dependencies = [
- "indexmap 2.14.0",
- "serde_core",
- "serde_spanned",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
@@ -7788,19 +7442,10 @@ dependencies = [
  "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.3",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
+ "winnow",
 ]
 
 [[package]]
@@ -7819,9 +7464,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap 2.14.0",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
- "winnow 1.0.3",
+ "winnow",
 ]
 
 [[package]]
@@ -7830,7 +7475,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.3",
+ "winnow",
 ]
 
 [[package]]
@@ -8060,17 +7705,6 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
-
-[[package]]
-name = "uds_windows"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
-dependencies = [
- "memoffset",
- "tempfile",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "unarray"
@@ -8504,7 +8138,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8648,6 +8282,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-native-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5fd986f648459dd29aa252ed3a5ad11a60c0b1251bf81625fb03a86c69d274e"
+dependencies = [
+ "byteorder",
+ "keyring-core",
+ "regex",
+ "windows-sys 0.61.2",
+ "zeroize",
+]
+
+[[package]]
 name = "windows-numerics"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8676,17 +8323,6 @@ dependencies = [
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -8745,15 +8381,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -8785,28 +8412,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link 0.2.1",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -8840,12 +8450,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8856,12 +8460,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8876,22 +8474,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -8906,12 +8492,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8922,12 +8502,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -8942,12 +8516,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8958,18 +8526,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
@@ -9104,7 +8660,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "der 0.7.10",
  "sha1",
  "signature 2.2.0",
@@ -9131,16 +8687,6 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix 1.1.4",
-]
-
-[[package]]
-name = "xdg-home"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9196,68 +8742,6 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
-]
-
-[[package]]
-name = "zbus"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
-dependencies = [
- "async-broadcast",
- "async-executor",
- "async-fs",
- "async-io",
- "async-lock",
- "async-process",
- "async-recursion",
- "async-task",
- "async-trait",
- "blocking",
- "enumflags2",
- "event-listener",
- "futures-core",
- "futures-sink",
- "futures-util",
- "hex",
- "nix 0.29.0",
- "ordered-stream",
- "rand 0.8.6",
- "serde",
- "serde_repr",
- "sha1",
- "static_assertions",
- "tracing",
- "uds_windows",
- "windows-sys 0.52.0",
- "xdg-home",
- "zbus_macros",
- "zbus_names",
- "zvariant",
-]
-
-[[package]]
-name = "zbus_macros"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
- "zvariant_utils",
-]
-
-[[package]]
-name = "zbus_names"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
-dependencies = [
- "serde",
- "static_assertions",
- "zvariant",
 ]
 
 [[package]]
@@ -9419,41 +8903,4 @@ checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",
-]
-
-[[package]]
-name = "zvariant"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
-dependencies = [
- "endi",
- "enumflags2",
- "serde",
- "static_assertions",
- "zvariant_derive",
-]
-
-[[package]]
-name = "zvariant_derive"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
- "zvariant_utils",
-]
-
-[[package]]
-name = "zvariant_utils"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ async-once-cell = "0.5.4"
 async-recursion = "1.1.1"
 async-trait = "0.1"
 bzip2 = "0.6.1"
-chrono = "0.4.44"
 clap = { version = "4.6.0", features = ["derive"] }
 dashmap = "6.1"
 dunce = "1.0.5"
@@ -56,6 +55,7 @@ indexmap = "2.13.0"
 indicatif = "0.18.4"
 insta = "1.46.3"
 itertools = "0.14.0"
+jiff = { version = "0.2", default-features = false, features = ["std", "serde"] }
 hex = "0.4.3"
 libc = "0.2"
 md-5 = "0.10"
@@ -134,37 +134,35 @@ tracing-test = "0.2.6"
 
 # rattler crates
 # Rattler crates
-rattler_conda_types = { version = "0.46.0", default-features = false }
-rattler_digest = { version = "1.2.3", default-features = false, features = [
+rattler_conda_types = { version = "0.46.0", git = "https://github.com/conda/rattler", branch = "main", default-features = false }
+rattler_digest = { version = "1.2.3", git = "https://github.com/conda/rattler", branch = "main", default-features = false, features = [
   "serde",
 ] }
-rattler_networking = { version = "0.27.0", default-features = false }
-rattler_package_streaming = { version = "0.26.0", default-features = false }
-rattler_shell = { version = "0.27.0", default-features = false, features = [
-  "sysinfo",
-] }
-rattler_git = { version = "0.1.3" }
-rattler_prefix_guard = { version = "0.1.0" }
+rattler_networking = { version = "0.27.0", git = "https://github.com/conda/rattler", branch = "main", default-features = false }
+rattler_package_streaming = { version = "0.26.0", git = "https://github.com/conda/rattler", branch = "main", default-features = false }
+rattler_shell = { version = "0.27.0", git = "https://github.com/conda/rattler", branch = "main", default-features = false }
+rattler_git = { version = "0.1.3", git = "https://github.com/conda/rattler", branch = "main" }
+rattler_prefix_guard = { version = "0.1.0", git = "https://github.com/conda/rattler", branch = "main" }
 
-rattler_config = { version = "0.4.1" }
-rattler = { version = "0.43.0", default-features = false, features = [
+rattler_config = { version = "0.4.1", git = "https://github.com/conda/rattler", branch = "main" }
+rattler = { version = "0.43.0", git = "https://github.com/conda/rattler", branch = "main", default-features = false, features = [
   "cli-tools",
   "indicatif",
 ] }
-rattler_cache = { version = "0.8.0", default-features = false }
-rattler_index = { version = "0.30.1", default-features = false }
-rattler_upload = { version = "0.7.0", default-features = false }
-rattler_s3 = { version = "0.2.0" }
-rattler_redaction = { version = "0.2.0", default-features = false }
-rattler_repodata_gateway = { version = "0.29.0", default-features = false, features = [
+rattler_cache = { version = "0.8.0", git = "https://github.com/conda/rattler", branch = "main", default-features = false }
+rattler_index = { version = "0.30.1", git = "https://github.com/conda/rattler", branch = "main", default-features = false }
+rattler_upload = { version = "0.7.0", git = "https://github.com/conda/rattler", branch = "main", default-features = false }
+rattler_s3 = { version = "0.2.0", git = "https://github.com/conda/rattler", branch = "main" }
+rattler_redaction = { version = "0.2.0", git = "https://github.com/conda/rattler", branch = "main", default-features = false }
+rattler_repodata_gateway = { version = "0.29.0", git = "https://github.com/conda/rattler", branch = "main", default-features = false, features = [
   "gateway",
 ] }
-rattler_solve = { version = "7.1.1", default-features = false, features = [
+rattler_solve = { version = "7.1.1", git = "https://github.com/conda/rattler", branch = "main", default-features = false, features = [
   "resolvo",
   "serde",
 ] }
-rattler_virtual_packages = { version = "2.4.1", default-features = false }
-rattler_menuinst = "0.2.57"
+rattler_virtual_packages = { version = "2.4.1", git = "https://github.com/conda/rattler", branch = "main", default-features = false }
+rattler_menuinst = { version = "0.2.57", git = "https://github.com/conda/rattler", branch = "main" }
 
 
 # Internal rattler-build crates
@@ -239,7 +237,8 @@ comfy-table = { workspace = true }
 futures = { workspace = true }
 console = { workspace = true }
 tempfile = { workspace = true }
-chrono = { workspace = true }
+jiff = { workspace = true }
+hex = { workspace = true }
 ignore = { workspace = true }
 globset = { workspace = true }
 clap-verbosity-flag = { workspace = true }

--- a/crates/rattler_build_core/Cargo.toml
+++ b/crates/rattler_build_core/Cargo.toml
@@ -82,7 +82,7 @@ indicatif = { workspace = true, features = ["in_memory"] }
 console = { workspace = true }
 thiserror = { workspace = true }
 tempfile = { workspace = true }
-chrono = { workspace = true }
+jiff = { workspace = true }
 ignore = { workspace = true }
 globset = { workspace = true }
 text-stub-library = { workspace = true }
@@ -121,9 +121,7 @@ rattler_redaction = { workspace = true, default-features = false }
 rattler_repodata_gateway = { workspace = true, default-features = false, features = [
   "gateway",
 ] }
-rattler_shell = { workspace = true, default-features = false, features = [
-  "sysinfo",
-] }
+rattler_shell = { workspace = true, default-features = false }
 rattler_solve = { workspace = true, default-features = false, features = [
   "resolvo",
   "serde",

--- a/crates/rattler_build_core/src/bump_recipe.rs
+++ b/crates/rattler_build_core/src/bump_recipe.rs
@@ -9,7 +9,7 @@ use fs_err as fs;
 use indexmap::IndexMap;
 use minijinja::Value;
 use rattler_conda_types::Platform;
-use rattler_digest::Sha256Hash;
+use rattler_digest::{Sha256, Sha256Hash, compute_bytes_digest};
 use regex::Regex;
 use reqwest::Client;
 use serde::Deserialize;
@@ -529,10 +529,7 @@ pub async fn fetch_sha256(client: &Client, url: &str) -> Result<Sha256Hash, Bump
 
     let bytes = response.bytes().await?;
 
-    use sha2::{Digest, Sha256};
-    let mut hasher = Sha256::new();
-    hasher.update(&bytes);
-    Ok(hasher.finalize())
+    Ok(compute_bytes_digest::<Sha256>(&bytes))
 }
 
 /// Reset the build number to 0 in the recipe content
@@ -684,7 +681,8 @@ pub async fn bump_recipe(
 
         tracing::info!("Fetching {}", new_url);
         let sha256 = fetch_sha256(client, &new_url).await?;
-        let sha256_str = format!("{:x}", sha256);
+        let sha256_bytes: &[u8] = sha256.as_ref();
+        let sha256_str = hex::encode(sha256_bytes);
         tracing::debug!("Fetched SHA256: {}", sha256_str);
 
         new_sha256s.push(sha256_str);

--- a/crates/rattler_build_core/src/env_vars.rs
+++ b/crates/rattler_build_core/src/env_vars.rs
@@ -419,7 +419,7 @@ pub fn vars(output: &Output, build_state: &str) -> HashMap<String, Option<String
 
     // for reproducibility purposes, set the SOURCE_DATE_EPOCH to the configured timestamp
     // this value will be taken from the previous package for rebuild purposes
-    let timestamp_epoch_secs = output.build_configuration.timestamp.timestamp();
+    let timestamp_epoch_secs = output.build_configuration.timestamp.as_second();
     insert!(vars, "SOURCE_DATE_EPOCH", timestamp_epoch_secs);
 
     vars

--- a/crates/rattler_build_core/src/metadata.rs
+++ b/crates/rattler_build_core/src/metadata.rs
@@ -5,7 +5,6 @@ pub use crate::types::{
 
 #[cfg(test)]
 mod test {
-    use chrono::TimeZone;
     use fs_err as fs;
     use insta::assert_yaml_snapshot;
     use rattler_conda_types::{
@@ -52,13 +51,13 @@ mod test {
                     ),
                     size: Some(123123),
                     subdir: "linux-64".into(),
-                    timestamp: Some(chrono::Utc.timestamp_opt(123123, 0).unwrap().into()),
+                    timestamp: Some(jiff::Timestamp::from_second(123123).unwrap().into()),
                     track_features: vec![],
                     version: VersionWithSource::from_str("1.2.3").unwrap(),
                     purls: None,
                     run_exports: None,
                     python_site_packages_path: None,
-                    experimental_extra_depends: Default::default(),
+                    extra_depends: Default::default(),
                 },
                 identifier: "test-1.2.3-h123.tar.bz2".parse().unwrap(),
                 url: Url::from_str("https://test.com/test/linux-64/test-1.2.3-h123.tar.bz2")

--- a/crates/rattler_build_core/src/package_info.rs
+++ b/crates/rattler_build_core/src/package_info.rs
@@ -255,8 +255,8 @@ fn output_human_readable(
     if let Some(timestamp) = index_json.timestamp {
         // Format timestamp as a readable date (e.g., "2025-11-25 07:56:45 UTC")
         let formatted_time = timestamp
-            .datetime()
-            .format("%Y-%m-%d %H:%M:%S UTC")
+            .jiff_timestamp()
+            .strftime("%Y-%m-%d %H:%M:%S UTC")
             .to_string();
         table.add_row(vec!["Timestamp", &formatted_time]);
     }
@@ -522,8 +522,10 @@ pub async fn extract_package(args: ExtractOpts) -> miette::Result<()> {
         console::style("✔").green(),
     );
     println!("  Destination: {}", destination.display());
-    println!("  SHA256: {:x}", result.sha256);
-    println!("  MD5: {:x}", result.md5);
+    let sha256: &[u8] = result.sha256.as_ref();
+    let md5: &[u8] = result.md5.as_ref();
+    println!("  SHA256: {}", hex::encode(sha256));
+    println!("  MD5: {}", hex::encode(md5));
     println!(
         "  Size: {} ({} bytes)",
         HumanBytes(result.total_size),

--- a/crates/rattler_build_core/src/package_test/run_test.rs
+++ b/crates/rattler_build_core/src/package_test/run_test.rs
@@ -310,7 +310,7 @@ pub struct TestConfiguration {
     /// The output directory to create the test prefixes in (will be `output_dir/test`)
     pub output_dir: PathBuf,
     /// Exclude packages newer than this date from the solver
-    pub exclude_newer: Option<chrono::DateTime<chrono::Utc>>,
+    pub exclude_newer: Option<jiff::Timestamp>,
     /// The environment isolation mode for test scripts
     pub env_isolation: EnvironmentIsolation,
 }

--- a/crates/rattler_build_core/src/packaging/metadata.rs
+++ b/crates/rattler_build_core/src/packaging/metadata.rs
@@ -21,7 +21,7 @@ use rattler_conda_types::{
         PathsJson, PrefixPlaceholder, PythonEntryPoints, RunExportsJson,
     },
 };
-use rattler_digest::{compute_bytes_digest, compute_file_digest};
+use rattler_digest::{Sha256, compute_bytes_digest, compute_file_digest};
 use rayon::prelude::*;
 use url::Url;
 
@@ -390,7 +390,7 @@ impl Output {
                 .map(|dep| dep.spec().to_string())
                 .unique()
                 .collect(),
-            experimental_extra_depends: finalized_dependencies
+            extra_depends: finalized_dependencies
                 .run
                 .extra_depends
                 .iter()
@@ -513,9 +513,9 @@ impl Output {
                     let file_size = meta.len();
                     // Compute SHA256 for files - empty files get empty hash
                     let digest = if file_size > 0 {
-                        Some(compute_file_digest::<sha2::Sha256>(p)?)
+                        Some(compute_file_digest::<Sha256>(p)?)
                     } else {
-                        Some(compute_bytes_digest::<sha2::Sha256>(&[]))
+                        Some(compute_bytes_digest::<Sha256>(&[]))
                     };
                     let no_link = always_copy_files.is_match(&relative_path);
                     return Ok(Some(PathsEntry {
@@ -529,9 +529,9 @@ impl Output {
                 } else if meta.is_symlink() {
                     // For symlinks, compute hash of the target file content if it exists and is within package, otherwise empty digest
                     let digest = if is_symlink_to_file(p) {
-                        compute_file_digest::<sha2::Sha256>(p)?
+                        compute_file_digest::<Sha256>(p)?
                     } else {
-                        compute_bytes_digest::<sha2::Sha256>(&[])
+                        compute_bytes_digest::<Sha256>(&[])
                     };
                     return Ok(Some(PathsEntry {
                         sha256: Some(digest),

--- a/crates/rattler_build_core/src/render/solver.rs
+++ b/crates/rattler_build_core/src/render/solver.rs
@@ -62,7 +62,7 @@ pub async fn solve_environment(
     tool_configuration: &tool_configuration::Configuration,
     channel_priority: ChannelPriority,
     solve_strategy: SolveStrategy,
-    exclude_newer: Option<chrono::DateTime<chrono::Utc>>,
+    exclude_newer: Option<jiff::Timestamp>,
 ) -> miette::Result<Vec<RepoDataRecord>> {
     let span_msg = format!("Resolving {name} environment");
     let span = tracing::info_span!("", message = %span_msg);
@@ -134,7 +134,7 @@ pub async fn create_environment(
     tool_configuration: &tool_configuration::Configuration,
     channel_priority: ChannelPriority,
     solve_strategy: SolveStrategy,
-    exclude_newer: Option<chrono::DateTime<chrono::Utc>>,
+    exclude_newer: Option<jiff::Timestamp>,
 ) -> miette::Result<Vec<RepoDataRecord>> {
     let required_packages = solve_environment(
         name,

--- a/crates/rattler_build_core/src/types/build_configuration.rs
+++ b/crates/rattler_build_core/src/types/build_configuration.rs
@@ -41,7 +41,7 @@ pub struct BuildConfiguration {
     /// The solve strategy to use when resolving dependencies
     pub solve_strategy: SolveStrategy,
     /// The timestamp to use for the build
-    pub timestamp: chrono::DateTime<chrono::Utc>,
+    pub timestamp: jiff::Timestamp,
     /// All subpackages coming from this output or other outputs from the same
     /// recipe
     pub subpackages: BTreeMap<PackageName, PackageIdentifier>,
@@ -65,7 +65,7 @@ pub struct BuildConfiguration {
     pub sandbox_config: Option<SandboxConfiguration>,
     /// Exclude packages newer than this date from the solver
     #[serde(skip_serializing, default)]
-    pub exclude_newer: Option<chrono::DateTime<chrono::Utc>>,
+    pub exclude_newer: Option<jiff::Timestamp>,
     /// Whether to write V3 package metadata.
     #[serde(skip_serializing, default)]
     pub v3: bool,

--- a/crates/rattler_build_core/src/types/build_output.rs
+++ b/crates/rattler_build_core/src/types/build_output.rs
@@ -106,7 +106,7 @@ impl BuildOutput {
 
     /// Record the start of the build
     pub fn record_build_start(&self) {
-        self.build_summary.lock().unwrap().build_start = Some(chrono::Utc::now());
+        self.build_summary.lock().unwrap().build_start = Some(jiff::Timestamp::now());
     }
 
     /// Record the artifact that was created during the build
@@ -119,7 +119,7 @@ impl BuildOutput {
     /// Record the end of the build
     pub fn record_build_end(&self) {
         let mut summary = self.build_summary.lock().unwrap();
-        summary.build_end = Some(chrono::Utc::now());
+        summary.build_end = Some(jiff::Timestamp::now());
     }
 
     /// Shorthand to retrieve the variant configuration for this output

--- a/crates/rattler_build_core/src/types/directories.rs
+++ b/crates/rattler_build_core/src/types/directories.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
-use chrono::{DateTime, Utc};
 use fs_err as fs;
+use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
 use dunce::canonicalize;
@@ -14,7 +14,7 @@ pub struct DirectoriesBuilder<'a> {
     name: &'a str,
     recipe_path: &'a Path,
     output_dir: &'a Path,
-    timestamp: &'a DateTime<Utc>,
+    timestamp: &'a Timestamp,
     no_build_id: bool,
     merge_build_and_host: bool,
     skip_directory_creation: bool,
@@ -26,7 +26,7 @@ impl<'a> DirectoriesBuilder<'a> {
         name: &'a str,
         recipe_path: &'a Path,
         output_dir: &'a Path,
-        timestamp: &'a DateTime<Utc>,
+        timestamp: &'a Timestamp,
     ) -> Self {
         Self {
             name,
@@ -104,9 +104,9 @@ fn get_build_dir(
     output_dir: &Path,
     name: &str,
     no_build_id: bool,
-    timestamp: &DateTime<Utc>,
+    timestamp: &Timestamp,
 ) -> Result<PathBuf, std::io::Error> {
-    let since_the_epoch = timestamp.timestamp();
+    let since_the_epoch = timestamp.as_second();
 
     let dirname = if no_build_id {
         format!("rattler-build_{}", name)
@@ -122,7 +122,7 @@ impl Directories {
         name: &'a str,
         recipe_path: &'a Path,
         output_dir: &'a Path,
-        timestamp: &'a DateTime<Utc>,
+        timestamp: &'a Timestamp,
     ) -> DirectoriesBuilder<'a> {
         DirectoriesBuilder::new(name, recipe_path, output_dir, timestamp)
     }
@@ -133,7 +133,7 @@ impl Directories {
         recipe_path: &Path,
         output_dir: &Path,
         no_build_id: bool,
-        timestamp: &DateTime<Utc>,
+        timestamp: &Timestamp,
         merge_build_and_host: bool,
         skip_directory_creation: bool,
     ) -> Result<Directories, std::io::Error> {
@@ -321,15 +321,15 @@ mod tests {
     fn setup_build_dir_test() {
         // without build_id (aka timestamp)
         let dir = tempfile::tempdir().unwrap();
-        let p1 = get_build_dir(dir.path(), "name", true, &Utc::now()).unwrap();
+        let p1 = get_build_dir(dir.path(), "name", true, &Timestamp::now()).unwrap();
         let f1 = p1.file_name().unwrap();
         assert!(f1.eq("rattler-build_name"));
 
         // with build_id (aka timestamp)
-        let timestamp = &Utc::now();
+        let timestamp = &Timestamp::now();
         let p2 = get_build_dir(dir.path(), "name", false, timestamp).unwrap();
         let f2 = p2.file_name().unwrap();
-        let epoch = timestamp.timestamp();
+        let epoch = timestamp.as_second();
         assert!(f2.eq(format!("rattler-build_name_{epoch}").as_str()));
     }
 
@@ -341,7 +341,7 @@ mod tests {
             "name",
             &tempdir.path().join("recipe"),
             &tempdir.path().join("output"),
-            &chrono::Utc::now(),
+            &Timestamp::now(),
         )
         .build()
         .unwrap();
@@ -374,7 +374,7 @@ mod tests {
             "name",
             &tempdir.path().join("recipe"),
             &tempdir.path().join("output"),
-            &chrono::Utc::now(),
+            &Timestamp::now(),
         )
         .build()
         .unwrap();

--- a/crates/rattler_build_core/src/types/mod.rs
+++ b/crates/rattler_build_core/src/types/mod.rs
@@ -2,7 +2,6 @@
 //! All the metadata that makes up a recipe file
 use std::{iter, path::PathBuf, str::FromStr};
 
-use chrono::{DateTime, Utc};
 use rattler_conda_types::{
     Channel, ChannelUrl, GenericVirtualPackage, PackageName, Platform, VersionWithSource,
     compression_level::CompressionLevel,
@@ -129,9 +128,9 @@ pub struct PackageIdentifier {
 #[derive(Debug, Clone, Default)]
 pub struct BuildSummary {
     /// The start time of the build
-    pub build_start: Option<DateTime<Utc>>,
+    pub build_start: Option<jiff::Timestamp>,
     /// The end time of the build
-    pub build_end: Option<DateTime<Utc>>,
+    pub build_end: Option<jiff::Timestamp>,
 
     /// The path to the artifact
     pub artifact: Option<PathBuf>,

--- a/crates/rattler_build_package/Cargo.toml
+++ b/crates/rattler_build_package/Cargo.toml
@@ -41,7 +41,7 @@ serde_json = { workspace = true }
 rayon = { workspace = true }
 
 # Utilities
-chrono = { workspace = true }
+jiff = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/rattler_build_package/examples/simple_package.rs
+++ b/crates/rattler_build_package/examples/simple_package.rs
@@ -41,14 +41,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_target_platform(&platform)
         .with_license("MIT".to_string())
         .with_dependency("python >=3.8".to_string())
-        .with_timestamp(chrono::Utc::now())
+        .with_timestamp(jiff::Timestamp::now())
         .build()?;
 
     // Configure package creation
     let config = PackageConfig {
         compression_level: 6,
         archive_type: ArchiveType::Conda,
-        timestamp: Some(chrono::Utc::now()),
+        timestamp: Some(jiff::Timestamp::now()),
         compression_threads: 4,
         detect_prefix: true,
         store_recipe: false,

--- a/crates/rattler_build_package/src/archiver/writer.rs
+++ b/crates/rattler_build_package/src/archiver/writer.rs
@@ -3,7 +3,7 @@
 use std::fs::File;
 use std::path::{Path, PathBuf};
 
-use chrono::{DateTime, Utc};
+use jiff::Timestamp;
 use rattler_conda_types::compression_level::CompressionLevel;
 use rattler_package_streaming::write::{write_conda_package, write_tar_bz2_package};
 
@@ -18,7 +18,7 @@ pub struct PackageWriter {
     compression_level: u8,
 
     /// Timestamp for reproducible builds
-    timestamp: Option<DateTime<Utc>>,
+    timestamp: Option<Timestamp>,
 
     /// Number of compression threads
     compression_threads: usize,
@@ -36,7 +36,7 @@ impl PackageWriter {
     }
 
     /// Set the timestamp for reproducible builds
-    pub fn with_timestamp(mut self, timestamp: DateTime<Utc>) -> Self {
+    pub fn with_timestamp(mut self, timestamp: Timestamp) -> Self {
         self.timestamp = Some(timestamp);
         self
     }

--- a/crates/rattler_build_package/src/builder.rs
+++ b/crates/rattler_build_package/src/builder.rs
@@ -2,7 +2,7 @@
 
 use std::path::{Path, PathBuf};
 
-use chrono::{DateTime, Utc};
+use jiff::Timestamp;
 use rattler_conda_types::package::{AboutJson, IndexJson, PathsJson, RunExportsJson};
 use rattler_conda_types::{PackageName, Platform, VersionWithSource};
 
@@ -19,7 +19,7 @@ pub struct PackageConfig {
     pub archive_type: ArchiveType,
 
     /// Timestamp for reproducible builds
-    pub timestamp: Option<DateTime<Utc>>,
+    pub timestamp: Option<Timestamp>,
 
     /// Number of threads to use for compression
     pub compression_threads: usize,

--- a/crates/rattler_build_package/src/metadata/index.rs
+++ b/crates/rattler_build_package/src/metadata/index.rs
@@ -1,6 +1,6 @@
 //! IndexJson builder
 
-use chrono::{DateTime, Utc};
+use jiff::Timestamp;
 use rattler_conda_types::package::IndexJson;
 use rattler_conda_types::{NoArchType, PackageName, Platform, VersionWithSource};
 
@@ -37,7 +37,7 @@ pub struct IndexJsonBuilder {
     subdir: Option<String>,
     license: Option<String>,
     license_family: Option<String>,
-    timestamp: Option<DateTime<Utc>>,
+    timestamp: Option<Timestamp>,
     depends: Vec<String>,
     constrains: Vec<String>,
     noarch: NoArchType,
@@ -109,7 +109,7 @@ impl IndexJsonBuilder {
     }
 
     /// Set the timestamp
-    pub fn with_timestamp(mut self, timestamp: DateTime<Utc>) -> Self {
+    pub fn with_timestamp(mut self, timestamp: Timestamp) -> Self {
         self.timestamp = Some(timestamp);
         self
     }
@@ -171,7 +171,7 @@ impl IndexJsonBuilder {
             features: None,
             python_site_packages_path: None,
             purls: None,
-            experimental_extra_depends: Default::default(),
+            extra_depends: Default::default(),
             repodata_revision: None,
         })
     }

--- a/crates/rattler_build_package/src/metadata/paths.rs
+++ b/crates/rattler_build_package/src/metadata/paths.rs
@@ -3,7 +3,7 @@
 use fs_err as fs;
 use rattler_conda_types::Platform;
 use rattler_conda_types::package::{FileMode, PathType, PathsEntry, PathsJson, PrefixPlaceholder};
-use rattler_digest::{compute_bytes_digest, compute_file_digest};
+use rattler_digest::{Sha256, compute_bytes_digest, compute_file_digest};
 use rayon::prelude::*;
 use std::path::{Path, PathBuf};
 
@@ -115,9 +115,9 @@ impl PathsJsonBuilder {
         if metadata.is_symlink() {
             // For symlinks, compute hash of target content if it's a file
             let digest = if self.is_symlink_to_file(&file.source) {
-                compute_file_digest::<sha2::Sha256>(&file.source)?
+                compute_file_digest::<Sha256>(&file.source)?
             } else {
-                compute_bytes_digest::<sha2::Sha256>(&[])
+                compute_bytes_digest::<Sha256>(&[])
             };
 
             return Ok(PathsEntry {
@@ -133,9 +133,9 @@ impl PathsJsonBuilder {
         // Regular file
         let file_size = metadata.len();
         let digest = if file_size > 0 {
-            Some(compute_file_digest::<sha2::Sha256>(&file.source)?)
+            Some(compute_file_digest::<Sha256>(&file.source)?)
         } else {
-            Some(compute_bytes_digest::<sha2::Sha256>(&[]))
+            Some(compute_bytes_digest::<Sha256>(&[]))
         };
 
         // Detect prefix placeholder

--- a/crates/rattler_build_package/tests/integration_test.rs
+++ b/crates/rattler_build_package/tests/integration_test.rs
@@ -46,7 +46,7 @@ fn test_complete_package_creation() -> Result<(), Box<dyn std::error::Error>> {
     let config = PackageConfig {
         compression_level: 1, // Use low compression for faster tests
         archive_type: ArchiveType::TarBz2,
-        timestamp: Some(chrono::Utc::now()),
+        timestamp: Some(jiff::Timestamp::now()),
         compression_threads: 1,
         detect_prefix: true,
         store_recipe: false,

--- a/crates/rattler_build_playground/Cargo.lock
+++ b/crates/rattler_build_playground/Cargo.lock
@@ -201,11 +201,11 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "blake2"
-version = "0.10.6"
+version = "0.11.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+checksum = "061f1a09225e328e1ffbb378d2d49923c0ca5fee19fb5ac1cc9c1e9d52b93690"
 dependencies = [
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -215,6 +215,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -302,6 +311,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,6 +345,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,6 +376,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,6 +392,24 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -414,9 +462,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
- "subtle",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -524,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -541,9 +600,8 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "file_url"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e546758dbcde9d10c0d3bd8b83adb535b23fa81121cf4dc5c3e7b5907cc8eb8"
+version = "0.3.1"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "itertools",
  "percent-encoding",
@@ -733,6 +791,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -915,6 +982,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jiff"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,12 +1096,12 @@ dependencies = [
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1157,6 +1248,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1271,6 +1377,7 @@ version = "0.1.7"
 dependencies = [
  "fs-err",
  "globset",
+ "hex",
  "indexmap 2.13.0",
  "itertools",
  "marked-yaml",
@@ -1353,12 +1460,10 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add942503b3cf8c6f797707762bcf9206709ce1bc001b974860b0313fd002ced"
+version = "0.46.4"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "ahash",
- "chrono",
  "core-foundation",
  "dirs",
  "fancy-regex",
@@ -1368,6 +1473,7 @@ dependencies = [
  "hex",
  "indexmap 2.13.0",
  "itertools",
+ "jiff",
  "lazy-regex",
  "memmap2",
  "nom",
@@ -1395,16 +1501,16 @@ dependencies = [
 
 [[package]]
 name = "rattler_digest"
-version = "1.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbab3541bf7e471550c91b70dad8edf392ffa9f57c6b0de4bbe6dd2c6c0d53d4"
+version = "1.3.0"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "blake2",
- "digest",
+ "digest 0.11.3",
  "generic-array",
  "hex",
  "md-5",
  "serde",
+ "serde-untagged",
  "serde_bytes",
  "serde_with",
  "sha2",
@@ -1413,9 +1519,8 @@ dependencies = [
 
 [[package]]
 name = "rattler_macros"
-version = "1.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677367cf07dd4ca5b863a91cf060feea246f3b23d50af9e9fadf980db760d270"
+version = "1.1.0"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "quote",
  "syn",
@@ -1423,9 +1528,8 @@ dependencies = [
 
 [[package]]
 name = "rattler_redaction"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222837efcfa358dbb6107a741bb73bfdae75dae19d5e7eb9c869d84a9edd0a9c"
+version = "0.2.1"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "url",
 ]
@@ -1691,19 +1795,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1788,12 +1892,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "subtle"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"

--- a/crates/rattler_build_playground/Cargo.toml
+++ b/crates/rattler_build_playground/Cargo.toml
@@ -24,7 +24,7 @@ rattler_build_jinja = { path = "../rattler_build_jinja" }
 rattler_build_types = { path = "../rattler_build_types" }
 rattler_build_yaml_parser = { path = "../rattler_build_yaml_parser" }
 indexmap = "2"
-rattler_conda_types = { version = "0.46.0", default-features = false }
+rattler_conda_types = { version = "0.46.0", git = "https://github.com/conda/rattler", branch = "main", default-features = false }
 serde_yaml = "0.9"
 arborium = { version = "2", default-features = false, features = ["lang-yaml"] }
 

--- a/crates/rattler_build_recipe/Cargo.toml
+++ b/crates/rattler_build_recipe/Cargo.toml
@@ -39,6 +39,7 @@ spdx = { workspace = true }
 globset = { workspace = true }
 fs-err = { workspace = true }
 regex = { workspace = true }
+hex = { workspace = true }
 sha1 = { workspace = true }
 petgraph = { workspace = true, optional = true, default-features = false }
 

--- a/crates/rattler_build_recipe/src/stage0/source.rs
+++ b/crates/rattler_build_recipe/src/stage0/source.rs
@@ -1,4 +1,5 @@
-use rattler_digest::{Md5Hash, Sha256Hash};
+use rattler_build_yaml_parser::ValueInner;
+use rattler_digest::{Md5, Md5Hash, Sha256, Sha256Hash, parse_digest_from_hex};
 use serde::{Deserialize, Serialize};
 use serde_with::{OneOrMany, formats::PreferMany, serde_as};
 use std::path::PathBuf;
@@ -127,7 +128,8 @@ pub struct UrlSource {
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
-        serialize_with = "sha256_serialization::serialize"
+        serialize_with = "sha256_serialization::serialize",
+        deserialize_with = "sha256_serialization::deserialize"
     )]
     pub sha256: Option<Value<Sha256Hash>>,
 
@@ -135,7 +137,8 @@ pub struct UrlSource {
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
-        serialize_with = "md5_serialization::serialize"
+        serialize_with = "md5_serialization::serialize",
+        deserialize_with = "md5_serialization::deserialize"
     )]
     pub md5: Option<Value<Md5Hash>>,
 
@@ -166,7 +169,8 @@ pub struct PathSource {
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
-        serialize_with = "sha256_serialization::serialize"
+        serialize_with = "sha256_serialization::serialize",
+        deserialize_with = "sha256_serialization::deserialize"
     )]
     pub sha256: Option<Value<Sha256Hash>>,
 
@@ -174,7 +178,8 @@ pub struct PathSource {
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
-        serialize_with = "md5_serialization::serialize"
+        serialize_with = "md5_serialization::serialize",
+        deserialize_with = "md5_serialization::deserialize"
     )]
     pub md5: Option<Value<Md5Hash>>,
 
@@ -210,7 +215,7 @@ fn is_true(value: &bool) -> bool {
 /// Serialize a SHA256 hash Value as a hex string
 mod sha256_serialization {
     use super::*;
-    use serde::Serializer;
+    use serde::{Deserialize, Deserializer, Serializer};
 
     pub fn serialize<S>(value: &Option<Value<Sha256Hash>>, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -219,7 +224,8 @@ mod sha256_serialization {
         match value {
             None => serializer.serialize_none(),
             Some(v) if v.is_concrete() => {
-                serializer.serialize_str(&format!("{:x}", v.as_concrete().unwrap()))
+                let hash: &[u8] = v.as_concrete().unwrap().as_ref();
+                serializer.serialize_str(&hex::encode(hash))
             }
             Some(v) if v.is_template() => {
                 serializer.serialize_str(v.as_template().unwrap().source())
@@ -227,12 +233,28 @@ mod sha256_serialization {
             _ => unreachable!("Value must be either concrete or template"),
         }
     }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Value<Sha256Hash>>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let Some(value) = Option::<Value<String>>::deserialize(deserializer)? else {
+            return Ok(None);
+        };
+        let (inner, span) = value.into_parts();
+        match inner {
+            ValueInner::Concrete(hash) => parse_digest_from_hex::<Sha256>(&hash)
+                .map(|hash| Some(Value::new_concrete(hash, span)))
+                .ok_or_else(|| serde::de::Error::custom("failed to parse SHA256 digest")),
+            ValueInner::Template(template) => Ok(Some(Value::new_template(template, span))),
+        }
+    }
 }
 
 /// Serialize an MD5 hash Value as a hex string
 mod md5_serialization {
     use super::*;
-    use serde::Serializer;
+    use serde::{Deserialize, Deserializer, Serializer};
 
     pub fn serialize<S>(value: &Option<Value<Md5Hash>>, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -241,12 +263,29 @@ mod md5_serialization {
         match value {
             None => serializer.serialize_none(),
             Some(v) if v.is_concrete() => {
-                serializer.serialize_str(&format!("{:x}", v.as_concrete().unwrap()))
+                let hash: &[u8] = v.as_concrete().unwrap().as_ref();
+                serializer.serialize_str(&hex::encode(hash))
             }
             Some(v) if v.is_template() => {
                 serializer.serialize_str(v.as_template().unwrap().source())
             }
             _ => unreachable!("Value must be either concrete or template"),
+        }
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Value<Md5Hash>>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let Some(value) = Option::<Value<String>>::deserialize(deserializer)? else {
+            return Ok(None);
+        };
+        let (inner, span) = value.into_parts();
+        match inner {
+            ValueInner::Concrete(hash) => parse_digest_from_hex::<Md5>(&hash)
+                .map(|hash| Some(Value::new_concrete(hash, span)))
+                .ok_or_else(|| serde::de::Error::custom("failed to parse MD5 digest")),
+            ValueInner::Template(template) => Ok(Some(Value::new_template(template, span))),
         }
     }
 }

--- a/crates/rattler_build_recipe_generator/Cargo.toml
+++ b/crates/rattler_build_recipe_generator/Cargo.toml
@@ -20,6 +20,7 @@ async-once-cell = { workspace = true }
 async-recursion = { workspace = true }
 flate2 = { workspace = true }
 fs-err = { workspace = true }
+hex = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
 miette = { workspace = true }

--- a/crates/rattler_build_recipe_generator/src/cran.rs
+++ b/crates/rattler_build_recipe_generator/src/cran.rs
@@ -4,9 +4,8 @@ use std::{collections::HashMap, collections::HashSet, path::PathBuf};
 use clap::Parser;
 use itertools::Itertools;
 use miette::IntoDiagnostic;
-use rattler_digest::{Sha256Hash, compute_bytes_digest};
+use rattler_digest::{Sha256, Sha256Hash, compute_bytes_digest};
 use serde::{Deserialize, Serialize};
-use sha2::Sha256;
 use url::Url;
 
 use crate::{
@@ -268,11 +267,12 @@ async fn build_cran_recipe_and_deps(
     .expect("Failed to parse URL");
 
     let sha256 = fetch_package_sha256sum(&url).await?;
+    let sha256_hex: &[u8] = sha256.as_ref();
 
     let source = UrlSourceElement {
         url: vec![url.to_string(), url_archive.to_string()],
         md5: None,
-        sha256: Some(format!("{:x}", sha256)),
+        sha256: Some(hex::encode(sha256_hex)),
     };
     recipe.source.push(source.into());
 

--- a/crates/rattler_build_source_cache/Cargo.toml
+++ b/crates/rattler_build_source_cache/Cargo.toml
@@ -25,7 +25,7 @@ rustls = ["rattler_build_networking/rustls", "sigstore-verify?/rustls"]
 
 [dependencies]
 async-trait = { workspace = true }
-chrono = { workspace = true, features = ["serde"] }
+jiff = { workspace = true }
 fs-err = { workspace = true, features = ["tokio"] }
 futures = { workspace = true }
 rattler_prefix_guard = { workspace = true }

--- a/crates/rattler_build_source_cache/README.md
+++ b/crates/rattler_build_source_cache/README.md
@@ -28,7 +28,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a cache with custom configuration
     let cache = SourceCacheBuilder::new()
         .cache_dir("/path/to/cache")
-        .max_age(chrono::Duration::days(30))
+        .max_age(jiff::SignedDuration::from_hours(24 * 30))
         .enable_cleanup(true)
         .cleanup_interval(std::time::Duration::from_secs(3600))
         .build()

--- a/crates/rattler_build_source_cache/src/cache.rs
+++ b/crates/rattler_build_source_cache/src/cache.rs
@@ -149,8 +149,8 @@ impl SourceCache {
                 .unwrap_or(&repo_path)
                 .to_path_buf(),
             extracted_path: None,
-            last_accessed: chrono::Utc::now(),
-            created: chrono::Utc::now(),
+            last_accessed: jiff::Timestamp::now(),
+            created: jiff::Timestamp::now(),
             lock_file: Some(_lock.path().to_path_buf()),
             attestation_verified: false,
         };
@@ -411,8 +411,8 @@ impl SourceCache {
             extracted_path: final_path
                 .as_ref()
                 .map(|p| p.strip_prefix(&self.cache_dir).unwrap_or(p).to_path_buf()),
-            last_accessed: chrono::Utc::now(),
-            created: chrono::Utc::now(),
+            last_accessed: jiff::Timestamp::now(),
+            created: jiff::Timestamp::now(),
             lock_file: Some(_lock.path().to_path_buf()),
             attestation_verified: attestation.is_some(),
         };

--- a/crates/rattler_build_source_cache/src/index.rs
+++ b/crates/rattler_build_source_cache/src/index.rs
@@ -1,6 +1,7 @@
 //! Cache index management for content-addressable storage
 
 use crate::error::CacheError;
+use jiff::{SignedDuration, Timestamp};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -46,10 +47,10 @@ pub struct CacheEntry {
     pub extracted_path: Option<PathBuf>,
 
     /// When this entry was last accessed
-    pub last_accessed: chrono::DateTime<chrono::Utc>,
+    pub last_accessed: Timestamp,
 
     /// When this entry was created
-    pub created: chrono::DateTime<chrono::Utc>,
+    pub created: Timestamp,
 
     /// Lock file path for this entry
     pub lock_file: Option<PathBuf>,
@@ -177,7 +178,7 @@ impl CacheIndex {
     pub async fn touch(&self, key: &str) -> Result<(), CacheError> {
         let mut entries = self.entries.write().await;
         if let Some(entry) = entries.get_mut(key) {
-            entry.last_accessed = chrono::Utc::now();
+            entry.last_accessed = Timestamp::now();
             let updated_entry = entry.clone();
             drop(entries); // Release lock before writing to disk
 
@@ -228,8 +229,10 @@ impl CacheIndex {
     }
 
     /// Clean up entries that haven't been accessed in the specified duration
-    pub async fn cleanup_old_entries(&self, max_age: chrono::Duration) -> Result<(), CacheError> {
-        let cutoff = chrono::Utc::now() - max_age;
+    pub async fn cleanup_old_entries(&self, max_age: SignedDuration) -> Result<(), CacheError> {
+        let cutoff = Timestamp::now()
+            .checked_sub(max_age)
+            .map_err(|e| CacheError::Other(format!("invalid max age: {}", e)))?;
         let entries = self.list_entries().await;
 
         for (key, entry) in entries {

--- a/crates/rattler_build_source_cache/src/tests.rs
+++ b/crates/rattler_build_source_cache/src/tests.rs
@@ -65,8 +65,8 @@ mod source_cache_tests {
             git_rev: None,
             cache_path: std::path::PathBuf::from("file_abcd.tar.gz"),
             extracted_path: Some(std::path::PathBuf::from("file_abcd_extracted")),
-            last_accessed: chrono::Utc::now(),
-            created: chrono::Utc::now(),
+            last_accessed: jiff::Timestamp::now(),
+            created: jiff::Timestamp::now(),
             lock_file: None,
             attestation_verified: false,
         };

--- a/py-rattler-build/rust/Cargo.lock
+++ b/py-rattler-build/rust/Cargo.lock
@@ -136,6 +136,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "apple-native-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7be2f067ccd8d4b4d4a66ddafe0f32a5dff31732f32dbff85fefc40929b1f72"
+dependencies = [
+ "keyring-core",
+ "log",
+ "security-framework",
+]
+
+[[package]]
 name = "archspec"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,7 +180,7 @@ checksum = "35d7a19757bfe3658d5a95bf25a0492f29ebb21933549bdbfa4075c895510124"
 dependencies = [
  "goblin",
  "scroll",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
 ]
 
@@ -260,30 +271,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-broadcast"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-channel"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "async-compression"
 version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,20 +281,6 @@ dependencies = [
  "futures-io",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "pin-project-lite",
- "slab",
 ]
 
 [[package]]
@@ -326,68 +299,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-fs"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
-dependencies = [
- "async-lock",
- "blocking",
- "futures-lite",
-]
-
-[[package]]
-name = "async-io"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
-dependencies = [
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite",
- "parking",
- "polling",
- "rustix 1.1.4",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
 name = "async-once-cell"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288f83726785267c6f2ef073a3d83dc3f9b81464e9f99898240cced85fce35a"
-
-[[package]]
-name = "async-process"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
-dependencies = [
- "async-channel",
- "async-io",
- "async-lock",
- "async-signal",
- "async-task",
- "blocking",
- "cfg-if",
- "event-listener",
- "futures-lite",
- "rustix 1.1.4",
-]
 
 [[package]]
 name = "async-recursion"
@@ -401,24 +316,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-signal"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
-dependencies = [
- "async-io",
- "async-lock",
- "atomic-waker",
- "cfg-if",
- "futures-core",
- "futures-io",
- "rustix 1.1.4",
- "signal-hook-registry",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "async-spooled-tempfile"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,12 +324,6 @@ dependencies = [
  "tempfile",
  "tokio",
 ]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -484,7 +375,7 @@ dependencies = [
  "p256 0.13.2",
  "rand 0.8.5",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "time",
  "tokio",
  "tracing",
@@ -586,7 +477,7 @@ dependencies = [
  "lru",
  "percent-encoding",
  "regex-lite",
- "sha2",
+ "sha2 0.10.9",
  "tracing",
  "url",
 ]
@@ -709,7 +600,7 @@ dependencies = [
  "p256 0.11.1",
  "percent-encoding",
  "ring",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "time",
  "tracing",
@@ -741,10 +632,10 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "md-5",
+ "md-5 0.10.6",
  "pin-project-lite",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "tracing",
 ]
 
@@ -1034,11 +925,11 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.10.6"
+version = "0.11.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+checksum = "061f1a09225e328e1ffbb378d2d49923c0ca5fee19fb5ac1cc9c1e9d52b93690"
 dependencies = [
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1051,25 +942,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "blocking"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
-dependencies = [
- "async-channel",
- "async-task",
- "futures-io",
- "futures-lite",
- "piper",
 ]
 
 [[package]]
@@ -1143,7 +1030,7 @@ dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 1.3.0",
 ]
 
 [[package]]
@@ -1195,7 +1082,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -1279,6 +1166,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
 name = "cmpv2"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1296,7 +1189,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b77c319abfd5219629c45c34c89ba945ed3c5e49fcde9d16b6c3885f118a730"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "der 0.7.10",
  "spki 0.7.3",
  "x509-cert",
@@ -1305,8 +1198,7 @@ dependencies = [
 [[package]]
 name = "coalesced_map"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fe09392885c9af28aed39c6ddd06e41b43dbe98a850ccf0abe3f88d7cc75de"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "dashmap",
  "tokio",
@@ -1391,6 +1283,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const-random"
@@ -1487,7 +1385,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd92aca2c6001b1bf5ba0ff84ee74ec8501b52bbef0cac80bf25a6c1d87a83d"
 dependencies = [
  "crc",
- "digest",
+ "digest 0.10.7",
  "rustversion",
  "spin 0.10.0",
 ]
@@ -1611,6 +1509,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1619,7 +1535,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -1710,8 +1626,19 @@ dependencies = [
  "hkdf",
  "num",
  "once_cell",
- "sha2",
+ "openssl",
+ "sha2 0.10.9",
  "zeroize",
+]
+
+[[package]]
+name = "dbus-secret-service-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21d8f54da401bb5eb2a4d873ac4b359f4a599df2ca8634bb5b8c045e5ee78757"
+dependencies = [
+ "dbus-secret-service",
+ "keyring-core",
 ]
 
 [[package]]
@@ -1720,7 +1647,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
 ]
 
@@ -1730,7 +1657,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "der_derive",
  "flagset",
  "pem-rfc7468",
@@ -1776,10 +1703,22 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1878,7 +1817,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der 0.7.10",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve 0.13.8",
  "rfc6979 0.4.0",
  "signature 2.2.0",
@@ -1904,7 +1843,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -1924,7 +1863,7 @@ dependencies = [
  "base16ct 0.1.1",
  "crypto-bigint 0.4.9",
  "der 0.6.1",
- "digest",
+ "digest 0.10.7",
  "ff 0.12.1",
  "generic-array",
  "group 0.12.1",
@@ -1943,7 +1882,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct 0.2.0",
  "crypto-bigint 0.5.5",
- "digest",
+ "digest 0.10.7",
  "ff 0.13.1",
  "generic-array",
  "group 0.13.0",
@@ -1981,12 +1920,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "endi"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
-
-[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2005,27 +1938,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
 dependencies = [
  "once_cell",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "enumflags2"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
-dependencies = [
- "enumflags2_derive",
- "serde",
-]
-
-[[package]]
-name = "enumflags2_derive"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
-dependencies = [
  "proc-macro2",
  "quote",
  "syn",
@@ -2070,20 +1982,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener-strategy"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
-dependencies = [
- "event-listener",
- "pin-project-lite",
-]
-
-[[package]]
 name = "fancy-regex"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -2125,8 +2027,7 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 [[package]]
 name = "file_url"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d8c8b9119e366c1b4103d3ca9b5e09cc5684ae14f1265d1472d0a7fbc61747"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "itertools 0.14.0",
  "percent-encoding",
@@ -2569,6 +2470,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
 name = "hashlink"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2613,7 +2525,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2720,6 +2632,15 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -3200,20 +3121,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "keyring"
-version = "3.6.3"
+name = "keyring-core"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
 dependencies = [
- "byteorder",
- "dbus-secret-service",
  "log",
- "secret-service",
- "security-framework 2.11.1",
- "security-framework 3.7.0",
- "windows-sys 0.60.2",
- "zbus",
- "zeroize",
 ]
 
 [[package]]
@@ -3281,6 +3194,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
 dependencies = [
+ "cc",
  "pkg-config",
 ]
 
@@ -3384,7 +3298,7 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47bb1e988e6fb779cf720ad431242d3f03167c1b3f2b1aae7f1a94b2495b36ae"
 dependencies = [
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3414,7 +3328,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3446,15 +3370,6 @@ name = "memo-map"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "miette"
@@ -3546,7 +3461,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework 3.7.0",
+ "security-framework",
  "security-framework-sys",
  "tempfile",
 ]
@@ -3556,19 +3471,6 @@ name = "netrc-rs"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2970fbbc8c785e8246234a7bd004ed66cd1ed1a35ec73669a92545e419b836"
-
-[[package]]
-name = "nix"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
-dependencies = [
- "bitflags",
- "cfg-if",
- "cfg_aliases",
- "libc",
- "memoffset",
-]
 
 [[package]]
 name = "nix"
@@ -3598,15 +3500,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2de2bc5b451bfedaef92c90b8939a8fff5770bdcc1fafd6239d086aab8fa6b29"
 dependencies = [
  "nom",
-]
-
-[[package]]
-name = "ntapi"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -3738,7 +3631,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "url",
 ]
@@ -3751,25 +3644,6 @@ checksum = "234fb5c965bbce983ee5de636a7a51d6a3223da8067ea02f9ab2d2d78ac08be2"
 dependencies = [
  "oauth2",
  "reqwest 0.13.3",
-]
-
-[[package]]
-name = "objc2-core-foundation"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "objc2-io-kit"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
-dependencies = [
- "libc",
- "objc2-core-foundation",
 ]
 
 [[package]]
@@ -3841,7 +3715,7 @@ dependencies = [
  "http-body 1.0.1",
  "jiff",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "mea",
  "percent-encoding",
  "quick-xml 0.38.4",
@@ -3891,7 +3765,7 @@ dependencies = [
  "crc32c",
  "http 1.4.0",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "opendal-core",
  "quick-xml 0.38.4",
  "reqsign-aws-v4",
@@ -3926,7 +3800,7 @@ dependencies = [
  "serde_path_to_error",
  "serde_plain",
  "serde_with",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "thiserror 1.0.69",
  "url",
@@ -3965,6 +3839,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.0+3.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3972,6 +3855,7 @@ checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -4002,16 +3886,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered-stream"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
-dependencies = [
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4031,7 +3905,7 @@ checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
 dependencies = [
  "ecdsa 0.14.8",
  "elliptic-curve 0.12.3",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4043,7 +3917,7 @@ dependencies = [
  "ecdsa 0.16.9",
  "elliptic-curve 0.13.8",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4055,7 +3929,7 @@ dependencies = [
  "ecdsa 0.16.9",
  "elliptic-curve 0.13.8",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4090,8 +3964,7 @@ dependencies = [
 [[package]]
 name = "path_resolver"
 version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a9f07f388f2a58768a34000c2b956bbc44f51630aa39d84f1d362c6785075a1"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "ahash",
  "fs-err",
@@ -4178,17 +4051,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "piper"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
-dependencies = [
- "atomic-waker",
- "fastrand",
- "futures-io",
-]
-
-[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4242,20 +4104,6 @@ dependencies = [
  "quick-xml 0.38.4",
  "serde",
  "time",
-]
-
-[[package]]
-name = "polling"
-version = "3.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi",
- "pin-project-lite",
- "rustix 1.1.4",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4323,15 +4171,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
-dependencies = [
- "toml_edit",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4375,11 +4214,12 @@ dependencies = [
 name = "py-rattler-build"
 version = "0.65.0"
 dependencies = [
- "chrono",
  "clap",
  "fs-err",
+ "hex",
  "indexmap 2.13.0",
  "indicatif",
+ "jiff",
  "miette",
  "pyo3",
  "pyo3-build-config",
@@ -4414,8 +4254,8 @@ version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf85e27e86080aafd5a22eae58a162e133a589551542b3e5cee4beb27e54f8e1"
 dependencies = [
- "chrono",
  "inventory",
+ "jiff",
  "libc",
  "once_cell",
  "portable-atomic",
@@ -4684,22 +4524,24 @@ dependencies = [
 [[package]]
 name = "rattler"
 version = "0.43.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "188a5ce39ea764f92fb4868ac74a722e27d33a52f3aba18be8ec705fba911cbd"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
+ "base64 0.22.1",
  "clap",
  "console",
- "digest",
+ "digest 0.11.3",
  "dirs",
  "filetime",
  "fs-err",
  "futures",
+ "hex",
  "humantime",
  "indexmap 2.13.0",
  "indicatif",
  "itertools 0.14.0",
+ "jiff",
  "memchr",
  "memmap2",
  "oauth2-reqwest",
@@ -4741,7 +4583,6 @@ dependencies = [
  "astral_async_http_range_reader",
  "astral_async_zip",
  "async-compression",
- "chrono",
  "clap",
  "clap-verbosity-flag",
  "clap_complete",
@@ -4753,9 +4594,11 @@ dependencies = [
  "fs-err",
  "futures",
  "globset",
+ "hex",
  "http 1.4.0",
  "ignore",
  "indexmap 2.13.0",
+ "jiff",
  "memmap2",
  "miette",
  "minijinja",
@@ -4781,7 +4624,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "tokio",
  "tokio-util",
@@ -4799,7 +4642,6 @@ dependencies = [
  "astral-reqwest-middleware",
  "async-once-cell",
  "async-recursion",
- "chrono",
  "clap",
  "clap-verbosity-flag",
  "comfy-table",
@@ -4816,6 +4658,7 @@ dependencies = [
  "indexmap 2.13.0",
  "indicatif",
  "itertools 0.14.0",
+ "jiff",
  "line-ending",
  "memchr",
  "memmap2",
@@ -4857,7 +4700,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serde_yaml",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "terminal_size",
  "text-stub-library",
@@ -4890,7 +4733,7 @@ dependencies = [
  "serde_yaml",
  "strum",
  "thiserror 2.0.18",
- "toml 1.0.7+spec-1.1.0",
+ "toml",
 ]
 
 [[package]]
@@ -4908,11 +4751,11 @@ dependencies = [
 name = "rattler_build_package"
 version = "0.1.7"
 dependencies = [
- "chrono",
  "content_inspector",
  "fs-err",
  "globset",
  "indicatif",
+ "jiff",
  "memchr",
  "memmap2",
  "pathdiff",
@@ -4924,7 +4767,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
@@ -4938,6 +4781,7 @@ version = "0.1.7"
 dependencies = [
  "fs-err",
  "globset",
+ "hex",
  "indexmap 2.13.0",
  "itertools 0.14.0",
  "marked-yaml",
@@ -4973,6 +4817,7 @@ dependencies = [
  "clap",
  "flate2",
  "fs-err",
+ "hex",
  "indexmap 2.13.0",
  "itertools 0.14.0",
  "miette",
@@ -4984,10 +4829,10 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serde_yaml",
- "sha2",
+ "sha2 0.10.9",
  "tar",
  "tempfile",
- "toml 1.0.7+spec-1.1.0",
+ "toml",
  "tracing",
  "url",
  "zip",
@@ -5022,15 +4867,15 @@ dependencies = [
  "astral-reqwest-retry",
  "async-trait",
  "bzip2",
- "chrono",
  "dunce",
  "flate2",
  "fs-err",
  "futures",
  "hex",
  "indicatif",
+ "jiff",
  "lzma-rust2",
- "md-5",
+ "md-5 0.10.6",
  "rattler_build_networking",
  "rattler_git",
  "rattler_prefix_guard",
@@ -5038,9 +4883,9 @@ dependencies = [
  "serde",
  "serde_json",
  "sevenz-rust2",
- "sha2",
- "sigstore-trust-root 0.7.0",
- "sigstore-types 0.7.0",
+ "sha2 0.10.9",
+ "sigstore-trust-root",
+ "sigstore-types",
  "sigstore-verify",
  "tar",
  "tempfile",
@@ -5100,18 +4945,18 @@ dependencies = [
 [[package]]
 name = "rattler_cache"
 version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2aa78ff1be938e28fdcdb9837f90da858d090ec1147a00a2aab8490c077f557"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "ahash",
  "anyhow",
  "astral-reqwest-middleware",
  "dashmap",
- "digest",
+ "digest 0.11.3",
  "dirs",
  "fs-err",
  "fs4",
  "futures",
+ "hex",
  "itertools 0.14.0",
  "parking_lot",
  "rattler_conda_types",
@@ -5133,11 +4978,9 @@ dependencies = [
 [[package]]
 name = "rattler_conda_types"
 version = "0.46.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6018a34d7edb8a6b97c971ba935e59d217a0986376d14f4d515fb238b28bdf02"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "ahash",
- "chrono",
  "core-foundation 0.10.1",
  "dirs",
  "fancy-regex",
@@ -5147,6 +4990,7 @@ dependencies = [
  "hex",
  "indexmap 2.13.0",
  "itertools 0.14.0",
+ "jiff",
  "lazy-regex",
  "memmap2",
  "nom",
@@ -5176,8 +5020,7 @@ dependencies = [
 [[package]]
 name = "rattler_config"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e61e6eba72c2e8cc59f8fe7bd120eee4f0d34ed141ae1985ac5bd8c107261ecd"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "console",
  "fs-err",
@@ -5186,7 +5029,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
  "tracing",
  "url",
 ]
@@ -5194,19 +5037,18 @@ dependencies = [
 [[package]]
 name = "rattler_digest"
 version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c44304c9353802e910fac1dbdf6e16df44c341d07b1850bc1fd8b03912cbaab"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "blake2",
- "digest",
+ "digest 0.11.3",
  "generic-array",
  "hex",
- "md-5",
+ "md-5 0.11.0",
  "serde",
  "serde-untagged",
  "serde_bytes",
  "serde_with",
- "sha2",
+ "sha2 0.11.0",
  "tokio",
  "url",
 ]
@@ -5214,8 +5056,7 @@ dependencies = [
 [[package]]
 name = "rattler_git"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373265099ab8b2b816b30e0f8db4cddb6b8364be0a04bc9bdaa21c5ad3fe8943"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "astral-reqwest-middleware",
  "dashmap",
@@ -5235,20 +5076,20 @@ dependencies = [
 [[package]]
 name = "rattler_index"
 version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a8bafd1bc5ad33a81d97a57fee3668406ad37b5f526a3658b019b34b72aa8ca"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "ahash",
  "anyhow",
  "bytes",
- "chrono",
  "clap",
  "clap-verbosity-flag",
  "console",
  "fs-err",
  "futures",
+ "hex",
  "indexmap 2.13.0",
  "indicatif",
+ "jiff",
  "opendal",
  "rattler_conda_types",
  "rattler_config",
@@ -5261,7 +5102,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "tar",
  "thiserror 2.0.18",
  "tokio",
@@ -5274,8 +5115,7 @@ dependencies = [
 [[package]]
 name = "rattler_macros"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d44a87a904057524e32dc8beeb50197016cec467d487bce9d64e044adbcaeb5"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "quote",
  "syn",
@@ -5284,13 +5124,12 @@ dependencies = [
 [[package]]
 name = "rattler_menuinst"
 version = "0.2.62"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ac99b44fac7a9e6cb4bd65cee12c3ec281db52284f6c85fc929b1d1b775cea8"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
- "chrono",
  "configparser",
  "dirs",
  "fs-err",
+ "hex",
  "indexmap 2.13.0",
  "known-folders",
  "once_cell",
@@ -5301,8 +5140,8 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2",
- "shlex",
+ "sha2 0.11.0",
+ "shlex 2.0.1",
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
@@ -5315,11 +5154,11 @@ dependencies = [
 [[package]]
 name = "rattler_networking"
 version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19984b40494bdbaf785525ba36fdb1fa487fe44a36b4214851af4428c69ecf27"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "ambient-id",
  "anyhow",
+ "apple-native-keyring-store",
  "astral-reqwest-middleware",
  "async-once-cell",
  "async-trait",
@@ -5327,12 +5166,13 @@ dependencies = [
  "aws-sdk-s3",
  "aws-smithy-http-client",
  "base64 0.22.1",
+ "dbus-secret-service-keyring-store",
  "dirs",
  "fs-err",
  "getrandom 0.4.2",
  "http 1.4.0",
  "itertools 0.14.0",
- "keyring",
+ "keyring-core",
  "netrc-rs",
  "rattler_config",
  "reqwest 0.13.3",
@@ -5343,13 +5183,13 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "url",
+ "windows-native-keyring-store",
 ]
 
 [[package]]
 name = "rattler_package_streaming"
 version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eefa295dc7b49aa0b67d125400561d2b45b754c66c0f7a19e8fc375b1056bfa9"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-tokio-tar",
@@ -5358,13 +5198,14 @@ dependencies = [
  "async-compression",
  "async-spooled-tempfile",
  "bzip2",
- "chrono",
  "fs-err",
  "futures",
  "futures-util",
  "getrandom 0.2.17",
  "getrandom 0.4.2",
+ "hex",
  "http 1.4.0",
+ "jiff",
  "num_cpus",
  "rattler_conda_types",
  "rattler_digest",
@@ -5387,8 +5228,7 @@ dependencies = [
 [[package]]
 name = "rattler_prefix_guard"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d083796e99a8dbe46fdd5dbde5c853ce532d43419959f3c51578f9f59ada860d"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "fs-err",
  "libc",
@@ -5401,11 +5241,10 @@ dependencies = [
 [[package]]
 name = "rattler_pty"
 version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30f42171f331905af5752aeba3bd1a539b73a35d0754b7db9f7d06a314ad913e"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "libc",
- "nix 0.30.1",
+ "nix",
  "signal-hook",
  "tokio",
 ]
@@ -5413,8 +5252,7 @@ dependencies = [
 [[package]]
 name = "rattler_redaction"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1893dff3da09d778304797291869b17287e35a785cd8bc58fb9cd4760ef51b"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "astral-reqwest-middleware",
  "reqwest 0.13.3",
@@ -5424,8 +5262,7 @@ dependencies = [
 [[package]]
 name = "rattler_repodata_gateway"
 version = "0.29.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d033dc7d25fedc1918719b6d084983436d1cea15621ab5f4c8d722c9020376"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5437,7 +5274,6 @@ dependencies = [
  "bytes",
  "cache_control",
  "cfg-if",
- "chrono",
  "coalesced_map",
  "dashmap",
  "dirs",
@@ -5445,13 +5281,14 @@ dependencies = [
  "fs-err",
  "fslock",
  "futures",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "hex",
  "http 1.4.0",
  "http-cache-semantics",
  "humansize",
  "humantime",
  "itertools 0.14.0",
+ "jiff",
  "json-patch",
  "libc",
  "memmap2",
@@ -5487,8 +5324,7 @@ dependencies = [
 [[package]]
 name = "rattler_s3"
 version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58be09fc22d312cce5ac8158dd94950bb6ba080b23b352b4aa6d53a8dbec8fd4"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -5504,8 +5340,7 @@ dependencies = [
 [[package]]
 name = "rattler_shell"
 version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b57f7b11f6e6d0ef88e5d93b3ba5ea1c0cedeaa58195ec4e75680b465f38dc43"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -5515,8 +5350,7 @@ dependencies = [
  "rattler_conda_types",
  "rattler_pty",
  "serde_json",
- "shlex",
- "sysinfo",
+ "shlex 2.0.1",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -5526,13 +5360,12 @@ dependencies = [
 [[package]]
 name = "rattler_solve"
 version = "7.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eef2142527283596cad4f0b89f4fa0c87a2e20831bf8ef51422d72c9fc6bc316"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
- "chrono",
  "futures",
- "humantime",
+ "hex",
  "itertools 0.14.0",
+ "jiff",
  "rattler_conda_types",
  "rattler_digest",
  "resolvo",
@@ -5545,8 +5378,7 @@ dependencies = [
 [[package]]
 name = "rattler_upload"
 version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca99035497a581f847c76847bac53b18a9ce682daeef01e404f3a61faaf2d58"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-reqwest-retry",
@@ -5554,6 +5386,7 @@ dependencies = [
  "clap",
  "fs-err",
  "futures",
+ "hex",
  "indicatif",
  "miette",
  "opendal",
@@ -5569,8 +5402,9 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.11.0",
  "sigstore-sign",
+ "sigstore-trust-root",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -5582,8 +5416,7 @@ dependencies = [
 [[package]]
 name = "rattler_virtual_packages"
 version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0820759e1171d6ef08237cc7683181cb7aa954d3586b24142333ffe8c7efb5b"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "archspec",
  "libloading",
@@ -5753,7 +5586,7 @@ dependencies = [
  "log",
  "percent-encoding",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "windows-sys 0.61.2",
 ]
 
@@ -5943,8 +5776,8 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -6039,7 +5872,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.7.0",
+ "security-framework",
 ]
 
 [[package]]
@@ -6067,7 +5900,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.9",
- "security-framework 3.7.0",
+ "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -6239,38 +6072,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "secret-service"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4d35ad99a181be0a60ffcbe85d680d98f87bdc4d7644ade319b87076b9dbfd4"
-dependencies = [
- "aes",
- "cbc",
- "futures-util",
- "generic-array",
- "hkdf",
- "num",
- "once_cell",
- "rand 0.8.5",
- "serde",
- "sha2",
- "zbus",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6425,9 +6226,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -6502,7 +6303,7 @@ dependencies = [
  "js-sys",
  "lzma-rust2",
  "ppmd-rust",
- "sha2",
+ "sha2 0.10.9",
  "wasm-bindgen",
 ]
 
@@ -6514,7 +6315,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -6525,8 +6326,19 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
  "sha2-asm",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -6560,6 +6372,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6585,7 +6403,7 @@ version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -6595,26 +6413,8 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "sigstore-bundle"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1c326f5796df635de915cc1b2d29485423df10a4997be6103091772f503451"
-dependencies = [
- "base64 0.22.1",
- "hex",
- "serde",
- "serde_json",
- "sigstore-crypto 0.6.4",
- "sigstore-merkle 0.6.4",
- "sigstore-rekor 0.6.4",
- "sigstore-tsa 0.6.4",
- "sigstore-types 0.6.4",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6627,34 +6427,12 @@ dependencies = [
  "hex",
  "serde",
  "serde_json",
- "sigstore-crypto 0.7.0",
- "sigstore-merkle 0.7.0",
- "sigstore-rekor 0.7.0",
- "sigstore-tsa 0.7.0",
- "sigstore-types 0.7.0",
+ "sigstore-crypto",
+ "sigstore-merkle",
+ "sigstore-rekor",
+ "sigstore-tsa",
+ "sigstore-types",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "sigstore-crypto"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6271208173601a0f058f5fb5354561905a7ead9b4185d85a6c2ed97fbdd31338"
-dependencies = [
- "aws-lc-rs",
- "base64 0.22.1",
- "const-oid",
- "der 0.7.10",
- "digest",
- "pem",
- "rand_core 0.10.0",
- "sha2",
- "signature 2.2.0",
- "sigstore-types 0.6.4",
- "spki 0.7.3",
- "thiserror 2.0.18",
- "tracing",
- "x509-cert",
 ]
 
 [[package]]
@@ -6665,14 +6443,14 @@ checksum = "ac7172898e15789d69d12469bb3d33397aab0771fb4f8d32cd56972e97808bf3"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
- "const-oid",
+ "const-oid 0.9.6",
  "der 0.7.10",
- "digest",
+ "digest 0.10.7",
  "pem",
  "rand_core 0.9.5",
- "sha2",
+ "sha2 0.10.9",
  "signature 2.2.0",
- "sigstore-types 0.7.0",
+ "sigstore-types",
  "spki 0.7.3",
  "thiserror 2.0.18",
  "tracing",
@@ -6681,32 +6459,19 @@ dependencies = [
 
 [[package]]
 name = "sigstore-fulcio"
-version = "0.6.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "042ca72ca33e7981b84565137ed8beee52fd907914e86691feda4fd837b5a022"
+checksum = "a3dd9d2e96569798c7a6959a8712261d0c8048fe1a86604019eb19618b48cf00"
 dependencies = [
  "base64 0.22.1",
  "reqwest 0.13.3",
  "serde",
  "serde_json",
- "sigstore-crypto 0.6.4",
+ "sigstore-crypto",
  "sigstore-oidc",
- "sigstore-types 0.6.4",
+ "sigstore-types",
  "thiserror 2.0.18",
  "url",
-]
-
-[[package]]
-name = "sigstore-merkle"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692e1c1037124c0305e6e342c6a5fa180a31d6ce0eafc0e6c8f001d200083f8d"
-dependencies = [
- "base64 0.22.1",
- "hex",
- "sigstore-crypto 0.6.4",
- "sigstore-types 0.6.4",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6717,45 +6482,27 @@ checksum = "5e86ee272adfcfa21a2248b2fbf05a79b6e39a1fb699ef70c578c814af16e4db"
 dependencies = [
  "base64 0.22.1",
  "hex",
- "sigstore-crypto 0.7.0",
- "sigstore-types 0.7.0",
+ "sigstore-crypto",
+ "sigstore-types",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "sigstore-oidc"
-version = "0.6.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5890d2f982b19694ecf0c95ffb222aa167ff65e2ccb1f81e312c0d6f0c3d9ce5"
+checksum = "587e216497808f23de607ea7966b3ca312a48afa3babaf54fdef9b2518106070"
 dependencies = [
  "ambient-id",
  "base64 0.22.1",
- "rand 0.10.0",
+ "rand 0.9.4",
  "reqwest 0.13.3",
  "serde",
  "serde_json",
- "sigstore-crypto 0.6.4",
- "sigstore-types 0.6.4",
+ "sigstore-crypto",
+ "sigstore-types",
  "thiserror 2.0.18",
  "tokio",
- "url",
-]
-
-[[package]]
-name = "sigstore-rekor"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21abbf2ab10930dd2eb77cbc4c24b1efa6da89f6f0dce9b28b7c1362e7b80da8"
-dependencies = [
- "base64 0.22.1",
- "hex",
- "reqwest 0.13.3",
- "serde",
- "serde_json",
- "sigstore-crypto 0.6.4",
- "sigstore-merkle 0.6.4",
- "sigstore-types 0.6.4",
- "thiserror 2.0.18",
  "url",
 ]
 
@@ -6770,47 +6517,29 @@ dependencies = [
  "reqwest 0.13.3",
  "serde",
  "serde_json",
- "sigstore-crypto 0.7.0",
- "sigstore-merkle 0.7.0",
- "sigstore-types 0.7.0",
+ "sigstore-crypto",
+ "sigstore-merkle",
+ "sigstore-types",
  "thiserror 2.0.18",
  "url",
 ]
 
 [[package]]
 name = "sigstore-sign"
-version = "0.6.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2a4cb10b998aefc5fbe0248a3353e0175e4f44a92437ecca2aa39d05f36427"
+checksum = "a6fea3ac015830222b4083a9905681030430e079683aaf74e1ec6e75ab3b4b9e"
 dependencies = [
  "base64 0.22.1",
  "serde_json",
- "sigstore-bundle 0.6.4",
- "sigstore-crypto 0.6.4",
+ "sigstore-bundle",
+ "sigstore-crypto",
  "sigstore-fulcio",
  "sigstore-oidc",
- "sigstore-rekor 0.6.4",
- "sigstore-trust-root 0.6.4",
- "sigstore-tsa 0.6.4",
- "sigstore-types 0.6.4",
- "thiserror 2.0.18",
- "x509-cert",
-]
-
-[[package]]
-name = "sigstore-trust-root"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45f9d2f2dc33e04c80cfd5f11c93b64f0a2555b1d7f92b5aa16307266f05ad8c"
-dependencies = [
- "base64 0.22.1",
- "chrono",
- "hex",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "sigstore-crypto 0.6.4",
- "sigstore-types 0.6.4",
+ "sigstore-rekor",
+ "sigstore-trust-root",
+ "sigstore-tsa",
+ "sigstore-types",
  "thiserror 2.0.18",
  "x509-cert",
 ]
@@ -6830,40 +6559,14 @@ dependencies = [
  "rustls-pki-types",
  "serde",
  "serde_json",
- "sigstore-crypto 0.7.0",
- "sigstore-types 0.7.0",
+ "sigstore-crypto",
+ "sigstore-types",
  "thiserror 2.0.18",
  "tokio",
  "tough",
  "tracing",
  "url",
  "x509-cert",
-]
-
-[[package]]
-name = "sigstore-tsa"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43c677d430038c216b4f6368efc8cea42f35eca4d20fe5fcf51133d71b3b51b"
-dependencies = [
- "aws-lc-rs",
- "base64 0.22.1",
- "chrono",
- "cmpv2",
- "cms",
- "const-oid",
- "der 0.7.10",
- "hex",
- "rand 0.10.0",
- "reqwest 0.13.3",
- "rustls-pki-types",
- "rustls-webpki 0.103.9",
- "sigstore-crypto 0.6.4",
- "sigstore-types 0.6.4",
- "thiserror 2.0.18",
- "tracing",
- "x509-cert",
- "x509-tsp",
 ]
 
 [[package]]
@@ -6877,34 +6580,19 @@ dependencies = [
  "chrono",
  "cmpv2",
  "cms",
- "const-oid",
+ "const-oid 0.9.6",
  "der 0.7.10",
  "hex",
  "rand 0.9.4",
  "reqwest 0.13.3",
  "rustls-pki-types",
  "rustls-webpki 0.102.8",
- "sigstore-crypto 0.7.0",
- "sigstore-types 0.7.0",
+ "sigstore-crypto",
+ "sigstore-types",
  "thiserror 2.0.18",
  "tracing",
  "x509-cert",
  "x509-tsp",
-]
-
-[[package]]
-name = "sigstore-types"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa6bca8f329e06c7ccb5b9f9be82b165b2be063396be0ee57b13402b994744"
-dependencies = [
- "base64 0.22.1",
- "chrono",
- "hex",
- "pem",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6931,7 +6619,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "cms",
- "const-oid",
+ "const-oid 0.9.6",
  "hex",
  "pem",
  "rustls-pki-types",
@@ -6939,13 +6627,13 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_canonicalizer",
- "sigstore-bundle 0.7.0",
- "sigstore-crypto 0.7.0",
- "sigstore-merkle 0.7.0",
- "sigstore-rekor 0.7.0",
- "sigstore-trust-root 0.7.0",
- "sigstore-tsa 0.7.0",
- "sigstore-types 0.7.0",
+ "sigstore-bundle",
+ "sigstore-crypto",
+ "sigstore-merkle",
+ "sigstore-rekor",
+ "sigstore-trust-root",
+ "sigstore-tsa",
+ "sigstore-types",
  "thiserror 2.0.18",
  "tls_codec",
  "tracing",
@@ -6981,8 +6669,7 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 [[package]]
 name = "simple_spawn_blocking"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55c0b0b683828aa9d4f5c0e59b0c856a12c30a65b5f1ca4292664734d76fa9c2"
+source = "git+https://github.com/conda/rattler?branch=main#3f9ccf1606968e4e6c778ed2d13b5785961ea2ed"
 dependencies = [
  "tokio",
 ]
@@ -7081,12 +6768,6 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -7191,20 +6872,6 @@ dependencies = [
  "libc",
  "thiserror 1.0.69",
  "walkdir",
-]
-
-[[package]]
-name = "sysinfo"
-version = "0.38.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
-dependencies = [
- "libc",
- "memchr",
- "ntapi",
- "objc2-core-foundation",
- "objc2-io-kit",
- "windows 0.62.2",
 ]
 
 [[package]]
@@ -7507,78 +7174,42 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.12+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap 2.13.0",
  "serde_core",
  "serde_spanned",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml"
-version = "1.0.7+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd28d57d8a6f6e458bc0b8784f8fdcc4b99a437936056fa122cb234f18656a96"
-dependencies = [
- "indexmap 2.13.0",
- "serde_core",
- "serde_spanned",
- "toml_datetime 1.0.1+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow 1.0.0",
+ "winnow",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "1.0.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.25.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
-dependencies = [
- "indexmap 2.13.0",
- "toml_datetime 1.0.1+spec-1.1.0",
- "toml_parser",
- "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.10+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.0",
+ "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.7+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tough"
@@ -7768,17 +7399,6 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
-
-[[package]]
-name = "uds_windows"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
-dependencies = [
- "memoffset",
- "tempfile",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "unarray"
@@ -8360,6 +7980,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-native-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5fd986f648459dd29aa252ed3a5ad11a60c0b1251bf81625fb03a86c69d274e"
+dependencies = [
+ "byteorder",
+ "keyring-core",
+ "regex",
+ "windows-sys 0.61.2",
+ "zeroize",
+]
+
+[[package]]
 name = "windows-numerics"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8734,18 +8367,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-
-[[package]]
-name = "winnow"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winver"
@@ -8865,7 +8489,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "der 0.7.10",
  "sha1",
  "signature 2.2.0",
@@ -8892,16 +8516,6 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix 1.1.4",
-]
-
-[[package]]
-name = "xdg-home"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8951,68 +8565,6 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
-]
-
-[[package]]
-name = "zbus"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
-dependencies = [
- "async-broadcast",
- "async-executor",
- "async-fs",
- "async-io",
- "async-lock",
- "async-process",
- "async-recursion",
- "async-task",
- "async-trait",
- "blocking",
- "enumflags2",
- "event-listener",
- "futures-core",
- "futures-sink",
- "futures-util",
- "hex",
- "nix 0.29.0",
- "ordered-stream",
- "rand 0.8.5",
- "serde",
- "serde_repr",
- "sha1",
- "static_assertions",
- "tracing",
- "uds_windows",
- "windows-sys 0.52.0",
- "xdg-home",
- "zbus_macros",
- "zbus_names",
- "zvariant",
-]
-
-[[package]]
-name = "zbus_macros"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
- "zvariant_utils",
-]
-
-[[package]]
-name = "zbus_names"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
-dependencies = [
- "serde",
- "static_assertions",
- "zvariant",
 ]
 
 [[package]]
@@ -9174,41 +8726,4 @@ checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",
-]
-
-[[package]]
-name = "zvariant"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
-dependencies = [
- "endi",
- "enumflags2",
- "serde",
- "static_assertions",
- "zvariant_derive",
-]
-
-[[package]]
-name = "zvariant_derive"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
- "zvariant_utils",
-]
-
-[[package]]
-name = "zvariant_utils"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]

--- a/py-rattler-build/rust/Cargo.toml
+++ b/py-rattler-build/rust/Cargo.toml
@@ -26,8 +26,8 @@ indexmap = "2.13.0"
 pyo3 = { version = "0.28.2", features = [
   "abi3-py38",
   "extension-module",
+  "jiff-02",
   "multiple-pymethods",
-  "chrono",
 ] }
 tokio = { version = "1.50.0", features = [
   "rt",
@@ -35,16 +35,17 @@ tokio = { version = "1.50.0", features = [
   "rt-multi-thread",
   "process",
 ] }
-rattler_conda_types = "0.46.0"
-rattler_config = "0.4.1"
-rattler_networking = { version = "0.27.0" }
-rattler_solve = "7.1.1"
-rattler_virtual_packages = "2.4.1"
+rattler_conda_types = { version = "0.46.0", git = "https://github.com/conda/rattler", branch = "main" }
+rattler_config = { version = "0.4.1", git = "https://github.com/conda/rattler", branch = "main" }
+rattler_networking = { version = "0.27.0", git = "https://github.com/conda/rattler", branch = "main" }
+rattler_solve = { version = "7.1.1", git = "https://github.com/conda/rattler", branch = "main" }
+rattler_virtual_packages = { version = "2.4.1", git = "https://github.com/conda/rattler", branch = "main" }
 clap = "4.6.0"
 url = "2.5.8"
-chrono = "0.4.44"
-rattler_upload = "0.7.0"
-rattler_package_streaming = { version = "0.26.0", default-features = false }
+jiff = { version = "0.2", default-features = false, features = ["std", "serde"] }
+hex = "0.4.3"
+rattler_upload = { version = "0.7.0", git = "https://github.com/conda/rattler", branch = "main" }
+rattler_package_streaming = { version = "0.26.0", git = "https://github.com/conda/rattler", branch = "main", default-features = false }
 miette = "7.6.0"
 tempfile = "3.27.0"
 serde_yaml = "0.9"
@@ -58,6 +59,7 @@ indicatif = "0.18"
 
 [build-dependencies]
 pyo3-build-config = "0.28.2"
+
 
 # Prevent package from thinking it's in the workspace
 [workspace]

--- a/py-rattler-build/rust/src/build.rs
+++ b/py-rattler-build/rust/src/build.rs
@@ -119,12 +119,12 @@ pub(crate) fn output_from_rendered_variant(
     package_format: Option<&PackageFormatAndCompression>,
     no_include_recipe: bool,
     recipe_path: Option<&Path>,
-    exclude_newer: Option<chrono::DateTime<chrono::Utc>>,
+    exclude_newer: Option<jiff::Timestamp>,
     env_isolation: EnvironmentIsolation,
     v3: bool,
     extra_subpackages: BTreeMap<rattler_conda_types::PackageName, PackageIdentifier>,
 ) -> Result<Output, RattlerBuildError> {
-    let timestamp = chrono::Utc::now();
+    let timestamp = jiff::Timestamp::now();
     let virtual_package_override = rattler_virtual_packages::VirtualPackageOverrides::from_env();
 
     let mut subpackages = extra_subpackages;
@@ -257,7 +257,7 @@ pub fn build_rendered_variant_py(
     no_build_id: bool,
     package_format: Option<String>,
     no_include_recipe: bool,
-    exclude_newer: Option<chrono::DateTime<chrono::Utc>>,
+    exclude_newer: Option<jiff::Timestamp>,
     env_isolation: PyEnvironmentIsolation,
     sibling_variants: Vec<render::PyRenderedVariant>,
     v3: bool,

--- a/py-rattler-build/rust/src/cli_api.rs
+++ b/py-rattler-build/rust/src/cli_api.rs
@@ -51,7 +51,7 @@ pub fn build_recipes_py(
     error_prefix_in_binary: bool,
     allow_symlinks_on_windows: bool,
     allow_absolute_license_paths: bool,
-    exclude_newer: Option<chrono::DateTime<chrono::Utc>>,
+    exclude_newer: Option<jiff::Timestamp>,
     build_num: Option<u64>,
     build_string_prefix: Option<String>,
     use_bz2: bool,

--- a/py-rattler-build/rust/src/package.rs
+++ b/py-rattler-build/rust/src/package.rs
@@ -147,11 +147,11 @@ impl PyPackage {
 
     /// Build timestamp as a datetime object
     #[getter]
-    fn timestamp(&self) -> Option<chrono::DateTime<chrono::Utc>> {
+    fn timestamp(&self) -> Option<jiff::Timestamp> {
         self.index
             .timestamp
             .as_ref()
-            .map(|ts| ts.datetime().to_owned())
+            .map(|ts| ts.jiff_timestamp())
     }
 
     /// Architecture (e.g., "x86_64")
@@ -1091,7 +1091,10 @@ impl PyPathEntry {
     /// SHA256 hash of the file (if available)
     #[getter]
     fn sha256(&self) -> Option<String> {
-        self.inner.sha256.as_ref().map(|h| format!("{:x}", h))
+        self.inner.sha256.as_ref().map(|h| {
+            let bytes: &[u8] = h.as_ref();
+            hex::encode(bytes)
+        })
     }
 
     fn __repr__(&self) -> String {

--- a/py-rattler-build/rust/src/package_assembler.rs
+++ b/py-rattler-build/rust/src/package_assembler.rs
@@ -5,7 +5,7 @@
 
 use std::path::PathBuf;
 
-use chrono::{DateTime, Utc};
+use jiff::Timestamp;
 use pyo3::prelude::*;
 use rattler_build_package::{ArchiveType, FileCollector, FileEntry, PackageBuilder, PackageConfig};
 use rattler_conda_types::package::IndexJson;
@@ -262,7 +262,7 @@ pub fn assemble_package_py(
     // Build options
     compression_level: u8,
     archive_type: Option<PyArchiveType>,
-    timestamp: Option<DateTime<Utc>>,
+    timestamp: Option<Timestamp>,
     compression_threads: Option<usize>,
     detect_prefix: bool,
 ) -> PyResult<PyPackageOutput> {
@@ -369,7 +369,7 @@ pub fn assemble_package_py(
         features: None,
         python_site_packages_path: None,
         purls: None,
-        experimental_extra_depends: Default::default(),
+        extra_depends: Default::default(),
         repodata_revision: None,
     };
     builder = builder.with_index(index);

--- a/py-rattler-build/tests/unit/test_render.py
+++ b/py-rattler-build/tests/unit/test_render.py
@@ -307,7 +307,7 @@ python:
 
 
 def test_run_build_exclude_newer_datetime_conversion(tmp_path: Path) -> None:
-    """Test that Python datetime converts correctly to Rust chrono::DateTime<Utc>."""
+    """Test that Python datetime converts correctly to Rust jiff::Timestamp."""
     from datetime import datetime, timezone
 
     recipe_yaml = """
@@ -324,7 +324,7 @@ build:
     variant_config = VariantConfig()
     rendered = recipe.render(variant_config)
 
-    # Create a timezone-aware datetime (required for chrono::DateTime<Utc>)
+    # Create a timezone-aware datetime (required for jiff::Timestamp)
     exclude_newer = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
 
     result = rendered[0].run_build(output_dir=tmp_path, exclude_newer=exclude_newer)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -446,7 +446,7 @@ pub async fn get_build_output(
         .or_else(|| outputs_and_variants.first().map(|o| o.name.clone()))
         .unwrap_or_else(|| "build".to_string());
 
-    let timestamp = chrono::Utc::now();
+    let timestamp = jiff::Timestamp::now();
 
     for discovered_output in outputs_and_variants {
         let recipe = &discovered_output.recipe;
@@ -1031,7 +1031,10 @@ pub async fn rebuild_package_core(
     let original_sha = rattler_digest::compute_file_digest::<rattler_digest::Sha256>(&package_path)
         .into_diagnostic()?;
 
-    tracing::info!("Original package SHA256: {:x}", original_sha);
+    let original_sha_bytes: &[u8] = original_sha.as_ref();
+    let original_sha256 = hex::encode(original_sha_bytes);
+
+    tracing::info!("Original package SHA256: {}", original_sha256);
     tracing::info!("Rebuilding \"{}\"", package_path.display());
 
     // we extract the recipe folder from the package file (info/recipe/*)
@@ -1085,7 +1088,7 @@ pub async fn rebuild_package_core(
         run_build(output, &tool_config, WorkingDirectoryBehavior::Cleanup).await?;
 
     // Generate timestamp for the rebuilt package
-    let timestamp = chrono::Utc::now().format("%Y%m%d-%H%M%S");
+    let timestamp = jiff::Timestamp::now().strftime("%Y%m%d-%H%M%S");
 
     // Create final output directory
     let final_output_dir = rebuild_data.common.output_dir.clone();
@@ -1124,14 +1127,17 @@ pub async fn rebuild_package_core(
     let rebuilt_sha = rattler_digest::compute_file_digest::<rattler_digest::Sha256>(&rebuilt_path)
         .into_diagnostic()?;
 
-    tracing::info!("Rebuilt package SHA256: {:x}", rebuilt_sha);
+    let rebuilt_sha_bytes: &[u8] = rebuilt_sha.as_ref();
+    let rebuilt_sha256 = hex::encode(rebuilt_sha_bytes);
+
+    tracing::info!("Rebuilt package SHA256: {}", rebuilt_sha256);
     tracing::info!("Rebuilt package saved to: \"{:?}\"", rebuilt_path);
 
     Ok(RebuildOutput {
         original_path: package_path,
         rebuilt_path,
-        original_sha256: format!("{:x}", original_sha),
-        rebuilt_sha256: format!("{:x}", rebuilt_sha),
+        original_sha256,
+        rebuilt_sha256,
     })
 }
 

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -2,7 +2,6 @@
 
 use std::{collections::HashMap, error::Error, path::PathBuf, str::FromStr};
 
-use chrono;
 use clap::{Parser, ValueEnum, builder::ArgPredicate, crate_version};
 use clap_complete::{Generator, shells};
 use clap_complete_nushell::Nushell;
@@ -718,7 +717,7 @@ pub struct BuildOpts {
 
     /// Exclude packages newer than this date from the solver, in RFC3339 format (e.g. 2024-03-15T12:00:00Z)
     #[arg(long, help_heading = "Modifying result", value_parser = parse_datetime)]
-    pub exclude_newer: Option<chrono::DateTime<chrono::Utc>>,
+    pub exclude_newer: Option<jiff::Timestamp>,
 }
 
 /// Publish options for the `publish` command.
@@ -905,7 +904,7 @@ pub struct BuildData {
     pub error_prefix_in_binary: bool,
     pub allow_symlinks_on_windows: bool,
     pub allow_absolute_license_paths: bool,
-    pub exclude_newer: Option<chrono::DateTime<chrono::Utc>>,
+    pub exclude_newer: Option<jiff::Timestamp>,
     pub build_num_override: Option<u64>,
     pub build_string_prefix: Option<String>,
     pub markdown_summary: Option<PathBuf>,
@@ -942,7 +941,7 @@ impl BuildData {
         error_prefix_in_binary: bool,
         allow_symlinks_on_windows: bool,
         allow_absolute_license_paths: bool,
-        exclude_newer: Option<chrono::DateTime<chrono::Utc>>,
+        exclude_newer: Option<jiff::Timestamp>,
         build_num_override: Option<u64>,
         build_string_prefix: Option<String>,
         markdown_summary: Option<PathBuf>,
@@ -1075,15 +1074,13 @@ fn parse_variant_override(
 }
 
 /// Parse a datetime string in RFC3339 format
-fn parse_datetime(s: &str) -> Result<chrono::DateTime<chrono::Utc>, String> {
-    chrono::DateTime::parse_from_rfc3339(s)
-        .map(|dt| dt.with_timezone(&chrono::Utc))
-        .map_err(|e| {
-            format!(
-                "Invalid datetime format '{}': {}. Expected RFC3339 format (e.g., 2024-03-15T12:00:00Z)",
-                s, e
-            )
-        })
+fn parse_datetime(s: &str) -> Result<jiff::Timestamp, String> {
+    s.parse::<jiff::Timestamp>().map_err(|e| {
+        format!(
+            "Invalid datetime format '{}': {}. Expected RFC3339 format (e.g., 2024-03-15T12:00:00Z)",
+            s, e
+        )
+    })
 }
 
 /// Test options.


### PR DESCRIPTION
## Summary

- Replace direct `chrono` usage in rattler-build with `jiff` timestamps and durations.
- Update the Python binding to use PyO3's `jiff-02` support instead of the `chrono` feature.
- Point rattler dependencies at git `main` and adapt to the current rattler APIs, including `IndexJson.extra_depends`, `TimestampMs::jiff_timestamp()`, and digest hex encoding.
- Update the separate playground and Python lockfiles/manifests so they compile with rattler git main.

## Validation

- `cargo check --workspace --all-targets`
- `cargo check --manifest-path crates/rattler_build_playground/Cargo.toml`
- `cargo check --manifest-path py-rattler-build/rust/Cargo.toml --no-default-features`
- `rg -n "\bchrono\b|DateTime<|Utc::|chrono::Duration" --glob '*.rs' --glob '*.toml' --glob '*.md' --glob '!target/**'`