### PR TITLE
refactor: streamline script interpreters through a native shell wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5092,6 +5092,7 @@ dependencies = [
  "rattler_shell",
  "serde",
  "serde_yaml",
+ "serial_test",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5092,7 +5092,6 @@ dependencies = [
  "rattler_shell",
  "serde",
  "serde_yaml",
- "serial_test",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/rattler_build_core/src/build.rs
+++ b/crates/rattler_build_core/src/build.rs
@@ -196,6 +196,14 @@ pub async fn run_build(
                 "interpreter `{interpreter}` was not found in the build environment"
             ));
         }
+        Err(InterpreterError::InvalidInterpreter {
+            interpreter,
+            reason,
+        }) => {
+            return Err(miette::miette!(
+                "interpreter `{interpreter}` was found but is not valid: {reason}"
+            ));
+        }
     }
 
     // Package all the new files

--- a/crates/rattler_build_core/src/package_test/serialize_test.rs
+++ b/crates/rattler_build_core/src/package_test/serialize_test.rs
@@ -172,8 +172,11 @@ pub(crate) fn write_test_files(
     // filtered out by conditionals (e.g. `if: not build_win`).
     tests.retain(|test| {
         if let TestType::Commands(cmd) = test {
-            let has_content =
-                !matches!(&cmd.script.content, ScriptContent::Command(s) if s.is_empty());
+            let has_content = match &cmd.script.content {
+                ScriptContent::Command(s) => !s.is_empty(),
+                ScriptContent::Commands(c) => !c.is_empty(),
+                _ => true,
+            };
             let has_requirements = !cmd.requirements.is_empty();
             let has_files = !cmd.files.is_empty();
             has_content || has_requirements || has_files

--- a/crates/rattler_build_core/src/package_test/serialize_test.rs
+++ b/crates/rattler_build_core/src/package_test/serialize_test.rs
@@ -157,6 +157,9 @@ pub(crate) fn write_test_files(
                     }
                     command_test.script.content = ScriptContent::Command(contents);
                 }
+                ResolvedScriptContents::Commands(commands) => {
+                    command_test.script.content = ScriptContent::Commands(commands);
+                }
                 ResolvedScriptContents::Missing => {
                     command_test.script.content = ScriptContent::Command("".to_string());
                 }

--- a/crates/rattler_build_core/src/script.rs
+++ b/crates/rattler_build_core/src/script.rs
@@ -6,11 +6,10 @@
 use indexmap::IndexMap;
 use minijinja::Value;
 use rattler_build_jinja::Jinja;
-use rattler_conda_types::Platform;
 
 // Re-export from rattler_build_script
 pub use rattler_build_script::{
-    ExecutionArgs, InterpreterError, ResolvedScriptContents, SandboxArguments,
+    ExecutionArgs, InterpreterError, ResolvedScriptContents, RuntimeEnv, SandboxArguments,
     SandboxConfiguration, Script, ScriptContent, platform_script_extensions,
 };
 
@@ -64,7 +63,7 @@ impl Output {
             secrets: IndexMap::new(),
             build_prefix: build_prefix.map(|p| p.to_owned()),
             run_prefix: host_prefix,
-            execution_platform: Platform::current(),
+            runtime: RuntimeEnv::current(),
             work_dir: work_dir.clone(),
             sandbox_config: self.build_configuration.sandbox_config().cloned(),
             env_isolation,

--- a/crates/rattler_build_core/src/script.rs
+++ b/crates/rattler_build_core/src/script.rs
@@ -51,6 +51,7 @@ impl Output {
 
         let work_dir = &self.build_configuration.directories.work_dir;
         Ok(ExecutionArgs {
+            interpreter: self.recipe.build().script.interpreter.clone(),
             script: self.recipe.build().script.resolve_content(
                 &self.build_configuration.directories.recipe_dir,
                 Some(jinja_renderer),

--- a/crates/rattler_build_script/Cargo.toml
+++ b/crates/rattler_build_script/Cargo.toml
@@ -55,4 +55,3 @@ tokio = { workspace = true, features = ["rt", "macros", "fs"] }
 insta = { workspace = true, features = ["yaml"] }
 serde_yaml = { workspace = true }
 tempfile = { workspace = true }
-serial_test = { workspace = true }

--- a/crates/rattler_build_script/Cargo.toml
+++ b/crates/rattler_build_script/Cargo.toml
@@ -55,3 +55,4 @@ tokio = { workspace = true, features = ["rt", "macros", "fs"] }
 insta = { workspace = true, features = ["yaml"] }
 serde_yaml = { workspace = true }
 tempfile = { workspace = true }
+serial_test = { workspace = true }

--- a/crates/rattler_build_script/src/activation.rs
+++ b/crates/rattler_build_script/src/activation.rs
@@ -64,3 +64,58 @@ pub(crate) fn activation_script<T: Shell + Clone + 'static>(
 
     Ok(shell_script.contents()?)
 }
+
+#[cfg(test)]
+mod tests {
+    use indexmap::IndexMap;
+    use rattler_conda_types::Platform;
+    use rattler_shell::shell;
+
+    use crate::execution::{EnvironmentIsolation, ExecutionArgs, ResolvedScriptContents};
+
+    /// When a build prefix is present, both the run prefix and build prefix are
+    /// activated and the generated script references both paths.
+    #[test]
+    fn activation_with_build_prefix_references_both_prefixes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let run_prefix = tmp.path().join("run_prefix");
+        let build_prefix = tmp.path().join("build_prefix");
+        fs_err::create_dir_all(&run_prefix).unwrap();
+        fs_err::create_dir_all(&build_prefix).unwrap();
+
+        let args = ExecutionArgs {
+            script: ResolvedScriptContents::Inline(String::new()),
+            interpreter: None,
+            env_vars: IndexMap::new(),
+            secrets: IndexMap::new(),
+            execution_platform: Platform::current(),
+            build_prefix: Some(build_prefix.clone()),
+            run_prefix: run_prefix.clone(),
+            work_dir: tmp.path().to_path_buf(),
+            sandbox_config: None,
+            env_isolation: EnvironmentIsolation::None,
+        };
+
+        let script = super::activation_script(&args, shell::Bash::default()).unwrap();
+
+        // Both activations are appended. The Bash activator emits paths with
+        // forward slashes (and may use a normalized temp root), so we assert on
+        // the stable trailing component of each prefix rather than the full
+        // platform display path. Distinct names prove both activations ran.
+        assert!(
+            script.contains("run_prefix"),
+            "activation script must reference the run prefix, got:\n{script}"
+        );
+        assert!(
+            script.contains("build_prefix"),
+            "activation script must reference the build prefix, got:\n{script}"
+        );
+        // The build activation must be appended in addition to the run
+        // activation: two separate PATH exports, one per prefix.
+        let path_exports = script.matches("export PATH=").count();
+        assert!(
+            path_exports >= 2,
+            "expected separate PATH exports for both prefixes, got {path_exports}:\n{script}"
+        );
+    }
+}

--- a/crates/rattler_build_script/src/activation.rs
+++ b/crates/rattler_build_script/src/activation.rs
@@ -6,7 +6,6 @@
 
 use std::collections::HashMap;
 
-use rattler_conda_types::Platform;
 use rattler_shell::{
     activation::{ActivationError, ActivationVariables, Activator, PathModificationBehavior},
     shell::{self, Shell},
@@ -19,23 +18,25 @@ pub(crate) fn activation_script<T: Shell + Clone + 'static>(
     args: &ExecutionArgs,
     shell_type: T,
 ) -> Result<String, ActivationError> {
-    let mut shell_script = shell::ShellScript::new(shell_type.clone(), Platform::current());
+    let platform = args.runtime.platform();
+    let mut shell_script = shell::ShellScript::new(shell_type.clone(), platform);
     for (k, v) in args.env_vars.iter() {
         shell_script.set_env_var(k, v)?;
     }
     // Re-entrancy marker: this way the preamble sources this file
     // once and nested shells skip re-sourcing it.
     shell_script.set_env_var("CONDA_BUILD", "1")?;
-    let host_prefix_activator = Activator::from_path(
-        &args.run_prefix,
-        shell_type.clone(),
-        args.execution_platform,
-    )?;
+    let host_prefix_activator =
+        Activator::from_path(&args.run_prefix, shell_type.clone(), platform)?;
 
     // Do not pass the host CONDA_PREFIX to the activation. When
     // CONDA_PREFIX is set (e.g. running inside a pixi/conda env), the
     // activator generates deactivation scripts for that environment.
-    let current_env = std::env::vars().collect::<HashMap<_, _>>();
+    let current_env = args
+        .runtime
+        .vars()
+        .map(|(k, v)| (k.to_owned(), v.to_owned()))
+        .collect::<HashMap<_, _>>();
     let activation_vars = ActivationVariables {
         conda_prefix: None,
         path: None,
@@ -47,7 +48,7 @@ pub(crate) fn activation_script<T: Shell + Clone + 'static>(
 
     if let Some(build_prefix) = &args.build_prefix {
         let build_prefix_activator =
-            Activator::from_path(build_prefix, shell_type.clone(), args.execution_platform)?;
+            Activator::from_path(build_prefix, shell_type.clone(), platform)?;
         let activation_vars = ActivationVariables {
             conda_prefix: None,
             path: None,
@@ -72,6 +73,7 @@ mod tests {
     use rattler_shell::shell;
 
     use crate::execution::{EnvironmentIsolation, ExecutionArgs, ResolvedScriptContents};
+    use crate::runtime::RuntimeEnv;
 
     /// When a build prefix is present, both the run prefix and build prefix are
     /// activated and the generated script references both paths.
@@ -88,7 +90,7 @@ mod tests {
             interpreter: None,
             env_vars: IndexMap::new(),
             secrets: IndexMap::new(),
-            execution_platform: Platform::current(),
+            runtime: RuntimeEnv::for_test(Platform::current()),
             build_prefix: Some(build_prefix.clone()),
             run_prefix: run_prefix.clone(),
             work_dir: tmp.path().to_path_buf(),

--- a/crates/rattler_build_script/src/activation.rs
+++ b/crates/rattler_build_script/src/activation.rs
@@ -1,0 +1,66 @@
+//! Prefix activation script generation.
+//!
+//! This module creates the shell-specific `build_env.*` content that activates
+//! the run prefix and, when present, the build prefix before user script code
+//! runs.
+
+use std::collections::HashMap;
+
+use rattler_conda_types::Platform;
+use rattler_shell::{
+    activation::{ActivationError, ActivationVariables, Activator, PathModificationBehavior},
+    shell::{self, Shell},
+};
+
+use crate::execution::ExecutionArgs;
+
+/// Returns the shell-specific activation script sourced/called by the native wrapper.
+pub(crate) fn activation_script<T: Shell + Clone + 'static>(
+    args: &ExecutionArgs,
+    shell_type: T,
+) -> Result<String, ActivationError> {
+    let mut shell_script = shell::ShellScript::new(shell_type.clone(), Platform::current());
+    for (k, v) in args.env_vars.iter() {
+        shell_script.set_env_var(k, v)?;
+    }
+    // Re-entrancy marker: this way the preamble sources this file
+    // once and nested shells skip re-sourcing it.
+    shell_script.set_env_var("CONDA_BUILD", "1")?;
+    let host_prefix_activator = Activator::from_path(
+        &args.run_prefix,
+        shell_type.clone(),
+        args.execution_platform,
+    )?;
+
+    // Do not pass the host CONDA_PREFIX to the activation. When
+    // CONDA_PREFIX is set (e.g. running inside a pixi/conda env), the
+    // activator generates deactivation scripts for that environment.
+    let current_env = std::env::vars().collect::<HashMap<_, _>>();
+    let activation_vars = ActivationVariables {
+        conda_prefix: None,
+        path: None,
+        path_modification_behavior: PathModificationBehavior::Prepend,
+        current_env: current_env.clone(),
+    };
+
+    let host_activation = host_prefix_activator.activation(activation_vars)?;
+
+    if let Some(build_prefix) = &args.build_prefix {
+        let build_prefix_activator =
+            Activator::from_path(build_prefix, shell_type.clone(), args.execution_platform)?;
+        let activation_vars = ActivationVariables {
+            conda_prefix: None,
+            path: None,
+            path_modification_behavior: PathModificationBehavior::Prepend,
+            current_env: current_env.clone(),
+        };
+
+        let build_activation = build_prefix_activator.activation(activation_vars)?;
+        shell_script.append_script(&host_activation.script);
+        shell_script.append_script(&build_activation.script);
+    } else {
+        shell_script.append_script(&host_activation.script);
+    }
+
+    Ok(shell_script.contents()?)
+}

--- a/crates/rattler_build_script/src/execution.rs
+++ b/crates/rattler_build_script/src/execution.rs
@@ -4,13 +4,13 @@
 //! [`generate_build_script`], executes them with [`run_script`], and provides
 //! subprocess output handling via [`run_process_with_replacements`].
 
+use crate::runtime::RuntimeEnv;
 use crate::sandbox::SandboxConfiguration;
 use crate::script::{Script, ScriptContent};
 use fs_err as fs;
 use futures::TryStreamExt;
 use indexmap::IndexMap;
 use itertools::Itertools;
-use rattler_conda_types::Platform;
 use rattler_shell::shell::Shell;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -82,8 +82,9 @@ pub struct ExecutionArgs {
     /// Secrets to set as env vars and replace in the output
     pub secrets: IndexMap<String, String>,
 
-    /// The platform on which the script should be executed
-    pub execution_platform: Platform,
+    /// The environment rattler-build is running in: process environment
+    /// variables (including `PATH`) and the platform scripts execute on.
+    pub runtime: RuntimeEnv,
 
     /// The build prefix that should contain the interpreter to use
     pub build_prefix: Option<PathBuf>,
@@ -209,14 +210,16 @@ impl Script {
             crate::platform_script_extensions(),
         )?;
 
+        let runtime = RuntimeEnv::current();
+
         let secrets = self
             .secrets()
             .iter()
             .filter_map(|k| {
                 let secret = k.to_string();
 
-                if let Ok(value) = std::env::var(&secret) {
-                    Some((secret, value))
+                if let Some(value) = runtime.var(&secret) {
+                    Some((secret, value.to_string()))
                 } else {
                     tracing::warn!("Secret {} not found in environment", secret);
                     None
@@ -239,7 +242,7 @@ impl Script {
             secrets,
             build_prefix: build_prefix.map(|p| p.to_owned()),
             run_prefix: run_prefix.to_owned(),
-            execution_platform: Platform::current(),
+            runtime,
             work_dir,
             sandbox_config: sandbox_config.cloned(),
             env_isolation,
@@ -483,7 +486,7 @@ pub(crate) async fn generate_build_script(
         // user-facing errors even when the executable has a different name
         // (e.g. `nu`).
         let prefix = args.build_prefix.as_ref().or(Some(&args.run_prefix));
-        let executable = interpreter.resolve_executable(prefix, &args.execution_platform)?;
+        let executable = interpreter.resolve_executable(prefix, &args.runtime)?;
 
         let mut command = vec![executable.to_string_lossy().into_owned()];
         command.extend(interpreter.args(&script_path));
@@ -535,6 +538,7 @@ pub(crate) async fn run_script(exec_args: ExecutionArgs) -> Result<(), crate::In
         } else {
             None
         },
+        &exec_args.runtime,
     )
     .await?;
 
@@ -579,9 +583,11 @@ pub async fn create_build_script(exec_args: ExecutionArgs) -> Result<(), std::io
     Ok(())
 }
 
-/// Finds the rattler-sandbox executable in PATH.
-fn find_rattler_sandbox() -> Option<PathBuf> {
-    which::which("rattler-sandbox").ok()
+/// Finds the rattler-sandbox executable on the runtime `PATH`.
+fn find_rattler_sandbox(runtime: &RuntimeEnv) -> Option<PathBuf> {
+    which::which_in_global("rattler-sandbox", Some(runtime.path()))
+        .ok()?
+        .next()
 }
 
 /// Environment variables that are passed through from the host environment
@@ -643,6 +649,7 @@ fn configure_subprocess_env(
     env_vars: &IndexMap<String, String>,
     secrets: &IndexMap<String, String>,
     env_isolation: EnvironmentIsolation,
+    runtime: &RuntimeEnv,
 ) {
     match env_isolation {
         EnvironmentIsolation::Strict | EnvironmentIsolation::CondaBuild => {
@@ -652,7 +659,7 @@ fn configure_subprocess_env(
                 .iter()
                 .chain(PLATFORM_PASSTHROUGH_ENV_VARS)
             {
-                if let Ok(value) = std::env::var(var) {
+                if let Some(value) = runtime.var(var) {
                     command.env(var, value);
                 }
             }
@@ -668,6 +675,7 @@ fn configure_subprocess_env(
 
 /// Spawns a process and replaces the given strings in the output with the given replacements.
 /// This is used to replace the host prefix with $PREFIX and the build prefix with $BUILD_PREFIX
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn run_process_with_replacements(
     args: &[&str],
     cwd: &Path,
@@ -676,6 +684,7 @@ pub(crate) async fn run_process_with_replacements(
     secrets: &IndexMap<String, String>,
     env_isolation: EnvironmentIsolation,
     sandbox_config: Option<&SandboxConfiguration>,
+    runtime: &RuntimeEnv,
 ) -> Result<std::process::Output, std::io::Error> {
     // Create or open the build log file
     let log_file_path = cwd.join("conda_build.log");
@@ -688,7 +697,7 @@ pub(crate) async fn run_process_with_replacements(
         tracing::info!("{}", sandbox_config);
 
         // Try to find rattler-sandbox executable
-        if let Some(sandbox_exe) = find_rattler_sandbox() {
+        if let Some(sandbox_exe) = find_rattler_sandbox(runtime) {
             let mut cmd = tokio::process::Command::new(sandbox_exe);
 
             // Add sandbox configuration arguments
@@ -712,7 +721,7 @@ pub(crate) async fn run_process_with_replacements(
         tokio::process::Command::new(args[0])
     };
 
-    configure_subprocess_env(&mut command, env_vars, secrets, env_isolation);
+    configure_subprocess_env(&mut command, env_vars, secrets, env_isolation, runtime);
 
     command
         .current_dir(cwd)
@@ -801,6 +810,7 @@ pub(crate) async fn run_process_with_replacements(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rattler_conda_types::Platform;
     use tokio_util::bytes::BytesMut;
 
     /// `CONDA_BUILD=1` must live inside the sourced activation script so that
@@ -818,7 +828,7 @@ mod tests {
             interpreter: None,
             env_vars: IndexMap::new(),
             secrets: IndexMap::new(),
-            execution_platform: Platform::current(),
+            runtime: RuntimeEnv::for_test(Platform::current()),
             build_prefix: None,
             run_prefix: prefix,
             work_dir: tmp.path().to_path_buf(),
@@ -846,6 +856,7 @@ mod tests {
             &env_vars,
             &secrets,
             EnvironmentIsolation::None,
+            &RuntimeEnv::for_test(Platform::current()),
         );
 
         assert!(
@@ -1108,7 +1119,7 @@ mod tests {
             interpreter: interpreter.map(str::to_string),
             env_vars: IndexMap::new(),
             secrets: IndexMap::new(),
-            execution_platform: Platform::current(),
+            runtime: RuntimeEnv::current(),
             build_prefix: None,
             run_prefix,
             work_dir,
@@ -1119,17 +1130,13 @@ mod tests {
 
     /// In Strict mode the subprocess env is cleared, only the passthrough
     /// whitelist is forwarded from the host, and explicit env_vars + secrets are
-    /// applied on top.
+    /// applied on top. The host vars are injected through `RuntimeEnv`, so the
+    /// test does not touch the real process environment.
     #[test]
-    #[serial_test::serial]
     fn test_strict_env_clear_and_passthrough_whitelist() {
-        let original_random = std::env::var_os("RB_TEST_RANDOM_VAR");
-        let original_ssl = std::env::var_os("SSL_CERT_FILE");
-        // SAFETY: env mutation is serialized via #[serial] and restored below.
-        unsafe {
-            std::env::set_var("RB_TEST_RANDOM_VAR", "should-not-leak");
-            std::env::set_var("SSL_CERT_FILE", "/host/cacert.pem");
-        }
+        let runtime = RuntimeEnv::for_test(Platform::current())
+            .with_var("RB_TEST_RANDOM_VAR", "should-not-leak")
+            .with_var("SSL_CERT_FILE", "/host/cacert.pem");
 
         let mut env_vars = IndexMap::new();
         env_vars.insert("EXPLICIT_VAR".to_string(), "explicit".to_string());
@@ -1138,7 +1145,7 @@ mod tests {
 
         let collect_envs = |isolation: EnvironmentIsolation| {
             let mut command = tokio::process::Command::new("true");
-            configure_subprocess_env(&mut command, &env_vars, &secrets, isolation);
+            configure_subprocess_env(&mut command, &env_vars, &secrets, isolation, &runtime);
             command
                 .as_std()
                 .get_envs()
@@ -1179,18 +1186,6 @@ mod tests {
             conda_build.get("SSL_CERT_FILE").map(String::as_str),
             Some("/host/cacert.pem")
         );
-
-        // SAFETY: env mutation is serialized via #[serial].
-        unsafe {
-            match original_random {
-                Some(v) => std::env::set_var("RB_TEST_RANDOM_VAR", v),
-                None => std::env::remove_var("RB_TEST_RANDOM_VAR"),
-            }
-            match original_ssl {
-                Some(v) => std::env::set_var("SSL_CERT_FILE", v),
-                None => std::env::remove_var("SSL_CERT_FILE"),
-            }
-        }
     }
 
     /// The PowerShell prologue is written verbatim into the generated script

--- a/crates/rattler_build_script/src/execution.rs
+++ b/crates/rattler_build_script/src/execution.rs
@@ -104,7 +104,7 @@ impl ExecutionArgs {
     /// Returns strings that should be replaced. The template argument can be used to specify
     /// a nice "variable" syntax, e.g. "$((var))" for bash or "%((var))%" for cmd.exe. The `var` part
     /// will be replaced with the actual variable name.
-    pub fn replacements(&self, template: &str) -> HashMap<String, String> {
+    pub(crate) fn replacements(&self, template: &str) -> HashMap<String, String> {
         let mut replacements = HashMap::new();
         if let Some(build_prefix) = &self.build_prefix {
             replacements.insert(
@@ -167,7 +167,7 @@ impl ResolvedScriptContents {
     }
 
     /// Determine interpreter based on file extension from the path
-    pub fn infer_interpreter(&self) -> Option<String> {
+    pub(crate) fn infer_interpreter(&self) -> Option<String> {
         self.path()
             .and_then(crate::script::determine_interpreter_from_path)
     }
@@ -369,7 +369,7 @@ impl Script {
 }
 
 /// An AsyncRead wrapper that replaces carriage return (\r) bytes with newline (\n) bytes.
-pub fn normalize_crlf<R: AsyncRead + Unpin>(reader: R) -> impl AsyncRead + Unpin {
+pub(crate) fn normalize_crlf<R: AsyncRead + Unpin>(reader: R) -> impl AsyncRead + Unpin {
     FramedRead::new(reader, CrLfNormalizer::default())
         .into_async_read()
         .compat()
@@ -377,8 +377,8 @@ pub fn normalize_crlf<R: AsyncRead + Unpin>(reader: R) -> impl AsyncRead + Unpin
 
 /// Codec that normalizes CR and CRLF to LF
 #[derive(Default)]
-pub struct CrLfNormalizer {
-    last_was_cr: bool,
+pub(crate) struct CrLfNormalizer {
+    pub(crate) last_was_cr: bool,
 }
 
 impl Decoder for CrLfNormalizer {
@@ -418,20 +418,15 @@ impl Decoder for CrLfNormalizer {
     }
 }
 
-#[derive(Debug)]
-pub struct GeneratedBuildScript {
-    pub build_script_path: PathBuf,
-}
-
-/// Returns the generated native build wrapper and any interpreter script file.
+/// Returns the path to the generated native build wrapper script.
 ///
 /// If `args.interpreter` is set, or if the resolved script path has a known
 /// interpreter extension, inline script text is written to a separate file and
 /// the native wrapper invokes the resolved interpreter with that file. Otherwise
 /// the script contents are appended directly to the native wrapper.
-pub async fn generate_build_script(
+pub(crate) async fn generate_build_script(
     args: &ExecutionArgs,
-) -> Result<GeneratedBuildScript, crate::InterpreterError> {
+) -> Result<PathBuf, crate::InterpreterError> {
     let runner = crate::native_runner::native_runner();
     let shell = runner.shell();
 
@@ -459,43 +454,39 @@ pub async fn generate_build_script(
         .or_else(|| args.script.infer_interpreter());
 
     let body = if let Some(user_interpreter) = explicit_or_inferred {
-        let invocation =
-            crate::interpreter::interpreter_invocation(&user_interpreter).ok_or_else(|| {
-                std::io::Error::other(format!("Unsupported interpreter: {user_interpreter}"))
-            })?;
+        let interpreter =
+            crate::interpreter::SelectedInterpreter::from_recipe_name(&user_interpreter)
+                .ok_or_else(|| {
+                    std::io::Error::other(format!("Unsupported interpreter: {user_interpreter}"))
+                })?;
 
         let script_path = match &args.script {
             ResolvedScriptContents::Path(path, _) => path.clone(),
             ResolvedScriptContents::Inline(script) => {
                 let path = args
                     .work_dir
-                    .join(format!("conda_build_script.{}", invocation.extension()));
-                tokio::fs::write(&path, invocation.script_contents(script)).await?;
+                    .join(format!("conda_build_script.{}", interpreter.extension()));
+                tokio::fs::write(&path, interpreter.script_contents(script)).await?;
                 path
             }
             ResolvedScriptContents::Missing => {
                 let path = args
                     .work_dir
-                    .join(format!("conda_build_script.{}", invocation.extension()));
-                tokio::fs::write(&path, invocation.script_contents("")).await?;
+                    .join(format!("conda_build_script.{}", interpreter.extension()));
+                tokio::fs::write(&path, interpreter.script_contents("")).await?;
                 path
             }
         };
 
-        // Search the build environment for the executable described by the
-        // invocation. `user_interpreter` is the recipe value (e.g. `nushell`),
-        // which is preserved for user-facing errors even when the executable
-        // has a different name (e.g. `nu`).
+        // Search the build environment for the executable. The selected
+        // interpreter preserves the recipe value (e.g. `nushell`) for
+        // user-facing errors even when the executable has a different name
+        // (e.g. `nu`).
         let prefix = args.build_prefix.as_ref().or(Some(&args.run_prefix));
-        let executable = crate::interpreter::resolve_interpreter_executable(
-            prefix,
-            &args.execution_platform,
-            &user_interpreter,
-            invocation.as_ref(),
-        )?;
+        let executable = interpreter.resolve_executable(prefix, &args.execution_platform)?;
 
         let mut command = vec![executable.to_string_lossy().into_owned()];
-        command.extend(invocation.args(&script_path));
+        command.extend(interpreter.args(&script_path));
         let command_refs = command.iter().map(String::as_str).collect::<Vec<_>>();
         let mut body = String::new();
         shell
@@ -522,14 +513,14 @@ pub async fn generate_build_script(
         }
     }
 
-    Ok(GeneratedBuildScript { build_script_path })
+    Ok(build_script_path)
 }
 
 /// Runs a script with the given execution arguments.
-pub async fn run_script(exec_args: ExecutionArgs) -> Result<(), crate::InterpreterError> {
+pub(crate) async fn run_script(exec_args: ExecutionArgs) -> Result<(), crate::InterpreterError> {
     let runner = crate::native_runner::native_runner();
-    let generated = generate_build_script(&exec_args).await?;
-    let build_script_path_str = generated.build_script_path.to_string_lossy().to_string();
+    let build_script_path = generate_build_script(&exec_args).await?;
+    let build_script_path_str = build_script_path.to_string_lossy().to_string();
     let cmd_args = runner.command_to_run_script(&build_script_path_str);
 
     let output = crate::execution::run_process_with_replacements(
@@ -549,7 +540,11 @@ pub async fn run_script(exec_args: ExecutionArgs) -> Result<(), crate::Interpret
 
     if !output.status.success() {
         let status_code = output.status.code().unwrap_or(1);
-        let debug_info = runner.debug_info(&exec_args);
+        let debug_info = runner.debug_info(
+            &exec_args.work_dir,
+            &exec_args.run_prefix,
+            exec_args.build_prefix.as_deref(),
+        );
         tracing::error!("Script failed with status {}", status_code);
         tracing::error!("{}", debug_info);
         return Err(crate::InterpreterError::ExecutionFailed(
@@ -565,7 +560,7 @@ pub async fn run_script(exec_args: ExecutionArgs) -> Result<(), crate::Interpret
 
 /// Creates build script files without executing them.
 pub async fn create_build_script(exec_args: ExecutionArgs) -> Result<(), std::io::Error> {
-    let generated = generate_build_script(&exec_args)
+    let build_script_path = generate_build_script(&exec_args)
         .await
         .map_err(|err| match err {
             crate::InterpreterError::ExecutionFailed(err) => err,
@@ -580,10 +575,7 @@ pub async fn create_build_script(exec_args: ExecutionArgs) -> Result<(), std::io
             )),
         })?;
 
-    tracing::info!(
-        "Build script created at {}",
-        generated.build_script_path.display()
-    );
+    tracing::info!("Build script created at {}", build_script_path.display());
     Ok(())
 }
 
@@ -676,7 +668,7 @@ fn configure_subprocess_env(
 
 /// Spawns a process and replaces the given strings in the output with the given replacements.
 /// This is used to replace the host prefix with $PREFIX and the build prefix with $BUILD_PREFIX
-pub async fn run_process_with_replacements(
+pub(crate) async fn run_process_with_replacements(
     args: &[&str],
     cwd: &Path,
     replacements: &HashMap<String, String>,
@@ -1082,5 +1074,225 @@ mod tests {
             .unwrap()
             .to_owned();
         assert_eq!(ext, if cfg!(windows) { "bat" } else { "sh" });
+    }
+
+    use rattler_shell::activation::prefix_path_entries;
+
+    /// Mirrors the interpreter-module test helper: places a 0-byte executable in
+    /// the prefix's bin directory and returns its path.
+    fn create_fake_executable(prefix: &Path, name: &str) -> PathBuf {
+        let exe_name = format!("{}{}", name, std::env::consts::EXE_SUFFIX);
+        let bin_dir = prefix_path_entries(prefix, &Platform::current())
+            .into_iter()
+            .next()
+            .expect("prefix has executable path entries");
+        fs::create_dir_all(&bin_dir).unwrap();
+        let exe = bin_dir.join(exe_name);
+        fs::write(&exe, "").unwrap();
+        #[cfg(unix)]
+        {
+            use std::{fs::Permissions, os::unix::fs::PermissionsExt};
+            fs::set_permissions(&exe, Permissions::from_mode(0o755)).unwrap();
+        }
+        exe
+    }
+
+    fn execution_args(
+        work_dir: PathBuf,
+        run_prefix: PathBuf,
+        script: ResolvedScriptContents,
+        interpreter: Option<&str>,
+    ) -> ExecutionArgs {
+        ExecutionArgs {
+            script,
+            interpreter: interpreter.map(str::to_string),
+            env_vars: IndexMap::new(),
+            secrets: IndexMap::new(),
+            execution_platform: Platform::current(),
+            build_prefix: None,
+            run_prefix,
+            work_dir,
+            sandbox_config: None,
+            env_isolation: EnvironmentIsolation::None,
+        }
+    }
+
+    /// In Strict mode the subprocess env is cleared, only the passthrough
+    /// whitelist is forwarded from the host, and explicit env_vars + secrets are
+    /// applied on top.
+    #[test]
+    #[serial_test::serial]
+    fn test_strict_env_clear_and_passthrough_whitelist() {
+        let original_random = std::env::var_os("RB_TEST_RANDOM_VAR");
+        let original_ssl = std::env::var_os("SSL_CERT_FILE");
+        // SAFETY: env mutation is serialized via #[serial] and restored below.
+        unsafe {
+            std::env::set_var("RB_TEST_RANDOM_VAR", "should-not-leak");
+            std::env::set_var("SSL_CERT_FILE", "/host/cacert.pem");
+        }
+
+        let mut env_vars = IndexMap::new();
+        env_vars.insert("EXPLICIT_VAR".to_string(), "explicit".to_string());
+        let mut secrets = IndexMap::new();
+        secrets.insert("SECRET_VAR".to_string(), "secret".to_string());
+
+        let collect_envs = |isolation: EnvironmentIsolation| {
+            let mut command = tokio::process::Command::new("true");
+            configure_subprocess_env(&mut command, &env_vars, &secrets, isolation);
+            command
+                .as_std()
+                .get_envs()
+                .filter_map(|(k, v)| {
+                    v.map(|v| {
+                        (
+                            k.to_string_lossy().into_owned(),
+                            v.to_string_lossy().into_owned(),
+                        )
+                    })
+                })
+                .collect::<HashMap<String, String>>()
+        };
+
+        let strict = collect_envs(EnvironmentIsolation::Strict);
+        assert!(
+            !strict.contains_key("RB_TEST_RANDOM_VAR"),
+            "non-whitelisted host var must be absent in Strict mode"
+        );
+        assert_eq!(
+            strict.get("SSL_CERT_FILE").map(String::as_str),
+            Some("/host/cacert.pem"),
+            "whitelisted host var must be passed through"
+        );
+        assert_eq!(
+            strict.get("EXPLICIT_VAR").map(String::as_str),
+            Some("explicit")
+        );
+        assert_eq!(strict.get("SECRET_VAR").map(String::as_str), Some("secret"));
+
+        // CondaBuild also clears the env and applies the same whitelist.
+        let conda_build = collect_envs(EnvironmentIsolation::CondaBuild);
+        assert!(
+            !conda_build.contains_key("RB_TEST_RANDOM_VAR"),
+            "non-whitelisted host var must be absent in CondaBuild mode"
+        );
+        assert_eq!(
+            conda_build.get("SSL_CERT_FILE").map(String::as_str),
+            Some("/host/cacert.pem")
+        );
+
+        // SAFETY: env mutation is serialized via #[serial].
+        unsafe {
+            match original_random {
+                Some(v) => std::env::set_var("RB_TEST_RANDOM_VAR", v),
+                None => std::env::remove_var("RB_TEST_RANDOM_VAR"),
+            }
+            match original_ssl {
+                Some(v) => std::env::set_var("SSL_CERT_FILE", v),
+                None => std::env::remove_var("SSL_CERT_FILE"),
+            }
+        }
+    }
+
+    /// The PowerShell prologue is written verbatim into the generated script
+    /// file for an inline body.
+    #[tokio::test]
+    async fn test_powershell_prologue_written_into_script_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let prefix = tmp.path().join("prefix");
+        fs::create_dir_all(&prefix).unwrap();
+        // The fake pwsh is 0 bytes; `is_pwsh_new_enough` will fail to parse a
+        // version and only warn, so resolution still succeeds.
+        create_fake_executable(&prefix, "pwsh");
+
+        let args = execution_args(
+            tmp.path().to_path_buf(),
+            prefix,
+            ResolvedScriptContents::Inline("Write-Output 'hi'".to_string()),
+            Some("powershell"),
+        );
+
+        generate_build_script(&args).await.unwrap();
+
+        let script_file = tmp.path().join("conda_build_script.ps1");
+        let contents = fs::read_to_string(&script_file).unwrap();
+        assert!(
+            contents.contains("$ErrorActionPreference = 'Stop'"),
+            "missing ErrorActionPreference, got:\n{contents}"
+        );
+        assert!(
+            contents.contains("$PSNativeCommandUseErrorActionPreference"),
+            "missing PSNativeCommandUseErrorActionPreference, got:\n{contents}"
+        );
+        assert!(
+            contents.contains("Write-Output 'hi'"),
+            "user body must be appended after the prologue"
+        );
+    }
+
+    /// `create_build_script` maps `InterpreterNotFound` to an io::Error whose
+    /// message mentions the build environment.
+    #[tokio::test]
+    async fn test_create_build_script_missing_interpreter_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let prefix = tmp.path().join("prefix");
+        fs::create_dir_all(&prefix).unwrap();
+
+        let args = execution_args(
+            tmp.path().to_path_buf(),
+            prefix,
+            ResolvedScriptContents::Inline("print('hi')".to_string()),
+            Some("python"),
+        );
+
+        let err = create_build_script(args).await.unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("was not found in the build environment"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// An unsupported interpreter name surfaces as an `Unsupported interpreter`
+    /// io::Error.
+    #[tokio::test]
+    async fn test_create_build_script_unsupported_interpreter_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let prefix = tmp.path().join("prefix");
+        fs::create_dir_all(&prefix).unwrap();
+
+        let args = execution_args(
+            tmp.path().to_path_buf(),
+            prefix,
+            ResolvedScriptContents::Inline("noop".to_string()),
+            Some("not-a-real-interp"),
+        );
+
+        let err = create_build_script(args).await.unwrap_err();
+        assert!(
+            err.to_string().contains("Unsupported interpreter"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// `EnvironmentIsolation` round-trips between `FromStr` and `Display`, and an
+    /// unknown value errors with the documented message.
+    #[test]
+    fn test_environment_isolation_round_trip() {
+        use std::str::FromStr;
+
+        for (text, value) in [
+            ("strict", EnvironmentIsolation::Strict),
+            ("conda-build", EnvironmentIsolation::CondaBuild),
+            ("none", EnvironmentIsolation::None),
+        ] {
+            assert_eq!(EnvironmentIsolation::from_str(text).unwrap(), value);
+            assert_eq!(value.to_string(), text);
+        }
+
+        let err = EnvironmentIsolation::from_str("bogus").unwrap_err();
+        assert!(
+            err.contains("unknown environment isolation mode 'bogus'"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/crates/rattler_build_script/src/execution.rs
+++ b/crates/rattler_build_script/src/execution.rs
@@ -1,4 +1,8 @@
 //! Script execution types and utilities.
+//!
+//! This module resolves script contents, generates build scripts with
+//! [`generate_build_script`], executes them with [`run_script`], and provides
+//! subprocess output handling via [`run_process_with_replacements`].
 
 use crate::sandbox::SandboxConfiguration;
 use crate::script::{Script, ScriptContent};
@@ -7,6 +11,7 @@ use futures::TryStreamExt;
 use indexmap::IndexMap;
 use itertools::Itertools;
 use rattler_conda_types::Platform;
+use rattler_shell::shell::Shell;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt;
@@ -70,6 +75,8 @@ impl std::str::FromStr for EnvironmentIsolation {
 pub struct ExecutionArgs {
     /// Contents of the script to execute
     pub script: ResolvedScriptContents,
+    /// Explicit interpreter requested for the script, if any.
+    pub interpreter: Option<String>,
     /// Environment variables to set before executing the script
     pub env_vars: IndexMap<String, String>,
     /// Secrets to set as env vars and replace in the output
@@ -225,22 +232,9 @@ impl Script {
 
         tracing::debug!("Running script in {}", work_dir.display());
 
-        // Determine the interpreter to use:
-        // 1. Use explicitly specified interpreter if set
-        // 2. Try to infer from the resolved script path (if it's a file)
-        // 3. Finally fall back to platform default (bash/cmd)
-        let inferred_interpreter = contents.infer_interpreter();
-        let interpreter = if self.interpreter.is_some() {
-            self.interpreter()
-        } else if let Some(ref inferred) = inferred_interpreter {
-            tracing::debug!("Inferred interpreter '{}' from script file path", inferred);
-            inferred.as_str()
-        } else {
-            self.interpreter()
-        };
-
         let exec_args = ExecutionArgs {
             script: contents,
+            interpreter: self.interpreter.clone(),
             env_vars,
             secrets,
             build_prefix: build_prefix.map(|p| p.to_owned()),
@@ -251,7 +245,7 @@ impl Script {
             env_isolation,
         };
 
-        crate::execution::run_script(exec_args, interpreter).await?;
+        crate::execution::run_script(exec_args).await?;
 
         Ok(())
     }
@@ -424,85 +418,176 @@ impl Decoder for CrLfNormalizer {
     }
 }
 
-use crate::interpreter::{
-    BASH_PREAMBLE, BashInterpreter, BrushInterpreter, CMDEXE_PREAMBLE, CmdExeInterpreter,
-    Interpreter, NodeJsInterpreter, NuShellInterpreter, PerlInterpreter, PowerShellInterpreter,
-    PythonInterpreter, RInterpreter, RubyInterpreter,
-};
-use rattler_shell::shell;
-
-/// Run a script with the given execution arguments and interpreter
-pub async fn run_script(
-    exec_args: ExecutionArgs,
-    interpreter: &str,
-) -> Result<(), crate::InterpreterError> {
-    match interpreter {
-        "nushell" | "nu" => NuShellInterpreter.run(exec_args).await?,
-        "bash" => BashInterpreter.run(exec_args).await?,
-        "brush" => BrushInterpreter.run(exec_args).await?,
-        "cmd" => CmdExeInterpreter.run(exec_args).await?,
-        "python" => PythonInterpreter.run(exec_args).await?,
-        "perl" => PerlInterpreter.run(exec_args).await?,
-        "rscript" => RInterpreter.run(exec_args).await?,
-        "ruby" => RubyInterpreter.run(exec_args).await?,
-        "node" | "nodejs" => NodeJsInterpreter.run(exec_args).await?,
-        "powershell" => PowerShellInterpreter.run(exec_args).await?,
-        _ => {
-            return Err(
-                std::io::Error::other(format!("Unsupported interpreter: {}", interpreter)).into(),
-            );
-        }
-    };
-
-    Ok(())
+#[derive(Debug)]
+pub struct GeneratedBuildScript {
+    pub build_script_path: PathBuf,
 }
 
-/// Create build script files without executing them
-pub async fn create_build_script(exec_args: ExecutionArgs) -> Result<(), std::io::Error> {
-    let interpreter = if cfg!(windows) { "cmd" } else { "bash" };
-    let work_dir = &exec_args.work_dir;
+/// Returns the generated native build wrapper and any interpreter script file.
+///
+/// If `args.interpreter` is set, or if the resolved script path has a known
+/// interpreter extension, inline script text is written to a separate file and
+/// the native wrapper invokes the resolved interpreter with that file. Otherwise
+/// the script contents are appended directly to the native wrapper.
+pub async fn generate_build_script(
+    args: &ExecutionArgs,
+) -> Result<GeneratedBuildScript, crate::InterpreterError> {
+    let runner = crate::native_runner::native_runner();
+    let shell = runner.shell();
 
-    if interpreter == "bash" {
-        let script = BashInterpreter
-            .get_script(&exec_args, shell::Bash::default())
-            .unwrap();
-        let build_env_path = work_dir.join("build_env.sh");
-        let build_script_path = work_dir.join("conda_build.sh");
+    let script_extension = shell.extension();
+    let activation_script_path = args.work_dir.join(format!("build_env.{script_extension}"));
+    let build_script_path = args
+        .work_dir
+        .join(format!("conda_build.{script_extension}"));
 
-        tokio::fs::write(&build_env_path, script).await?;
+    let activation_script = crate::activation::activation_script(args, shell.clone())
+        .map_err(|err| std::io::Error::other(err.to_string()))?;
+    tokio::fs::write(
+        &activation_script_path,
+        crate::native_runner::write_shell_script(shell.clone(), &activation_script)?,
+    )
+    .await?;
 
-        let preamble = BASH_PREAMBLE.replace("((script_path))", &build_env_path.to_string_lossy());
-        let script = format!("{}\n{}", preamble, exec_args.script.script());
-        tokio::fs::write(&build_script_path, script).await?;
+    // Interpreter inference is intentionally done after content resolution:
+    // only file-backed scripts can infer from their resolved path. Inline
+    // scripts use the explicit recipe interpreter or remain native shell code.
+    let explicit_or_inferred = args
+        .interpreter
+        .as_deref()
+        .map(str::to_string)
+        .or_else(|| args.script.infer_interpreter());
 
-        tracing::info!("Build script created at {}", build_script_path.display());
-    } else if interpreter == "cmd" {
-        let script = CmdExeInterpreter
-            .get_script(&exec_args, shell::CmdExe)
-            .unwrap();
-        let build_env_path = work_dir.join("build_env.bat");
-        let build_script_path = work_dir.join("conda_build.bat");
+    let body = if let Some(user_interpreter) = explicit_or_inferred {
+        let invocation =
+            crate::interpreter::interpreter_invocation(&user_interpreter).ok_or_else(|| {
+                std::io::Error::other(format!("Unsupported interpreter: {user_interpreter}"))
+            })?;
 
-        tokio::fs::write(&build_env_path, script).await?;
+        let script_path = match &args.script {
+            ResolvedScriptContents::Path(path, _) => path.clone(),
+            ResolvedScriptContents::Inline(script) => {
+                let path = args
+                    .work_dir
+                    .join(format!("conda_build_script.{}", invocation.extension()));
+                tokio::fs::write(&path, invocation.script_contents(script)).await?;
+                path
+            }
+            ResolvedScriptContents::Missing => {
+                let path = args
+                    .work_dir
+                    .join(format!("conda_build_script.{}", invocation.extension()));
+                tokio::fs::write(&path, invocation.script_contents("")).await?;
+                path
+            }
+        };
 
-        let build_script = format!(
-            "{}\n{}",
-            CMDEXE_PREAMBLE.replace("((script_path))", &build_env_path.to_string_lossy()),
-            exec_args.script.script()
-        );
-        tokio::fs::write(
-            &build_script_path,
-            &build_script.replace('\n', "\r\n").as_bytes(),
-        )
-        .await?;
+        // Search the build environment for the executable described by the
+        // invocation. `user_interpreter` is the recipe value (e.g. `nushell`),
+        // which is preserved for user-facing errors even when the executable
+        // has a different name (e.g. `nu`).
+        let prefix = args.build_prefix.as_ref().or(Some(&args.run_prefix));
+        let executable = crate::interpreter::resolve_interpreter_executable(
+            prefix,
+            &args.execution_platform,
+            &user_interpreter,
+            invocation.as_ref(),
+        )?;
 
-        tracing::info!("Build script created at {}", build_script_path.display());
+        let mut command = vec![executable.to_string_lossy().into_owned()];
+        command.extend(invocation.args(&script_path));
+        let command_refs = command.iter().map(String::as_str).collect::<Vec<_>>();
+        let mut body = String::new();
+        shell
+            .run_command(&mut body, command_refs)
+            .map_err(std::io::Error::other)?;
+        body
+    } else {
+        args.script.script().to_string()
+    };
+
+    let build_script = format!("{}\n{}", runner.preamble(&activation_script_path), body);
+    tokio::fs::write(
+        &build_script_path,
+        crate::native_runner::write_shell_script(shell, &build_script)?,
+    )
+    .await?;
+
+    #[cfg(unix)]
+    {
+        if build_script_path.extension().and_then(|e| e.to_str()) == Some("sh") {
+            use std::{fs::Permissions, os::unix::fs::PermissionsExt};
+            let permissions = Permissions::from_mode(0o755);
+            tokio::fs::set_permissions(&build_script_path, permissions).await?;
+        }
+    }
+
+    Ok(GeneratedBuildScript { build_script_path })
+}
+
+/// Runs a script with the given execution arguments.
+pub async fn run_script(exec_args: ExecutionArgs) -> Result<(), crate::InterpreterError> {
+    let runner = crate::native_runner::native_runner();
+    let generated = generate_build_script(&exec_args).await?;
+    let build_script_path_str = generated.build_script_path.to_string_lossy().to_string();
+    let cmd_args = runner.command_to_run_script(&build_script_path_str);
+
+    let output = crate::execution::run_process_with_replacements(
+        &cmd_args,
+        &exec_args.work_dir,
+        &exec_args.replacements(runner.replacements_template()),
+        &exec_args.env_vars,
+        &exec_args.secrets,
+        exec_args.env_isolation,
+        if runner.supports_sandbox() {
+            exec_args.sandbox_config.as_ref()
+        } else {
+            None
+        },
+    )
+    .await?;
+
+    if !output.status.success() {
+        let status_code = output.status.code().unwrap_or(1);
+        let debug_info = runner.debug_info(&exec_args);
+        tracing::error!("Script failed with status {}", status_code);
+        tracing::error!("{}", debug_info);
+        return Err(crate::InterpreterError::ExecutionFailed(
+            std::io::Error::other(format!(
+                "Script failed with status {}{}",
+                status_code, debug_info
+            )),
+        ));
     }
 
     Ok(())
 }
 
-/// Find the rattler-sandbox executable in PATH
+/// Creates build script files without executing them.
+pub async fn create_build_script(exec_args: ExecutionArgs) -> Result<(), std::io::Error> {
+    let generated = generate_build_script(&exec_args)
+        .await
+        .map_err(|err| match err {
+            crate::InterpreterError::ExecutionFailed(err) => err,
+            crate::InterpreterError::InterpreterNotFound(interpreter) => std::io::Error::other(
+                format!("interpreter '{interpreter}' was not found in the build environment"),
+            ),
+            crate::InterpreterError::InvalidInterpreter {
+                interpreter,
+                reason,
+            } => std::io::Error::other(format!(
+                "interpreter '{interpreter}' was found but is not valid: {reason}"
+            )),
+        })?;
+
+    tracing::info!(
+        "Build script created at {}",
+        generated.build_script_path.display()
+    );
+    Ok(())
+}
+
+/// Finds the rattler-sandbox executable in PATH.
 fn find_rattler_sandbox() -> Option<PathBuf> {
     which::which("rattler-sandbox").ok()
 }
@@ -730,7 +815,6 @@ mod tests {
     /// nested shells inherit it while the outer subprocess starts without it.
     #[test]
     fn test_conda_build_marker_written_into_build_env_script() {
-        use crate::interpreter::BashInterpreter;
         use rattler_shell::shell;
 
         let tmp = tempfile::tempdir().unwrap();
@@ -739,6 +823,7 @@ mod tests {
 
         let args = ExecutionArgs {
             script: ResolvedScriptContents::Inline(String::new()),
+            interpreter: None,
             env_vars: IndexMap::new(),
             secrets: IndexMap::new(),
             execution_platform: Platform::current(),
@@ -749,41 +834,10 @@ mod tests {
             env_isolation: EnvironmentIsolation::None,
         };
 
-        let script = BashInterpreter
-            .get_script(&args, shell::Bash::default())
-            .unwrap();
+        let script = crate::activation::activation_script(&args, shell::Bash::default()).unwrap();
         assert!(
             script.contains("CONDA_BUILD") && script.contains("1"),
             "build_env.sh must set CONDA_BUILD=1 for nested-shell re-entrancy, got:\n{script}"
-        );
-    }
-
-    /// brush must be provided by the build environment. With no build prefix
-    /// it cannot be located and a clear `InterpreterNotFound` is returned.
-    #[tokio::test]
-    async fn test_brush_not_found_without_build_prefix() {
-        use crate::interpreter::BrushInterpreter;
-
-        let tmp = tempfile::tempdir().unwrap();
-        let prefix = tmp.path().join("prefix");
-        fs_err::create_dir_all(&prefix).unwrap();
-
-        let args = ExecutionArgs {
-            script: ResolvedScriptContents::Inline("echo hello".to_string()),
-            env_vars: IndexMap::new(),
-            secrets: IndexMap::new(),
-            execution_platform: Platform::current(),
-            build_prefix: None,
-            run_prefix: prefix,
-            work_dir: tmp.path().to_path_buf(),
-            sandbox_config: None,
-            env_isolation: EnvironmentIsolation::None,
-        };
-
-        let err = BrushInterpreter.run(args).await.unwrap_err();
-        assert!(
-            matches!(err, crate::InterpreterError::InterpreterNotFound(ref name) if name == "brush"),
-            "expected InterpreterNotFound for brush, got: {err:?}"
         );
     }
 

--- a/crates/rattler_build_script/src/execution.rs
+++ b/crates/rattler_build_script/src/execution.rs
@@ -10,9 +10,9 @@ use crate::script::{Script, ScriptContent};
 use fs_err as fs;
 use futures::TryStreamExt;
 use indexmap::IndexMap;
-use itertools::Itertools;
 use rattler_shell::shell::Shell;
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt;
 use std::io;
@@ -145,17 +145,22 @@ pub enum ResolvedScriptContents {
     Path(PathBuf, String),
     /// The script contents from an inline YAML string
     Inline(String),
+    /// A list of inline commands; the interpreter assembles them at generation
+    /// time (so kept as a list, not joined here).
+    Commands(Vec<String>),
     /// There are no script contents
     Missing,
 }
 
 impl ResolvedScriptContents {
-    /// Get the script contents as a string
-    pub fn script(&self) -> &str {
+    /// The script contents as text (a command list is plainly newline-joined;
+    /// interpreter-specific assembly happens at generation time).
+    pub fn script(&self) -> Cow<'_, str> {
         match self {
-            ResolvedScriptContents::Path(_, script) => script,
-            ResolvedScriptContents::Inline(script) => script,
-            ResolvedScriptContents::Missing => "",
+            ResolvedScriptContents::Path(_, script) => Cow::Borrowed(script),
+            ResolvedScriptContents::Inline(script) => Cow::Borrowed(script),
+            ResolvedScriptContents::Commands(commands) => Cow::Owned(commands.join("\n")),
+            ResolvedScriptContents::Missing => Cow::Borrowed(""),
         }
     }
 
@@ -333,35 +338,36 @@ impl Script {
                     }
                 }
             }
+            // Keep the list; the interpreter assembles it in `generate_build_script`.
             ScriptContent::Commands(commands) => {
-                if self.interpreter() == "cmd" {
-                    // add in an `if %errorlevel% neq 0` check
-                    Ok(ResolvedScriptContents::Inline(
-                        commands
-                            .iter()
-                            .map(|c| format!("{}\nif %errorlevel% neq 0 exit /b %errorlevel%", c))
-                            .join("\n"),
-                    ))
-                } else {
-                    Ok(ResolvedScriptContents::Inline(commands.iter().join("\n")))
-                }
+                Ok(ResolvedScriptContents::Commands(commands.clone()))
             }
             ScriptContent::Command(command) => {
                 Ok(ResolvedScriptContents::Inline(command.to_owned()))
             }
         };
 
-        // render jinja if it is an inline script
+        // Render jinja for inline content, each command individually; file-backed
+        // scripts are not rendered.
         if let Some(renderer) = jinja_renderer {
+            let render = |script: &str| -> Result<String, std::io::Error> {
+                renderer(script).map_err(|e| {
+                    std::io::Error::other(format!(
+                        "Failed to render jinja template in build `script`: {}",
+                        e
+                    ))
+                })
+            };
             match script_content? {
                 ResolvedScriptContents::Inline(script) => {
-                    let rendered = renderer(&script).map_err(|e| {
-                        std::io::Error::other(format!(
-                            "Failed to render jinja template in build `script`: {}",
-                            e
-                        ))
-                    })?;
-                    Ok(ResolvedScriptContents::Inline(rendered))
+                    Ok(ResolvedScriptContents::Inline(render(&script)?))
+                }
+                ResolvedScriptContents::Commands(commands) => {
+                    let rendered = commands
+                        .iter()
+                        .map(|c| render(c))
+                        .collect::<Result<Vec<_>, _>>()?;
+                    Ok(ResolvedScriptContents::Commands(rendered))
                 }
                 other => Ok(other),
             }
@@ -430,7 +436,7 @@ impl Decoder for CrLfNormalizer {
 pub(crate) async fn generate_build_script(
     args: &ExecutionArgs,
 ) -> Result<PathBuf, crate::InterpreterError> {
-    let runner = crate::native_runner::native_runner();
+    let runner = crate::native_runner::native_runner(args.runtime.platform());
     let shell = runner.shell();
 
     let script_extension = shell.extension();
@@ -456,48 +462,66 @@ pub(crate) async fn generate_build_script(
         .map(str::to_string)
         .or_else(|| args.script.infer_interpreter());
 
-    let body = if let Some(user_interpreter) = explicit_or_inferred {
-        let interpreter =
-            crate::interpreter::SelectedInterpreter::from_recipe_name(&user_interpreter)
-                .ok_or_else(|| {
-                    std::io::Error::other(format!("Unsupported interpreter: {user_interpreter}"))
-                })?;
+    // The interpreter that runs the content (and assembles a command list).
+    // With none specified, default to the wrapper shell from the runner.
+    let interpreter_name = explicit_or_inferred
+        .clone()
+        .unwrap_or_else(|| runner.default_interpreter().to_string());
+    let interpreter = crate::interpreter::SelectedInterpreter::from_recipe_name(&interpreter_name)
+        .ok_or_else(|| {
+            std::io::Error::other(format!("Unsupported interpreter: {interpreter_name}"))
+        })?;
 
+    // Assemble the rendered content; the interpreter joins a command list.
+    let script_text = match &args.script {
+        ResolvedScriptContents::Commands(commands) => interpreter.join_commands(commands),
+        ResolvedScriptContents::Inline(script) => script.clone(),
+        ResolvedScriptContents::Path(_, script) => script.clone(),
+        ResolvedScriptContents::Missing => String::new(),
+    };
+
+    let body = if explicit_or_inferred.is_some() {
+        // Specialized interpreter: invoke a script file (the original path, or
+        // one written next to the wrapper).
         let script_path = match &args.script {
             ResolvedScriptContents::Path(path, _) => path.clone(),
-            ResolvedScriptContents::Inline(script) => {
+            _ => {
                 let path = args
                     .work_dir
                     .join(format!("conda_build_script.{}", interpreter.extension()));
-                tokio::fs::write(&path, interpreter.script_contents(script)).await?;
-                path
-            }
-            ResolvedScriptContents::Missing => {
-                let path = args
-                    .work_dir
-                    .join(format!("conda_build_script.{}", interpreter.extension()));
-                tokio::fs::write(&path, interpreter.script_contents("")).await?;
+                tokio::fs::write(&path, interpreter.script_contents(&script_text)).await?;
                 path
             }
         };
 
-        // Search the build environment for the executable. The selected
-        // interpreter preserves the recipe value (e.g. `nushell`) for
-        // user-facing errors even when the executable has a different name
+        // Resolve the executable from the activated environment (build prefix,
+        // then host prefix, then the system PATH depending on the interpreter).
+        // The selected interpreter preserves the recipe value (e.g. `nushell`)
+        // for user-facing errors even when the executable has a different name
         // (e.g. `nu`).
-        let prefix = args.build_prefix.as_ref().or(Some(&args.run_prefix));
-        let executable = interpreter.resolve_executable(prefix, &args.runtime)?;
+        let executable = interpreter.resolve_executable(
+            args.build_prefix.as_deref(),
+            &args.run_prefix,
+            &args.runtime,
+        )?;
 
+        // Quote the resolved path and arguments so a prefix or script path
+        // containing spaces survives the native shell.
         let mut command = vec![executable.to_string_lossy().into_owned()];
         command.extend(interpreter.args(&script_path));
-        let command_refs = command.iter().map(String::as_str).collect::<Vec<_>>();
+        let quoted = command
+            .iter()
+            .map(|arg| crate::native_runner::quote_arg(&shell, arg))
+            .collect::<Vec<_>>();
+        let command_refs = quoted.iter().map(String::as_str).collect::<Vec<_>>();
         let mut body = String::new();
         shell
             .run_command(&mut body, command_refs)
             .map_err(std::io::Error::other)?;
         body
     } else {
-        args.script.script().to_string()
+        // No interpreter: the content is the native wrapper body.
+        script_text
     };
 
     let build_script = format!("{}\n{}", runner.preamble(&activation_script_path), body);
@@ -521,7 +545,7 @@ pub(crate) async fn generate_build_script(
 
 /// Runs a script with the given execution arguments.
 pub(crate) async fn run_script(exec_args: ExecutionArgs) -> Result<(), crate::InterpreterError> {
-    let runner = crate::native_runner::native_runner();
+    let runner = crate::native_runner::native_runner(exec_args.runtime.platform());
     let build_script_path = generate_build_script(&exec_args).await?;
     let build_script_path_str = build_script_path.to_string_lossy().to_string();
     let cmd_args = runner.command_to_run_script(&build_script_path_str);
@@ -865,8 +889,10 @@ mod tests {
         );
     }
 
+    /// `resolve_content` keeps a command list as `Commands`, unjoined and
+    /// without shell-specific error handling (the interpreter's job).
     #[test]
-    fn test_cmd_errorlevel_injected() {
+    fn test_commands_resolved_as_list() {
         use crate::script::{Script, ScriptContent};
         let commands = vec!["echo Hello".to_string(), "echo World".to_string()];
         let script = Script {
@@ -878,31 +904,78 @@ mod tests {
             content_explicit: false,
         };
 
-        // Use dummy paths for recipe_dir and extensions
-        let recipe_dir = std::path::Path::new(".");
-        let extensions = &["bat"];
-
         let resolved = script
             .resolve_content(
-                recipe_dir,
+                std::path::Path::new("."),
                 None::<fn(&str) -> Result<String, String>>,
-                extensions,
+                &["bat"],
             )
             .unwrap();
 
-        if cfg!(windows) {
-            let expected = "echo Hello\nif %errorlevel% neq 0 exit /b %errorlevel%\necho World\nif %errorlevel% neq 0 exit /b %errorlevel%";
-            match resolved {
-                ResolvedScriptContents::Inline(s) => assert_eq!(s, expected),
-                _ => panic!("Expected Inline variant"),
-            }
-        } else {
-            let expected = "echo Hello\necho World";
-            match resolved {
-                ResolvedScriptContents::Inline(s) => assert_eq!(s, expected),
-                _ => panic!("Expected Inline variant"),
-            }
+        match resolved {
+            ResolvedScriptContents::Commands(c) => assert_eq!(c, commands),
+            other => panic!("expected Commands variant, got {other:?}"),
         }
+    }
+
+    /// A command list is jinja-rendered per command in `resolve_content`.
+    #[test]
+    fn test_command_list_rendered_per_command() {
+        use crate::script::{Script, ScriptContent};
+        let script = Script {
+            content: ScriptContent::Commands(vec![
+                "echo MARK one".to_string(),
+                "echo MARK two".to_string(),
+            ]),
+            ..Script::default()
+        };
+        let renderer = |s: &str| -> Result<String, String> { Ok(s.replace("MARK", "rendered")) };
+
+        let resolved = script
+            .resolve_content(std::path::Path::new("."), Some(renderer), &["sh"])
+            .unwrap();
+
+        match resolved {
+            ResolvedScriptContents::Commands(c) => {
+                assert_eq!(c, vec!["echo rendered one", "echo rendered two"]);
+            }
+            other => panic!("expected Commands variant, got {other:?}"),
+        }
+    }
+
+    /// Unified path: a command list with no interpreter, on a Windows runtime,
+    /// is assembled by `cmd` (errorlevel) into the generated `.bat`, on any host.
+    #[tokio::test]
+    async fn test_command_list_errorlevel_in_generated_cmd_wrapper() {
+        let tmp = tempfile::tempdir().unwrap();
+        let prefix = tmp.path().join("prefix");
+        fs::create_dir_all(&prefix).unwrap();
+
+        let args = ExecutionArgs {
+            script: ResolvedScriptContents::Commands(vec![
+                "echo Hello".to_string(),
+                "echo World".to_string(),
+            ]),
+            interpreter: None,
+            env_vars: IndexMap::new(),
+            secrets: IndexMap::new(),
+            runtime: RuntimeEnv::for_test(Platform::Win64),
+            build_prefix: None,
+            run_prefix: prefix,
+            work_dir: tmp.path().to_path_buf(),
+            sandbox_config: None,
+            env_isolation: EnvironmentIsolation::None,
+        };
+
+        crate::execution::generate_build_script(&args)
+            .await
+            .unwrap();
+
+        let wrapper = fs::read_to_string(tmp.path().join("conda_build.bat")).unwrap();
+        assert!(
+            wrapper.contains("if %errorlevel% neq 0 exit /b %errorlevel%"),
+            "cmd wrapper must propagate errors between commands, got:\n{wrapper}"
+        );
     }
 
     #[test]
@@ -1225,7 +1298,8 @@ mod tests {
     }
 
     /// `create_build_script` maps `InterpreterNotFound` to an io::Error whose
-    /// message mentions the build environment.
+    /// message mentions the build environment. `brush` is build-prefix-only, so
+    /// it errors when absent (unlike `python`, which falls back to `PATH`).
     #[tokio::test]
     async fn test_create_build_script_missing_interpreter_error() {
         let tmp = tempfile::tempdir().unwrap();
@@ -1235,8 +1309,8 @@ mod tests {
         let args = execution_args(
             tmp.path().to_path_buf(),
             prefix,
-            ResolvedScriptContents::Inline("print('hi')".to_string()),
-            Some("python"),
+            ResolvedScriptContents::Inline("echo hi".to_string()),
+            Some("brush"),
         );
 
         let err = create_build_script(args).await.unwrap_err();

--- a/crates/rattler_build_script/src/interpreter/bash.rs
+++ b/crates/rattler_build_script/src/interpreter/bash.rs
@@ -1,96 +1,27 @@
-use std::path::PathBuf;
-
 use rattler_conda_types::Platform;
-use rattler_shell::shell;
 
-use crate::execution::{ExecutionArgs, run_process_with_replacements};
+use super::{InterpreterInvocation, InterpreterSearchScope};
 
-use super::{
-    BASH_PREAMBLE, Interpreter, InterpreterError, InterpreterSearchScope, find_interpreter,
-};
+pub struct BashInvocation;
 
-pub struct BashInterpreter;
-
-fn print_debug_info(args: &ExecutionArgs) -> String {
-    let mut output = String::new();
-
-    output.push_str("\nScript execution failed.\n\n");
-
-    output.push_str(&format!("  Work directory: {}\n", args.work_dir.display()));
-    output.push_str(&format!("  Prefix: {}\n", args.run_prefix.display()));
-
-    if let Some(build_prefix) = &args.build_prefix {
-        output.push_str(&format!("  Build prefix: {}\n", build_prefix.display()));
-    } else {
-        output.push_str("  Build prefix: None\n");
+impl InterpreterInvocation for BashInvocation {
+    fn executable_names(&self, _build_platform: &Platform) -> &'static [&'static str] {
+        &["bash"]
     }
 
-    output.push_str("\nTo run the script manually, use the following command:\n\n");
-    output.push_str(&format!("  cd {:?} && ./conda_build.sh\n\n", args.work_dir));
-    output.push_str("To run commands interactively in the build environment:\n\n");
-    output.push_str(&format!("  cd {:?} && source build_env.sh", args.work_dir));
-
-    output
-}
-
-impl Interpreter for BashInterpreter {
-    async fn run(&self, args: ExecutionArgs) -> Result<(), InterpreterError> {
-        let script = self.get_script(&args, shell::Bash::default()).unwrap();
-
-        let build_env_path = args.work_dir.join("build_env.sh");
-        let build_script_path = args.work_dir.join("conda_build.sh");
-
-        tokio::fs::write(&build_env_path, script).await?;
-
-        let preamble = BASH_PREAMBLE.replace("((script_path))", &build_env_path.to_string_lossy());
-        let script = format!("{}\n{}", preamble, args.script.script());
-        tokio::fs::write(&build_script_path, script).await?;
-
-        // Mark build_env.sh and conda_build.sh as executable
-        #[cfg(unix)]
-        {
-            use std::{fs::Permissions, os::unix::fs::PermissionsExt};
-            let permissions = Permissions::from_mode(0o755);
-            tokio::fs::set_permissions(&build_script_path, permissions).await?;
+    fn search_scope(&self, build_platform: &Platform) -> InterpreterSearchScope {
+        if build_platform.is_unix() {
+            InterpreterSearchScope::PrefixThenSystemPath
+        } else {
+            InterpreterSearchScope::BuildPrefixOnly
         }
-
-        let build_script_path_str = build_script_path.to_string_lossy().to_string();
-        let cmd_args = vec!["bash", &build_script_path_str];
-
-        let output = run_process_with_replacements(
-            &cmd_args,
-            &args.work_dir,
-            &args.replacements("$((var))"),
-            &args.env_vars,
-            &args.secrets,
-            args.env_isolation,
-            args.sandbox_config.as_ref(),
-        )
-        .await?;
-
-        if !output.status.success() {
-            let status_code = output.status.code().unwrap_or(1);
-            let debug_info = print_debug_info(&args);
-            tracing::error!("Script failed with status {}", status_code);
-            tracing::error!("{}", debug_info);
-            return Err(InterpreterError::ExecutionFailed(std::io::Error::other(
-                format!("Script failed with status {}{}", status_code, debug_info),
-            )));
-        }
-
-        Ok(())
     }
 
-    async fn find_interpreter(
-        &self,
-        build_prefix: Option<&PathBuf>,
-        platform: &Platform,
-    ) -> Result<Option<PathBuf>, which::Error> {
-        find_interpreter(
-            "bash",
-            build_prefix,
-            platform,
-            InterpreterSearchScope::PrefixThenSystemPath,
-        )
+    fn extension(&self) -> &'static str {
+        "sh"
+    }
+
+    fn args(&self, script_path: &std::path::Path) -> Vec<String> {
+        vec![script_path.to_string_lossy().into_owned()]
     }
 }

--- a/crates/rattler_build_script/src/interpreter/bash.rs
+++ b/crates/rattler_build_script/src/interpreter/bash.rs
@@ -11,9 +11,9 @@ impl InterpreterInvocation for BashInvocation {
 
     fn search_scope(&self, build_platform: &Platform) -> InterpreterSearchScope {
         if build_platform.is_unix() {
-            InterpreterSearchScope::PrefixThenSystemPath
+            InterpreterSearchScope::build_and_host_with_system_fallback()
         } else {
-            InterpreterSearchScope::BuildPrefixOnly
+            InterpreterSearchScope::build_only()
         }
     }
 

--- a/crates/rattler_build_script/src/interpreter/brush.rs
+++ b/crates/rattler_build_script/src/interpreter/brush.rs
@@ -1,57 +1,19 @@
-use std::path::PathBuf;
-
 use rattler_conda_types::Platform;
 
-use crate::execution::{ExecutionArgs, ResolvedScriptContents};
+use super::InterpreterInvocation;
 
-use super::{
-    BashInterpreter, CmdExeInterpreter, Interpreter, InterpreterError, InterpreterSearchScope,
-    find_interpreter,
-};
+pub struct BrushInvocation;
 
-pub struct BrushInterpreter;
-
-// Brush runs bash-compatible scripts. The native bash/cmd wrapper performs
-// activation and then invokes brush on the user script as a child process.
-impl Interpreter for BrushInterpreter {
-    async fn run(&self, args: ExecutionArgs) -> Result<(), InterpreterError> {
-        // brush must be provided by the build environment, not the system PATH.
-        let brush_path = find_interpreter(
-            "brush",
-            args.build_prefix.as_ref(),
-            &args.execution_platform,
-            InterpreterSearchScope::BuildPrefixOnly,
-        )
-        .ok()
-        .flatten()
-        .ok_or_else(|| InterpreterError::InterpreterNotFound("brush".to_string()))?;
-
-        let brush_script = args.work_dir.join("conda_build_script.sh");
-        tokio::fs::write(&brush_script, args.script.script()).await?;
-
-        // Invoke the resolved brush from the wrapper so the build-env binary runs.
-        let args = ExecutionArgs {
-            script: ResolvedScriptContents::Inline(format!("{:?} {:?}", brush_path, brush_script)),
-            ..args
-        };
-
-        if cfg!(windows) {
-            CmdExeInterpreter.run(args).await
-        } else {
-            BashInterpreter.run(args).await
-        }
+impl InterpreterInvocation for BrushInvocation {
+    fn executable_names(&self, _build_platform: &Platform) -> &'static [&'static str] {
+        &["brush"]
     }
 
-    async fn find_interpreter(
-        &self,
-        build_prefix: Option<&PathBuf>,
-        platform: &Platform,
-    ) -> Result<Option<PathBuf>, which::Error> {
-        find_interpreter(
-            "brush",
-            build_prefix,
-            platform,
-            InterpreterSearchScope::BuildPrefixOnly,
-        )
+    fn extension(&self) -> &'static str {
+        "sh"
+    }
+
+    fn args(&self, script_path: &std::path::Path) -> Vec<String> {
+        vec![script_path.to_string_lossy().into_owned()]
     }
 }

--- a/crates/rattler_build_script/src/interpreter/brush.rs
+++ b/crates/rattler_build_script/src/interpreter/brush.rs
@@ -4,6 +4,8 @@ use super::InterpreterInvocation;
 
 pub struct BrushInvocation;
 
+// Uses the default `build_only` scope: a system `brush` is never used, for
+// reproducibility.
 impl InterpreterInvocation for BrushInvocation {
     fn executable_names(&self, _build_platform: &Platform) -> &'static [&'static str] {
         &["brush"]

--- a/crates/rattler_build_script/src/interpreter/cmd_exe.rs
+++ b/crates/rattler_build_script/src/interpreter/cmd_exe.rs
@@ -14,9 +14,9 @@ impl InterpreterInvocation for CmdExeInvocation {
 
     fn search_scope(&self, build_platform: &Platform) -> InterpreterSearchScope {
         if build_platform.is_windows() {
-            InterpreterSearchScope::PrefixThenSystemPath
+            InterpreterSearchScope::build_and_host_with_system_fallback()
         } else {
-            InterpreterSearchScope::BuildPrefixOnly
+            InterpreterSearchScope::build_only()
         }
     }
 
@@ -24,22 +24,32 @@ impl InterpreterInvocation for CmdExeInvocation {
         "bat"
     }
 
+    fn join_commands(&self, commands: &[String]) -> String {
+        // `cmd` has no `set -e`, so propagate a non-zero exit between commands.
+        commands
+            .iter()
+            .map(|c| format!("{c}\nif %errorlevel% neq 0 exit /b %errorlevel%"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
     fn resolve_executable(
         &self,
-        build_prefix: Option<&PathBuf>,
+        build_prefix: Option<&Path>,
+        run_prefix: &Path,
         runtime: &RuntimeEnv,
     ) -> Result<PathBuf, super::InterpreterError> {
         let platform = runtime.platform();
         let scope = self.search_scope(&platform);
         if platform.is_windows()
-            && let InterpreterSearchScope::PrefixThenSystemPath = scope
+            && scope.allows_system_fallback()
             && let Some(comspec) = runtime.var("COMSPEC")
             && comspec.to_lowercase().contains("cmd.exe")
         {
             return Ok(PathBuf::from(comspec));
         }
 
-        super::find_interpreter("cmd", build_prefix, runtime, scope)
+        super::find_interpreter("cmd", build_prefix, run_prefix, runtime, scope)
             .ok_or_else(|| super::InterpreterError::InterpreterNotFound("cmd".to_string()))
     }
 

--- a/crates/rattler_build_script/src/interpreter/cmd_exe.rs
+++ b/crates/rattler_build_script/src/interpreter/cmd_exe.rs
@@ -1,106 +1,57 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use rattler_conda_types::Platform;
-use rattler_shell::shell;
 
-use crate::execution::{ExecutionArgs, run_process_with_replacements};
+use super::{InterpreterInvocation, InterpreterSearchScope};
 
-use super::{
-    CMDEXE_PREAMBLE, Interpreter, InterpreterError, InterpreterSearchScope, find_interpreter,
-};
+pub struct CmdExeInvocation;
 
-fn print_debug_info(args: &ExecutionArgs) -> String {
-    let mut output = String::new();
-
-    output.push_str("\nScript execution failed.\n\n");
-
-    output.push_str(&format!("  Work directory: {}\n", args.work_dir.display()));
-    output.push_str(&format!("  Prefix: {}\n", args.run_prefix.display()));
-
-    if let Some(build_prefix) = &args.build_prefix {
-        output.push_str(&format!("  Build prefix: {}\n", build_prefix.display()));
-    } else {
-        output.push_str("  Build prefix: None\n");
+impl InterpreterInvocation for CmdExeInvocation {
+    fn executable_names(&self, _build_platform: &Platform) -> &'static [&'static str] {
+        &["cmd"]
     }
 
-    output.push_str("\nTo run the script manually, use the following command:\n");
-    output.push_str(&format!(
-        "  cd {:?} && ./conda_build.bat\n\n",
-        args.work_dir
-    ));
-    output.push_str("To run commands interactively in the build environment:\n");
-    output.push_str(&format!("  cd {:?} && call build_env.bat", args.work_dir));
-
-    output
-}
-
-pub struct CmdExeInterpreter;
-
-impl Interpreter for CmdExeInterpreter {
-    async fn run(&self, args: ExecutionArgs) -> Result<(), InterpreterError> {
-        let script = self.get_script(&args, shell::CmdExe).unwrap();
-
-        let build_env_path = args.work_dir.join("build_env.bat");
-        let build_script_path = args.work_dir.join("conda_build.bat");
-
-        tokio::fs::write(&build_env_path, script).await?;
-
-        let build_script = format!(
-            "{}\n{}",
-            CMDEXE_PREAMBLE.replace("((script_path))", &build_env_path.to_string_lossy()),
-            args.script.script()
-        );
-        tokio::fs::write(
-            &build_script_path,
-            &build_script.replace('\n', "\r\n").as_bytes(),
-        )
-        .await?;
-
-        let build_script_path_str = build_script_path.to_string_lossy().to_string();
-        let cmd_args = ["cmd.exe", "/d", "/c", &build_script_path_str];
-
-        let output = run_process_with_replacements(
-            &cmd_args,
-            &args.work_dir,
-            &args.replacements("%((var))%"),
-            &args.env_vars,
-            &args.secrets,
-            args.env_isolation,
-            None,
-        )
-        .await?;
-
-        if !output.status.success() {
-            let status_code = output.status.code().unwrap_or(1);
-            let debug_info = print_debug_info(&args);
-            tracing::error!("Script failed with status {}", status_code);
-            tracing::error!("{}", debug_info);
-            return Err(InterpreterError::ExecutionFailed(std::io::Error::other(
-                format!("Script failed with status {}{}", status_code, debug_info),
-            )));
+    fn search_scope(&self, build_platform: &Platform) -> InterpreterSearchScope {
+        if build_platform.is_windows() {
+            InterpreterSearchScope::PrefixThenSystemPath
+        } else {
+            InterpreterSearchScope::BuildPrefixOnly
         }
-
-        Ok(())
     }
 
-    async fn find_interpreter(
+    fn extension(&self) -> &'static str {
+        "bat"
+    }
+
+    fn resolve_executable(
         &self,
         build_prefix: Option<&PathBuf>,
-        platform: &Platform,
-    ) -> Result<Option<PathBuf>, which::Error> {
-        // check if COMSPEC is set to cmd.exe
-        if let Ok(comspec) = std::env::var("COMSPEC")
+        build_platform: &Platform,
+    ) -> Result<PathBuf, super::InterpreterError> {
+        if build_platform.is_windows()
+            && let InterpreterSearchScope::PrefixThenSystemPath = self.search_scope(build_platform)
+            && let Ok(comspec) = std::env::var("COMSPEC")
             && comspec.to_lowercase().contains("cmd.exe")
         {
-            return Ok(Some(PathBuf::from(comspec)));
+            return Ok(PathBuf::from(comspec));
         }
 
-        // check if cmd.exe is in PATH
-        find_interpreter(
+        super::find_interpreter(
             "cmd",
             build_prefix,
-            platform,
-            InterpreterSearchScope::PrefixThenSystemPath,
+            build_platform,
+            self.search_scope(build_platform),
         )
+        .ok()
+        .flatten()
+        .ok_or_else(|| super::InterpreterError::InterpreterNotFound("cmd".to_string()))
+    }
+
+    fn args(&self, script_path: &Path) -> Vec<String> {
+        vec![
+            "/d".to_string(),
+            "/c".to_string(),
+            script_path.to_string_lossy().into_owned(),
+        ]
     }
 }

--- a/crates/rattler_build_script/src/interpreter/cmd_exe.rs
+++ b/crates/rattler_build_script/src/interpreter/cmd_exe.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use rattler_conda_types::Platform;
 
 use super::{InterpreterInvocation, InterpreterSearchScope};
+use crate::runtime::RuntimeEnv;
 
 pub struct CmdExeInvocation;
 
@@ -26,23 +27,20 @@ impl InterpreterInvocation for CmdExeInvocation {
     fn resolve_executable(
         &self,
         build_prefix: Option<&PathBuf>,
-        build_platform: &Platform,
+        runtime: &RuntimeEnv,
     ) -> Result<PathBuf, super::InterpreterError> {
-        if build_platform.is_windows()
-            && let InterpreterSearchScope::PrefixThenSystemPath = self.search_scope(build_platform)
-            && let Ok(comspec) = std::env::var("COMSPEC")
+        let platform = runtime.platform();
+        let scope = self.search_scope(&platform);
+        if platform.is_windows()
+            && let InterpreterSearchScope::PrefixThenSystemPath = scope
+            && let Some(comspec) = runtime.var("COMSPEC")
             && comspec.to_lowercase().contains("cmd.exe")
         {
             return Ok(PathBuf::from(comspec));
         }
 
-        super::find_interpreter(
-            "cmd",
-            build_prefix,
-            build_platform,
-            self.search_scope(build_platform),
-        )
-        .ok_or_else(|| super::InterpreterError::InterpreterNotFound("cmd".to_string()))
+        super::find_interpreter("cmd", build_prefix, runtime, scope)
+            .ok_or_else(|| super::InterpreterError::InterpreterNotFound("cmd".to_string()))
     }
 
     fn args(&self, script_path: &Path) -> Vec<String> {

--- a/crates/rattler_build_script/src/interpreter/cmd_exe.rs
+++ b/crates/rattler_build_script/src/interpreter/cmd_exe.rs
@@ -42,8 +42,6 @@ impl InterpreterInvocation for CmdExeInvocation {
             build_platform,
             self.search_scope(build_platform),
         )
-        .ok()
-        .flatten()
         .ok_or_else(|| super::InterpreterError::InterpreterNotFound("cmd".to_string()))
     }
 

--- a/crates/rattler_build_script/src/interpreter/mod.rs
+++ b/crates/rattler_build_script/src/interpreter/mod.rs
@@ -21,6 +21,8 @@ use std::path::{Path, PathBuf};
 use rattler_conda_types::Platform;
 use rattler_shell::activation::prefix_path_entries;
 
+use crate::runtime::RuntimeEnv;
+
 /// Describes interpreter execution and lookup errors.
 #[derive(Debug, thiserror::Error)]
 pub enum InterpreterError {
@@ -49,26 +51,27 @@ pub enum InterpreterSearchScope {
 pub(crate) fn find_interpreter(
     name: &str,
     build_prefix: Option<&PathBuf>,
-    platform: &Platform,
+    runtime: &RuntimeEnv,
     scope: InterpreterSearchScope,
 ) -> Option<PathBuf> {
     let exe_name = format!("{}{}", name, std::env::consts::EXE_SUFFIX);
+    let platform = runtime.platform();
 
     // Build-prefix-only: search just the prefix bin entries, no PATH fallback.
     if let InterpreterSearchScope::BuildPrefixOnly = scope {
         let build_prefix = build_prefix?;
-        let prefix_path = prefix_path_entries(build_prefix, platform);
+        let prefix_path = prefix_path_entries(build_prefix, &platform);
         return which::which_in_global(exe_name, std::env::join_paths(prefix_path).ok())
             .ok()?
             .next();
     }
 
-    let path = std::env::var("PATH").unwrap_or_default();
+    let path = runtime.path();
     if let Some(build_prefix) = build_prefix {
-        let mut prepend_path = prefix_path_entries(build_prefix, platform)
+        let mut prepend_path = prefix_path_entries(build_prefix, &platform)
             .into_iter()
             .collect::<Vec<_>>();
-        prepend_path.extend(std::env::split_paths(&path));
+        prepend_path.extend(std::env::split_paths(path));
         return which::which_in_global(exe_name, std::env::join_paths(prepend_path).ok())
             .ok()?
             .next();
@@ -123,13 +126,14 @@ pub(crate) trait InterpreterInvocation: Send + Sync {
     fn resolve_executable(
         &self,
         build_prefix: Option<&PathBuf>,
-        build_platform: &Platform,
+        runtime: &RuntimeEnv,
     ) -> Result<PathBuf, InterpreterError> {
-        let scope = self.search_scope(build_platform);
+        let platform = runtime.platform();
+        let scope = self.search_scope(&platform);
         let mut unusable_candidate = None;
 
-        for executable_name in self.executable_names(build_platform) {
-            match find_interpreter(executable_name, build_prefix, build_platform, scope) {
+        for executable_name in self.executable_names(&platform) {
+            match find_interpreter(executable_name, build_prefix, runtime, scope) {
                 Some(path) => match self.is_usable_executable(&path) {
                     Ok(()) => return Ok(path),
                     Err(err) => unusable_candidate = Some((path, err)),
@@ -146,7 +150,7 @@ pub(crate) trait InterpreterInvocation: Send + Sync {
         }
 
         Err(InterpreterError::InterpreterNotFound(
-            self.executable_names(build_platform)
+            self.executable_names(&platform)
                 .first()
                 .copied()
                 .unwrap_or("<unknown>")
@@ -211,10 +215,10 @@ impl SelectedInterpreter {
     pub(crate) fn resolve_executable(
         &self,
         build_prefix: Option<&PathBuf>,
-        platform: &Platform,
+        runtime: &RuntimeEnv,
     ) -> Result<PathBuf, InterpreterError> {
         self.invocation
-            .resolve_executable(build_prefix, platform)
+            .resolve_executable(build_prefix, runtime)
             .map_err(|err| match err {
                 InterpreterError::InterpreterNotFound(_) => {
                     InterpreterError::InterpreterNotFound(self.user_name.clone())
@@ -250,7 +254,7 @@ mod tests {
             interpreter: interpreter.map(str::to_string),
             env_vars: IndexMap::new(),
             secrets: IndexMap::new(),
-            execution_platform: Platform::current(),
+            runtime: RuntimeEnv::current(),
             build_prefix: None,
             run_prefix,
             work_dir,
@@ -458,7 +462,7 @@ mod tests {
 
         let stub = RejectFirstStub;
         let resolved = stub
-            .resolve_executable(Some(&prefix), &Platform::current())
+            .resolve_executable(Some(&prefix), &RuntimeEnv::current())
             .expect("second candidate should resolve");
         assert_eq!(resolved, second);
     }
@@ -477,7 +481,7 @@ mod tests {
 
         let stub = RejectFirstStub;
         let err = stub
-            .resolve_executable(Some(&prefix), &Platform::current())
+            .resolve_executable(Some(&prefix), &RuntimeEnv::current())
             .expect_err("only candidate is rejected");
         match err {
             InterpreterError::InvalidInterpreter { interpreter, .. } => {
@@ -507,7 +511,7 @@ mod tests {
         };
 
         let err = selected
-            .resolve_executable(Some(&prefix), &Platform::current())
+            .resolve_executable(Some(&prefix), &RuntimeEnv::current())
             .expect_err("only candidate is rejected");
         match err {
             InterpreterError::InvalidInterpreter {
@@ -523,16 +527,16 @@ mod tests {
 
     /// Language interpreters must not leak from the system PATH: `find_interpreter`
     /// with `PrefixThenSystemPath` finds an exe present only on PATH, while
-    /// `BuildPrefixOnly` does not.
+    /// `BuildPrefixOnly` does not. The `PATH` is injected through `RuntimeEnv`, so
+    /// the test does not touch the real process environment.
     #[test]
-    #[serial_test::serial]
     fn search_scope_path_fallback_vs_prefix_only() {
         let tmp = tempfile::tempdir().unwrap();
         let prefix = tmp.path().join("prefix");
         fs::create_dir_all(&prefix).unwrap();
 
-        // Place a fake exe in a separate dir that we prepend onto PATH, NOT in
-        // the build prefix.
+        // Place a fake exe in a separate dir that we expose only via the runtime
+        // PATH, NOT in the build prefix.
         let path_dir = tmp.path().join("path_only");
         fs::create_dir_all(&path_dir).unwrap();
         let exe_name = format!("rb_path_only_tool{}", std::env::consts::EXE_SUFFIX);
@@ -544,38 +548,21 @@ mod tests {
             fs::set_permissions(&exe, Permissions::from_mode(0o755)).unwrap();
         }
 
-        let original_path = std::env::var_os("PATH");
-        let mut new_paths = vec![path_dir.clone()];
-        if let Some(orig) = &original_path {
-            new_paths.extend(std::env::split_paths(orig));
-        }
-        // SAFETY: env mutation is serialized via #[serial] and restored below.
-        unsafe {
-            std::env::set_var("PATH", std::env::join_paths(&new_paths).unwrap());
-        }
+        let runtime = RuntimeEnv::for_test(Platform::current())
+            .with_var("PATH", path_dir.to_string_lossy().into_owned());
 
-        let platform = Platform::current();
         let found_via_path = find_interpreter(
             "rb_path_only_tool",
             Some(&prefix),
-            &platform,
+            &runtime,
             InterpreterSearchScope::PrefixThenSystemPath,
         );
         let found_prefix_only = find_interpreter(
             "rb_path_only_tool",
             Some(&prefix),
-            &platform,
+            &runtime,
             InterpreterSearchScope::BuildPrefixOnly,
         );
-
-        // Restore PATH before asserting so a failure does not corrupt later tests.
-        // SAFETY: env mutation is serialized via #[serial].
-        unsafe {
-            match original_path {
-                Some(orig) => std::env::set_var("PATH", orig),
-                None => std::env::remove_var("PATH"),
-            }
-        }
 
         assert!(
             found_via_path.is_some(),
@@ -612,38 +599,26 @@ mod tests {
         let second = create_fake_executable(&prefix, "stub_second");
 
         let resolved = RejectFirstStub
-            .resolve_executable(Some(&prefix), &Platform::current())
+            .resolve_executable(Some(&prefix), &RuntimeEnv::current())
             .expect("second candidate should resolve when the first is absent");
         assert_eq!(resolved, second);
     }
 
     /// On Windows, cmd resolution special-cases `COMSPEC` when it points at
-    /// `cmd.exe`, returning it verbatim.
-    #[cfg(windows)]
+    /// `cmd.exe`, returning it verbatim. `COMSPEC` and the platform are injected
+    /// through `RuntimeEnv`, so this runs on every host without touching the real
+    /// environment.
     #[test]
-    #[serial_test::serial]
     fn cmd_uses_comspec_special_case() {
         let tmp = tempfile::tempdir().unwrap();
         let fake_cmd = tmp.path().join("system32").join("cmd.exe");
         fs::create_dir_all(fake_cmd.parent().unwrap()).unwrap();
         fs::write(&fake_cmd, "").unwrap();
 
-        let original = std::env::var_os("COMSPEC");
-        // SAFETY: env mutation is serialized via #[serial] and restored below.
-        unsafe {
-            std::env::set_var("COMSPEC", &fake_cmd);
-        }
+        let runtime = RuntimeEnv::for_test(Platform::Win64)
+            .with_var("COMSPEC", fake_cmd.to_string_lossy().into_owned());
 
-        let resolved = super::cmd_exe::CmdExeInvocation.resolve_executable(None, &Platform::Win64);
-
-        // SAFETY: env mutation is serialized via #[serial].
-        unsafe {
-            match original {
-                Some(orig) => std::env::set_var("COMSPEC", orig),
-                None => std::env::remove_var("COMSPEC"),
-            }
-        }
-
+        let resolved = super::cmd_exe::CmdExeInvocation.resolve_executable(None, &runtime);
         assert_eq!(resolved.unwrap(), fake_cmd);
     }
 

--- a/crates/rattler_build_script/src/interpreter/mod.rs
+++ b/crates/rattler_build_script/src/interpreter/mod.rs
@@ -1,3 +1,10 @@
+//! Support for specialized script interpreters.
+//!
+//! This module maps recipe `interpreter` values and inferred file extensions to
+//! [`InterpreterInvocation`] implementations. It resolves interpreter executables
+//! with [`find_interpreter`] and reports failures through [`InterpreterError`].
+//! Native wrapper execution lives in `crate::native_runner`.
+
 mod bash;
 mod brush;
 mod cmd_exe;
@@ -9,72 +16,37 @@ mod python;
 mod r;
 mod ruby;
 
-use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-pub use bash::BashInterpreter;
-pub use brush::BrushInterpreter;
-pub use cmd_exe::CmdExeInterpreter;
-pub use nodejs::NodeJsInterpreter;
-pub use nushell::NuShellInterpreter;
-pub use perl::PerlInterpreter;
-pub(crate) use powershell::PowerShellInterpreter;
-pub use python::PythonInterpreter;
-pub use r::RInterpreter;
 use rattler_conda_types::Platform;
-use rattler_shell::{
-    activation::{
-        ActivationError, ActivationVariables, Activator, PathModificationBehavior,
-        prefix_path_entries,
-    },
-    shell::{self, Shell},
-};
-pub use ruby::RubyInterpreter;
+use rattler_shell::activation::prefix_path_entries;
 
-use crate::execution::ExecutionArgs;
-
-/// The error type for the interpreter
+/// Describes interpreter execution and lookup errors.
 #[derive(Debug, thiserror::Error)]
 pub enum InterpreterError {
-    /// This error is returned when the script execution fails or the
-    /// interpreter is not found
+    /// Indicates that script execution failed.
     #[error("IO Error: {0}")]
     ExecutionFailed(#[from] std::io::Error),
 
-    /// The interpreter executable could not be located.
+    /// Indicates that the interpreter executable could not be located.
     #[error("interpreter '{0}' was not found in the build environment")]
     InterpreterNotFound(String),
+
+    /// Indicates that the interpreter executable was found but rejected by validation.
+    #[error("interpreter '{interpreter}' was found but is not valid: {reason}")]
+    InvalidInterpreter { interpreter: String, reason: String },
 }
 
-/// Where to look for an interpreter executable.
+/// Defines where to look for an interpreter executable.
+#[derive(Debug, Clone, Copy)]
 pub enum InterpreterSearchScope {
-    /// Search the build prefix (if any), then fall back to the system PATH.
+    /// Searches through the build prefix, then the system PATH.
     PrefixThenSystemPath,
-    /// Search only the build prefix; never the host prefix or system PATH.
+    /// Searches only the build prefix.
     BuildPrefixOnly,
 }
 
-pub const BASH_PREAMBLE: &str = r#"#!/usr/bin/env bash
-set -e
-## Start of bash preamble
-if [ -z ${CONDA_BUILD+x} ]; then
-    source "((script_path))"
-fi
-## End of preamble
-"#;
-
-pub const CMDEXE_PREAMBLE: &str = r#"
-@chcp 65001 > nul
-@echo on
-IF "%CONDA_BUILD%" == "" (
-    @rem special behavior from conda-build for Windows
-    call "((script_path))"
-)
-@rem re-enable echo because the activation scripts might have messed with it
-@echo on
-"#;
-
-fn find_interpreter(
+pub(crate) fn find_interpreter(
     name: &str,
     build_prefix: Option<&PathBuf>,
     platform: &Platform,
@@ -107,64 +79,301 @@ fn find_interpreter(
     Ok(which::which_in_global(exe_name, Some(path))?.next())
 }
 
-pub trait Interpreter {
-    fn get_script<T: Shell + Copy + 'static>(
-        &self,
-        args: &ExecutionArgs,
-        shell_type: T,
-    ) -> Result<String, ActivationError> {
-        let mut shell_script = shell::ShellScript::new(shell_type, Platform::current());
-        for (k, v) in args.env_vars.iter() {
-            shell_script.set_env_var(k, v)?;
-        }
-        // Re-entrancy marker: this way the preamble sources this file
-        // once and nested shells skip re-sourcing it.
-        shell_script.set_env_var("CONDA_BUILD", "1")?;
-        let host_prefix_activator =
-            Activator::from_path(&args.run_prefix, shell_type, args.execution_platform)?;
+/// Describes how a specialized interpreter executes a script file.
+pub(crate) trait InterpreterInvocation: Send + Sync {
+    /// Returns executable names to try for this interpreter.
+    ///
+    /// Recipe-facing interpreter names may differ from executable names, for
+    /// example `nushell` maps to `nu`.
+    fn executable_names(&self, build_platform: &Platform) -> &'static [&'static str];
 
-        // Do not pass the host CONDA_PREFIX to the activation. When
-        // CONDA_PREFIX is set (e.g. running inside a pixi/conda env), the
-        // activator generates deactivation scripts for that environment.
-        // Those deactivation scripts can fail inside the clean build
-        // subprocess (especially on macOS/Windows where compiler
-        // deactivation scripts may reference tools not in the stripped PATH).
-        let current_env = std::env::vars().collect::<HashMap<_, _>>();
-        let activation_vars = ActivationVariables {
-            conda_prefix: None,
-            path: None,
-            path_modification_behavior: PathModificationBehavior::Prepend,
-            current_env: current_env.clone(),
-        };
-
-        let host_activation = host_prefix_activator.activation(activation_vars)?;
-
-        if let Some(build_prefix) = &args.build_prefix {
-            let build_prefix_activator =
-                Activator::from_path(build_prefix, shell_type, args.execution_platform)?;
-            let activation_vars = ActivationVariables {
-                conda_prefix: None,
-                path: None,
-                path_modification_behavior: PathModificationBehavior::Prepend,
-                current_env: current_env.clone(),
-            };
-
-            let build_activation = build_prefix_activator.activation(activation_vars)?;
-            shell_script.append_script(&host_activation.script);
-            shell_script.append_script(&build_activation.script);
-        } else {
-            shell_script.append_script(&host_activation.script);
-        }
-
-        Ok(shell_script.contents()?)
+    /// Returns where the executable should be searched for.
+    ///
+    /// Implementations can opt into platform-specific system tools such as Unix
+    /// `bash` or Windows `cmd`; language interpreters default to the build
+    /// prefix to avoid host-tool leakage.
+    fn search_scope(&self, _build_platform: &Platform) -> InterpreterSearchScope {
+        InterpreterSearchScope::BuildPrefixOnly
     }
 
-    async fn run(&self, args: ExecutionArgs) -> Result<(), InterpreterError>;
+    /// Returns the default extension for files executed by this interpreter.
+    ///
+    /// The execution layer uses this for inline script blocks before invoking
+    /// the interpreter from the native wrapper.
+    fn extension(&self) -> &'static str;
 
-    #[allow(dead_code)]
-    async fn find_interpreter(
+    /// Returns the contents to write to files executed by this interpreter.
+    ///
+    /// Interpreters can add a small prologue around user code; most return the
+    /// script unchanged.
+    fn script_contents(&self, raw: &str) -> String {
+        raw.to_string()
+    }
+
+    /// Checks whether an executable candidate is usable for this interpreter.
+    ///
+    /// Implementations can reject a found executable and let lookup continue
+    /// with later candidates.
+    fn is_usable_executable(&self, _executable: &Path) -> Result<(), InterpreterError> {
+        Ok(())
+    }
+
+    /// Returns an executable for this interpreter.
+    ///
+    /// The default implementation provides shared lookup behavior; interpreters
+    /// can override it for platform-specific behavior.
+    fn resolve_executable(
         &self,
         build_prefix: Option<&PathBuf>,
-        platform: &Platform,
-    ) -> Result<Option<PathBuf>, which::Error>;
+        build_platform: &Platform,
+    ) -> Result<PathBuf, InterpreterError> {
+        let scope = self.search_scope(build_platform);
+        let mut unusable_candidate = None;
+
+        for executable_name in self.executable_names(build_platform) {
+            match find_interpreter(executable_name, build_prefix, build_platform, scope) {
+                Ok(Some(path)) => match self.is_usable_executable(&path) {
+                    Ok(()) => return Ok(path),
+                    Err(err) => unusable_candidate = Some((path, err)),
+                },
+                Ok(None) | Err(_) => continue,
+            }
+        }
+
+        if let Some((path, err)) = unusable_candidate {
+            return Err(InterpreterError::InvalidInterpreter {
+                interpreter: path.display().to_string(),
+                reason: err.to_string(),
+            });
+        }
+
+        Err(InterpreterError::InterpreterNotFound(
+            self.executable_names(build_platform)
+                .first()
+                .copied()
+                .unwrap_or("<unknown>")
+                .to_string(),
+        ))
+    }
+
+    /// Returns raw argument values after the executable.
+    ///
+    /// Each interpreter can provide its own flags and convention for receiving
+    /// the script file path.
+    fn args(&self, script_path: &Path) -> Vec<String>;
+}
+
+pub(crate) fn interpreter_invocation(interpreter: &str) -> Option<Box<dyn InterpreterInvocation>> {
+    match interpreter {
+        "bash" => Some(Box::new(bash::BashInvocation)),
+        "cmd" => Some(Box::new(cmd_exe::CmdExeInvocation)),
+        "brush" => Some(Box::new(brush::BrushInvocation)),
+        "nushell" | "nu" => Some(Box::new(nushell::NuShellInvocation)),
+        "python" => Some(Box::new(python::PythonInvocation)),
+        "perl" => Some(Box::new(perl::PerlInvocation)),
+        "rscript" => Some(Box::new(r::RInvocation)),
+        "ruby" => Some(Box::new(ruby::RubyInvocation)),
+        "node" | "nodejs" => Some(Box::new(nodejs::NodeJsInvocation)),
+        "powershell" => Some(Box::new(powershell::PowerShellInvocation)),
+        _ => None,
+    }
+}
+
+pub(crate) fn resolve_interpreter_executable(
+    build_prefix: Option<&PathBuf>,
+    build_platform: &Platform,
+    user_interpreter: &str,
+    invocation: &dyn InterpreterInvocation,
+) -> Result<PathBuf, InterpreterError> {
+    invocation
+        .resolve_executable(build_prefix, build_platform)
+        .map_err(|err| match err {
+            InterpreterError::InterpreterNotFound(_) => {
+                InterpreterError::InterpreterNotFound(user_interpreter.to_string())
+            }
+            InterpreterError::InvalidInterpreter { reason, .. } => {
+                InterpreterError::InvalidInterpreter {
+                    interpreter: user_interpreter.to_string(),
+                    reason,
+                }
+            }
+            other => other,
+        })
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::execution::{ExecutionArgs, ResolvedScriptContents};
+    use fs_err as fs;
+    use indexmap::IndexMap;
+    use rattler_conda_types::Platform;
+    use rattler_shell::activation::prefix_path_entries;
+    use std::path::{Path, PathBuf};
+
+    fn execution_args(
+        work_dir: PathBuf,
+        run_prefix: PathBuf,
+        script: ResolvedScriptContents,
+        interpreter: Option<&str>,
+    ) -> ExecutionArgs {
+        ExecutionArgs {
+            script,
+            interpreter: interpreter.map(str::to_string),
+            env_vars: IndexMap::new(),
+            secrets: IndexMap::new(),
+            execution_platform: Platform::current(),
+            build_prefix: None,
+            run_prefix,
+            work_dir,
+            sandbox_config: None,
+            env_isolation: crate::execution::EnvironmentIsolation::None,
+        }
+    }
+
+    fn native_build_script_path(work_dir: &Path) -> PathBuf {
+        work_dir.join(if cfg!(windows) {
+            "conda_build.bat"
+        } else {
+            "conda_build.sh"
+        })
+    }
+
+    fn create_fake_executable(prefix: &Path, name: &str) -> PathBuf {
+        let exe_name = format!("{}{}", name, std::env::consts::EXE_SUFFIX);
+        let bin_dir = prefix_path_entries(&prefix.to_path_buf(), &Platform::current())
+            .into_iter()
+            .next()
+            .expect("prefix has executable path entries");
+        fs::create_dir_all(&bin_dir).unwrap();
+        let exe = bin_dir.join(exe_name);
+        fs::write(&exe, "").unwrap();
+        #[cfg(unix)]
+        {
+            use std::{fs::Permissions, os::unix::fs::PermissionsExt};
+            fs::set_permissions(&exe, Permissions::from_mode(0o755)).unwrap();
+        }
+        exe
+    }
+
+    #[tokio::test]
+    async fn inline_without_interpreter_is_native_body() {
+        let tmp = tempfile::tempdir().unwrap();
+        let prefix = tmp.path().join("prefix");
+        fs::create_dir_all(&prefix).unwrap();
+
+        let args = execution_args(
+            tmp.path().to_path_buf(),
+            prefix,
+            ResolvedScriptContents::Inline("echo native".to_string()),
+            None,
+        );
+
+        crate::execution::generate_build_script(&args)
+            .await
+            .unwrap();
+
+        let build_script = fs::read_to_string(native_build_script_path(tmp.path())).unwrap();
+        assert!(build_script.contains("echo native"));
+        assert!(!tmp.path().join("conda_build_script.py").exists());
+    }
+
+    #[tokio::test]
+    async fn explicit_interpreter_writes_script_file_and_invocation() {
+        let tmp = tempfile::tempdir().unwrap();
+        let prefix = tmp.path().join("prefix");
+        fs::create_dir_all(&prefix).unwrap();
+        let python = create_fake_executable(&prefix, "python");
+
+        let args = execution_args(
+            tmp.path().to_path_buf(),
+            prefix,
+            ResolvedScriptContents::Inline("print('script file')".to_string()),
+            Some("python"),
+        );
+
+        crate::execution::generate_build_script(&args)
+            .await
+            .unwrap();
+
+        let script_file = tmp.path().join("conda_build_script.py");
+        assert_eq!(
+            fs::read_to_string(&script_file).unwrap(),
+            "print('script file')"
+        );
+
+        let build_script = fs::read_to_string(native_build_script_path(tmp.path())).unwrap();
+        assert!(build_script.contains(&python.to_string_lossy().to_string()));
+        assert!(build_script.contains(&script_file.to_string_lossy().to_string()));
+    }
+
+    #[tokio::test]
+    async fn inferred_file_interpreter_invokes_original_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let prefix = tmp.path().join("prefix");
+        fs::create_dir_all(&prefix).unwrap();
+        create_fake_executable(&prefix, "python");
+        let source_script = tmp.path().join("build.py");
+
+        let args = execution_args(
+            tmp.path().to_path_buf(),
+            prefix,
+            ResolvedScriptContents::Path(source_script.clone(), "print('from file')".to_string()),
+            None,
+        );
+
+        crate::execution::generate_build_script(&args)
+            .await
+            .unwrap();
+
+        assert!(!tmp.path().join("conda_build_script.py").exists());
+        let build_script = fs::read_to_string(native_build_script_path(tmp.path())).unwrap();
+        assert!(build_script.contains(&source_script.to_string_lossy().to_string()));
+        assert!(!build_script.contains("print('from file')"));
+    }
+
+    #[tokio::test]
+    async fn unknown_file_extension_without_interpreter_is_native_body() {
+        let tmp = tempfile::tempdir().unwrap();
+        let prefix = tmp.path().join("prefix");
+        fs::create_dir_all(&prefix).unwrap();
+
+        let args = execution_args(
+            tmp.path().to_path_buf(),
+            prefix,
+            ResolvedScriptContents::Path(
+                tmp.path().join("build.custom"),
+                "echo custom".to_string(),
+            ),
+            None,
+        );
+
+        crate::execution::generate_build_script(&args)
+            .await
+            .unwrap();
+
+        let build_script = fs::read_to_string(native_build_script_path(tmp.path())).unwrap();
+        assert!(build_script.contains("echo custom"));
+    }
+
+    #[tokio::test]
+    async fn build_prefix_only_interpreter_missing_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let prefix = tmp.path().join("prefix");
+        fs::create_dir_all(&prefix).unwrap();
+
+        let args = execution_args(
+            tmp.path().to_path_buf(),
+            prefix,
+            ResolvedScriptContents::Inline("print('missing')".to_string()),
+            Some("python"),
+        );
+
+        let err = crate::execution::generate_build_script(&args)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, InterpreterError::InterpreterNotFound(ref name) if name == "python"),
+            "expected missing python error, got {err:?}"
+        );
+    }
 }

--- a/crates/rattler_build_script/src/interpreter/mod.rs
+++ b/crates/rattler_build_script/src/interpreter/mod.rs
@@ -39,45 +39,81 @@ pub enum InterpreterError {
     InvalidInterpreter { interpreter: String, reason: String },
 }
 
-/// Defines where to look for an interpreter executable.
+/// Describes where to look for an interpreter executable: which environments to
+/// search and whether to fall back to the system `PATH`.
 #[derive(Debug, Clone, Copy)]
-pub enum InterpreterSearchScope {
-    /// Searches through the build prefix, then the system PATH.
-    PrefixThenSystemPath,
-    /// Searches only the build prefix.
-    BuildPrefixOnly,
+pub(crate) struct InterpreterSearchScope {
+    /// Search the build environment (the build prefix, or the host prefix when
+    /// build and host are merged).
+    search_build: bool,
+    /// Search the host (run) prefix.
+    search_host: bool,
+    /// Fall back to the system `PATH`.
+    system_fallback: bool,
+}
+
+impl InterpreterSearchScope {
+    /// Search only the build environment. For interpreters that must come from
+    /// the build environment for reproducibility (e.g. `brush`).
+    pub(crate) fn build_only() -> Self {
+        Self {
+            search_build: true,
+            search_host: false,
+            system_fallback: false,
+        }
+    }
+
+    /// Search the build and host environments, then fall back to the system
+    /// `PATH`. Mirrors the activated `PATH` a script actually runs under.
+    pub(crate) fn build_and_host_with_system_fallback() -> Self {
+        Self {
+            search_build: true,
+            search_host: true,
+            system_fallback: true,
+        }
+    }
+
+    /// Whether this scope falls back to the system `PATH`.
+    pub(crate) fn allows_system_fallback(&self) -> bool {
+        self.system_fallback
+    }
 }
 
 pub(crate) fn find_interpreter(
     name: &str,
-    build_prefix: Option<&PathBuf>,
+    build_prefix: Option<&Path>,
+    run_prefix: &Path,
     runtime: &RuntimeEnv,
     scope: InterpreterSearchScope,
 ) -> Option<PathBuf> {
-    let exe_name = format!("{}{}", name, std::env::consts::EXE_SUFFIX);
+    let exe_name = format!("{}{}", name, runtime.exe_suffix());
     let platform = runtime.platform();
 
-    // Build-prefix-only: search just the prefix bin entries, no PATH fallback.
-    if let InterpreterSearchScope::BuildPrefixOnly = scope {
-        let build_prefix = build_prefix?;
-        let prefix_path = prefix_path_entries(build_prefix, &platform);
-        return which::which_in_global(exe_name, std::env::join_paths(prefix_path).ok())
-            .ok()?
-            .next();
+    let mut search_path = Vec::new();
+    if scope.search_build {
+        // When build and host are merged there is no separate build prefix; the
+        // run prefix is the build environment.
+        let build_env = build_prefix.unwrap_or(run_prefix);
+        search_path.extend(prefix_path_entries(build_env, &platform));
+    }
+    if scope.search_host {
+        search_path.extend(prefix_path_entries(run_prefix, &platform));
+    }
+    if scope.system_fallback {
+        search_path.extend(std::env::split_paths(runtime.path()));
     }
 
-    let path = runtime.path();
-    if let Some(build_prefix) = build_prefix {
-        let mut prepend_path = prefix_path_entries(build_prefix, &platform)
-            .into_iter()
-            .collect::<Vec<_>>();
-        prepend_path.extend(std::env::split_paths(path));
-        return which::which_in_global(exe_name, std::env::join_paths(prepend_path).ok())
-            .ok()?
-            .next();
+    if search_path.is_empty() {
+        return None;
     }
-
-    which::which_in_global(exe_name, Some(path)).ok()?.next()
+    // The interpreter is resolved on the host filesystem, so use the host's path
+    // conventions throughout: `std::env::{split_paths,join_paths}` and `which`
+    // (path-list separator, `PATHEXT`, executable bit) all key off the host
+    // platform. `runtime.platform()` always equals the host here, so there is no
+    // cross-platform case to handle.
+    which::which_in_global(exe_name, std::env::join_paths(search_path).ok())
+        .ok()?
+        .next()
 }
 
 /// Describes how a specialized interpreter executes a script file.
@@ -90,11 +126,11 @@ pub(crate) trait InterpreterInvocation: Send + Sync {
 
     /// Returns where the executable should be searched for.
     ///
-    /// Implementations can opt into platform-specific system tools such as Unix
-    /// `bash` or Windows `cmd`; language interpreters default to the build
-    /// prefix to avoid host-tool leakage.
+    /// Defaults to the build environment only, for reproducibility. Native
+    /// shells and language interpreters override this to also search the host
+    /// environment and the system `PATH`; `brush` keeps the default.
     fn search_scope(&self, _build_platform: &Platform) -> InterpreterSearchScope {
-        InterpreterSearchScope::BuildPrefixOnly
+        InterpreterSearchScope::build_only()
     }
 
     /// Returns the default extension for files executed by this interpreter.
@@ -111,6 +147,14 @@ pub(crate) trait InterpreterInvocation: Send + Sync {
         raw.to_string()
     }
 
+    /// Assembles a list of recipe commands into a single script.
+    ///
+    /// The default joins with newlines; interpreters needing explicit error
+    /// propagation between commands (`cmd`) override it.
+    fn join_commands(&self, commands: &[String]) -> String {
+        commands.join("\n")
+    }
+
     /// Checks whether an executable candidate is usable for this interpreter.
     ///
     /// Implementations can reject a found executable and let lookup continue
@@ -125,7 +169,8 @@ pub(crate) trait InterpreterInvocation: Send + Sync {
     /// can override it for platform-specific behavior.
     fn resolve_executable(
         &self,
-        build_prefix: Option<&PathBuf>,
+        build_prefix: Option<&Path>,
+        run_prefix: &Path,
         runtime: &RuntimeEnv,
     ) -> Result<PathBuf, InterpreterError> {
         let platform = runtime.platform();
@@ -133,7 +178,7 @@ pub(crate) trait InterpreterInvocation: Send + Sync {
         let mut unusable_candidate = None;
 
         for executable_name in self.executable_names(&platform) {
-            match find_interpreter(executable_name, build_prefix, runtime, scope) {
+            match find_interpreter(executable_name, build_prefix, run_prefix, runtime, scope) {
                 Some(path) => match self.is_usable_executable(&path) {
                     Ok(()) => return Ok(path),
                     Err(err) => unusable_candidate = Some((path, err)),
@@ -206,6 +251,11 @@ impl SelectedInterpreter {
         self.invocation.script_contents(raw)
     }
 
+    /// Assembles a list of recipe commands into a single script.
+    pub(crate) fn join_commands(&self, commands: &[String]) -> String {
+        self.invocation.join_commands(commands)
+    }
+
     /// Returns the argument values following the executable for the given script file.
     pub(crate) fn args(&self, script_path: &Path) -> Vec<String> {
         self.invocation.args(script_path)
@@ -214,11 +264,12 @@ impl SelectedInterpreter {
     /// Resolve the executable, remapping internal errors to the user-facing name.
     pub(crate) fn resolve_executable(
         &self,
-        build_prefix: Option<&PathBuf>,
+        build_prefix: Option<&Path>,
+        run_prefix: &Path,
         runtime: &RuntimeEnv,
     ) -> Result<PathBuf, InterpreterError> {
         self.invocation
-            .resolve_executable(build_prefix, runtime)
+            .resolve_executable(build_prefix, run_prefix, runtime)
             .map_err(|err| match err {
                 InterpreterError::InterpreterNotFound(_) => {
                     InterpreterError::InterpreterNotFound(self.user_name.clone())
@@ -388,6 +439,8 @@ mod tests {
         assert!(build_script.contains("echo custom"));
     }
 
+    /// A build-prefix-only interpreter (`brush`) errors when absent instead of
+    /// falling back to a system copy (which `python` would).
     #[tokio::test]
     async fn build_prefix_only_interpreter_missing_errors() {
         let tmp = tempfile::tempdir().unwrap();
@@ -397,23 +450,23 @@ mod tests {
         let args = execution_args(
             tmp.path().to_path_buf(),
             prefix,
-            ResolvedScriptContents::Inline("print('missing')".to_string()),
-            Some("python"),
+            ResolvedScriptContents::Inline("echo missing".to_string()),
+            Some("brush"),
         );
 
         let err = crate::execution::generate_build_script(&args)
             .await
             .unwrap_err();
         assert!(
-            matches!(err, InterpreterError::InterpreterNotFound(ref name) if name == "python"),
-            "expected missing python error, got {err:?}"
+            matches!(err, InterpreterError::InterpreterNotFound(ref name) if name == "brush"),
+            "expected missing brush error, got {err:?}"
         );
     }
 
     /// Stub interpreter that exercises the candidate iteration and
     /// `is_usable_executable` rejection path of the default
-    /// `resolve_executable`. It searches the build prefix only and tries two
-    /// executable names; the first name is always rejected by validation.
+    /// `resolve_executable`. It searches the build environment only and tries
+    /// two executable names; the first name is always rejected by validation.
     struct RejectFirstStub;
 
     impl InterpreterInvocation for RejectFirstStub {
@@ -422,7 +475,7 @@ mod tests {
         }
 
         fn search_scope(&self, _build_platform: &Platform) -> InterpreterSearchScope {
-            InterpreterSearchScope::BuildPrefixOnly
+            InterpreterSearchScope::build_only()
         }
 
         fn extension(&self) -> &'static str {
@@ -462,7 +515,11 @@ mod tests {
 
         let stub = RejectFirstStub;
         let resolved = stub
-            .resolve_executable(Some(&prefix), &RuntimeEnv::current())
+            .resolve_executable(
+                Some(prefix.as_path()),
+                prefix.as_path(),
+                &RuntimeEnv::current(),
+            )
             .expect("second candidate should resolve");
         assert_eq!(resolved, second);
     }
@@ -481,7 +538,11 @@ mod tests {
 
         let stub = RejectFirstStub;
         let err = stub
-            .resolve_executable(Some(&prefix), &RuntimeEnv::current())
+            .resolve_executable(
+                Some(prefix.as_path()),
+                prefix.as_path(),
+                &RuntimeEnv::current(),
+            )
             .expect_err("only candidate is rejected");
         match err {
             InterpreterError::InvalidInterpreter { interpreter, .. } => {
@@ -511,7 +572,11 @@ mod tests {
         };
 
         let err = selected
-            .resolve_executable(Some(&prefix), &RuntimeEnv::current())
+            .resolve_executable(
+                Some(prefix.as_path()),
+                prefix.as_path(),
+                &RuntimeEnv::current(),
+            )
             .expect_err("only candidate is rejected");
         match err {
             InterpreterError::InvalidInterpreter {
@@ -525,18 +590,18 @@ mod tests {
         }
     }
 
-    /// Language interpreters must not leak from the system PATH: `find_interpreter`
-    /// with `PrefixThenSystemPath` finds an exe present only on PATH, while
-    /// `BuildPrefixOnly` does not. The `PATH` is injected through `RuntimeEnv`, so
-    /// the test does not touch the real process environment.
+    /// A `build_only` interpreter must not leak from the system PATH, while one
+    /// with a system fallback finds an exe present only on PATH. The `PATH` is
+    /// injected through `RuntimeEnv`, so the test does not touch the real process
+    /// environment.
     #[test]
-    fn search_scope_path_fallback_vs_prefix_only() {
+    fn system_fallback_scope_finds_path_only_exe() {
         let tmp = tempfile::tempdir().unwrap();
         let prefix = tmp.path().join("prefix");
         fs::create_dir_all(&prefix).unwrap();
 
         // Place a fake exe in a separate dir that we expose only via the runtime
-        // PATH, NOT in the build prefix.
+        // PATH, NOT in any prefix.
         let path_dir = tmp.path().join("path_only");
         fs::create_dir_all(&path_dir).unwrap();
         let exe_name = format!("rb_path_only_tool{}", std::env::consts::EXE_SUFFIX);
@@ -553,31 +618,103 @@ mod tests {
 
         let found_via_path = find_interpreter(
             "rb_path_only_tool",
-            Some(&prefix),
+            Some(prefix.as_path()),
+            prefix.as_path(),
             &runtime,
-            InterpreterSearchScope::PrefixThenSystemPath,
+            InterpreterSearchScope::build_and_host_with_system_fallback(),
         );
-        let found_prefix_only = find_interpreter(
+        let found_build_only = find_interpreter(
             "rb_path_only_tool",
-            Some(&prefix),
+            Some(prefix.as_path()),
+            prefix.as_path(),
             &runtime,
-            InterpreterSearchScope::BuildPrefixOnly,
+            InterpreterSearchScope::build_only(),
         );
 
         assert!(
             found_via_path.is_some(),
-            "PrefixThenSystemPath should find the exe on PATH"
+            "system-fallback scope should find the exe on PATH"
         );
         assert_eq!(found_via_path.unwrap(), exe);
         assert!(
-            found_prefix_only.is_none(),
-            "BuildPrefixOnly must not find an exe that lives only on PATH"
+            found_build_only.is_none(),
+            "build_only must not find an exe that lives only on PATH"
+        );
+    }
+
+    /// The generated wrapper quotes a resolved interpreter path that contains
+    /// spaces (the cmd.exe-on-Windows failure), so it survives the native shell.
+    #[tokio::test]
+    async fn generated_wrapper_quotes_spaced_interpreter_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        // A prefix path containing a space, like `C:\Program Files\...`.
+        let prefix = tmp.path().join("pre fix");
+        fs::create_dir_all(&prefix).unwrap();
+        let python = create_fake_executable(&prefix, "python");
+        assert!(python.to_string_lossy().contains(' '));
+
+        let args = execution_args(
+            tmp.path().to_path_buf(),
+            prefix,
+            ResolvedScriptContents::Inline("print('hi')".to_string()),
+            Some("python"),
+        );
+        crate::execution::generate_build_script(&args)
+            .await
+            .unwrap();
+
+        let wrapper = fs::read_to_string(native_build_script_path(tmp.path())).unwrap();
+        let path = python.to_string_lossy();
+        let quoted = if cfg!(windows) {
+            format!("\"{path}\"")
+        } else {
+            format!("'{path}'")
+        };
+        assert!(
+            wrapper.contains(&quoted),
+            "wrapper must quote the spaced interpreter path `{quoted}`, got:\n{wrapper}"
+        );
+    }
+
+    /// An interpreter provided as a `host` dependency lives in the run prefix.
+    /// A system-fallback scope searches it, while `build_only` does not.
+    #[test]
+    fn host_prefix_searched_only_with_system_fallback_scope() {
+        let tmp = tempfile::tempdir().unwrap();
+        let build_prefix = tmp.path().join("build");
+        let host_prefix = tmp.path().join("host");
+        fs::create_dir_all(&build_prefix).unwrap();
+        fs::create_dir_all(&host_prefix).unwrap();
+        // The tool exists only in the host prefix.
+        let tool = create_fake_executable(&host_prefix, "rb_host_tool");
+        // Empty runtime PATH so resolution can only come from a prefix.
+        let runtime = RuntimeEnv::for_test(Platform::current()).with_var("PATH", "");
+
+        let found = find_interpreter(
+            "rb_host_tool",
+            Some(build_prefix.as_path()),
+            host_prefix.as_path(),
+            &runtime,
+            InterpreterSearchScope::build_and_host_with_system_fallback(),
+        );
+        assert_eq!(found.as_deref(), Some(tool.as_path()));
+
+        let build_only = find_interpreter(
+            "rb_host_tool",
+            Some(build_prefix.as_path()),
+            host_prefix.as_path(),
+            &runtime,
+            InterpreterSearchScope::build_only(),
+        );
+        assert!(
+            build_only.is_none(),
+            "build_only must not search the host prefix"
         );
     }
 
     /// PowerShell tries `pwsh` first then `powershell` on the windows branch.
     /// This documents the candidate order without resolving (the real invocation
-    /// uses `PrefixThenSystemPath`, so a system `pwsh` would leak into resolution).
+    /// has a system fallback, so a system `pwsh` would leak into resolution).
     #[test]
     fn powershell_lists_pwsh_then_powershell_on_windows() {
         let names = super::powershell::PowerShellInvocation.executable_names(&Platform::Win64);
@@ -585,7 +722,7 @@ mod tests {
     }
 
     /// When the first executable name is absent from the prefix, resolution falls
-    /// through to a later name. Uses the `BuildPrefixOnly` stub so the system PATH
+    /// through to a later name. Uses the `build_only` stub so the system PATH
     /// cannot leak a real `stub_first`/`stub_second` into the result. This covers
     /// the `find_interpreter == None` continue branch (distinct from the
     /// `is_usable_executable` rejection branch above), mirroring how PowerShell
@@ -599,7 +736,11 @@ mod tests {
         let second = create_fake_executable(&prefix, "stub_second");
 
         let resolved = RejectFirstStub
-            .resolve_executable(Some(&prefix), &RuntimeEnv::current())
+            .resolve_executable(
+                Some(prefix.as_path()),
+                prefix.as_path(),
+                &RuntimeEnv::current(),
+            )
             .expect("second candidate should resolve when the first is absent");
         assert_eq!(resolved, second);
     }
@@ -618,7 +759,8 @@ mod tests {
         let runtime = RuntimeEnv::for_test(Platform::Win64)
             .with_var("COMSPEC", fake_cmd.to_string_lossy().into_owned());
 
-        let resolved = super::cmd_exe::CmdExeInvocation.resolve_executable(None, &runtime);
+        let resolved =
+            super::cmd_exe::CmdExeInvocation.resolve_executable(None, tmp.path(), &runtime);
         assert_eq!(resolved.unwrap(), fake_cmd);
     }
 
@@ -648,6 +790,28 @@ mod tests {
                 .unwrap()
                 .extension(),
             "py"
+        );
+    }
+
+    /// `cmd` propagates a non-zero exit between commands; others join plainly.
+    #[test]
+    fn join_commands_is_interpreter_specific() {
+        let commands = vec!["echo Hello".to_string(), "echo World".to_string()];
+
+        assert_eq!(
+            super::cmd_exe::CmdExeInvocation.join_commands(&commands),
+            "echo Hello\nif %errorlevel% neq 0 exit /b %errorlevel%\n\
+             echo World\nif %errorlevel% neq 0 exit /b %errorlevel%"
+        );
+        // bash relies on `set -e` in the preamble, so a plain join is enough.
+        assert_eq!(
+            super::bash::BashInvocation.join_commands(&commands),
+            "echo Hello\necho World"
+        );
+        // A language interpreter uses the default plain join too.
+        assert_eq!(
+            super::python::PythonInvocation.join_commands(&commands),
+            "echo Hello\necho World"
         );
     }
 }

--- a/crates/rattler_build_script/src/interpreter/mod.rs
+++ b/crates/rattler_build_script/src/interpreter/mod.rs
@@ -51,18 +51,16 @@ pub(crate) fn find_interpreter(
     build_prefix: Option<&PathBuf>,
     platform: &Platform,
     scope: InterpreterSearchScope,
-) -> Result<Option<PathBuf>, which::Error> {
+) -> Option<PathBuf> {
     let exe_name = format!("{}{}", name, std::env::consts::EXE_SUFFIX);
 
     // Build-prefix-only: search just the prefix bin entries, no PATH fallback.
     if let InterpreterSearchScope::BuildPrefixOnly = scope {
-        let Some(build_prefix) = build_prefix else {
-            return Ok(None);
-        };
+        let build_prefix = build_prefix?;
         let prefix_path = prefix_path_entries(build_prefix, platform);
-        return Ok(
-            which::which_in_global(exe_name, std::env::join_paths(prefix_path).ok())?.next(),
-        );
+        return which::which_in_global(exe_name, std::env::join_paths(prefix_path).ok())
+            .ok()?
+            .next();
     }
 
     let path = std::env::var("PATH").unwrap_or_default();
@@ -71,12 +69,12 @@ pub(crate) fn find_interpreter(
             .into_iter()
             .collect::<Vec<_>>();
         prepend_path.extend(std::env::split_paths(&path));
-        return Ok(
-            which::which_in_global(exe_name, std::env::join_paths(prepend_path).ok())?.next(),
-        );
+        return which::which_in_global(exe_name, std::env::join_paths(prepend_path).ok())
+            .ok()?
+            .next();
     }
 
-    Ok(which::which_in_global(exe_name, Some(path))?.next())
+    which::which_in_global(exe_name, Some(path)).ok()?.next()
 }
 
 /// Describes how a specialized interpreter executes a script file.
@@ -132,11 +130,11 @@ pub(crate) trait InterpreterInvocation: Send + Sync {
 
         for executable_name in self.executable_names(build_platform) {
             match find_interpreter(executable_name, build_prefix, build_platform, scope) {
-                Ok(Some(path)) => match self.is_usable_executable(&path) {
+                Some(path) => match self.is_usable_executable(&path) {
                     Ok(()) => return Ok(path),
                     Err(err) => unusable_candidate = Some((path, err)),
                 },
-                Ok(None) | Err(_) => continue,
+                None => continue,
             }
         }
 
@@ -163,7 +161,7 @@ pub(crate) trait InterpreterInvocation: Send + Sync {
     fn args(&self, script_path: &Path) -> Vec<String>;
 }
 
-pub(crate) fn interpreter_invocation(interpreter: &str) -> Option<Box<dyn InterpreterInvocation>> {
+fn interpreter_invocation(interpreter: &str) -> Option<Box<dyn InterpreterInvocation>> {
     match interpreter {
         "bash" => Some(Box::new(bash::BashInvocation)),
         "cmd" => Some(Box::new(cmd_exe::CmdExeInvocation)),
@@ -179,26 +177,57 @@ pub(crate) fn interpreter_invocation(interpreter: &str) -> Option<Box<dyn Interp
     }
 }
 
-pub(crate) fn resolve_interpreter_executable(
-    build_prefix: Option<&PathBuf>,
-    build_platform: &Platform,
-    user_interpreter: &str,
-    invocation: &dyn InterpreterInvocation,
-) -> Result<PathBuf, InterpreterError> {
-    invocation
-        .resolve_executable(build_prefix, build_platform)
-        .map_err(|err| match err {
-            InterpreterError::InterpreterNotFound(_) => {
-                InterpreterError::InterpreterNotFound(user_interpreter.to_string())
-            }
-            InterpreterError::InvalidInterpreter { reason, .. } => {
-                InterpreterError::InvalidInterpreter {
-                    interpreter: user_interpreter.to_string(),
-                    reason,
-                }
-            }
-            other => other,
+/// An interpreter selected from a recipe, pairing the user-facing name with its invocation behavior.
+pub(crate) struct SelectedInterpreter {
+    user_name: String,
+    invocation: Box<dyn InterpreterInvocation>,
+}
+
+impl SelectedInterpreter {
+    /// Look up the interpreter by its recipe name, returning None if unsupported.
+    pub(crate) fn from_recipe_name(name: &str) -> Option<Self> {
+        interpreter_invocation(name).map(|invocation| Self {
+            user_name: name.to_string(),
+            invocation,
         })
+    }
+
+    /// Returns the default file extension for scripts run by this interpreter.
+    pub(crate) fn extension(&self) -> &'static str {
+        self.invocation.extension()
+    }
+
+    /// Returns the contents to write to files executed by this interpreter.
+    pub(crate) fn script_contents(&self, raw: &str) -> String {
+        self.invocation.script_contents(raw)
+    }
+
+    /// Returns the argument values following the executable for the given script file.
+    pub(crate) fn args(&self, script_path: &Path) -> Vec<String> {
+        self.invocation.args(script_path)
+    }
+
+    /// Resolve the executable, remapping internal errors to the user-facing name.
+    pub(crate) fn resolve_executable(
+        &self,
+        build_prefix: Option<&PathBuf>,
+        platform: &Platform,
+    ) -> Result<PathBuf, InterpreterError> {
+        self.invocation
+            .resolve_executable(build_prefix, platform)
+            .map_err(|err| match err {
+                InterpreterError::InterpreterNotFound(_) => {
+                    InterpreterError::InterpreterNotFound(self.user_name.clone())
+                }
+                InterpreterError::InvalidInterpreter { reason, .. } => {
+                    InterpreterError::InvalidInterpreter {
+                        interpreter: self.user_name.clone(),
+                        reason,
+                    }
+                }
+                other => other,
+            })
+    }
 }
 #[cfg(test)]
 mod tests {
@@ -240,7 +269,7 @@ mod tests {
 
     fn create_fake_executable(prefix: &Path, name: &str) -> PathBuf {
         let exe_name = format!("{}{}", name, std::env::consts::EXE_SUFFIX);
-        let bin_dir = prefix_path_entries(&prefix.to_path_buf(), &Platform::current())
+        let bin_dir = prefix_path_entries(prefix, &Platform::current())
             .into_iter()
             .next()
             .expect("prefix has executable path entries");
@@ -374,6 +403,276 @@ mod tests {
         assert!(
             matches!(err, InterpreterError::InterpreterNotFound(ref name) if name == "python"),
             "expected missing python error, got {err:?}"
+        );
+    }
+
+    /// Stub interpreter that exercises the candidate iteration and
+    /// `is_usable_executable` rejection path of the default
+    /// `resolve_executable`. It searches the build prefix only and tries two
+    /// executable names; the first name is always rejected by validation.
+    struct RejectFirstStub;
+
+    impl InterpreterInvocation for RejectFirstStub {
+        fn executable_names(&self, _build_platform: &Platform) -> &'static [&'static str] {
+            &["stub_first", "stub_second"]
+        }
+
+        fn search_scope(&self, _build_platform: &Platform) -> InterpreterSearchScope {
+            InterpreterSearchScope::BuildPrefixOnly
+        }
+
+        fn extension(&self) -> &'static str {
+            "stub"
+        }
+
+        fn is_usable_executable(&self, executable: &Path) -> Result<(), InterpreterError> {
+            // Reject any candidate whose file stem is `stub_first`.
+            let stem = executable
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or_default();
+            if stem == "stub_first" {
+                Err(InterpreterError::InvalidInterpreter {
+                    interpreter: executable.display().to_string(),
+                    reason: "rejected by test stub".to_string(),
+                })
+            } else {
+                Ok(())
+            }
+        }
+
+        fn args(&self, script_path: &Path) -> Vec<String> {
+            vec![script_path.to_string_lossy().into_owned()]
+        }
+    }
+
+    /// Case A: the first candidate is rejected by `is_usable_executable`, so
+    /// lookup continues and returns the second (usable) candidate.
+    #[test]
+    fn rejected_first_candidate_falls_through_to_second() {
+        let tmp = tempfile::tempdir().unwrap();
+        let prefix = tmp.path().join("prefix");
+        fs::create_dir_all(&prefix).unwrap();
+        create_fake_executable(&prefix, "stub_first");
+        let second = create_fake_executable(&prefix, "stub_second");
+
+        let stub = RejectFirstStub;
+        let resolved = stub
+            .resolve_executable(Some(&prefix), &Platform::current())
+            .expect("second candidate should resolve");
+        assert_eq!(resolved, second);
+    }
+
+    /// Case B: the only available candidate is rejected, so
+    /// `resolve_executable` reports `InvalidInterpreter`. Going through
+    /// `SelectedInterpreter` is not possible for a test-only stub, so the
+    /// recipe-name remapping is asserted by exercising the same `map_err`
+    /// behavior directly via a real factory interpreter below.
+    #[test]
+    fn only_candidate_rejected_yields_invalid_interpreter() {
+        let tmp = tempfile::tempdir().unwrap();
+        let prefix = tmp.path().join("prefix");
+        fs::create_dir_all(&prefix).unwrap();
+        let first = create_fake_executable(&prefix, "stub_first");
+
+        let stub = RejectFirstStub;
+        let err = stub
+            .resolve_executable(Some(&prefix), &Platform::current())
+            .expect_err("only candidate is rejected");
+        match err {
+            InterpreterError::InvalidInterpreter { interpreter, .. } => {
+                // The raw error carries the executable path, not a user-facing name.
+                assert_eq!(interpreter, first.display().to_string());
+            }
+            other => panic!("expected InvalidInterpreter, got {other:?}"),
+        }
+    }
+
+    /// Wrapping a `SelectedInterpreter` around an invocation remaps the
+    /// `InvalidInterpreter.interpreter` field from the executable path to the
+    /// user-facing recipe name. We exercise this with the powershell factory
+    /// interpreter, whose `is_usable_executable` never errors, so we instead
+    /// assert the remapping logic via a directly-constructed SelectedInterpreter
+    /// whose invocation always rejects.
+    #[test]
+    fn selected_interpreter_remaps_invalid_to_user_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let prefix = tmp.path().join("prefix");
+        fs::create_dir_all(&prefix).unwrap();
+        create_fake_executable(&prefix, "stub_first");
+
+        let selected = SelectedInterpreter {
+            user_name: "my-recipe-interp".to_string(),
+            invocation: Box::new(RejectFirstStub),
+        };
+
+        let err = selected
+            .resolve_executable(Some(&prefix), &Platform::current())
+            .expect_err("only candidate is rejected");
+        match err {
+            InterpreterError::InvalidInterpreter {
+                interpreter,
+                reason,
+            } => {
+                assert_eq!(interpreter, "my-recipe-interp");
+                assert!(reason.contains("rejected by test stub"), "reason: {reason}");
+            }
+            other => panic!("expected InvalidInterpreter, got {other:?}"),
+        }
+    }
+
+    /// Language interpreters must not leak from the system PATH: `find_interpreter`
+    /// with `PrefixThenSystemPath` finds an exe present only on PATH, while
+    /// `BuildPrefixOnly` does not.
+    #[test]
+    #[serial_test::serial]
+    fn search_scope_path_fallback_vs_prefix_only() {
+        let tmp = tempfile::tempdir().unwrap();
+        let prefix = tmp.path().join("prefix");
+        fs::create_dir_all(&prefix).unwrap();
+
+        // Place a fake exe in a separate dir that we prepend onto PATH, NOT in
+        // the build prefix.
+        let path_dir = tmp.path().join("path_only");
+        fs::create_dir_all(&path_dir).unwrap();
+        let exe_name = format!("rb_path_only_tool{}", std::env::consts::EXE_SUFFIX);
+        let exe = path_dir.join(&exe_name);
+        fs::write(&exe, "").unwrap();
+        #[cfg(unix)]
+        {
+            use std::{fs::Permissions, os::unix::fs::PermissionsExt};
+            fs::set_permissions(&exe, Permissions::from_mode(0o755)).unwrap();
+        }
+
+        let original_path = std::env::var_os("PATH");
+        let mut new_paths = vec![path_dir.clone()];
+        if let Some(orig) = &original_path {
+            new_paths.extend(std::env::split_paths(orig));
+        }
+        // SAFETY: env mutation is serialized via #[serial] and restored below.
+        unsafe {
+            std::env::set_var("PATH", std::env::join_paths(&new_paths).unwrap());
+        }
+
+        let platform = Platform::current();
+        let found_via_path = find_interpreter(
+            "rb_path_only_tool",
+            Some(&prefix),
+            &platform,
+            InterpreterSearchScope::PrefixThenSystemPath,
+        );
+        let found_prefix_only = find_interpreter(
+            "rb_path_only_tool",
+            Some(&prefix),
+            &platform,
+            InterpreterSearchScope::BuildPrefixOnly,
+        );
+
+        // Restore PATH before asserting so a failure does not corrupt later tests.
+        // SAFETY: env mutation is serialized via #[serial].
+        unsafe {
+            match original_path {
+                Some(orig) => std::env::set_var("PATH", orig),
+                None => std::env::remove_var("PATH"),
+            }
+        }
+
+        assert!(
+            found_via_path.is_some(),
+            "PrefixThenSystemPath should find the exe on PATH"
+        );
+        assert_eq!(found_via_path.unwrap(), exe);
+        assert!(
+            found_prefix_only.is_none(),
+            "BuildPrefixOnly must not find an exe that lives only on PATH"
+        );
+    }
+
+    /// PowerShell tries `pwsh` first then `powershell` on the windows branch.
+    /// This documents the candidate order without resolving (the real invocation
+    /// uses `PrefixThenSystemPath`, so a system `pwsh` would leak into resolution).
+    #[test]
+    fn powershell_lists_pwsh_then_powershell_on_windows() {
+        let names = super::powershell::PowerShellInvocation.executable_names(&Platform::Win64);
+        assert_eq!(names, &["pwsh", "powershell"]);
+    }
+
+    /// When the first executable name is absent from the prefix, resolution falls
+    /// through to a later name. Uses the `BuildPrefixOnly` stub so the system PATH
+    /// cannot leak a real `stub_first`/`stub_second` into the result. This covers
+    /// the `find_interpreter == None` continue branch (distinct from the
+    /// `is_usable_executable` rejection branch above), mirroring how PowerShell
+    /// falls through from `pwsh` to `powershell`.
+    #[test]
+    fn missing_first_candidate_falls_through_to_second() {
+        let tmp = tempfile::tempdir().unwrap();
+        let prefix = tmp.path().join("prefix");
+        fs::create_dir_all(&prefix).unwrap();
+        // Create only the second candidate; `stub_first` is never found on disk.
+        let second = create_fake_executable(&prefix, "stub_second");
+
+        let resolved = RejectFirstStub
+            .resolve_executable(Some(&prefix), &Platform::current())
+            .expect("second candidate should resolve when the first is absent");
+        assert_eq!(resolved, second);
+    }
+
+    /// On Windows, cmd resolution special-cases `COMSPEC` when it points at
+    /// `cmd.exe`, returning it verbatim.
+    #[cfg(windows)]
+    #[test]
+    #[serial_test::serial]
+    fn cmd_uses_comspec_special_case() {
+        let tmp = tempfile::tempdir().unwrap();
+        let fake_cmd = tmp.path().join("system32").join("cmd.exe");
+        fs::create_dir_all(fake_cmd.parent().unwrap()).unwrap();
+        fs::write(&fake_cmd, "").unwrap();
+
+        let original = std::env::var_os("COMSPEC");
+        // SAFETY: env mutation is serialized via #[serial] and restored below.
+        unsafe {
+            std::env::set_var("COMSPEC", &fake_cmd);
+        }
+
+        let resolved = super::cmd_exe::CmdExeInvocation.resolve_executable(None, &Platform::Win64);
+
+        // SAFETY: env mutation is serialized via #[serial].
+        unsafe {
+            match original {
+                Some(orig) => std::env::set_var("COMSPEC", orig),
+                None => std::env::remove_var("COMSPEC"),
+            }
+        }
+
+        assert_eq!(resolved.unwrap(), fake_cmd);
+    }
+
+    /// Recipe-name factory mapping to file extensions.
+    #[test]
+    fn factory_maps_recipe_names_to_extensions() {
+        assert_eq!(
+            SelectedInterpreter::from_recipe_name("nushell")
+                .unwrap()
+                .extension(),
+            "nu"
+        );
+        assert_eq!(
+            SelectedInterpreter::from_recipe_name("nu")
+                .unwrap()
+                .extension(),
+            "nu"
+        );
+        assert_eq!(
+            SelectedInterpreter::from_recipe_name("brush")
+                .unwrap()
+                .extension(),
+            "sh"
+        );
+        assert_eq!(
+            SelectedInterpreter::from_recipe_name("python")
+                .unwrap()
+                .extension(),
+            "py"
         );
     }
 }

--- a/crates/rattler_build_script/src/interpreter/nodejs.rs
+++ b/crates/rattler_build_script/src/interpreter/nodejs.rs
@@ -1,44 +1,19 @@
-use std::path::PathBuf;
-
 use rattler_conda_types::Platform;
 
-use crate::execution::{ExecutionArgs, ResolvedScriptContents};
+use super::InterpreterInvocation;
 
-use super::{
-    BashInterpreter, CmdExeInterpreter, Interpreter, InterpreterError, InterpreterSearchScope,
-    find_interpreter,
-};
+pub struct NodeJsInvocation;
 
-pub struct NodeJsInterpreter;
-
-// NodeJS interpreter calls either bash or cmd.exe interpreter for activation and then runs Node script
-impl Interpreter for NodeJsInterpreter {
-    async fn run(&self, args: ExecutionArgs) -> Result<(), InterpreterError> {
-        let node_script = args.work_dir.join("conda_build_script.js");
-        tokio::fs::write(&node_script, args.script.script()).await?;
-
-        let args = ExecutionArgs {
-            script: ResolvedScriptContents::Inline(format!("node {:?}", node_script)),
-            ..args
-        };
-
-        if cfg!(windows) {
-            CmdExeInterpreter.run(args).await
-        } else {
-            BashInterpreter.run(args).await
-        }
+impl InterpreterInvocation for NodeJsInvocation {
+    fn executable_names(&self, _build_platform: &Platform) -> &'static [&'static str] {
+        &["node"]
     }
 
-    async fn find_interpreter(
-        &self,
-        build_prefix: Option<&PathBuf>,
-        platform: &Platform,
-    ) -> Result<Option<PathBuf>, which::Error> {
-        find_interpreter(
-            "node",
-            build_prefix,
-            platform,
-            InterpreterSearchScope::PrefixThenSystemPath,
-        )
+    fn extension(&self) -> &'static str {
+        "js"
+    }
+
+    fn args(&self, script_path: &std::path::Path) -> Vec<String> {
+        vec![script_path.to_string_lossy().into_owned()]
     }
 }

--- a/crates/rattler_build_script/src/interpreter/nodejs.rs
+++ b/crates/rattler_build_script/src/interpreter/nodejs.rs
@@ -1,12 +1,16 @@
 use rattler_conda_types::Platform;
 
-use super::InterpreterInvocation;
+use super::{InterpreterInvocation, InterpreterSearchScope};
 
 pub struct NodeJsInvocation;
 
 impl InterpreterInvocation for NodeJsInvocation {
     fn executable_names(&self, _build_platform: &Platform) -> &'static [&'static str] {
         &["node"]
+    }
+
+    fn search_scope(&self, _build_platform: &Platform) -> InterpreterSearchScope {
+        InterpreterSearchScope::build_and_host_with_system_fallback()
     }
 
     fn extension(&self) -> &'static str {

--- a/crates/rattler_build_script/src/interpreter/nushell.rs
+++ b/crates/rattler_build_script/src/interpreter/nushell.rs
@@ -1,12 +1,16 @@
 use rattler_conda_types::Platform;
 
-use super::InterpreterInvocation;
+use super::{InterpreterInvocation, InterpreterSearchScope};
 
 pub struct NuShellInvocation;
 
 impl InterpreterInvocation for NuShellInvocation {
     fn executable_names(&self, _build_platform: &Platform) -> &'static [&'static str] {
         &["nu"]
+    }
+
+    fn search_scope(&self, _build_platform: &Platform) -> InterpreterSearchScope {
+        InterpreterSearchScope::build_and_host_with_system_fallback()
     }
 
     fn extension(&self) -> &'static str {

--- a/crates/rattler_build_script/src/interpreter/nushell.rs
+++ b/crates/rattler_build_script/src/interpreter/nushell.rs
@@ -1,58 +1,19 @@
-use std::path::PathBuf;
-
 use rattler_conda_types::Platform;
 
-use crate::execution::{ExecutionArgs, ResolvedScriptContents};
+use super::InterpreterInvocation;
 
-use super::{
-    BashInterpreter, CmdExeInterpreter, Interpreter, InterpreterError, InterpreterSearchScope,
-    find_interpreter,
-};
+pub struct NuShellInvocation;
 
-pub struct NuShellInterpreter;
-
-// NuShell scripts are executed by invoking `nu` on the user script. The native
-// bash/cmd wrapper performs activation and then invokes nu on the user script
-// as a child process.
-impl Interpreter for NuShellInterpreter {
-    async fn run(&self, args: ExecutionArgs) -> Result<(), InterpreterError> {
-        // nu must be provided by the build environment, not the system PATH.
-        let nu_path = find_interpreter(
-            "nu",
-            args.build_prefix.as_ref(),
-            &args.execution_platform,
-            InterpreterSearchScope::BuildPrefixOnly,
-        )
-        .ok()
-        .flatten()
-        .ok_or_else(|| InterpreterError::InterpreterNotFound("nu".to_string()))?;
-
-        let nu_script = args.work_dir.join("conda_build_script.nu");
-        tokio::fs::write(&nu_script, args.script.script()).await?;
-
-        // Invoke the resolved nu from the wrapper so the build-env binary runs.
-        let args = ExecutionArgs {
-            script: ResolvedScriptContents::Inline(format!("{:?} {:?}", nu_path, nu_script)),
-            ..args
-        };
-
-        if cfg!(windows) {
-            CmdExeInterpreter.run(args).await
-        } else {
-            BashInterpreter.run(args).await
-        }
+impl InterpreterInvocation for NuShellInvocation {
+    fn executable_names(&self, _build_platform: &Platform) -> &'static [&'static str] {
+        &["nu"]
     }
 
-    async fn find_interpreter(
-        &self,
-        build_prefix: Option<&PathBuf>,
-        platform: &Platform,
-    ) -> Result<Option<PathBuf>, which::Error> {
-        find_interpreter(
-            "nu",
-            build_prefix,
-            platform,
-            InterpreterSearchScope::BuildPrefixOnly,
-        )
+    fn extension(&self) -> &'static str {
+        "nu"
+    }
+
+    fn args(&self, script_path: &std::path::Path) -> Vec<String> {
+        vec![script_path.to_string_lossy().into_owned()]
     }
 }

--- a/crates/rattler_build_script/src/interpreter/perl.rs
+++ b/crates/rattler_build_script/src/interpreter/perl.rs
@@ -1,12 +1,16 @@
 use rattler_conda_types::Platform;
 
-use super::InterpreterInvocation;
+use super::{InterpreterInvocation, InterpreterSearchScope};
 
 pub struct PerlInvocation;
 
 impl InterpreterInvocation for PerlInvocation {
     fn executable_names(&self, _build_platform: &Platform) -> &'static [&'static str] {
         &["perl"]
+    }
+
+    fn search_scope(&self, _build_platform: &Platform) -> InterpreterSearchScope {
+        InterpreterSearchScope::build_and_host_with_system_fallback()
     }
 
     fn extension(&self) -> &'static str {

--- a/crates/rattler_build_script/src/interpreter/perl.rs
+++ b/crates/rattler_build_script/src/interpreter/perl.rs
@@ -1,44 +1,19 @@
-use std::path::PathBuf;
-
 use rattler_conda_types::Platform;
 
-use crate::execution::{ExecutionArgs, ResolvedScriptContents};
+use super::InterpreterInvocation;
 
-use super::{
-    BashInterpreter, CmdExeInterpreter, Interpreter, InterpreterError, InterpreterSearchScope,
-    find_interpreter,
-};
+pub struct PerlInvocation;
 
-pub struct PerlInterpreter;
-
-// Perl interpreter calls either bash or cmd.exe interpreter for activation and then runs Perl script
-impl Interpreter for PerlInterpreter {
-    async fn run(&self, args: ExecutionArgs) -> Result<(), InterpreterError> {
-        let perl_script = args.work_dir.join("conda_build_script.pl");
-        tokio::fs::write(&perl_script, args.script.script()).await?;
-
-        let args = ExecutionArgs {
-            script: ResolvedScriptContents::Inline(format!("perl {:?}", perl_script)),
-            ..args
-        };
-
-        if cfg!(windows) {
-            CmdExeInterpreter.run(args).await
-        } else {
-            BashInterpreter.run(args).await
-        }
+impl InterpreterInvocation for PerlInvocation {
+    fn executable_names(&self, _build_platform: &Platform) -> &'static [&'static str] {
+        &["perl"]
     }
 
-    async fn find_interpreter(
-        &self,
-        build_prefix: Option<&PathBuf>,
-        platform: &Platform,
-    ) -> Result<Option<PathBuf>, which::Error> {
-        find_interpreter(
-            "perl",
-            build_prefix,
-            platform,
-            InterpreterSearchScope::PrefixThenSystemPath,
-        )
+    fn extension(&self) -> &'static str {
+        "pl"
+    }
+
+    fn args(&self, script_path: &std::path::Path) -> Vec<String> {
+        vec![script_path.to_string_lossy().into_owned()]
     }
 }

--- a/crates/rattler_build_script/src/interpreter/powershell.rs
+++ b/crates/rattler_build_script/src/interpreter/powershell.rs
@@ -1,16 +1,11 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
 
 use rattler_conda_types::Platform;
 
-use crate::execution::ExecutionArgs;
+use super::{InterpreterError, InterpreterInvocation, InterpreterSearchScope};
 
-use super::{
-    BashInterpreter, CmdExeInterpreter, Interpreter, InterpreterError, InterpreterSearchScope,
-    find_interpreter,
-};
-
-pub(crate) struct PowerShellInterpreter;
+pub struct PowerShellInvocation;
 
 const POWERSHELL_PREAMBLE: &str = r#"
 $ErrorActionPreference = 'Stop'
@@ -24,7 +19,7 @@ foreach ($envVar in Get-ChildItem Env:) {
 
 "#;
 
-/// Check if the given pwsh binary is PowerShell 7.4+.
+/// Returns whether the given pwsh binary is PowerShell 7.4+.
 fn is_pwsh_new_enough(pwsh_path: &Path) -> bool {
     let result: Option<bool> = (|| {
         let out =
@@ -47,75 +42,46 @@ fn is_pwsh_new_enough(pwsh_path: &Path) -> bool {
     result.unwrap_or(false)
 }
 
-// PowerShell interpreter: writes a .ps1 script then delegates to cmd.exe (Windows) or bash (Unix)
-// to run it via the pwsh/powershell command.
-impl Interpreter for PowerShellInterpreter {
-    async fn run(&self, args: ExecutionArgs) -> Result<(), InterpreterError> {
-        // Try to find pwsh in the build prefix or system PATH for version checking.
-        // The actual command used in the script may rely on the activation script
-        // (build_env.sh) to put pwsh on PATH at runtime.
-        let pwsh_path = find_interpreter(
-            "pwsh",
-            args.build_prefix.as_ref(),
-            &args.execution_platform,
-            InterpreterSearchScope::PrefixThenSystemPath,
-        )
-        .ok()
-        .flatten();
+impl InterpreterInvocation for PowerShellInvocation {
+    fn executable_names(&self, build_platform: &Platform) -> &'static [&'static str] {
+        if build_platform.is_windows() {
+            &["pwsh", "powershell"]
+        } else {
+            &["pwsh"]
+        }
+    }
 
-        let (shell_cmd, new_enough) = match &pwsh_path {
-            Some(path) => {
-                let new_enough = is_pwsh_new_enough(path);
-                (path.to_string_lossy().into_owned(), new_enough)
-            }
-            // Fall back to "pwsh" by name — the conda `powershell` package provides the
-            // `pwsh` binary, and the activation scripts will put it on PATH.
-            None => ("pwsh".to_owned(), false),
-        };
+    fn search_scope(&self, build_platform: &Platform) -> InterpreterSearchScope {
+        if build_platform.is_windows() {
+            InterpreterSearchScope::PrefixThenSystemPath
+        } else {
+            InterpreterSearchScope::BuildPrefixOnly
+        }
+    }
 
-        if !new_enough {
+    fn extension(&self) -> &'static str {
+        "ps1"
+    }
+
+    fn script_contents(&self, raw: &str) -> String {
+        POWERSHELL_PREAMBLE.to_owned() + raw
+    }
+
+    fn is_usable_executable(&self, executable: &Path) -> Result<(), InterpreterError> {
+        if !is_pwsh_new_enough(executable) {
             tracing::warn!(
                 "rattler-build requires PowerShell 7.4+, \
                  otherwise it will skip native command errors!"
             );
         }
-
-        let ps1_script = args.work_dir.join("conda_build_script.ps1");
-        let contents = POWERSHELL_PREAMBLE.to_owned() + args.script.script();
-        tokio::fs::write(&ps1_script, contents).await?;
-
-        // Quote the shell command if it contains spaces (e.g. "C:\Program Files\...")
-        let quoted_shell_cmd = if shell_cmd.contains(' ') {
-            format!("\"{}\"", shell_cmd)
-        } else {
-            shell_cmd
-        };
-
-        let args = ExecutionArgs {
-            script: crate::execution::ResolvedScriptContents::Inline(format!(
-                "{} -NoLogo -NoProfile {:?}",
-                quoted_shell_cmd, ps1_script
-            )),
-            ..args
-        };
-
-        if cfg!(windows) {
-            CmdExeInterpreter.run(args).await
-        } else {
-            BashInterpreter.run(args).await
-        }
+        Ok(())
     }
 
-    async fn find_interpreter(
-        &self,
-        build_prefix: Option<&PathBuf>,
-        platform: &Platform,
-    ) -> Result<Option<PathBuf>, which::Error> {
-        find_interpreter(
-            "pwsh",
-            build_prefix,
-            platform,
-            InterpreterSearchScope::PrefixThenSystemPath,
-        )
+    fn args(&self, script_path: &Path) -> Vec<String> {
+        vec![
+            "-NoLogo".to_string(),
+            "-NoProfile".to_string(),
+            script_path.to_string_lossy().into_owned(),
+        ]
     }
 }

--- a/crates/rattler_build_script/src/interpreter/powershell.rs
+++ b/crates/rattler_build_script/src/interpreter/powershell.rs
@@ -53,9 +53,9 @@ impl InterpreterInvocation for PowerShellInvocation {
 
     fn search_scope(&self, build_platform: &Platform) -> InterpreterSearchScope {
         if build_platform.is_windows() {
-            InterpreterSearchScope::PrefixThenSystemPath
+            InterpreterSearchScope::build_and_host_with_system_fallback()
         } else {
-            InterpreterSearchScope::BuildPrefixOnly
+            InterpreterSearchScope::build_only()
         }
     }
 

--- a/crates/rattler_build_script/src/interpreter/python.rs
+++ b/crates/rattler_build_script/src/interpreter/python.rs
@@ -1,44 +1,19 @@
-use std::path::PathBuf;
-
 use rattler_conda_types::Platform;
 
-use crate::execution::{ExecutionArgs, ResolvedScriptContents};
+use super::InterpreterInvocation;
 
-use super::{
-    BashInterpreter, CmdExeInterpreter, Interpreter, InterpreterError, InterpreterSearchScope,
-    find_interpreter,
-};
+pub struct PythonInvocation;
 
-pub struct PythonInterpreter;
-
-// python interpreter calls either bash or cmd.exe interpreter for activation and then runs python script
-impl Interpreter for PythonInterpreter {
-    async fn run(&self, args: ExecutionArgs) -> Result<(), InterpreterError> {
-        let py_script = args.work_dir.join("conda_build_script.py");
-        tokio::fs::write(&py_script, args.script.script()).await?;
-
-        let args = ExecutionArgs {
-            script: ResolvedScriptContents::Inline(format!("python {:?}", py_script)),
-            ..args
-        };
-
-        if cfg!(windows) {
-            CmdExeInterpreter.run(args).await
-        } else {
-            BashInterpreter.run(args).await
-        }
+impl InterpreterInvocation for PythonInvocation {
+    fn executable_names(&self, _build_platform: &Platform) -> &'static [&'static str] {
+        &["python"]
     }
 
-    async fn find_interpreter(
-        &self,
-        build_prefix: Option<&PathBuf>,
-        platform: &Platform,
-    ) -> Result<Option<PathBuf>, which::Error> {
-        find_interpreter(
-            "python",
-            build_prefix,
-            platform,
-            InterpreterSearchScope::PrefixThenSystemPath,
-        )
+    fn extension(&self) -> &'static str {
+        "py"
+    }
+
+    fn args(&self, script_path: &std::path::Path) -> Vec<String> {
+        vec![script_path.to_string_lossy().into_owned()]
     }
 }

--- a/crates/rattler_build_script/src/interpreter/python.rs
+++ b/crates/rattler_build_script/src/interpreter/python.rs
@@ -1,12 +1,16 @@
 use rattler_conda_types::Platform;
 
-use super::InterpreterInvocation;
+use super::{InterpreterInvocation, InterpreterSearchScope};
 
 pub struct PythonInvocation;
 
 impl InterpreterInvocation for PythonInvocation {
     fn executable_names(&self, _build_platform: &Platform) -> &'static [&'static str] {
         &["python"]
+    }
+
+    fn search_scope(&self, _build_platform: &Platform) -> InterpreterSearchScope {
+        InterpreterSearchScope::build_and_host_with_system_fallback()
     }
 
     fn extension(&self) -> &'static str {

--- a/crates/rattler_build_script/src/interpreter/r.rs
+++ b/crates/rattler_build_script/src/interpreter/r.rs
@@ -1,12 +1,16 @@
 use rattler_conda_types::Platform;
 
-use super::InterpreterInvocation;
+use super::{InterpreterInvocation, InterpreterSearchScope};
 
 pub struct RInvocation;
 
 impl InterpreterInvocation for RInvocation {
     fn executable_names(&self, _build_platform: &Platform) -> &'static [&'static str] {
         &["Rscript"]
+    }
+
+    fn search_scope(&self, _build_platform: &Platform) -> InterpreterSearchScope {
+        InterpreterSearchScope::build_and_host_with_system_fallback()
     }
 
     fn extension(&self) -> &'static str {

--- a/crates/rattler_build_script/src/interpreter/r.rs
+++ b/crates/rattler_build_script/src/interpreter/r.rs
@@ -1,46 +1,19 @@
-use std::path::PathBuf;
-
 use rattler_conda_types::Platform;
 
-use crate::execution::{ExecutionArgs, ResolvedScriptContents};
+use super::InterpreterInvocation;
 
-use super::{
-    BashInterpreter, CmdExeInterpreter, Interpreter, InterpreterError, InterpreterSearchScope,
-    find_interpreter,
-};
+pub struct RInvocation;
 
-pub struct RInterpreter;
-
-// R interpreter calls either bash or cmd.exe interpreter for activation and then runs R script
-impl Interpreter for RInterpreter {
-    async fn run(&self, args: ExecutionArgs) -> Result<(), InterpreterError> {
-        let script = args.script.script();
-        let r_script = args.work_dir.join("conda_build_script.R");
-        tokio::fs::write(&r_script, script).await?;
-        let r_command = format!("Rscript {:?}", r_script);
-
-        let args = ExecutionArgs {
-            script: ResolvedScriptContents::Inline(r_command),
-            ..args
-        };
-
-        if cfg!(windows) {
-            CmdExeInterpreter.run(args).await
-        } else {
-            BashInterpreter.run(args).await
-        }
+impl InterpreterInvocation for RInvocation {
+    fn executable_names(&self, _build_platform: &Platform) -> &'static [&'static str] {
+        &["Rscript"]
     }
 
-    async fn find_interpreter(
-        &self,
-        build_prefix: Option<&PathBuf>,
-        platform: &Platform,
-    ) -> Result<Option<PathBuf>, which::Error> {
-        find_interpreter(
-            "Rscript",
-            build_prefix,
-            platform,
-            InterpreterSearchScope::PrefixThenSystemPath,
-        )
+    fn extension(&self) -> &'static str {
+        "R"
+    }
+
+    fn args(&self, script_path: &std::path::Path) -> Vec<String> {
+        vec![script_path.to_string_lossy().into_owned()]
     }
 }

--- a/crates/rattler_build_script/src/interpreter/ruby.rs
+++ b/crates/rattler_build_script/src/interpreter/ruby.rs
@@ -1,12 +1,16 @@
 use rattler_conda_types::Platform;
 
-use super::InterpreterInvocation;
+use super::{InterpreterInvocation, InterpreterSearchScope};
 
 pub struct RubyInvocation;
 
 impl InterpreterInvocation for RubyInvocation {
     fn executable_names(&self, _build_platform: &Platform) -> &'static [&'static str] {
         &["ruby"]
+    }
+
+    fn search_scope(&self, _build_platform: &Platform) -> InterpreterSearchScope {
+        InterpreterSearchScope::build_and_host_with_system_fallback()
     }
 
     fn extension(&self) -> &'static str {

--- a/crates/rattler_build_script/src/interpreter/ruby.rs
+++ b/crates/rattler_build_script/src/interpreter/ruby.rs
@@ -1,44 +1,19 @@
-use std::path::PathBuf;
-
 use rattler_conda_types::Platform;
 
-use crate::execution::{ExecutionArgs, ResolvedScriptContents};
+use super::InterpreterInvocation;
 
-use super::{
-    BashInterpreter, CmdExeInterpreter, Interpreter, InterpreterError, InterpreterSearchScope,
-    find_interpreter,
-};
+pub struct RubyInvocation;
 
-pub struct RubyInterpreter;
-
-// Ruby interpreter calls either bash or cmd.exe interpreter for activation and then runs Ruby script
-impl Interpreter for RubyInterpreter {
-    async fn run(&self, args: ExecutionArgs) -> Result<(), InterpreterError> {
-        let ruby_script = args.work_dir.join("conda_build_script.rb");
-        tokio::fs::write(&ruby_script, args.script.script()).await?;
-
-        let args = ExecutionArgs {
-            script: ResolvedScriptContents::Inline(format!("ruby {:?}", ruby_script)),
-            ..args
-        };
-
-        if cfg!(windows) {
-            CmdExeInterpreter.run(args).await
-        } else {
-            BashInterpreter.run(args).await
-        }
+impl InterpreterInvocation for RubyInvocation {
+    fn executable_names(&self, _build_platform: &Platform) -> &'static [&'static str] {
+        &["ruby"]
     }
 
-    async fn find_interpreter(
-        &self,
-        build_prefix: Option<&PathBuf>,
-        platform: &Platform,
-    ) -> Result<Option<PathBuf>, which::Error> {
-        find_interpreter(
-            "ruby",
-            build_prefix,
-            platform,
-            InterpreterSearchScope::PrefixThenSystemPath,
-        )
+    fn extension(&self) -> &'static str {
+        "rb"
+    }
+
+    fn args(&self, script_path: &std::path::Path) -> Vec<String> {
+        vec![script_path.to_string_lossy().into_owned()]
     }
 }

--- a/crates/rattler_build_script/src/lib.rs
+++ b/crates/rattler_build_script/src/lib.rs
@@ -3,6 +3,11 @@
 //!
 //! This crate provides functionality for defining, parsing, and executing build scripts
 //! in various interpreters as part of the Rattler-Build process.
+//!
+//! Execution model: every script runs through a platform-native wrapper (bash on
+//! Unix, cmd on Windows) that first performs prefix activation, then invokes the
+//! chosen interpreter. Inline or file-backed scripts for specialized interpreters
+//! (python, perl, etc.) are written out and executed by the activated wrapper.
 
 pub mod sandbox;
 mod script;
@@ -24,7 +29,6 @@ mod native_runner;
 #[cfg(feature = "execution")]
 pub use execution::{
     EnvironmentIsolation, ExecutionArgs, ResolvedScriptContents, create_build_script,
-    generate_build_script, run_process_with_replacements, run_script,
 };
 #[cfg(feature = "execution")]
 pub use interpreter::InterpreterError;

--- a/crates/rattler_build_script/src/lib.rs
+++ b/crates/rattler_build_script/src/lib.rs
@@ -25,6 +25,8 @@ mod execution;
 mod interpreter;
 #[cfg(feature = "execution")]
 mod native_runner;
+#[cfg(feature = "execution")]
+mod runtime;
 
 #[cfg(feature = "execution")]
 pub use execution::{
@@ -32,3 +34,5 @@ pub use execution::{
 };
 #[cfg(feature = "execution")]
 pub use interpreter::InterpreterError;
+#[cfg(feature = "execution")]
+pub use runtime::RuntimeEnv;

--- a/crates/rattler_build_script/src/lib.rs
+++ b/crates/rattler_build_script/src/lib.rs
@@ -13,14 +13,18 @@ pub use script::{
 };
 
 #[cfg(feature = "execution")]
+mod activation;
+#[cfg(feature = "execution")]
 mod execution;
 #[cfg(feature = "execution")]
 mod interpreter;
+#[cfg(feature = "execution")]
+mod native_runner;
 
 #[cfg(feature = "execution")]
 pub use execution::{
     EnvironmentIsolation, ExecutionArgs, ResolvedScriptContents, create_build_script,
-    run_process_with_replacements, run_script,
+    generate_build_script, run_process_with_replacements, run_script,
 };
 #[cfg(feature = "execution")]
 pub use interpreter::InterpreterError;

--- a/crates/rattler_build_script/src/native_runner/bash.rs
+++ b/crates/rattler_build_script/src/native_runner/bash.rs
@@ -1,0 +1,56 @@
+use rattler_shell::shell;
+
+use crate::execution::ExecutionArgs;
+
+use super::NativeShellRunner;
+
+pub(crate) struct BashNativeRunner;
+
+impl NativeShellRunner for BashNativeRunner {
+    fn shell(&self) -> shell::ShellEnum {
+        shell::Bash::default().into()
+    }
+
+    fn preamble(&self, activation_script_path: &std::path::Path) -> String {
+        format!(
+            r#"#!/usr/bin/env bash
+set -e
+## Start of bash preamble
+if [ -z ${{CONDA_BUILD+x}} ]; then
+    source "{}"
+fi
+## End of preamble
+"#,
+            activation_script_path.to_string_lossy()
+        )
+    }
+
+    fn command_to_run_script<'a>(&self, build_script_path: &'a str) -> Vec<&'a str> {
+        vec!["bash", build_script_path]
+    }
+
+    fn replacements_template(&self) -> &'static str {
+        "$((var))"
+    }
+
+    fn debug_info(&self, args: &ExecutionArgs) -> String {
+        let mut output = String::new();
+
+        output.push_str("\nScript execution failed.\n\n");
+        output.push_str(&format!("  Work directory: {}\n", args.work_dir.display()));
+        output.push_str(&format!("  Prefix: {}\n", args.run_prefix.display()));
+
+        if let Some(build_prefix) = &args.build_prefix {
+            output.push_str(&format!("  Build prefix: {}\n", build_prefix.display()));
+        } else {
+            output.push_str("  Build prefix: None\n");
+        }
+
+        output.push_str("\nTo run the script manually, use the following command:\n\n");
+        output.push_str(&format!("  cd {:?} && ./conda_build.sh\n\n", args.work_dir));
+        output.push_str("To run commands interactively in the build environment:\n\n");
+        output.push_str(&format!("  cd {:?} && source build_env.sh", args.work_dir));
+
+        output
+    }
+}

--- a/crates/rattler_build_script/src/native_runner/bash.rs
+++ b/crates/rattler_build_script/src/native_runner/bash.rs
@@ -1,6 +1,6 @@
-use rattler_shell::shell;
+use std::path::Path;
 
-use crate::execution::ExecutionArgs;
+use rattler_shell::shell;
 
 use super::NativeShellRunner;
 
@@ -33,23 +33,29 @@ fi
         "$((var))"
     }
 
-    fn debug_info(&self, args: &ExecutionArgs) -> String {
+    /// Returns reproduction instructions for the failed bash wrapper script.
+    fn debug_info(
+        &self,
+        work_dir: &Path,
+        run_prefix: &Path,
+        build_prefix: Option<&Path>,
+    ) -> String {
         let mut output = String::new();
 
         output.push_str("\nScript execution failed.\n\n");
-        output.push_str(&format!("  Work directory: {}\n", args.work_dir.display()));
-        output.push_str(&format!("  Prefix: {}\n", args.run_prefix.display()));
+        output.push_str(&format!("  Work directory: {}\n", work_dir.display()));
+        output.push_str(&format!("  Prefix: {}\n", run_prefix.display()));
 
-        if let Some(build_prefix) = &args.build_prefix {
+        if let Some(build_prefix) = build_prefix {
             output.push_str(&format!("  Build prefix: {}\n", build_prefix.display()));
         } else {
             output.push_str("  Build prefix: None\n");
         }
 
         output.push_str("\nTo run the script manually, use the following command:\n\n");
-        output.push_str(&format!("  cd {:?} && ./conda_build.sh\n\n", args.work_dir));
+        output.push_str(&format!("  cd {:?} && ./conda_build.sh\n\n", work_dir));
         output.push_str("To run commands interactively in the build environment:\n\n");
-        output.push_str(&format!("  cd {:?} && source build_env.sh", args.work_dir));
+        output.push_str(&format!("  cd {:?} && source build_env.sh", work_dir));
 
         output
     }

--- a/crates/rattler_build_script/src/native_runner/bash.rs
+++ b/crates/rattler_build_script/src/native_runner/bash.rs
@@ -11,6 +11,10 @@ impl NativeShellRunner for BashNativeRunner {
         shell::Bash::default().into()
     }
 
+    fn default_interpreter(&self) -> &'static str {
+        "bash"
+    }
+
     fn preamble(&self, activation_script_path: &std::path::Path) -> String {
         format!(
             r#"#!/usr/bin/env bash

--- a/crates/rattler_build_script/src/native_runner/cmd_exe.rs
+++ b/crates/rattler_build_script/src/native_runner/cmd_exe.rs
@@ -1,6 +1,6 @@
-use rattler_shell::shell;
+use std::path::Path;
 
-use crate::execution::ExecutionArgs;
+use rattler_shell::shell;
 
 use super::NativeShellRunner;
 
@@ -39,26 +39,29 @@ IF "%CONDA_BUILD%" == "" (
         false
     }
 
-    fn debug_info(&self, args: &ExecutionArgs) -> String {
+    /// Returns reproduction instructions for the failed cmd wrapper script.
+    fn debug_info(
+        &self,
+        work_dir: &Path,
+        run_prefix: &Path,
+        build_prefix: Option<&Path>,
+    ) -> String {
         let mut output = String::new();
 
         output.push_str("\nScript execution failed.\n\n");
-        output.push_str(&format!("  Work directory: {}\n", args.work_dir.display()));
-        output.push_str(&format!("  Prefix: {}\n", args.run_prefix.display()));
+        output.push_str(&format!("  Work directory: {}\n", work_dir.display()));
+        output.push_str(&format!("  Prefix: {}\n", run_prefix.display()));
 
-        if let Some(build_prefix) = &args.build_prefix {
+        if let Some(build_prefix) = build_prefix {
             output.push_str(&format!("  Build prefix: {}\n", build_prefix.display()));
         } else {
             output.push_str("  Build prefix: None\n");
         }
 
         output.push_str("\nTo run the script manually, use the following command:\n");
-        output.push_str(&format!(
-            "  cd {:?} && ./conda_build.bat\n\n",
-            args.work_dir
-        ));
+        output.push_str(&format!("  cd {:?} && ./conda_build.bat\n\n", work_dir));
         output.push_str("To run commands interactively in the build environment:\n");
-        output.push_str(&format!("  cd {:?} && call build_env.bat", args.work_dir));
+        output.push_str(&format!("  cd {:?} && call build_env.bat", work_dir));
 
         output
     }

--- a/crates/rattler_build_script/src/native_runner/cmd_exe.rs
+++ b/crates/rattler_build_script/src/native_runner/cmd_exe.rs
@@ -1,0 +1,65 @@
+use rattler_shell::shell;
+
+use crate::execution::ExecutionArgs;
+
+use super::NativeShellRunner;
+
+pub(crate) struct CmdExeNativeRunner;
+
+impl NativeShellRunner for CmdExeNativeRunner {
+    fn shell(&self) -> shell::ShellEnum {
+        shell::CmdExe.into()
+    }
+
+    fn preamble(&self, activation_script_path: &std::path::Path) -> String {
+        format!(
+            r#"
+@chcp 65001 > nul
+@echo on
+IF "%CONDA_BUILD%" == "" (
+    @rem special behavior from conda-build for Windows
+    call "{}"
+)
+@rem re-enable echo because the activation scripts might have messed with it
+@echo on
+"#,
+            activation_script_path.to_string_lossy()
+        )
+    }
+
+    fn command_to_run_script<'a>(&self, build_script_path: &'a str) -> Vec<&'a str> {
+        vec!["cmd.exe", "/d", "/c", build_script_path]
+    }
+
+    fn replacements_template(&self) -> &'static str {
+        "%((var))%"
+    }
+
+    fn supports_sandbox(&self) -> bool {
+        false
+    }
+
+    fn debug_info(&self, args: &ExecutionArgs) -> String {
+        let mut output = String::new();
+
+        output.push_str("\nScript execution failed.\n\n");
+        output.push_str(&format!("  Work directory: {}\n", args.work_dir.display()));
+        output.push_str(&format!("  Prefix: {}\n", args.run_prefix.display()));
+
+        if let Some(build_prefix) = &args.build_prefix {
+            output.push_str(&format!("  Build prefix: {}\n", build_prefix.display()));
+        } else {
+            output.push_str("  Build prefix: None\n");
+        }
+
+        output.push_str("\nTo run the script manually, use the following command:\n");
+        output.push_str(&format!(
+            "  cd {:?} && ./conda_build.bat\n\n",
+            args.work_dir
+        ));
+        output.push_str("To run commands interactively in the build environment:\n");
+        output.push_str(&format!("  cd {:?} && call build_env.bat", args.work_dir));
+
+        output
+    }
+}

--- a/crates/rattler_build_script/src/native_runner/cmd_exe.rs
+++ b/crates/rattler_build_script/src/native_runner/cmd_exe.rs
@@ -11,6 +11,10 @@ impl NativeShellRunner for CmdExeNativeRunner {
         shell::CmdExe.into()
     }
 
+    fn default_interpreter(&self) -> &'static str {
+        "cmd"
+    }
+
     fn preamble(&self, activation_script_path: &std::path::Path) -> String {
         format!(
             r#"

--- a/crates/rattler_build_script/src/native_runner/mod.rs
+++ b/crates/rattler_build_script/src/native_runner/mod.rs
@@ -12,8 +12,6 @@ use std::path::Path;
 
 use rattler_shell::shell::{Shell, ShellEnum};
 
-use crate::execution::ExecutionArgs;
-
 /// Defines platform-native wrapper execution.
 pub(crate) trait NativeShellRunner: Send + Sync {
     /// Returns the shell syntax used for the generated native wrapper script.
@@ -34,7 +32,8 @@ pub(crate) trait NativeShellRunner: Send + Sync {
     }
 
     /// Returns human-readable reproduction instructions shown when execution fails.
-    fn debug_info(&self, args: &ExecutionArgs) -> String;
+    fn debug_info(&self, work_dir: &Path, run_prefix: &Path, build_prefix: Option<&Path>)
+    -> String;
 }
 
 pub(crate) fn native_runner() -> Box<dyn NativeShellRunner> {

--- a/crates/rattler_build_script/src/native_runner/mod.rs
+++ b/crates/rattler_build_script/src/native_runner/mod.rs
@@ -1,0 +1,55 @@
+//! Platform-native wrapper execution support.
+//!
+//! This module selects the [`NativeShellRunner`] for the current platform and
+//! provides helpers for writing shell-specific scripts. Specialized interpreters
+//! are described by `crate::interpreter` and are emitted as commands inside the
+//! native wrapper.
+
+mod bash;
+mod cmd_exe;
+
+use std::path::Path;
+
+use rattler_shell::shell::{Shell, ShellEnum};
+
+use crate::execution::ExecutionArgs;
+
+/// Defines platform-native wrapper execution.
+pub(crate) trait NativeShellRunner: Send + Sync {
+    /// Returns the shell syntax used for the generated native wrapper script.
+    fn shell(&self) -> ShellEnum;
+
+    /// Returns the shell preamble inserted at the top of `conda_build.*`.
+    fn preamble(&self, activation_script_path: &Path) -> String;
+
+    /// Returns process argv used to execute the generated native wrapper script.
+    fn command_to_run_script<'a>(&self, build_script_path: &'a str) -> Vec<&'a str>;
+
+    /// Returns the replacement template used when streaming process output.
+    fn replacements_template(&self) -> &'static str;
+
+    /// Returns whether this native shell runner supports rattler-sandbox execution.
+    fn supports_sandbox(&self) -> bool {
+        true
+    }
+
+    /// Returns human-readable reproduction instructions shown when execution fails.
+    fn debug_info(&self, args: &ExecutionArgs) -> String;
+}
+
+pub(crate) fn native_runner() -> Box<dyn NativeShellRunner> {
+    if cfg!(windows) {
+        Box::new(cmd_exe::CmdExeNativeRunner)
+    } else {
+        Box::new(bash::BashNativeRunner)
+    }
+}
+
+pub(crate) fn write_shell_script(
+    shell: ShellEnum,
+    script: &str,
+) -> Result<Vec<u8>, std::io::Error> {
+    let mut bytes = Vec::new();
+    shell.write_script(&mut bytes, script)?;
+    Ok(bytes)
+}

--- a/crates/rattler_build_script/src/native_runner/mod.rs
+++ b/crates/rattler_build_script/src/native_runner/mod.rs
@@ -1,8 +1,8 @@
 //! Platform-native wrapper execution support.
 //!
-//! This module selects the [`NativeShellRunner`] for the current platform and
-//! provides helpers for writing shell-specific scripts. Specialized interpreters
-//! are described by `crate::interpreter` and are emitted as commands inside the
+//! This module selects the [`NativeShellRunner`] for a platform and provides
+//! helpers for writing shell-specific scripts. Specialized interpreters are
+//! described by `crate::interpreter` and are emitted as commands inside the
 //! native wrapper.
 
 mod bash;
@@ -10,12 +10,17 @@ mod cmd_exe;
 
 use std::path::Path;
 
+use rattler_conda_types::Platform;
 use rattler_shell::shell::{Shell, ShellEnum};
 
 /// Defines platform-native wrapper execution.
 pub(crate) trait NativeShellRunner: Send + Sync {
     /// Returns the shell syntax used for the generated native wrapper script.
     fn shell(&self) -> ShellEnum;
+
+    /// The recipe interpreter name for this wrapper shell (`bash`/`cmd`), used
+    /// as the default when no interpreter is specified.
+    fn default_interpreter(&self) -> &'static str;
 
     /// Returns the shell preamble inserted at the top of `conda_build.*`.
     fn preamble(&self, activation_script_path: &Path) -> String;
@@ -36,8 +41,11 @@ pub(crate) trait NativeShellRunner: Send + Sync {
     -> String;
 }
 
-pub(crate) fn native_runner() -> Box<dyn NativeShellRunner> {
-    if cfg!(windows) {
+/// Selects the native wrapper shell for the given platform: `cmd.exe` on
+/// Windows, `bash` elsewhere. The script runs on the host, so callers pass the
+/// runtime platform (which equals the host).
+pub(crate) fn native_runner(platform: Platform) -> Box<dyn NativeShellRunner> {
+    if platform.is_windows() {
         Box::new(cmd_exe::CmdExeNativeRunner)
     } else {
         Box::new(bash::BashNativeRunner)
@@ -51,4 +59,67 @@ pub(crate) fn write_shell_script(
     let mut bytes = Vec::new();
     shell.write_script(&mut bytes, script)?;
     Ok(bytes)
+}
+
+/// Quotes a single command argument for the given shell when it contains
+/// whitespace (or is empty). `rattler_shell::Shell::run_command` joins arguments
+/// with spaces without quoting, so a resolved interpreter or script path
+/// containing spaces (e.g. `C:\Program Files\nodejs\node.exe`) would otherwise
+/// be split by the shell.
+pub(crate) fn quote_arg(shell: &ShellEnum, arg: &str) -> String {
+    if !arg.is_empty() && !arg.chars().any(char::is_whitespace) {
+        return arg.to_string();
+    }
+    match shell {
+        ShellEnum::CmdExe(_) => format!("\"{arg}\""),
+        // POSIX single-quoting neutralizes spaces and metacharacters; an
+        // embedded single quote is closed, escaped, and reopened.
+        _ => format!("'{}'", arg.replace('\'', r"'\''")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{native_runner, quote_arg};
+    use rattler_conda_types::Platform;
+    use rattler_shell::shell::{self, Shell};
+
+    #[test]
+    fn native_runner_follows_the_platform() {
+        // Independent of the host this test runs on.
+        assert_eq!(native_runner(Platform::Win64).shell().extension(), "bat");
+        assert_eq!(native_runner(Platform::Linux64).shell().extension(), "sh");
+        assert_eq!(native_runner(Platform::OsxArm64).shell().extension(), "sh");
+
+        assert_eq!(native_runner(Platform::Win64).default_interpreter(), "cmd");
+        assert_eq!(
+            native_runner(Platform::Linux64).default_interpreter(),
+            "bash"
+        );
+    }
+
+    #[test]
+    fn quotes_only_when_needed() {
+        let bash = shell::Bash::default().into();
+        // No whitespace: left untouched (flags must not be quoted).
+        assert_eq!(quote_arg(&bash, "-NoLogo"), "-NoLogo");
+        assert_eq!(quote_arg(&bash, "/usr/bin/python"), "/usr/bin/python");
+        // Whitespace: single-quoted for posix shells.
+        assert_eq!(
+            quote_arg(&bash, "/opt/my tools/node"),
+            "'/opt/my tools/node'"
+        );
+        // Embedded single quote is escaped.
+        assert_eq!(quote_arg(&bash, "a'b c"), "'a'\\''b c'");
+    }
+
+    #[test]
+    fn quotes_for_cmd_with_double_quotes() {
+        let cmd = shell::CmdExe.into();
+        assert_eq!(quote_arg(&cmd, "/d"), "/d");
+        assert_eq!(
+            quote_arg(&cmd, r"C:\Program Files\nodejs\node.exe"),
+            "\"C:\\Program Files\\nodejs\\node.exe\""
+        );
+    }
 }

--- a/crates/rattler_build_script/src/runtime.rs
+++ b/crates/rattler_build_script/src/runtime.rs
@@ -1,0 +1,73 @@
+//! The runtime environment rattler-build itself executes in.
+//!
+//! [`RuntimeEnv`] bundles the process environment variables (including `PATH`)
+//! and the current [`Platform`]. Threading a `RuntimeEnv` explicitly through
+//! script generation and execution, instead of reading process globals
+//! (`std::env::var`, `Platform::current`), keeps behavior deterministic and lets
+//! tests inject a synthetic environment without mutating global process state.
+
+use std::collections::HashMap;
+
+use rattler_conda_types::Platform;
+
+/// The environment rattler-build is running in: the process environment
+/// variables (including `PATH`) and the platform.
+#[derive(Debug, Clone)]
+pub struct RuntimeEnv {
+    env: HashMap<String, String>,
+    platform: Platform,
+}
+
+impl RuntimeEnv {
+    /// Captures the real process environment variables and the current platform.
+    pub fn current() -> Self {
+        Self {
+            env: std::env::vars().collect(),
+            platform: Platform::current(),
+        }
+    }
+
+    /// Creates a runtime environment with an empty variable set and the given
+    /// platform. Intended for tests; combine with [`RuntimeEnv::with_var`] to
+    /// inject the variables a test needs.
+    pub fn for_test(platform: Platform) -> Self {
+        Self {
+            env: HashMap::new(),
+            platform,
+        }
+    }
+
+    /// The platform rattler-build is running on.
+    pub fn platform(&self) -> Platform {
+        self.platform
+    }
+
+    /// Looks up an environment variable by name.
+    pub fn var(&self, name: &str) -> Option<&str> {
+        self.env.get(name).map(String::as_str)
+    }
+
+    /// The value of `PATH`, or an empty string when it is unset.
+    pub fn path(&self) -> &str {
+        self.var("PATH").unwrap_or_default()
+    }
+
+    /// Iterates over all environment variables as `(name, value)` pairs.
+    pub fn vars(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.env.iter().map(|(k, v)| (k.as_str(), v.as_str()))
+    }
+
+    /// Returns a copy with `name` set to `value` (builder style, for tests).
+    #[must_use]
+    pub fn with_var(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
+        self.env.insert(name.into(), value.into());
+        self
+    }
+
+    /// Returns a copy that runs on the given platform (builder style, for tests).
+    #[must_use]
+    pub fn with_platform(mut self, platform: Platform) -> Self {
+        self.platform = platform;
+        self
+    }
+}

--- a/crates/rattler_build_script/src/runtime.rs
+++ b/crates/rattler_build_script/src/runtime.rs
@@ -52,6 +52,17 @@ impl RuntimeEnv {
         self.var("PATH").unwrap_or_default()
     }
 
+    /// The executable file suffix for this platform (`.exe` on Windows, empty
+    /// elsewhere), keyed off the platform rather than the one rattler-build was
+    /// compiled for (unlike [`std::env::consts::EXE_SUFFIX`]).
+    pub(crate) fn exe_suffix(&self) -> &'static str {
+        if self.platform.is_windows() {
+            ".exe"
+        } else {
+            ""
+        }
+    }
+
     /// Iterates over all environment variables as `(name, value)` pairs.
     pub fn vars(&self) -> impl Iterator<Item = (&str, &str)> {
         self.env.iter().map(|(k, v)| (k.as_str(), v.as_str()))
@@ -69,5 +80,17 @@ impl RuntimeEnv {
     pub fn with_platform(mut self, platform: Platform) -> Self {
         self.platform = platform;
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exe_suffix_follows_the_platform() {
+        assert_eq!(RuntimeEnv::for_test(Platform::Win64).exe_suffix(), ".exe");
+        assert_eq!(RuntimeEnv::for_test(Platform::Linux64).exe_suffix(), "");
+        assert_eq!(RuntimeEnv::for_test(Platform::OsxArm64).exe_suffix(), "");
     }
 }

--- a/docs/build_script.md
+++ b/docs/build_script.md
@@ -107,6 +107,14 @@ requirements:
     `cmd.exe`. If you encounter any issues, please
     [open an issue](https://github.com/prefix-dev/rattler-build/issues/new).
 
+!!! tip "Put the interpreter in `build`"
+    An interpreter that runs the build script is a build-time tool, so the
+    correct place for it is the `build` section of `requirements`. The `host`
+    environment is searched as well (and, for most interpreters, the system
+    `PATH` as a last resort), so a `host` dependency also works — but `build` is
+    preferred. `brush` is the exception: it must be in `build`, and a system
+    copy is never used.
+
 ### Using `nushell`
 
 In order to use `nushell` you can select the `interpreter: nu` or have a
@@ -120,7 +128,7 @@ build:
     content: |
       echo "Hello from nushell!"
 
-# Note: it's required to have `nushell` in the `build` section of your recipe!
+# Note: add `nushell` to the `build` section of your recipe!
 requirements:
   build:
     - nushell
@@ -158,7 +166,7 @@ build:
     content: |
       print("Hello from Python!")
 
-# Note: it's required to have `python` in the `build` section of your recipe!
+# Note: add `python` to the `build` section of your recipe!
 requirements:
   build:
     - python
@@ -177,7 +185,7 @@ build:
     content: |
       puts "Hello from Ruby!"
 
-# Note: it's required to have `ruby` in the `build` section of your recipe!
+# Note: add `ruby` to the `build` section of your recipe!
 requirements:
   build:
     - ruby
@@ -196,7 +204,7 @@ build:
     content: |
       console.log("Hello from NodeJS!");
 
-# Note: it's required to have `nodejs` in the `build` section of your recipe!
+# Note: add `nodejs` to the `build` section of your recipe!
 requirements:
   build:
     - nodejs
@@ -215,7 +223,7 @@ build:
     content: |
       print "Hello from Perl!\n";
 
-# Note: it's required to have `perl` in the `build` section of your recipe!
+# Note: add `perl` to the `build` section of your recipe!
 requirements:
   build:
     - perl
@@ -235,7 +243,7 @@ build:
     content: |
       cat("Hello from R!\n")
 
-# Note: it's required to have `r-base` in the `build` section of your recipe!
+# Note: add `r-base` to the `build` section of your recipe!
 requirements:
   build:
     - r-base

--- a/docs/build_script.md
+++ b/docs/build_script.md
@@ -80,7 +80,9 @@ So far, the following interpreters are supported:
 
 - `bash` (default on Unix)
 - `cmd.exe` (default on Windows)
+- `powershell`
 - `nushell`
+- `brush`
 - `python`
 - `perl`
 - `rscript` (for R scripts)
@@ -88,8 +90,8 @@ So far, the following interpreters are supported:
 - `node` or `nodejs` (for NodeJS scripts)
 
 Rattler-Build automatically detects the interpreter based on the file extension
-(`.sh`, `.bat`, `.nu`, `.py`, `.pl`, `.r`, `.rb`, `.js`) or you can specify it in the
-`interpreter` key in the `script` section of your recipe.
+(`.sh`/`.bash`, `.bat`/`.cmd`, `.ps1`, `.nu`, `.py`, `.pl`, `.r`, `.rb`, `.js`) or you
+can specify it in the `interpreter` key in the `script` section of your recipe.
 
 ```yaml title="recipe.yaml"
 build:
@@ -198,6 +200,70 @@ build:
 requirements:
   build:
     - nodejs
+```
+
+### Using `perl`
+
+In order to use `perl` you can select the `interpreter: perl` or have a
+`build.pl` file in your recipe directory and `perl` in the
+`requirements/build` section.
+
+```yaml title="recipe.yaml"
+build:
+  script:
+    interpreter: perl
+    content: |
+      print "Hello from Perl!\n";
+
+# Note: it's required to have `perl` in the `build` section of your recipe!
+requirements:
+  build:
+    - perl
+```
+
+### Using `rscript` (R)
+
+In order to run R scripts you can select the `interpreter: rscript` or have a
+`build.r` file in your recipe directory and `r-base` in the
+`requirements/build` section. The script is executed with `Rscript` from the
+build environment.
+
+```yaml title="recipe.yaml"
+build:
+  script:
+    interpreter: rscript
+    content: |
+      cat("Hello from R!\n")
+
+# Note: it's required to have `r-base` in the `build` section of your recipe!
+requirements:
+  build:
+    - r-base
+```
+
+### Using `powershell`
+
+In order to use `powershell` you can select the `interpreter: powershell` or
+have a `build.ps1` file in your recipe directory. On Windows, PowerShell is
+taken from the system, so no extra dependency is required. On other platforms
+`pwsh` must be available in the build environment, so add `powershell-core` to
+`requirements/build`. Rattler-Build prefers PowerShell 7.4+; on older versions
+errors from native commands may be skipped and you have to check `$?` or
+`$LASTEXITCODE` manually.
+
+```yaml title="recipe.yaml"
+build:
+  script:
+    interpreter: powershell
+    content: |
+      Write-Host "Hello from PowerShell!"
+
+# Note: on non-Windows platforms `powershell-core` must be in the `build` section!
+requirements:
+  build:
+    - if: not win
+      then:
+        - powershell-core
 ```
 
 

--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -539,23 +539,27 @@ with the following fields (all optional):
   `[build folder]/work` directory. Defaults to the `[build folder]/work`
   directory itself.
 
-!!! warning "Non-default interpreters need a build dependency"
+!!! note "Where interpreters come from"
 
     Every build and test script is launched through a native shell wrapper
     (`bash` on Unix, `cmd.exe` on Windows) that activates the build/host
-    prefixes and then invokes the chosen interpreter as a command. Only the
-    native shells are assumed to exist on the build machine: `bash`/`cmd.exe`,
-    plus `powershell` on Windows, may be taken from the system `PATH` on their
-    native platform.
+    prefixes and then invokes the chosen interpreter as a command.
 
-    Every other interpreter (`python`, `perl`, `ruby`, `node`/`nodejs`,
-    `rscript`, `nu`/nushell and `brush`) is resolved **only** from the build
-    (or host) prefix, so it must be added to `requirements.build`. A copy
-    found on the system `PATH` is intentionally ignored to keep builds
-    reproducible. For example:
-     - `interpreter: nu` requires `nushell` in `requirements.build`
-     - `interpreter: python` requires `python`
-     - `interpreter: node` requires `nodejs`
+    An interpreter that runs the build script is a build-time tool, so add it to
+    `requirements.build` (for example `interpreter: nu` → `nushell`,
+    `interpreter: rscript` → `r-base`, `interpreter: node` → `nodejs`). It is
+    resolved from the activated environment in the same order the `PATH` would:
+    the **build** prefix, then the **host** prefix, and for most interpreters the
+    system `PATH` as a last resort. So a `host` dependency is also found, but
+    `build` is the correct place; relying on a system copy works but makes builds
+    non-reproducible. When the build and host environments are merged
+    (`build.merge_build_and_host_envs`), that single environment is used.
+
+    Two interpreters are resolved differently:
+     - `bash`/`cmd.exe` (and `powershell` on Windows) may be taken from the
+       system `PATH` on their native platform.
+     - `brush` is resolved **only** from the build environment (not the host
+       prefix or the system `PATH`), so it must be in `requirements.build`.
 
 ```yaml title="recipe.yaml"
 build:

--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -530,20 +530,29 @@ with the following fields (all optional):
   the rendered recipe. The variables must already be set in the environment
   running `rattler-build`.
 - **`interpreter`** - Explicit interpreter to run `content` with. Supported
-  values are `bash` (default on Unix), `cmd.exe` (default on Windows), `nu`
-  (nushell), `python`, `perl`, `rscript`, `ruby` and `node`/`nodejs`. When
-  unset, the interpreter is auto-detected from the script's file extension
-  (`.sh`, `.bat`, `.nu`, `.py`, `.pl`, `.r`, `.rb`, `.js`).
+  values are `bash` (default on Unix), `cmd.exe` (default on Windows),
+  `powershell`, `nu` (nushell), `brush`, `python`, `perl`, `rscript`, `ruby`
+  and `node`/`nodejs`. When unset, the interpreter is auto-detected from the
+  script's file extension (`.sh`/`.bash`, `.bat`/`.cmd`, `.ps1`, `.nu`, `.py`,
+  `.pl`, `.r`, `.rb`, `.js`).
 - **`cwd`** - Working directory for the script, relative to the
   `[build folder]/work` directory. Defaults to the `[build folder]/work`
   directory itself.
 
 !!! warning "Non-default interpreters need a build dependency"
 
-    Only `bash` and `cmd.exe` are assumed to exist on the build machine.
-    Every other interpreter must be added to `requirements.build` (or
-    otherwise be available on `PATH`) so the build environment actually
-    has it. For example:
+    Every build and test script is launched through a native shell wrapper
+    (`bash` on Unix, `cmd.exe` on Windows) that activates the build/host
+    prefixes and then invokes the chosen interpreter as a command. Only the
+    native shells are assumed to exist on the build machine: `bash`/`cmd.exe`,
+    plus `powershell` on Windows, may be taken from the system `PATH` on their
+    native platform.
+
+    Every other interpreter (`python`, `perl`, `ruby`, `node`/`nodejs`,
+    `rscript`, `nu`/nushell and `brush`) is resolved **only** from the build
+    (or host) prefix, so it must be added to `requirements.build`. A copy
+    found on the system `PATH` is intentionally ignored to keep builds
+    reproducible. For example:
      - `interpreter: nu` requires `nushell` in `requirements.build`
      - `interpreter: python` requires `python`
      - `interpreter: node` requires `nodejs`

--- a/test/end-to-end/__snapshots__/test_simple.ambr
+++ b/test/end-to-end/__snapshots__/test_simple.ambr
@@ -14,9 +14,8 @@
       - flask
       - flask.json
   - script:
-      content: |-
-        flask --help
-        pip check
+    - flask --help
+    - pip check
     requirements:
       run:
       - pip

--- a/test/end-to-end/__snapshots__/test_tests.ambr
+++ b/test/end-to-end/__snapshots__/test_tests.ambr
@@ -16,13 +16,9 @@
 # name: test_win_errorlevel_injection
   '''
   - script:
-      content: |-
-        echo "This test is designed to fail."
-        if %errorlevel% neq 0 exit /b %errorlevel%
-        python.exe -c "import sys; sys.exit(1)"
-        if %errorlevel% neq 0 exit /b %errorlevel%
-        echo "This line will not be executed."
-        if %errorlevel% neq 0 exit /b %errorlevel%
+    - echo "This test is designed to fail."
+    - python.exe -c "import sys; sys.exit(1)"
+    - echo "This line will not be executed."
     requirements:
       run:
       - python

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -1397,12 +1397,10 @@ def test_noarch_flask(
 
     assert (pkg / "info/tests/tests.yaml").exists()
 
-    # check that the snapshot matches (different on windows vs. unix)
+    # The serialized test script stores the command list verbatim (the same on
+    # all platforms); per-command error handling is applied when the test runs.
     test_yaml = (pkg / "info/tests/tests.yaml").read_text()
-    if os.name == "nt":
-        assert "if %errorlevel% neq 0 exit /b %errorlevel%" in test_yaml
-    else:
-        assert test_yaml == snapshot
+    assert test_yaml == snapshot
 
     # make sure that the entry point does not exist
     assert not (pkg / "python-scripts/flask").exists()


### PR DESCRIPTION
## Description

Streamlines how build and test scripts run across all interpreters. Every script now runs through a native shell wrapper (bash on Unix, cmd.exe on Windows) that activates the build and host prefixes first and then invokes the chosen interpreter. This gives python, perl, ruby, node, R, nushell, brush and powershell the same activation behavior, instead of each interpreter handling activation in its own way.

The script crate's public interface was also tightened to a small, functional surface. The process environment variables and platform are now injected as a single value instead of read from global system state, which makes script generation deterministic and testable without serial_test workarounds.

## Behavior change

Interpreter resolution is unchanged for existing recipes: python, perl, ruby, node, rscript and nushell are still taken from the build or host prefix when present, and otherwise fall back to the system PATH. Declaring the interpreter in requirements.build is recommended for reproducible builds. brush is the exception and is always taken from the build environment.

Nushell now inherits its activated environment from the native wrapper like the other interpreters, rather than running its own activation.

## Testing

- Added unit coverage for interpreter resolution, environment isolation, activation, and the generated scripts.
- Existing interpreter end-to-end tests (python, ruby, perl, R, nushell, brush, powershell) still pass.
