### PR TITLE
feat: Add brush interpreter support

### DIFF
--- a/crates/rattler_build_core/src/build.rs
+++ b/crates/rattler_build_core/src/build.rs
@@ -188,6 +188,14 @@ pub async fn run_build(
         Err(InterpreterError::ExecutionFailed(_)) => {
             return Err(miette::miette!("Script failed to execute"));
         }
+        Err(InterpreterError::InterpreterNotFound(interpreter)) => {
+            return Err(miette::miette!(
+                help = format!(
+                    "Add `{interpreter}` to the `requirements/build` section of your recipe so it is provided by the build environment."
+                ),
+                "interpreter `{interpreter}` was not found in the build environment"
+            ));
+        }
     }
 
     // Package all the new files

--- a/crates/rattler_build_script/src/execution.rs
+++ b/crates/rattler_build_script/src/execution.rs
@@ -425,8 +425,8 @@ impl Decoder for CrLfNormalizer {
 }
 
 use crate::interpreter::{
-    BASH_PREAMBLE, BashInterpreter, CMDEXE_PREAMBLE, CmdExeInterpreter, Interpreter,
-    NodeJsInterpreter, NuShellInterpreter, PerlInterpreter, PowerShellInterpreter,
+    BASH_PREAMBLE, BashInterpreter, BrushInterpreter, CMDEXE_PREAMBLE, CmdExeInterpreter,
+    Interpreter, NodeJsInterpreter, NuShellInterpreter, PerlInterpreter, PowerShellInterpreter,
     PythonInterpreter, RInterpreter, RubyInterpreter,
 };
 use rattler_shell::shell;
@@ -439,6 +439,7 @@ pub async fn run_script(
     match interpreter {
         "nushell" | "nu" => NuShellInterpreter.run(exec_args).await?,
         "bash" => BashInterpreter.run(exec_args).await?,
+        "brush" => BrushInterpreter.run(exec_args).await?,
         "cmd" => CmdExeInterpreter.run(exec_args).await?,
         "python" => PythonInterpreter.run(exec_args).await?,
         "perl" => PerlInterpreter.run(exec_args).await?,
@@ -754,6 +755,35 @@ mod tests {
         assert!(
             script.contains("CONDA_BUILD") && script.contains("1"),
             "build_env.sh must set CONDA_BUILD=1 for nested-shell re-entrancy, got:\n{script}"
+        );
+    }
+
+    /// brush must be provided by the build environment. With no build prefix
+    /// it cannot be located and a clear `InterpreterNotFound` is returned.
+    #[tokio::test]
+    async fn test_brush_not_found_without_build_prefix() {
+        use crate::interpreter::BrushInterpreter;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let prefix = tmp.path().join("prefix");
+        fs_err::create_dir_all(&prefix).unwrap();
+
+        let args = ExecutionArgs {
+            script: ResolvedScriptContents::Inline("echo hello".to_string()),
+            env_vars: IndexMap::new(),
+            secrets: IndexMap::new(),
+            execution_platform: Platform::current(),
+            build_prefix: None,
+            run_prefix: prefix,
+            work_dir: tmp.path().to_path_buf(),
+            sandbox_config: None,
+            env_isolation: EnvironmentIsolation::None,
+        };
+
+        let err = BrushInterpreter.run(args).await.unwrap_err();
+        assert!(
+            matches!(err, crate::InterpreterError::InterpreterNotFound(ref name) if name == "brush"),
+            "expected InterpreterNotFound for brush, got: {err:?}"
         );
     }
 

--- a/crates/rattler_build_script/src/interpreter/bash.rs
+++ b/crates/rattler_build_script/src/interpreter/bash.rs
@@ -5,7 +5,9 @@ use rattler_shell::shell;
 
 use crate::execution::{ExecutionArgs, run_process_with_replacements};
 
-use super::{BASH_PREAMBLE, Interpreter, InterpreterError, find_interpreter};
+use super::{
+    BASH_PREAMBLE, Interpreter, InterpreterError, InterpreterSearchScope, find_interpreter,
+};
 
 pub struct BashInterpreter;
 
@@ -84,6 +86,11 @@ impl Interpreter for BashInterpreter {
         build_prefix: Option<&PathBuf>,
         platform: &Platform,
     ) -> Result<Option<PathBuf>, which::Error> {
-        find_interpreter("bash", build_prefix, platform)
+        find_interpreter(
+            "bash",
+            build_prefix,
+            platform,
+            InterpreterSearchScope::PrefixThenSystemPath,
+        )
     }
 }

--- a/crates/rattler_build_script/src/interpreter/brush.rs
+++ b/crates/rattler_build_script/src/interpreter/brush.rs
@@ -1,0 +1,57 @@
+use std::path::PathBuf;
+
+use rattler_conda_types::Platform;
+
+use crate::execution::{ExecutionArgs, ResolvedScriptContents};
+
+use super::{
+    BashInterpreter, CmdExeInterpreter, Interpreter, InterpreterError, InterpreterSearchScope,
+    find_interpreter,
+};
+
+pub struct BrushInterpreter;
+
+// Brush runs bash-compatible scripts. The native bash/cmd wrapper performs
+// activation and then invokes brush on the user script as a child process.
+impl Interpreter for BrushInterpreter {
+    async fn run(&self, args: ExecutionArgs) -> Result<(), InterpreterError> {
+        // brush must be provided by the build environment, not the system PATH.
+        let brush_path = find_interpreter(
+            "brush",
+            args.build_prefix.as_ref(),
+            &args.execution_platform,
+            InterpreterSearchScope::BuildPrefixOnly,
+        )
+        .ok()
+        .flatten()
+        .ok_or_else(|| InterpreterError::InterpreterNotFound("brush".to_string()))?;
+
+        let brush_script = args.work_dir.join("conda_build_script.sh");
+        tokio::fs::write(&brush_script, args.script.script()).await?;
+
+        // Invoke the resolved brush from the wrapper so the build-env binary runs.
+        let args = ExecutionArgs {
+            script: ResolvedScriptContents::Inline(format!("{:?} {:?}", brush_path, brush_script)),
+            ..args
+        };
+
+        if cfg!(windows) {
+            CmdExeInterpreter.run(args).await
+        } else {
+            BashInterpreter.run(args).await
+        }
+    }
+
+    async fn find_interpreter(
+        &self,
+        build_prefix: Option<&PathBuf>,
+        platform: &Platform,
+    ) -> Result<Option<PathBuf>, which::Error> {
+        find_interpreter(
+            "brush",
+            build_prefix,
+            platform,
+            InterpreterSearchScope::BuildPrefixOnly,
+        )
+    }
+}

--- a/crates/rattler_build_script/src/interpreter/cmd_exe.rs
+++ b/crates/rattler_build_script/src/interpreter/cmd_exe.rs
@@ -5,7 +5,9 @@ use rattler_shell::shell;
 
 use crate::execution::{ExecutionArgs, run_process_with_replacements};
 
-use super::{CMDEXE_PREAMBLE, Interpreter, InterpreterError, find_interpreter};
+use super::{
+    CMDEXE_PREAMBLE, Interpreter, InterpreterError, InterpreterSearchScope, find_interpreter,
+};
 
 fn print_debug_info(args: &ExecutionArgs) -> String {
     let mut output = String::new();
@@ -94,6 +96,11 @@ impl Interpreter for CmdExeInterpreter {
         }
 
         // check if cmd.exe is in PATH
-        find_interpreter("cmd", build_prefix, platform)
+        find_interpreter(
+            "cmd",
+            build_prefix,
+            platform,
+            InterpreterSearchScope::PrefixThenSystemPath,
+        )
     }
 }

--- a/crates/rattler_build_script/src/interpreter/mod.rs
+++ b/crates/rattler_build_script/src/interpreter/mod.rs
@@ -1,4 +1,5 @@
 mod bash;
+mod brush;
 mod cmd_exe;
 mod nodejs;
 mod nushell;
@@ -12,6 +13,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 pub use bash::BashInterpreter;
+pub use brush::BrushInterpreter;
 pub use cmd_exe::CmdExeInterpreter;
 pub use nodejs::NodeJsInterpreter;
 pub use nushell::NuShellInterpreter;
@@ -38,6 +40,18 @@ pub enum InterpreterError {
     /// interpreter is not found
     #[error("IO Error: {0}")]
     ExecutionFailed(#[from] std::io::Error),
+
+    /// The interpreter executable could not be located.
+    #[error("interpreter '{0}' was not found in the build environment")]
+    InterpreterNotFound(String),
+}
+
+/// Where to look for an interpreter executable.
+pub enum InterpreterSearchScope {
+    /// Search the build prefix (if any), then fall back to the system PATH.
+    PrefixThenSystemPath,
+    /// Search only the build prefix; never the host prefix or system PATH.
+    BuildPrefixOnly,
 }
 
 pub const BASH_PREAMBLE: &str = r#"#!/usr/bin/env bash
@@ -64,8 +78,20 @@ fn find_interpreter(
     name: &str,
     build_prefix: Option<&PathBuf>,
     platform: &Platform,
+    scope: InterpreterSearchScope,
 ) -> Result<Option<PathBuf>, which::Error> {
     let exe_name = format!("{}{}", name, std::env::consts::EXE_SUFFIX);
+
+    // Build-prefix-only: search just the prefix bin entries, no PATH fallback.
+    if let InterpreterSearchScope::BuildPrefixOnly = scope {
+        let Some(build_prefix) = build_prefix else {
+            return Ok(None);
+        };
+        let prefix_path = prefix_path_entries(build_prefix, platform);
+        return Ok(
+            which::which_in_global(exe_name, std::env::join_paths(prefix_path).ok())?.next(),
+        );
+    }
 
     let path = std::env::var("PATH").unwrap_or_default();
     if let Some(build_prefix) = build_prefix {

--- a/crates/rattler_build_script/src/interpreter/nodejs.rs
+++ b/crates/rattler_build_script/src/interpreter/nodejs.rs
@@ -4,7 +4,10 @@ use rattler_conda_types::Platform;
 
 use crate::execution::{ExecutionArgs, ResolvedScriptContents};
 
-use super::{BashInterpreter, CmdExeInterpreter, Interpreter, InterpreterError, find_interpreter};
+use super::{
+    BashInterpreter, CmdExeInterpreter, Interpreter, InterpreterError, InterpreterSearchScope,
+    find_interpreter,
+};
 
 pub struct NodeJsInterpreter;
 
@@ -31,6 +34,11 @@ impl Interpreter for NodeJsInterpreter {
         build_prefix: Option<&PathBuf>,
         platform: &Platform,
     ) -> Result<Option<PathBuf>, which::Error> {
-        find_interpreter("node", build_prefix, platform)
+        find_interpreter(
+            "node",
+            build_prefix,
+            platform,
+            InterpreterSearchScope::PrefixThenSystemPath,
+        )
     }
 }

--- a/crates/rattler_build_script/src/interpreter/nushell.rs
+++ b/crates/rattler_build_script/src/interpreter/nushell.rs
@@ -9,7 +9,7 @@ use rattler_shell::{
 
 use crate::execution::{ExecutionArgs, run_process_with_replacements};
 
-use super::{Interpreter, InterpreterError, find_interpreter};
+use super::{Interpreter, InterpreterError, InterpreterSearchScope, find_interpreter};
 
 pub struct NuShellInterpreter;
 
@@ -108,18 +108,22 @@ impl Interpreter for NuShellInterpreter {
 
         let build_script_path_str = build_script_path.to_string_lossy().to_string();
 
-        let nu_path =
-            match find_interpreter("nu", args.build_prefix.as_ref(), &args.execution_platform) {
-                Ok(Some(path)) => path,
-                _ => {
-                    return Err(InterpreterError::ExecutionFailed(std::io::Error::new(
-                        std::io::ErrorKind::NotFound,
-                        "NuShell executable not found in PATH",
-                    )));
-                }
+        let nu_path = match find_interpreter(
+            "nu",
+            args.build_prefix.as_ref(),
+            &args.execution_platform,
+            InterpreterSearchScope::PrefixThenSystemPath,
+        ) {
+            Ok(Some(path)) => path,
+            _ => {
+                return Err(InterpreterError::ExecutionFailed(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "NuShell executable not found in PATH",
+                )));
             }
-            .to_string_lossy()
-            .to_string();
+        }
+        .to_string_lossy()
+        .to_string();
 
         let cmd_args = [nu_path.as_str(), build_script_path_str.as_str()];
 
@@ -155,6 +159,11 @@ impl Interpreter for NuShellInterpreter {
         build_prefix: Option<&PathBuf>,
         platform: &Platform,
     ) -> Result<Option<PathBuf>, which::Error> {
-        find_interpreter("nu", build_prefix, platform)
+        find_interpreter(
+            "nu",
+            build_prefix,
+            platform,
+            InterpreterSearchScope::PrefixThenSystemPath,
+        )
     }
 }

--- a/crates/rattler_build_script/src/interpreter/perl.rs
+++ b/crates/rattler_build_script/src/interpreter/perl.rs
@@ -4,7 +4,10 @@ use rattler_conda_types::Platform;
 
 use crate::execution::{ExecutionArgs, ResolvedScriptContents};
 
-use super::{BashInterpreter, CmdExeInterpreter, Interpreter, InterpreterError, find_interpreter};
+use super::{
+    BashInterpreter, CmdExeInterpreter, Interpreter, InterpreterError, InterpreterSearchScope,
+    find_interpreter,
+};
 
 pub struct PerlInterpreter;
 
@@ -31,6 +34,11 @@ impl Interpreter for PerlInterpreter {
         build_prefix: Option<&PathBuf>,
         platform: &Platform,
     ) -> Result<Option<PathBuf>, which::Error> {
-        find_interpreter("perl", build_prefix, platform)
+        find_interpreter(
+            "perl",
+            build_prefix,
+            platform,
+            InterpreterSearchScope::PrefixThenSystemPath,
+        )
     }
 }

--- a/crates/rattler_build_script/src/interpreter/powershell.rs
+++ b/crates/rattler_build_script/src/interpreter/powershell.rs
@@ -5,7 +5,10 @@ use rattler_conda_types::Platform;
 
 use crate::execution::ExecutionArgs;
 
-use super::{BashInterpreter, CmdExeInterpreter, Interpreter, InterpreterError, find_interpreter};
+use super::{
+    BashInterpreter, CmdExeInterpreter, Interpreter, InterpreterError, InterpreterSearchScope,
+    find_interpreter,
+};
 
 pub(crate) struct PowerShellInterpreter;
 
@@ -51,10 +54,14 @@ impl Interpreter for PowerShellInterpreter {
         // Try to find pwsh in the build prefix or system PATH for version checking.
         // The actual command used in the script may rely on the activation script
         // (build_env.sh) to put pwsh on PATH at runtime.
-        let pwsh_path =
-            find_interpreter("pwsh", args.build_prefix.as_ref(), &args.execution_platform)
-                .ok()
-                .flatten();
+        let pwsh_path = find_interpreter(
+            "pwsh",
+            args.build_prefix.as_ref(),
+            &args.execution_platform,
+            InterpreterSearchScope::PrefixThenSystemPath,
+        )
+        .ok()
+        .flatten();
 
         let (shell_cmd, new_enough) = match &pwsh_path {
             Some(path) => {
@@ -104,6 +111,11 @@ impl Interpreter for PowerShellInterpreter {
         build_prefix: Option<&PathBuf>,
         platform: &Platform,
     ) -> Result<Option<PathBuf>, which::Error> {
-        find_interpreter("pwsh", build_prefix, platform)
+        find_interpreter(
+            "pwsh",
+            build_prefix,
+            platform,
+            InterpreterSearchScope::PrefixThenSystemPath,
+        )
     }
 }

--- a/crates/rattler_build_script/src/interpreter/python.rs
+++ b/crates/rattler_build_script/src/interpreter/python.rs
@@ -4,7 +4,10 @@ use rattler_conda_types::Platform;
 
 use crate::execution::{ExecutionArgs, ResolvedScriptContents};
 
-use super::{BashInterpreter, CmdExeInterpreter, Interpreter, InterpreterError, find_interpreter};
+use super::{
+    BashInterpreter, CmdExeInterpreter, Interpreter, InterpreterError, InterpreterSearchScope,
+    find_interpreter,
+};
 
 pub struct PythonInterpreter;
 
@@ -31,6 +34,11 @@ impl Interpreter for PythonInterpreter {
         build_prefix: Option<&PathBuf>,
         platform: &Platform,
     ) -> Result<Option<PathBuf>, which::Error> {
-        find_interpreter("python", build_prefix, platform)
+        find_interpreter(
+            "python",
+            build_prefix,
+            platform,
+            InterpreterSearchScope::PrefixThenSystemPath,
+        )
     }
 }

--- a/crates/rattler_build_script/src/interpreter/r.rs
+++ b/crates/rattler_build_script/src/interpreter/r.rs
@@ -4,7 +4,10 @@ use rattler_conda_types::Platform;
 
 use crate::execution::{ExecutionArgs, ResolvedScriptContents};
 
-use super::{BashInterpreter, CmdExeInterpreter, Interpreter, InterpreterError, find_interpreter};
+use super::{
+    BashInterpreter, CmdExeInterpreter, Interpreter, InterpreterError, InterpreterSearchScope,
+    find_interpreter,
+};
 
 pub struct RInterpreter;
 
@@ -33,6 +36,11 @@ impl Interpreter for RInterpreter {
         build_prefix: Option<&PathBuf>,
         platform: &Platform,
     ) -> Result<Option<PathBuf>, which::Error> {
-        find_interpreter("Rscript", build_prefix, platform)
+        find_interpreter(
+            "Rscript",
+            build_prefix,
+            platform,
+            InterpreterSearchScope::PrefixThenSystemPath,
+        )
     }
 }

--- a/crates/rattler_build_script/src/interpreter/ruby.rs
+++ b/crates/rattler_build_script/src/interpreter/ruby.rs
@@ -4,7 +4,10 @@ use rattler_conda_types::Platform;
 
 use crate::execution::{ExecutionArgs, ResolvedScriptContents};
 
-use super::{BashInterpreter, CmdExeInterpreter, Interpreter, InterpreterError, find_interpreter};
+use super::{
+    BashInterpreter, CmdExeInterpreter, Interpreter, InterpreterError, InterpreterSearchScope,
+    find_interpreter,
+};
 
 pub struct RubyInterpreter;
 
@@ -31,6 +34,11 @@ impl Interpreter for RubyInterpreter {
         build_prefix: Option<&PathBuf>,
         platform: &Platform,
     ) -> Result<Option<PathBuf>, which::Error> {
-        find_interpreter("ruby", build_prefix, platform)
+        find_interpreter(
+            "ruby",
+            build_prefix,
+            platform,
+            InterpreterSearchScope::PrefixThenSystemPath,
+        )
     }
 }

--- a/docs/build_script.md
+++ b/docs/build_script.md
@@ -124,6 +124,25 @@ requirements:
     - nushell
 ```
 
+### Using `brush`
+
+[`brush`](https://github.com/reubeno/brush) is a bash-compatible shell written in Rust. Select it with `interpreter: brush`. Activation is handled by the native shell (`bash` on Unix, `cmd.exe` on Windows), which then invokes `brush` on your script, so existing bash scripts work unchanged across platforms.
+
+`brush` is always taken from the build environment, so it must be listed in `requirements/build`. A `brush` found on the system `PATH` is intentionally not used, which keeps builds reproducible.
+
+```yaml title="recipe.yaml"
+build:
+  script:
+    interpreter: brush
+    content: |
+      echo "Hello from brush!"
+
+# Note: `brush` must be in the `build` section of your recipe!
+requirements:
+  build:
+    - brush
+```
+
 ### Using `python`
 
 In order to use `python` you can select the `interpreter: python` or have a

--- a/test-data/recipes/brush-test/recipe.yaml
+++ b/test-data/recipes/brush-test/recipe.yaml
@@ -1,0 +1,16 @@
+package:
+  name: brush-test
+  version: 0.1.0
+
+build:
+  script:
+    # `brush` is a bash-compatible shell, so an ordinary bash script runs
+    # unchanged. The activated `$PREFIX` is inherited from the bash/cmd
+    # wrapper that performs activation before invoking brush.
+    interpreter: brush
+    content: |
+      echo "Hello from brush!" > "$PREFIX/hello.txt"
+
+requirements:
+  build:
+    - brush

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -1302,6 +1302,21 @@ def test_nushell_script_detection(
     assert "Hello, world!" == content
 
 
+def test_brush(rattler_build: RattlerBuild, recipes: Path, tmp_path: Path):
+    # Builds a recipe with `interpreter: brush`. `brush` is pulled from the
+    # build environment (requirements/build), the bash wrapper activates the
+    # environment, and brush then runs the bash-syntax script.
+    rattler_build.build(
+        recipes / "brush-test/recipe.yaml",
+        tmp_path,
+    )
+    pkg = get_extracted_package(tmp_path, "brush-test")
+
+    assert (pkg / "info/paths.json").exists()
+    content = (pkg / "hello.txt").read_text()
+    assert "Hello from brush!" == content.strip()
+
+
 def test_channel_specific(rattler_build: RattlerBuild, recipes: Path, tmp_path: Path):
     rattler_build.build(
         recipes / "channel_specific/recipe.yaml",


### PR DESCRIPTION
Adds support for [`brush`](https://github.com/reubeno/brush), a bash-compatible shell written in Rust, as a build script interpreter.

Recipes can now opt in with `interpreter: brush` and an ordinary bash script will run under brush instead of the system bash. This works the same way on Linux, macOS, and Windows.

```yaml
build:
  script:
    interpreter: brush
    content: |
      echo "Hello from brush!"
requirements:
  build:
    - brush
```

`brush` is taken from the build environment, so it must be listed in `requirements/build`. A `brush` found on the system is intentionally not used, which keeps builds reproducible. I explicitly used this instead of embedding brush itself into rattler-build (which is also possible) because I think this approach makes the recipe more reproducible and if we ever run things inside a container in the future this will work out of the box (e.g. if the build script itself is not run on the host). 

## Notes

- Documentation is updated with a "Using `brush`" section.
- An end-to-end test which also runs on windows builds a brush-based recipe and was verified against conda-forge.