### PR TITLE
feat: support debugging staging (compile) outputs in `debug setup`

### DIFF
--- a/crates/rattler_build_core/src/debug.rs
+++ b/crates/rattler_build_core/src/debug.rs
@@ -537,12 +537,14 @@ pub async fn add_packages_to_prefix(
 impl crate::metadata::Output {
     /// Set up a debug environment without running the build.
     ///
-    /// This consolidates the 5-step setup sequence:
+    /// This consolidates the setup sequence (mirroring the prefix of
+    /// [`crate::build::run_build`], stopping before the build script runs):
     /// 1. Recreate directories
-    /// 2. Fetch sources
-    /// 3. Resolve dependencies
-    /// 4. Install environments
-    /// 5. Create build script
+    /// 2. Build or restore any inherited staging caches
+    /// 3. Fetch sources
+    /// 4. Resolve dependencies
+    /// 5. Install environments
+    /// 6. Create build script
     pub async fn setup_debug_environment(
         self,
         tool_config: &Configuration,
@@ -554,7 +556,21 @@ impl crate::metadata::Output {
             .recreate_directories()
             .into_diagnostic()?;
 
-        let output: crate::metadata::Output = self
+        // Build or restore any staging caches this output inherits from, exactly
+        // as `run_build` does, so that an inheriting (package) output's work dir
+        // is populated with the staged sources and `./install` tree and the
+        // inherited dependencies are available. This is a no-op for outputs that
+        // do not inherit from a staging cache (including a synthesized staging
+        // debug output, see `as_staging_debug_output`).
+        let mut output = self;
+        let staging_result = output.process_staging_caches(tool_config).await?;
+        if let Some((deps, sources, library_name_map)) = staging_result {
+            output.finalized_cache_dependencies = Some(deps);
+            output.finalized_cache_sources = Some(sources);
+            output.staging_library_name_map = Some(library_name_map);
+        }
+
+        let output: crate::metadata::Output = output
             .fetch_sources(tool_config, apply_patch_custom)
             .await
             .into_diagnostic()?;
@@ -572,5 +588,54 @@ impl crate::metadata::Output {
         output.create_build_script().await.into_diagnostic()?;
 
         Ok(output)
+    }
+
+    /// If `staging_name` names a staging cache that this (package) output
+    /// inherits from, return a synthesized output whose source, build section,
+    /// requirements and variant are those of the staging build.
+    ///
+    /// Setting up the debug environment of the returned output therefore
+    /// prepares the staging *compile* environment (the shared CMake/build step)
+    /// — sources, build/host prefixes and the staging build script — rather than
+    /// the package output's own (e.g. file-copying) environment. This is what
+    /// lets `rattler-build debug setup --output-name <staging>` drop into the
+    /// interactive compilation environment of a multi-output recipe.
+    ///
+    /// Returns `None` if no inherited staging cache has that name.
+    pub fn as_staging_debug_output(&self, staging_name: &str) -> Option<crate::metadata::Output> {
+        let staging = self
+            .recipe
+            .staging_caches
+            .iter()
+            .find(|cache| cache.name == staging_name)?;
+
+        let mut output = self.clone();
+        output.recipe.source = staging.source.clone();
+        // Keep the carrier output's (already resolved) build metadata — notably
+        // its resolved build string — and only adopt the parts of the staging
+        // build that define the compile: the build script and the build/host
+        // env layout. Cloning `staging.build` wholesale would bring in its
+        // unresolved `BuildString` and panic downstream.
+        output.recipe.build.script = staging.build.script.clone();
+        output.recipe.build.merge_build_and_host_envs = staging.build.merge_build_and_host_envs;
+        output.recipe.requirements = staging.requirements.clone();
+        // The synthesized output *is* the staging build, so it must not try to
+        // build/restore a parent staging cache of its own.
+        output.recipe.staging_caches = Vec::new();
+        output.recipe.inherits_from = None;
+        // Use the staging cache's own variant (e.g. for CONDA_BUILD_SYSROOT and
+        // the compilers), which can differ from the inheriting output's.
+        output.build_configuration.variant = staging.used_variant.clone();
+        // Force re-resolution / re-fetch against the staging configuration.
+        output.finalized_dependencies = None;
+        output.finalized_sources = None;
+        output.finalized_cache_dependencies = None;
+        output.finalized_cache_sources = None;
+        output.staging_library_name_map = None;
+        // Strip the carrier package's PKG_* env vars from the staging build
+        // script, matching the real staging build (`build_staging_cache`).
+        output.is_staging_debug = true;
+
+        Some(output)
     }
 }

--- a/crates/rattler_build_core/src/script.rs
+++ b/crates/rattler_build_core/src/script.rs
@@ -41,6 +41,22 @@ impl Output {
         ));
         env_vars.extend(env_vars::env_vars_from_variant(self.variant()));
 
+        // A synthesized staging-debug output borrows a package output's
+        // identity, but the staging build does not produce a package. Mirror
+        // `build_staging_cache` and drop the misleading PKG_* vars so the debug
+        // environment matches what the real staging compile sees.
+        if self.is_staging_debug {
+            for key in [
+                "PKG_NAME",
+                "PKG_VERSION",
+                "PKG_BUILDNUM",
+                "PKG_BUILD_STRING",
+                "PKG_HASH",
+            ] {
+                env_vars.remove(key);
+            }
+        }
+
         let jinja_renderer = self.jinja_renderer();
 
         let build_prefix = if self.recipe.build().merge_build_and_host_envs {

--- a/crates/rattler_build_core/src/types/build_output.rs
+++ b/crates/rattler_build_core/src/types/build_output.rs
@@ -67,6 +67,14 @@ pub struct BuildOutput {
     /// physically installed in the host prefix.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub staging_library_name_map: Option<LibraryNameMap>,
+
+    /// True if this output was synthesized to debug a staging (compile) output
+    /// of a multi-output recipe (see `Output::as_staging_debug_output`). When
+    /// set, the build-script setup strips the package-identity `PKG_*` env vars
+    /// so the debug environment matches the real staging build, which does not
+    /// produce a package and therefore removes them.
+    #[serde(skip)]
+    pub is_staging_debug: bool,
 }
 
 impl BuildOutput {

--- a/py-rattler-build/rust/src/build.rs
+++ b/py-rattler-build/rust/src/build.rs
@@ -233,6 +233,7 @@ pub(crate) fn output_from_rendered_variant(
         finalized_cache_dependencies: None,
         finalized_cache_sources: None,
         staging_library_name_map: None,
+        is_staging_debug: false,
         build_summary: Arc::new(Mutex::new(BuildSummary::default())),
         system_tools: SystemTools::new("rattler-build", env!("CARGO_PKG_VERSION")),
         extra_meta: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -576,6 +576,7 @@ pub async fn get_build_output(
             finalized_cache_dependencies: None,
             finalized_cache_sources: None,
             staging_library_name_map: None,
+            is_staging_debug: false,
             system_tools: SystemTools::new("rattler-build", env!("CARGO_PKG_VERSION")),
             build_summary: Arc::new(Mutex::new(BuildSummary::default())),
             extra_meta: Some(
@@ -1574,27 +1575,53 @@ pub async fn debug_recipe(
 
     let mut outputs = get_build_output(&build_data, &recipe_path, &tool_config).await?;
 
-    if let Some(output_name) = &debug_data.output_name {
-        let original_count = outputs.len();
-        outputs.retain(|output| output.name().as_normalized() == output_name);
-
-        if outputs.is_empty() {
-            return Err(miette::miette!(
-                "Output with name '{}' not found in recipe. Available outputs: {}",
-                output_name,
-                original_count
-            ));
-        }
-    } else if outputs.len() > 1 {
-        let output_names: Vec<String> = outputs
+    // Names that can be passed to --output-name: the package outputs plus any
+    // staging (compile) caches they inherit from.
+    let debuggable_names = |outputs: &[Output]| -> Vec<String> {
+        let mut names: Vec<String> = outputs
             .iter()
             .map(|output| output.name().as_normalized().to_string())
             .collect();
+        names.extend(
+            outputs
+                .iter()
+                .flat_map(|output| output.recipe.staging_caches.iter())
+                .map(|cache| cache.name.clone()),
+        );
+        names.sort();
+        names.dedup();
+        names
+    };
 
+    if let Some(output_name) = &debug_data.output_name {
+        if outputs
+            .iter()
+            .any(|output| output.name().as_normalized() == output_name)
+        {
+            outputs.retain(|output| output.name().as_normalized() == output_name);
+        } else if let Some(staging_output) = outputs
+            .iter()
+            .find_map(|output| output.as_staging_debug_output(output_name))
+        {
+            // The requested name is a staging (compile) output rather than a
+            // package output: debug the shared build environment itself.
+            tracing::info!(
+                "Setting up debug environment for staging output '{}'",
+                output_name
+            );
+            outputs = vec![staging_output];
+        } else {
+            return Err(miette::miette!(
+                "Output with name '{}' not found in recipe. Available outputs: {}",
+                output_name,
+                debuggable_names(&outputs).join(", ")
+            ));
+        }
+    } else if outputs.len() > 1 {
         return Err(miette::miette!(
             "Multiple outputs found in recipe ({}). Please specify which output to debug using --output-name. Available outputs: {}",
             outputs.len(),
-            output_names.join(", ")
+            debuggable_names(&outputs).join(", ")
         ));
     }
 

--- a/test-data/recipes/debug-staging/recipe.yaml
+++ b/test-data/recipes/debug-staging/recipe.yaml
@@ -1,0 +1,43 @@
+# Multi-output recipe with a `staging:` (compile) output that the package
+# output inherits. Used to test `rattler-build debug setup` against both the
+# staging compile stage and the inheriting package stage.
+schema_version: 1
+
+recipe:
+  name: debug-staging
+  version: 1.0.0
+
+outputs:
+  # Staging "compile" stage: builds once into ./install (work-dir relative).
+  - staging:
+      name: build-stage
+    build:
+      script:
+        - if: unix
+          then: |
+            echo "Compiling in staging"
+            mkdir -p ./install
+            echo "artifact" > ./install/artifact.txt
+        - if: win
+          then: |
+            echo Compiling in staging
+            mkdir install
+            echo artifact > install\artifact.txt
+
+  # Package stage: inherits the staging cache and copies the built artifact.
+  - package:
+      name: debug-staging
+      version: 1.0.0
+    inherit: build-stage
+    build:
+      script:
+        - if: unix
+          then: |
+            echo "Packaging from staging"
+            mkdir -p $PREFIX/share
+            cp ./install/artifact.txt $PREFIX/share/artifact.txt
+        - if: win
+          then: |
+            echo Packaging from staging
+            mkdir %PREFIX%\share
+            copy install\artifact.txt %PREFIX%\share\artifact.txt

--- a/test/end-to-end/test_debug.py
+++ b/test/end-to-end/test_debug.py
@@ -115,3 +115,75 @@ def test_debug_multiple_outputs(
             "--output-name",
             "invalid_output",
         )
+
+
+def _build_script(work_dir: Path) -> str:
+    name = "conda_build.bat" if platform.system() == "Windows" else "conda_build.sh"
+    script = work_dir / name
+    assert script.exists()
+    return script.read_text(encoding="utf-8")
+
+
+def test_debug_staging_output(
+    rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
+):
+    # The staging (compile) output is selectable by name and its debug
+    # environment runs the staging build script.
+    stage_dir = tmp_path / "stage"
+    rattler_build(
+        "debug",
+        "setup",
+        "--recipe",
+        str(recipes / "debug-staging"),
+        "--output-dir",
+        str(stage_dir),
+        "--output-name",
+        "build-stage",
+    )
+    work_dir = next(stage_dir.glob("**/work"))
+    assert "Compiling in staging" in _build_script(work_dir)
+
+    # An inheriting package output builds/restores the staging cache, so its
+    # debug work dir is populated with the staged ./install tree.
+    pkg_dir = tmp_path / "pkg"
+    rattler_build(
+        "debug",
+        "setup",
+        "--recipe",
+        str(recipes / "debug-staging"),
+        "--output-dir",
+        str(pkg_dir),
+        "--output-name",
+        "debug-staging",
+    )
+    work_dir = next(pkg_dir.glob("**/work"))
+    assert "Packaging from staging" in _build_script(work_dir)
+    assert (work_dir / "install" / "artifact.txt").exists()
+
+
+def test_debug_staging_listed_in_available_outputs(
+    rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
+):
+    # An unknown --output-name reports both the package output and the staging
+    # (compile) output as valid targets.
+    result = rattler_build(
+        "debug",
+        "setup",
+        "--recipe",
+        str(recipes / "debug-staging"),
+        "--output-dir",
+        str(tmp_path),
+        "--output-name",
+        "does-not-exist",
+        need_result_object=True,
+        # rattler-build emits UTF-8 (incl. the box-drawing error frame); decode
+        # it explicitly so the Windows locale (cp1252) does not choke.
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    assert result.returncode != 0
+    combined = (result.stdout or "") + (result.stderr or "")
+    assert "Available outputs" in combined
+    assert "build-stage" in combined
+    assert "debug-staging" in combined


### PR DESCRIPTION
I (well claude) was working through https://github.com/conda-forge/conda-smithy/pull/2566 and the recipe i was testing with didn't have the ability to troubleshoot the staging output

I still need to review claude's code, so please don't read too much into this PR quite yet.

- [ ] I have reviewed all of the AI generated code and stand behind it.


<details><summary>Claude's draft</summary>

`rattler-build debug setup --output-name <name>` could previously only target package outputs. For a multi-output recipe that uses a `staging:` output to compile once and `inherit:` it from package outputs, this meant:

- the staging (compile) output was not selectable at all ("Output with name '<staging>' not found"); and
- debugging a package output that inherits a staging cache produced an empty work dir (no sources, no `./install`), because the inherited cache was never built/restored.

This makes both work:

- `setup_debug_environment` now runs `process_staging_caches` (mirroring `run_build`) before fetching sources, so debugging an inheriting output builds-or-restores its staging cache and the work dir is populated with the staged sources and `./install` tree. No-op for recipes without staging.
- A new `Output::as_staging_debug_output` synthesizes an output from a `StagingCache` (its source, build script, requirements and variant), so `debug setup --output-name <staging>` prepares the shared *compile* environment. The synthesized output keeps the carrier's resolved build metadata (avoiding an unresolved `BuildString`) and sets `is_staging_debug` so the build-script setup strips the package `PKG_*` env vars, matching the real staging build.
- The `debug setup` output selection accepts staging names and lists them in the "available outputs" hints.

After `debug setup --output-name <staging>` a developer can `rattler-build debug shell`/`debug run` to interactively run and iterate on the compile.

</details>