### PR TITLE
ci: run lefthook lints in parallel again

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -19,7 +19,7 @@ output:
   - skips # Print "skip" (i.e. no files matched)
 
 pre-commit:
-  parallel: false
+  parallel: true
   jobs:
     - name: actionlint
       run: pixi {run} actionlint


### PR DESCRIPTION
Thanks to this https://github.com/prefix-dev/pixi/pull/6233, running in parallel is safe again