### PR TITLE
feat(playground): add PyPI/CRAN/CPAN recipe generator

### DIFF
--- a/crates/rattler_build_playground/Cargo.lock
+++ b/crates/rattler_build_playground/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,6 +173,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
+name = "async-once-cell"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288f83726785267c6f2ef073a3d83dc3f9b81464e9f99898240cced85fce35a"
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,6 +270,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
@@ -382,6 +417,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -612,6 +656,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,6 +676,17 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+ "zlib-rs",
+]
 
 [[package]]
 name = "float-cmp"
@@ -660,6 +725,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
 ]
 
 [[package]]
@@ -792,12 +890,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -960,6 +1140,12 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1157,6 +1343,27 @@ dependencies = [
  "aho-corasick",
  "memo-map",
  "serde",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1362,6 +1569,7 @@ dependencies = [
  "indexmap 2.13.0",
  "rattler_build_jinja",
  "rattler_build_recipe",
+ "rattler_build_recipe_generator",
  "rattler_build_types",
  "rattler_build_variant_config",
  "rattler_build_yaml_parser",
@@ -1370,6 +1578,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -1403,6 +1612,35 @@ dependencies = [
  "spdx",
  "thiserror",
  "url",
+]
+
+[[package]]
+name = "rattler_build_recipe_generator"
+version = "0.1.6"
+dependencies = [
+ "async-once-cell",
+ "async-recursion",
+ "flate2",
+ "fs-err",
+ "hex",
+ "indexmap 2.13.0",
+ "itertools",
+ "miette",
+ "rattler_conda_types",
+ "rattler_digest",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "serde_yaml",
+ "sha2",
+ "tar",
+ "tempfile",
+ "toml",
+ "tracing",
+ "url",
+ "zip",
 ]
 
 [[package]]
@@ -1598,6 +1836,37 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "rustix"
@@ -1822,6 +2091,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "simd-json"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1842,12 +2117,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1910,6 +2201,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1918,6 +2218,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -1995,6 +2306,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys",
+]
+
+[[package]]
 name = "toml"
 version = "1.0.7+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2034,6 +2358,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2069,6 +2438,12 @@ name = "tree-sitter-language"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typed-path"
@@ -2162,6 +2537,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2196,6 +2580,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2262,6 +2660,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.13.0",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2433,6 +2841,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "yaml-rust2"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2541,7 +2959,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap 2.13.0",
+ "memchr",
+ "typed-path",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/crates/rattler_build_playground/Cargo.toml
+++ b/crates/rattler_build_playground/Cargo.toml
@@ -13,12 +13,14 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 console_error_panic_hook = "0.1"
 rattler_build_recipe = { path = "../rattler_build_recipe", default-features = false, features = [
   "variant-config",
 ] }
+rattler_build_recipe_generator = { path = "../rattler_build_recipe_generator", default-features = false }
 rattler_build_variant_config = { path = "../rattler_build_variant_config" }
 rattler_build_jinja = { path = "../rattler_build_jinja" }
 rattler_build_types = { path = "../rattler_build_types" }

--- a/crates/rattler_build_playground/src/lib.rs
+++ b/crates/rattler_build_playground/src/lib.rs
@@ -10,6 +10,10 @@ use rattler_build_recipe::{
     stage1::{Evaluate, EvaluationContext},
     variant_render::{RenderConfig, render_recipe_with_variant_config},
 };
+use rattler_build_recipe_generator::{
+    CpanOpts, PyPIOpts, generate_cpan_recipe_string, generate_pypi_recipe_string,
+    generate_r_recipe_string,
+};
 use rattler_build_variant_config::{VariantConfig, parse_conda_build_config};
 use rattler_conda_types::{Platform, RepodataRevision};
 use serde::Serialize;
@@ -445,5 +449,68 @@ fn format_parse_error(e: &rattler_build_yaml_parser::ParseError) -> String {
                 error_json(&message, None, None)
             }
         }
+    }
+}
+
+/// Build a JSON success response containing the raw generated recipe YAML.
+fn ok_recipe(yaml: &str) -> String {
+    serde_json::to_string(&serde_json::json!({
+        "ok": true,
+        "result": yaml,
+    }))
+    .expect("serialization of ok response cannot fail")
+}
+
+/// Generate a recipe from PyPI for the given package name (and optional version).
+///
+/// Returns a JSON string: `{ "ok": true, "result": "<yaml>" }` or
+/// `{ "ok": false, "error": {...} }`.
+#[wasm_bindgen]
+pub async fn generate_pypi_recipe(package: String, version: Option<String>) -> String {
+    let opts = PyPIOpts {
+        package,
+        version,
+        write: false,
+        use_mapping: true,
+        tree: false,
+        pypi_index_urls: vec!["https://pypi.org/pypi".to_string()],
+    };
+
+    match generate_pypi_recipe_string(&opts).await {
+        Ok(yaml) => ok_recipe(&yaml),
+        Err(e) => error_json(&format!("{e:?}"), None, None),
+    }
+}
+
+/// Generate a recipe from CRAN (via R-universe) for the given package name.
+///
+/// `universe` defaults to "cran" when `None`.
+///
+/// Returns a JSON string: `{ "ok": true, "result": "<yaml>" }` or
+/// `{ "ok": false, "error": {...} }`.
+#[wasm_bindgen]
+pub async fn generate_cran_recipe(package: String, universe: Option<String>) -> String {
+    match generate_r_recipe_string(&package, universe.as_deref()).await {
+        Ok(yaml) => ok_recipe(&yaml),
+        Err(e) => error_json(&format!("{e:?}"), None, None),
+    }
+}
+
+/// Generate a recipe from CPAN (via MetaCPAN) for the given package/module name.
+///
+/// Returns a JSON string: `{ "ok": true, "result": "<yaml>" }` or
+/// `{ "ok": false, "error": {...} }`.
+#[wasm_bindgen]
+pub async fn generate_cpan_recipe(package: String, version: Option<String>) -> String {
+    let opts = CpanOpts {
+        package,
+        version,
+        write: false,
+        tree: false,
+    };
+
+    match generate_cpan_recipe_string(&opts).await {
+        Ok(yaml) => ok_recipe(&yaml),
+        Err(e) => error_json(&format!("{e:?}"), None, None),
     }
 }

--- a/crates/rattler_build_playground/www/app.js
+++ b/crates/rattler_build_playground/www/app.js
@@ -1,4 +1,4 @@
-import wasmInit, { parse_recipe, evaluate_recipe, get_used_variables, get_platforms, render_variants, get_theme_css, highlight_source_yaml, first_variant_values } from './rattler_build_playground.js';
+import wasmInit, { parse_recipe, evaluate_recipe, get_used_variables, get_platforms, render_variants, get_theme_css, highlight_source_yaml, first_variant_values, generate_pypi_recipe, generate_cran_recipe, generate_cpan_recipe } from './rattler_build_playground.js';
 
 // ===== HTML utilities =====
 
@@ -98,6 +98,10 @@ const outputBadge = document.getElementById('output-badge');
 const platformSelect = document.getElementById('platform-select');
 const usedVarsEl = document.getElementById('used-vars');
 const loadPinningBtn = document.getElementById('load-pinning-btn');
+const generatorSource = document.getElementById('generator-source');
+const generatorPackage = document.getElementById('generator-package');
+const generatorVersion = document.getElementById('generator-version');
+const generatorBtn = document.getElementById('generator-btn');
 
 // ===== Editor helpers =====
 
@@ -327,6 +331,79 @@ variantsEditor.addEventListener('input', () => {
 platformSelect.addEventListener('change', () => {
   localStorage.setItem('playground-platform', platformSelect.value);
   update();
+});
+
+// Recipe generator (PyPI / CRAN / CPAN)
+const GENERATORS = {
+  pypi: { fn: generate_pypi_recipe, versioned: true, placeholder: 'package name' },
+  cran: { fn: generate_cran_recipe, versioned: false, placeholder: 'R package' },
+  cpan: { fn: generate_cpan_recipe, versioned: true, placeholder: 'Perl distribution' },
+};
+
+function updateGeneratorPlaceholders() {
+  const cfg = GENERATORS[generatorSource.value] || GENERATORS.pypi;
+  generatorPackage.placeholder = cfg.placeholder;
+  generatorVersion.style.display = cfg.versioned ? '' : 'none';
+}
+
+generatorSource.value = localStorage.getItem('playground-gen-source') || 'pypi';
+updateGeneratorPlaceholders();
+
+generatorSource.addEventListener('change', () => {
+  localStorage.setItem('playground-gen-source', generatorSource.value);
+  updateGeneratorPlaceholders();
+});
+
+async function runGenerator() {
+  const source = generatorSource.value;
+  const cfg = GENERATORS[source];
+  if (!cfg) return;
+  const pkg = generatorPackage.value.trim();
+  if (!pkg) {
+    generatorPackage.focus();
+    return;
+  }
+  const version = generatorVersion.value.trim() || null;
+
+  generatorBtn.disabled = true;
+  const originalText = generatorBtn.textContent;
+  generatorBtn.textContent = 'generating...';
+  outputBadge.textContent = `fetching ${source}…`;
+  outputBadge.style.color = '';
+  try {
+    const arg2 = cfg.versioned ? version : null;
+    const resultJson = await cfg.fn(pkg, arg2);
+    const result = JSON.parse(resultJson);
+    if (result.ok) {
+      recipeEditor.value = result.result;
+      localStorage.setItem('playground-recipe', recipeEditor.value);
+      if (wasmReady) highlightEditor(recipeEditor, recipeHighlight);
+      autoResize(recipeEditor);
+      scheduleUpdate();
+    } else {
+      outputBadge.textContent = 'error';
+      outputBadge.style.color = 'var(--error)';
+      renderError(result.error);
+    }
+  } catch (e) {
+    outputBadge.textContent = 'error';
+    outputBadge.style.color = 'var(--error)';
+    renderError({ message: e.toString() });
+  } finally {
+    generatorBtn.disabled = false;
+    generatorBtn.textContent = originalText;
+  }
+}
+
+generatorBtn.addEventListener('click', runGenerator);
+
+[generatorPackage, generatorVersion].forEach(input => {
+  input.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      runGenerator();
+    }
+  });
 });
 
 // Load conda-forge pinning

--- a/crates/rattler_build_playground/www/index.html
+++ b/crates/rattler_build_playground/www/index.html
@@ -27,6 +27,16 @@
         <div class="recipe-pane">
           <div class="panel-header">
             Recipe YAML
+            <div class="generator-controls">
+              <select id="generator-source" title="Recipe source">
+                <option value="pypi">PyPI</option>
+                <option value="cran">CRAN</option>
+                <option value="cpan">CPAN</option>
+              </select>
+              <input id="generator-package" type="text" placeholder="package name" spellcheck="false" autocomplete="off">
+              <input id="generator-version" type="text" placeholder="version (optional)" spellcheck="false" autocomplete="off">
+              <button id="generator-btn" title="Fetch package metadata and generate a recipe">generate</button>
+            </div>
           </div>
           <div class="editor-container">
             <pre class="editor-highlight" id="recipe-highlight"></pre>

--- a/crates/rattler_build_playground/www/style.css
+++ b/crates/rattler_build_playground/www/style.css
@@ -222,6 +222,65 @@ html, body {
   cursor: wait;
 }
 
+/* Recipe generator controls (PyPI / CRAN / CPAN) */
+.generator-controls {
+  display: flex;
+  gap: 6px;
+  margin-left: auto;
+  align-items: center;
+  text-transform: none;
+  letter-spacing: normal;
+}
+
+.generator-controls select,
+.generator-controls input {
+  background: var(--bg-editor);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 11px;
+  font-family: var(--font-sans);
+}
+
+.generator-controls input {
+  width: 110px;
+}
+
+.generator-controls input:focus,
+.generator-controls select:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.generator-controls input::placeholder {
+  color: var(--text-muted);
+}
+
+.generator-controls button {
+  background: var(--bg-editor);
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 2px 10px;
+  font-size: 11px;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  text-transform: none;
+  letter-spacing: normal;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.generator-controls button:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.generator-controls button:disabled {
+  opacity: 0.5;
+  cursor: wait;
+}
+
 .editor-container {
   flex: 1;
   position: relative;

--- a/crates/rattler_build_recipe_generator/Cargo.toml
+++ b/crates/rattler_build_recipe_generator/Cargo.toml
@@ -19,7 +19,6 @@ clap = { workspace = true, optional = true }
 async-once-cell = { workspace = true }
 async-recursion = { workspace = true }
 flate2 = { workspace = true }
-fs-err = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
 miette = { workspace = true }
@@ -34,11 +33,14 @@ serde_with = { workspace = true }
 serde_yaml = { workspace = true }
 sha2 = { workspace = true }
 tar = { workspace = true }
-tempfile = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 zip = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+fs-err = { workspace = true }
+tempfile = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true, features = ["yaml"] }

--- a/crates/rattler_build_recipe_generator/src/cpan.rs
+++ b/crates/rattler_build_recipe_generator/src/cpan.rs
@@ -4,10 +4,13 @@ use miette::{IntoDiagnostic, WrapErr};
 use serde::Deserialize;
 use std::{
     collections::{HashMap, HashSet},
-    process::Command,
     sync::OnceLock,
 };
 
+#[cfg(not(target_arch = "wasm32"))]
+use std::process::Command;
+
+#[cfg(not(target_arch = "wasm32"))]
 use super::write_recipe;
 use crate::serialize::{self, ScriptTest, Test, UrlSourceElement};
 
@@ -71,7 +74,10 @@ struct CpanReleaseMetadata {
 #[allow(dead_code)]
 struct CpanModule {
     name: String,
-    version: Option<String>,
+    /// MetaCPAN may return this as either a string (e.g. `"1.647"`) or a number
+    /// (e.g. `1.647`), so we accept arbitrary JSON.
+    #[serde(default)]
+    version: Option<serde_json::Value>,
     author: String,
     authorized: bool,
     indexed: bool,
@@ -112,14 +118,11 @@ struct MetaCpanResponse<T> {
 #[allow(dead_code)]
 struct MetaCpanHits<T> {
     hits: Vec<MetaCpanHit<T>>,
-    total: MetaCpanTotal,
-}
-
-#[derive(Deserialize, Debug, Clone)]
-#[allow(dead_code)]
-struct MetaCpanTotal {
-    value: i32,
-    relation: String,
+    /// MetaCPAN's elasticsearch may serialize this as either a plain integer
+    /// (old behavior) or as a `{ value, relation }` object (Elasticsearch 7+),
+    /// so we accept arbitrary JSON.
+    #[serde(default)]
+    total: serde_json::Value,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -138,6 +141,7 @@ pub struct CpanMetadata {
 
 static CORE_MODULES: OnceLock<HashSet<String>> = OnceLock::new();
 
+#[cfg(not(target_arch = "wasm32"))]
 fn get_core_modules_from_perl() -> Result<HashSet<String>, std::io::Error> {
     let output = Command::new("perl")
         .arg("-e")
@@ -234,21 +238,30 @@ fn get_fallback_core_modules() -> HashSet<String> {
 }
 
 fn initialize_core_modules() -> &'static HashSet<String> {
-    CORE_MODULES.get_or_init(|| match get_core_modules_from_perl() {
-        Ok(modules) => {
-            tracing::info!(
-                "Successfully loaded {} core modules from system Perl",
-                modules.len()
-            );
-            modules
+    CORE_MODULES.get_or_init(|| {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            match get_core_modules_from_perl() {
+                Ok(modules) => {
+                    tracing::info!(
+                        "Successfully loaded {} core modules from system Perl",
+                        modules.len()
+                    );
+                    modules
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "Warning: Failed to get core modules from system Perl: {}",
+                        e
+                    );
+                    tracing::warn!("Falling back to hardcoded core module list.");
+                    tracing::warn!("Consider installing Perl with: pixi global install perl");
+                    get_fallback_core_modules()
+                }
+            }
         }
-        Err(e) => {
-            tracing::warn!(
-                "Warning: Failed to get core modules from system Perl: {}",
-                e
-            );
-            tracing::warn!("Falling back to hardcoded core module list.");
-            tracing::warn!("Consider installing Perl with: pixi global install perl");
+        #[cfg(target_arch = "wasm32")]
+        {
             get_fallback_core_modules()
         }
     })
@@ -639,6 +652,7 @@ pub async fn generate_cpan_recipe_string(opts: &CpanOpts) -> miette::Result<Stri
     Ok(format_cpan_recipe_with_tests(&recipe))
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[async_recursion::async_recursion]
 /// Generate a CPAN recipe from `CpanOpts` and either print it or write it to disk.
 ///

--- a/crates/rattler_build_recipe_generator/src/cran.rs
+++ b/crates/rattler_build_recipe_generator/src/cran.rs
@@ -1,6 +1,6 @@
-use std::{collections::HashMap, collections::HashSet};
 #[cfg(not(target_arch = "wasm32"))]
 use std::path::PathBuf;
+use std::{collections::HashMap, collections::HashSet};
 
 #[cfg(feature = "cli")]
 use clap::Parser;

--- a/crates/rattler_build_recipe_generator/src/cran.rs
+++ b/crates/rattler_build_recipe_generator/src/cran.rs
@@ -1,4 +1,6 @@
-use std::{collections::HashMap, collections::HashSet, path::PathBuf};
+use std::{collections::HashMap, collections::HashSet};
+#[cfg(not(target_arch = "wasm32"))]
+use std::path::PathBuf;
 
 #[cfg(feature = "cli")]
 use clap::Parser;
@@ -9,10 +11,9 @@ use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use url::Url;
 
-use crate::{
-    serialize::{self, ScriptTest, Test, UrlSourceElement},
-    write_recipe,
-};
+use crate::serialize::{self, ScriptTest, Test, UrlSourceElement};
+#[cfg(not(target_arch = "wasm32"))]
+use crate::write_recipe;
 /// Package metadata returned by the R-universe/CRAN API.
 #[allow(non_snake_case)]
 #[derive(Serialize, Deserialize, Debug)]
@@ -267,12 +268,25 @@ async fn build_cran_recipe_and_deps(
     ))
     .expect("Failed to parse URL");
 
-    let sha256 = fetch_package_sha256sum(&url).await?;
+    // Fetching the tarball to hash it is best-effort: in restricted environments
+    // (e.g. WASM/browser with no CORS on cran.r-project.org) we fall back to the
+    // MD5 the R-universe API already gave us.
+    let (sha256, md5) = match fetch_package_sha256sum(&url).await {
+        Ok(hash) => (Some(hex::encode(hash)), None),
+        Err(e) => {
+            tracing::warn!(
+                "Failed to fetch SHA256 for {}: {} — falling back to MD5 from R-universe.",
+                package_info._file,
+                e
+            );
+            (None, Some(package_info.MD5sum.clone()))
+        }
+    };
 
     let source = UrlSourceElement {
         url: vec![url.to_string(), url_archive.to_string()],
-        md5: None,
-        sha256: Some(hex::encode(sha256)),
+        md5,
+        sha256,
     };
     recipe.source.push(source.into());
 
@@ -369,6 +383,7 @@ pub async fn generate_r_recipe_string(
     Ok(format_cran_recipe_with_suggests(&recipe))
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[async_recursion::async_recursion]
 /// Generate a CRAN recipe using `CranOpts` and either print it or write it to disk.
 ///

--- a/crates/rattler_build_recipe_generator/src/lib.rs
+++ b/crates/rattler_build_recipe_generator/src/lib.rs
@@ -5,18 +5,28 @@ use clap::Parser;
 
 mod cpan;
 mod cran;
+#[cfg(not(target_arch = "wasm32"))]
 mod luarocks;
 mod pypi;
 mod serialize;
 
-pub use self::cpan::{CpanOpts, generate_cpan_recipe, generate_cpan_recipe_string};
-pub use self::cran::{CranOpts, generate_r_recipe, generate_r_recipe_string};
+pub use self::cpan::{CpanOpts, generate_cpan_recipe_string};
+pub use self::cran::{CranOpts, generate_r_recipe_string};
+pub use self::pypi::{PyPIOpts, generate_pypi_recipe_string};
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use self::cpan::generate_cpan_recipe;
+#[cfg(not(target_arch = "wasm32"))]
+pub use self::cran::generate_r_recipe;
+#[cfg(not(target_arch = "wasm32"))]
 pub use self::luarocks::{LuarocksOpts, generate_luarocks_recipe, generate_luarocks_recipe_string};
-pub use self::pypi::{PyPIOpts, generate_pypi_recipe, generate_pypi_recipe_string};
+#[cfg(not(target_arch = "wasm32"))]
+pub use self::pypi::generate_pypi_recipe;
+#[cfg(not(target_arch = "wasm32"))]
 pub use serialize::write_recipe;
 
 /// The source of the package to generate a recipe for
-#[cfg(feature = "cli")]
+#[cfg(all(feature = "cli", not(target_arch = "wasm32")))]
 #[derive(Debug, Clone, Parser)]
 pub enum Source {
     /// Generate a recipe for a Python package from PyPI
@@ -33,7 +43,7 @@ pub enum Source {
 }
 
 /// Options for generating a recipe
-#[cfg(feature = "cli")]
+#[cfg(all(feature = "cli", not(target_arch = "wasm32")))]
 #[derive(Parser)]
 pub struct GenerateRecipeOpts {
     /// Type of package to generate a recipe for
@@ -42,7 +52,7 @@ pub struct GenerateRecipeOpts {
 }
 
 /// Generate a recipe for a package
-#[cfg(feature = "cli")]
+#[cfg(all(feature = "cli", not(target_arch = "wasm32")))]
 pub async fn generate_recipe(args: GenerateRecipeOpts) -> miette::Result<()> {
     match args.source {
         Source::Pypi(opts) => generate_pypi_recipe(&opts).await?,

--- a/crates/rattler_build_recipe_generator/src/pypi.rs
+++ b/crates/rattler_build_recipe_generator/src/pypi.rs
@@ -5,9 +5,11 @@ use miette::{IntoDiagnostic, WrapErr};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::io::{Cursor, Read as _};
+#[cfg(not(target_arch = "wasm32"))]
 use std::path::PathBuf;
 use zip::ZipArchive;
 
+#[cfg(not(target_arch = "wasm32"))]
 use super::write_recipe;
 use crate::serialize::{self, PythonTest, PythonTestInner, Test, UrlSourceElement};
 
@@ -809,12 +811,25 @@ pub async fn create_recipe(
     );
 
     if let Some(wheel_url) = &metadata.wheel_url {
-        let wheel_info = extract_wheel_info(wheel_url, client).await?;
-        if !wheel_info.entry_points.is_empty() {
-            recipe.build.python.entry_points = wheel_info.entry_points;
-        }
-        if !wheel_info.license_files.is_empty() {
-            recipe.about.license_file = wheel_info.license_files;
+        // Wheel extraction is best-effort: in restricted environments (e.g. WASM/browser
+        // with no CORS on files.pythonhosted.org) the request may fail. Treat that as
+        // non-fatal and continue producing the rest of the recipe.
+        match extract_wheel_info(wheel_url, client).await {
+            Ok(wheel_info) => {
+                if !wheel_info.entry_points.is_empty() {
+                    recipe.build.python.entry_points = wheel_info.entry_points;
+                }
+                if !wheel_info.license_files.is_empty() {
+                    recipe.about.license_file = wheel_info.license_files;
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to extract wheel info for {}: {} — entry points and license files may be missing.",
+                    opts.package,
+                    e
+                );
+            }
         }
     } else {
         tracing::warn!(
@@ -848,12 +863,20 @@ pub async fn create_recipe(
         &HashMap::new()
     };
 
-    // Check for build requirements
-    let build_reqs = extract_build_requirements(&metadata.release.url, client).await?;
-    if !build_reqs.is_empty() {
-        for req in build_reqs {
-            let mapped_req = map_requirement(&req, mapping, opts.use_mapping).await;
-            recipe.requirements.host.push(mapped_req);
+    // Check for build requirements — best-effort, fall back to just pip.
+    match extract_build_requirements(&metadata.release.url, client).await {
+        Ok(build_reqs) => {
+            for req in build_reqs {
+                let mapped_req = map_requirement(&req, mapping, opts.use_mapping).await;
+                recipe.requirements.host.push(mapped_req);
+            }
+        }
+        Err(e) => {
+            tracing::warn!(
+                "Failed to extract build requirements for {}: {} — only pip will be added as a build dep.",
+                opts.package,
+                e
+            );
         }
     }
     recipe.requirements.host.push("pip".to_string());
@@ -916,6 +939,7 @@ pub async fn generate_pypi_recipe_string(opts: &PyPIOpts) -> miette::Result<Stri
 /// Generate a recipe for a PyPI package and either write it to disk or print it.
 ///
 /// If `opts.tree` is set, recursively generates recipes for runtime dependencies.
+#[cfg(not(target_arch = "wasm32"))]
 #[async_recursion::async_recursion]
 pub async fn generate_pypi_recipe(opts: &PyPIOpts) -> miette::Result<()> {
     tracing::info!("Generating recipe for {}", opts.package);

--- a/crates/rattler_build_recipe_generator/src/serialize.rs
+++ b/crates/rattler_build_recipe_generator/src/serialize.rs
@@ -1,4 +1,6 @@
-use std::{fmt, path::PathBuf};
+use std::fmt;
+#[cfg(not(target_arch = "wasm32"))]
+use std::path::PathBuf;
 
 use indexmap::IndexMap;
 use serde::Serialize;
@@ -164,6 +166,7 @@ impl fmt::Display for Recipe {
 }
 
 /// Write a recipe to "{package_name}/recipe.yaml"
+#[cfg(not(target_arch = "wasm32"))]
 pub fn write_recipe(package_name: &str, recipe: &str) -> std::io::Result<()> {
     let path = PathBuf::from(&format!("{}/recipe.yaml", &package_name));
     fs_err::create_dir_all(path.parent().unwrap())?;


### PR DESCRIPTION
Wire the existing rattler-build recipe generator into the WASM
playground so users can fetch and scaffold a recipe directly from the
browser. A small UI in the Recipe panel header takes a source (PyPI,
CRAN, or CPAN), a package name, and an optional version, then drops the
generated YAML straight into the editor.

To make the generator crate build for wasm32, filesystem and subprocess
code paths are gated behind cfg(not(target_arch = "wasm32")): the disk-
writing generate_* variants, write_recipe, the CPAN perl Module::CoreList
probe (falls back to the hardcoded list), and the entire luarocks module
(needs a lua subprocess). Auxiliary network fetches are now best-effort
so a CORS rejection in the browser doesn't abort the whole recipe — PyPI
wheel/sdist inspection and CRAN's SHA256 tarball download degrade
gracefully (CRAN falls back to the MD5 returned by R-universe).

While verifying end-to-end through the playground I hit a pre-existing
CPAN bug unrelated to WASM: MetaCPAN's _search endpoint now returns
hits.total as a bare integer (Elasticsearch 7+), not the
{ value, relation } object the struct expected, which made every CPAN
recipe generation fail. Relaxed total (and the occasionally-numeric
version field) to serde_json::Value.