### PR TITLE
fix: don't treat non-exact run_constraints pins as build-order edges

### DIFF
--- a/crates/rattler_build_recipe/src/stage1/requirements.rs
+++ b/crates/rattler_build_recipe/src/stage1/requirements.rs
@@ -197,6 +197,16 @@ impl RunExports {
             && self.weak.is_empty()
             && self.weak_constraints.is_empty()
     }
+
+    /// Iterate over all run export dependencies across every strength.
+    pub fn iter(&self) -> impl Iterator<Item = &Dependency> {
+        self.noarch
+            .iter()
+            .chain(self.strong.iter())
+            .chain(self.strong_constraints.iter())
+            .chain(self.weak.iter())
+            .chain(self.weak_constraints.iter())
+    }
 }
 
 /// Ignore run exports configuration
@@ -295,12 +305,7 @@ impl Requirements {
 
     pub fn run_exports_and_constraints(&self) -> impl Iterator<Item = &Dependency> {
         self.run_exports
-            .noarch
             .iter()
-            .chain(self.run_exports.strong.iter())
-            .chain(self.run_exports.strong_constraints.iter())
-            .chain(self.run_exports.weak.iter())
-            .chain(self.run_exports.weak_constraints.iter())
             .chain(self.run_constraints.iter())
             .chain(self.run.iter())
     }

--- a/crates/rattler_build_recipe/src/variant_render.rs
+++ b/crates/rattler_build_recipe/src/variant_render.rs
@@ -1081,14 +1081,13 @@ fn finalize_build_string_single(
     Ok(())
 }
 
-/// Helper function to extract all dependency package names from a recipe.
+/// Extract the package names a recipe must be built after.
 ///
-/// This collects:
-/// - All named dependencies from build/host/run requirements
-/// - All pin_subpackage references from run_exports (these reference other outputs
-///   and create build-order dependencies even though they're not direct build deps)
+/// Collects build/host deps, pin_subpackage refs from run/run_exports, and
+/// *exact* pin_subpackage refs from run_constraints (non-exact constraints only
+/// pin a version, so they impose no build-order edge; see issue #2531).
 ///
-/// Note: May contain duplicates, which is acceptable for dependency graph construction.
+/// May contain duplicates, which is fine for graph construction.
 fn extract_dependency_names(recipe: &Stage1Recipe) -> Vec<rattler_conda_types::PackageName> {
     let requirements = recipe.requirements();
 
@@ -1097,29 +1096,36 @@ fn extract_dependency_names(recipe: &Stage1Recipe) -> Vec<rattler_conda_types::P
         .build_host()
         .filter_map(|dep| dep.name().cloned());
 
-    // Collect pin_subpackage references from run/run_constraints
-    // (we need those subpackages built first to resolve the pin,
-    // but plain run deps are not needed at build time and may contain cycles)
+    // pin_subpackage refs in run/run_exports must be built first to resolve the
+    // pin. (Plain run deps aren't needed at build time and may form cycles.)
     let run_pin_subpackages = requirements
         .run
         .iter()
-        .chain(requirements.run_constraints.iter())
+        .chain(requirements.run_exports.iter())
         .filter_map(|dep| match dep {
             Dependency::PinSubpackage(pin) => Some(pin.pin_subpackage.name.clone()),
             _ => None,
         });
 
-    // Collect pin_subpackage names from run_exports (these reference other outputs)
-    let run_export_pins = requirements
-        .run_exports_and_constraints()
-        .filter_map(|dep| match dep {
-            Dependency::PinSubpackage(pin) => Some(pin.pin_subpackage.name.clone()),
-            _ => None,
-        });
+    // Only *exact* run_constraints pins create an edge: they need the
+    // constrained package's build string. Non-exact constraints only pin a
+    // version (known from the recipe), so edging them produces false cycles
+    // (e.g. openblas runs on libopenblas, libopenblas run-constrains openblas).
+    // See https://github.com/prefix-dev/rattler-build/issues/2531.
+    let run_constraint_pin_subpackages =
+        requirements
+            .run_constraints
+            .iter()
+            .filter_map(|dep| match dep {
+                Dependency::PinSubpackage(pin) if pin.pin_subpackage.args.exact => {
+                    Some(pin.pin_subpackage.name.clone())
+                }
+                _ => None,
+            });
 
     build_host
         .chain(run_pin_subpackages)
-        .chain(run_export_pins)
+        .chain(run_constraint_pin_subpackages)
         .collect()
 }
 
@@ -2120,6 +2126,103 @@ outputs:
 
         // Self-pin should be tracked but not cause ordering issues
         assert_eq!(sorted[0].pin_subpackages.len(), 1);
+    }
+
+    #[test]
+    fn test_non_exact_run_constraint_is_not_a_cycle() {
+        // Regression test for issue #2531: a non-exact run_constraints pin must
+        // not edge the graph, so mutual references aren't a false cycle.
+        let recipe_yaml = r#"
+schema_version: 1
+
+context:
+  version: "0.3.20"
+
+recipe:
+  name: openblas-split
+  version: ${{ version }}
+
+build:
+  number: 0
+
+outputs:
+  - package:
+      name: libopenblas
+    build:
+      noarch: generic
+    requirements:
+      run_constraints:
+        - ${{ pin_subpackage("openblas", upper_bound="x.x.x") }}
+
+  - package:
+      name: openblas
+    build:
+      noarch: generic
+    requirements:
+      run:
+        - ${{ pin_subpackage("libopenblas", exact=true) }}
+"#;
+
+        let variant_yaml = r#"{}"#;
+
+        let stage0_recipe = stage0::parse_recipe_or_multi_from_source(recipe_yaml).unwrap();
+        let variant_config = VariantConfig::from_yaml_str(variant_yaml).unwrap();
+
+        let rendered =
+            render_recipe_with_variant_config(&stage0_recipe, &variant_config, RenderConfig::new())
+                .unwrap();
+
+        // No (false) cycle; libopenblas comes first via openblas's exact pin.
+        let sorted = topological_sort_variants(rendered).unwrap();
+        assert_eq!(sorted.len(), 2);
+        assert_eq!(sorted[0].recipe.package.name.as_normalized(), "libopenblas");
+        assert_eq!(sorted[1].recipe.package.name.as_normalized(), "openblas");
+    }
+
+    #[test]
+    fn test_exact_run_constraint_still_orders() {
+        // An exact run_constraints pin still edges the graph: base first.
+        let recipe_yaml = r#"
+schema_version: 1
+
+context:
+  version: "1.0.0"
+
+recipe:
+  name: split
+  version: ${{ version }}
+
+build:
+  number: 0
+
+outputs:
+  - package:
+      name: consumer
+    build:
+      noarch: generic
+    requirements:
+      run_constraints:
+        - ${{ pin_subpackage("base", exact=true) }}
+
+  - package:
+      name: base
+    build:
+      noarch: generic
+"#;
+
+        let variant_yaml = r#"{}"#;
+
+        let stage0_recipe = stage0::parse_recipe_or_multi_from_source(recipe_yaml).unwrap();
+        let variant_config = VariantConfig::from_yaml_str(variant_yaml).unwrap();
+
+        let rendered =
+            render_recipe_with_variant_config(&stage0_recipe, &variant_config, RenderConfig::new())
+                .unwrap();
+
+        let sorted = topological_sort_variants(rendered).unwrap();
+        assert_eq!(sorted.len(), 2);
+        assert_eq!(sorted[0].recipe.package.name.as_normalized(), "base");
+        assert_eq!(sorted[1].recipe.package.name.as_normalized(), "consumer");
     }
 
     #[test]

--- a/test-data/recipes/race-condition/recipe-constraint-no-cycle.yaml
+++ b/test-data/recipes/race-condition/recipe-constraint-no-cycle.yaml
@@ -1,0 +1,21 @@
+recipe:
+  name: openblas-split
+  version: "0.3.20"
+
+# Regression test for issue #2531: a non-exact run_constraints pin must not
+# create a build-order edge, so these mutual references are not a cycle.
+outputs:
+  - package:
+      name: libopenblas
+    build:
+      noarch: generic
+    requirements:
+      run_constraints:
+        - ${{ pin_subpackage('openblas', upper_bound='x.x.x') }}
+  - package:
+      name: openblas
+    build:
+      noarch: generic
+    requirements:
+      run:
+        - ${{ pin_subpackage('libopenblas', exact=True) }}

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -1716,6 +1716,21 @@ def test_cycle_detection(rattler_build: RattlerBuild, recipes: Path, tmp_path: P
     assert "Cycle detected in recipe outputs: bazbus, foobar" in stdout
 
 
+def test_non_exact_run_constraint_no_cycle(
+    rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
+):
+    # Issue #2531: a non-exact run_constraints pin must not edge the graph.
+    rendered = rattler_build.render(
+        recipes / "race-condition" / "recipe-constraint-no-cycle.yaml",
+        tmp_path,
+    )
+    # libopenblas first via openblas's exact run pin.
+    assert [rx["recipe"]["package"]["name"] for rx in rendered] == [
+        "libopenblas",
+        "openblas",
+    ]
+
+
 def test_sibling_run_dep_ordering(
     rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
 ):


### PR DESCRIPTION
## Description

Fixes #2531.

Recipes that split a package into a library and a metapackage commonly have the two outputs reference each other: one output runtime-depends on the other, while the other uses `run_constraints` to keep their versions aligned. Today rattler-build rejects this valid pattern with a false "Cycle detected in recipe outputs" error.

This change makes such recipes build successfully again, while still correctly detecting genuine cycles between outputs.

## Checklist

- [x] Added a regression test for the reported recipe
- [x] Existing tests pass