### PR TITLE
refactor(script): compose the build wrapper from scoped sections

### DIFF
--- a/crates/rattler_build_script/src/execution.rs
+++ b/crates/rattler_build_script/src/execution.rs
@@ -427,14 +427,51 @@ impl Decoder for CrLfNormalizer {
     }
 }
 
+/// One unit of a generated build wrapper: content run in a single interpreter,
+/// with optional step-local `env` and a boundary-comment label.
+///
+/// `env` is scoped to the section (see `NativeShellRunner::scope_section`) and is
+/// distinct from [`ExecutionArgs::env_vars`], the whole-build environment. Today
+/// one section is built from [`ExecutionArgs`]; the step expander will build many.
+pub(crate) struct ScriptSection<'a> {
+    /// Explicit interpreter, or `None` to infer from a file-backed path and
+    /// otherwise fall back to the wrapper shell.
+    pub interpreter: Option<&'a str>,
+    /// Resolved content for this section.
+    pub content: &'a ResolvedScriptContents,
+    /// Environment variables scoped to this section only.
+    pub env: &'a IndexMap<String, String>,
+    /// Optional annotation rendered as a boundary comment above the section.
+    pub label: Option<&'a str>,
+}
+
+/// A section's place in the wrapper. Used only for naming the interpreter script
+/// file so the single-section case keeps its historic name.
+#[derive(Clone, Copy)]
+struct SectionIndex {
+    position: usize,
+    total: usize,
+}
+
+/// Names the file an interpreter section's content is written to. A sole section
+/// keeps the historic `conda_build_script.<ext>` name (asserted by tests and
+/// referenced by the debugging docs); multiple sections are numbered.
+fn section_script_filename(extension: &str, index: SectionIndex) -> String {
+    if index.total == 1 {
+        format!("conda_build_script.{extension}")
+    } else {
+        format!("conda_build_step{}.{extension}", index.position)
+    }
+}
+
 /// Returns the path to the generated native build wrapper script.
 ///
-/// If `args.interpreter` is set, or if the resolved script path has a known
-/// interpreter extension, and that interpreter differs from the wrapper shell,
-/// inline script text is written to a separate file and the native wrapper
-/// invokes the resolved interpreter with that file. Otherwise — no interpreter,
-/// or one that is the wrapper shell itself (`cmd` on Windows, `bash` on Unix) —
-/// the script contents are appended directly to the native wrapper.
+/// The wrapper sources the activation script, then runs an ordered list of
+/// sections, each wrapped in an isolated scope (see `scope_section`). Sections
+/// with no interpreter, or with the native wrapper shell itself (`cmd` on
+/// Windows, `bash` on Unix), are appended directly to the wrapper; sections with
+/// a specialized interpreter are written to script files and invoked via the
+/// resolved interpreter.
 pub(crate) async fn generate_build_script(
     args: &ExecutionArgs,
 ) -> Result<PathBuf, crate::InterpreterError> {
@@ -455,17 +492,74 @@ pub(crate) async fn generate_build_script(
     )
     .await?;
 
-    // Interpreter inference is intentionally done after content resolution:
-    // only file-backed scripts can infer from their resolved path. Inline
-    // scripts use the explicit recipe interpreter or remain native shell code.
-    let explicit_or_inferred = args
-        .interpreter
-        .as_deref()
-        .map(str::to_string)
-        .or_else(|| args.script.infer_interpreter());
+    // One section today; the expander will build many.
+    let no_env = IndexMap::new();
+    let sections = [ScriptSection {
+        interpreter: args.interpreter.as_deref(),
+        content: &args.script,
+        env: &no_env,
+        label: None,
+    }];
 
-    // The interpreter that runs the content (and assembles a command list).
-    // With none specified, default to the wrapper shell from the runner.
+    let total = sections.len();
+    let mut fragments = Vec::with_capacity(total);
+    for (position, section) in sections.iter().enumerate() {
+        let body = build_section_body(
+            args,
+            runner.as_ref(),
+            &shell,
+            section,
+            SectionIndex { position, total },
+        )
+        .await?;
+        // Drop empty sections: an empty bash subshell `()` is a syntax error,
+        // and no-script recipes stay preamble-only.
+        if body.trim().is_empty() {
+            continue;
+        }
+        fragments.push(runner.scope_section(section.label, section.env, &body)?);
+    }
+
+    let build_script = format!(
+        "{}\n{}",
+        runner.preamble(&activation_script_path),
+        fragments.join("\n"),
+    );
+    tokio::fs::write(
+        &build_script_path,
+        crate::native_runner::write_shell_script(shell, &build_script)?,
+    )
+    .await?;
+
+    #[cfg(unix)]
+    {
+        if build_script_path.extension().and_then(|e| e.to_str()) == Some("sh") {
+            use std::{fs::Permissions, os::unix::fs::PermissionsExt};
+            let permissions = Permissions::from_mode(0o755);
+            tokio::fs::set_permissions(&build_script_path, permissions).await?;
+        }
+    }
+
+    Ok(build_script_path)
+}
+
+/// Builds the raw (unscoped) wrapper body for one section: native code when no
+/// interpreter applies, otherwise an invocation of the resolved interpreter.
+async fn build_section_body(
+    args: &ExecutionArgs,
+    runner: &dyn crate::native_runner::NativeShellRunner,
+    shell: &rattler_shell::shell::ShellEnum,
+    section: &ScriptSection<'_>,
+    index: SectionIndex,
+) -> Result<String, crate::InterpreterError> {
+    // Inference runs after resolution: only file-backed scripts infer from their
+    // path; inline scripts use the explicit interpreter or stay native code.
+    let explicit_or_inferred = section
+        .interpreter
+        .map(str::to_string)
+        .or_else(|| section.content.infer_interpreter());
+
+    // No interpreter specified: default to the wrapper shell.
     let interpreter_name = explicit_or_inferred
         .clone()
         .unwrap_or_else(|| runner.default_interpreter().to_string());
@@ -484,75 +578,52 @@ pub(crate) async fn generate_build_script(
         .is_some_and(|name| name != runner.default_interpreter());
 
     // Assemble the rendered content; the interpreter joins a command list.
-    let script_text = match &args.script {
+    let script_text = match section.content {
         ResolvedScriptContents::Commands(commands) => interpreter.join_commands(commands),
         ResolvedScriptContents::Inline(script) => script.clone(),
         ResolvedScriptContents::Path(_, script) => script.clone(),
         ResolvedScriptContents::Missing => String::new(),
     };
 
-    let body = if needs_specialized_interpreter {
-        // Specialized interpreter: invoke a script file (the original path, or
-        // one written next to the wrapper).
-        let script_path = match &args.script {
-            ResolvedScriptContents::Path(path, _) => path.clone(),
-            _ => {
-                let path = args
-                    .work_dir
-                    .join(format!("conda_build_script.{}", interpreter.extension()));
-                tokio::fs::write(&path, interpreter.script_contents(&script_text)).await?;
-                path
-            }
-        };
-
-        // Resolve the executable from the activated environment (build prefix,
-        // then host prefix, then the system PATH depending on the interpreter).
-        // The selected interpreter preserves the recipe value (e.g. `nushell`)
-        // for user-facing errors even when the executable has a different name
-        // (e.g. `nu`).
-        let executable = interpreter.resolve_executable(
-            args.build_prefix.as_deref(),
-            &args.run_prefix,
-            &args.runtime,
-        )?;
-
-        // Quote the resolved path and arguments so a prefix or script path
-        // containing spaces survives the native shell.
-        let mut command = vec![executable.to_string_lossy().into_owned()];
-        command.extend(interpreter.args(&script_path));
-        let quoted = command
-            .iter()
-            .map(|arg| crate::native_runner::quote_arg(&shell, arg))
-            .collect::<Vec<_>>();
-        let command_refs = quoted.iter().map(String::as_str).collect::<Vec<_>>();
-        let mut body = String::new();
-        shell
-            .run_command(&mut body, command_refs)
-            .map_err(std::io::Error::other)?;
-        body
-    } else {
+    if !needs_specialized_interpreter {
         // No interpreter, or one that matches the wrapper shell: the content is
         // the native wrapper body, run directly by the wrapper shell.
-        script_text
-    };
-
-    let build_script = format!("{}\n{}", runner.preamble(&activation_script_path), body);
-    tokio::fs::write(
-        &build_script_path,
-        crate::native_runner::write_shell_script(shell, &build_script)?,
-    )
-    .await?;
-
-    #[cfg(unix)]
-    {
-        if build_script_path.extension().and_then(|e| e.to_str()) == Some("sh") {
-            use std::{fs::Permissions, os::unix::fs::PermissionsExt};
-            let permissions = Permissions::from_mode(0o755);
-            tokio::fs::set_permissions(&build_script_path, permissions).await?;
-        }
+        return Ok(script_text);
     }
 
-    Ok(build_script_path)
+    // Specialized interpreter: invoke a script file (the original path, or one
+    // written next to the wrapper).
+    let script_path = match section.content {
+        ResolvedScriptContents::Path(path, _) => path.clone(),
+        _ => {
+            let path = args
+                .work_dir
+                .join(section_script_filename(interpreter.extension(), index));
+            tokio::fs::write(&path, interpreter.script_contents(&script_text)).await?;
+            path
+        }
+    };
+
+    // Resolve from the activated environment (build/host prefix, then PATH).
+    let executable = interpreter.resolve_executable(
+        args.build_prefix.as_deref(),
+        &args.run_prefix,
+        &args.runtime,
+    )?;
+
+    // Quote so a prefix or script path with spaces survives the native shell.
+    let mut command = vec![executable.to_string_lossy().into_owned()];
+    command.extend(interpreter.args(&script_path));
+    let quoted = command
+        .iter()
+        .map(|arg| crate::native_runner::quote_arg(shell, arg))
+        .collect::<Vec<_>>();
+    let command_refs = quoted.iter().map(String::as_str).collect::<Vec<_>>();
+    let mut body = String::new();
+    shell
+        .run_command(&mut body, command_refs)
+        .map_err(std::io::Error::other)?;
+    Ok(body)
 }
 
 /// Runs a script with the given execution arguments.
@@ -1417,6 +1488,114 @@ mod tests {
         assert!(
             err.contains("unknown environment isolation mode 'bogus'"),
             "unexpected error: {err}"
+        );
+    }
+
+    fn has_line(s: &str, want: &str) -> bool {
+        s.lines().any(|l| l.trim_end() == want)
+    }
+
+    /// The single section is subshell-wrapped on bash (uniform isolation).
+    #[tokio::test]
+    async fn test_bash_single_section_wrapped_in_subshell() {
+        let tmp = tempfile::tempdir().unwrap();
+        let prefix = tmp.path().join("prefix");
+        fs::create_dir_all(&prefix).unwrap();
+        let args = execution_args(
+            tmp.path().to_path_buf(),
+            prefix,
+            ResolvedScriptContents::Inline("echo hi".to_string()),
+            None,
+        );
+        let args = ExecutionArgs {
+            runtime: RuntimeEnv::for_test(Platform::Linux64),
+            ..args
+        };
+        generate_build_script(&args).await.unwrap();
+        let wrapper = fs::read_to_string(tmp.path().join("conda_build.sh")).unwrap();
+        assert!(
+            has_line(&wrapper, "("),
+            "section must be subshell-wrapped:\n{wrapper}"
+        );
+        assert!(has_line(&wrapper, ")"), "{wrapper}");
+        assert!(wrapper.contains("echo hi"), "{wrapper}");
+    }
+
+    /// A recipe with no build script stays preamble-only: no empty subshell.
+    #[tokio::test]
+    async fn test_bash_missing_script_is_preamble_only() {
+        let tmp = tempfile::tempdir().unwrap();
+        let prefix = tmp.path().join("prefix");
+        fs::create_dir_all(&prefix).unwrap();
+        let args = execution_args(
+            tmp.path().to_path_buf(),
+            prefix,
+            ResolvedScriptContents::Missing,
+            None,
+        );
+        let args = ExecutionArgs {
+            runtime: RuntimeEnv::for_test(Platform::Linux64),
+            ..args
+        };
+        generate_build_script(&args).await.unwrap();
+        let wrapper = fs::read_to_string(tmp.path().join("conda_build.sh")).unwrap();
+        assert!(
+            !has_line(&wrapper, "("),
+            "no script => no subshell:\n{wrapper}"
+        );
+        assert!(wrapper.contains("End of preamble"), "{wrapper}");
+    }
+
+    /// The single section is `setlocal`/`endlocal`-scoped on cmd, with the
+    /// trailing errorlevel guard.
+    #[tokio::test]
+    async fn test_cmd_single_section_setlocal_and_guard() {
+        let tmp = tempfile::tempdir().unwrap();
+        let prefix = tmp.path().join("prefix");
+        fs::create_dir_all(&prefix).unwrap();
+        let args = execution_args(
+            tmp.path().to_path_buf(),
+            prefix,
+            ResolvedScriptContents::Inline("echo hi".to_string()),
+            None,
+        );
+        let args = ExecutionArgs {
+            runtime: RuntimeEnv::for_test(Platform::Win64),
+            ..args
+        };
+        generate_build_script(&args).await.unwrap();
+        let wrapper = fs::read_to_string(tmp.path().join("conda_build.bat")).unwrap();
+        assert!(has_line(&wrapper, "setlocal"), "{wrapper}");
+        assert!(has_line(&wrapper, "endlocal"), "{wrapper}");
+        assert!(
+            has_line(&wrapper, "if %errorlevel% neq 0 exit /b %errorlevel%"),
+            "{wrapper}"
+        );
+    }
+
+    /// A sole section keeps the historic file name; multiple are numbered.
+    #[test]
+    fn test_section_script_filename_single_vs_multi() {
+        let single = SectionIndex {
+            position: 0,
+            total: 1,
+        };
+        assert_eq!(
+            section_script_filename("py", single),
+            "conda_build_script.py"
+        );
+        let first = SectionIndex {
+            position: 0,
+            total: 2,
+        };
+        let second = SectionIndex {
+            position: 1,
+            total: 2,
+        };
+        assert_eq!(section_script_filename("py", first), "conda_build_step0.py");
+        assert_eq!(
+            section_script_filename("py", second),
+            "conda_build_step1.py"
         );
     }
 }

--- a/crates/rattler_build_script/src/native_runner/bash.rs
+++ b/crates/rattler_build_script/src/native_runner/bash.rs
@@ -1,6 +1,8 @@
+use std::fmt::Write as _;
 use std::path::Path;
 
-use rattler_shell::shell;
+use indexmap::IndexMap;
+use rattler_shell::shell::{self, Shell};
 
 use super::NativeShellRunner;
 
@@ -35,6 +37,34 @@ fi
 
     fn replacements_template(&self) -> &'static str {
         "$((var))"
+    }
+
+    /// Subshell scope. Inherited `set -e` aborts on failure, so no guard is
+    /// needed — but it must stay a bare statement (chaining `||`/`&&` would
+    /// suppress `set -e`).
+    fn scope_section(
+        &self,
+        label: Option<&str>,
+        env: &IndexMap<String, String>,
+        body: &str,
+    ) -> Result<String, std::io::Error> {
+        let shell = shell::Bash::default();
+        let mut out = String::new();
+        if let Some(label) = label {
+            let _ = writeln!(out, "# === {label} ===");
+        }
+        out.push_str("(\n");
+        for (key, value) in env {
+            shell
+                .set_env_var(&mut out, key, value)
+                .map_err(std::io::Error::other)?;
+        }
+        out.push_str(body);
+        if !body.ends_with('\n') {
+            out.push('\n');
+        }
+        out.push(')');
+        Ok(out)
     }
 
     /// Returns reproduction instructions for the failed bash wrapper script.

--- a/crates/rattler_build_script/src/native_runner/cmd_exe.rs
+++ b/crates/rattler_build_script/src/native_runner/cmd_exe.rs
@@ -1,6 +1,8 @@
+use std::fmt::Write as _;
 use std::path::Path;
 
-use rattler_shell::shell;
+use indexmap::IndexMap;
+use rattler_shell::shell::{self, Shell};
 
 use super::NativeShellRunner;
 
@@ -41,6 +43,35 @@ IF "%CONDA_BUILD%" == "" (
 
     fn supports_sandbox(&self) -> bool {
         false
+    }
+
+    /// `setlocal`/`endlocal` scope plus an errorlevel guard. The guard is
+    /// required even on the last section: falling off the end after `endlocal`
+    /// exits 0 regardless of failure, but `endlocal` preserves the
+    /// `%errorlevel%` value so the guard still catches it.
+    fn scope_section(
+        &self,
+        label: Option<&str>,
+        env: &IndexMap<String, String>,
+        body: &str,
+    ) -> Result<String, std::io::Error> {
+        let shell = shell::CmdExe;
+        let mut out = String::new();
+        if let Some(label) = label {
+            let _ = writeln!(out, "@rem === {label} ===");
+        }
+        out.push_str("setlocal\n");
+        for (key, value) in env {
+            shell
+                .set_env_var(&mut out, key, value)
+                .map_err(std::io::Error::other)?;
+        }
+        out.push_str(body);
+        if !body.ends_with('\n') {
+            out.push('\n');
+        }
+        out.push_str("endlocal\nif %errorlevel% neq 0 exit /b %errorlevel%");
+        Ok(out)
     }
 
     /// Returns reproduction instructions for the failed cmd wrapper script.

--- a/crates/rattler_build_script/src/native_runner/mod.rs
+++ b/crates/rattler_build_script/src/native_runner/mod.rs
@@ -10,6 +10,7 @@ mod cmd_exe;
 
 use std::path::Path;
 
+use indexmap::IndexMap;
 use rattler_conda_types::Platform;
 use rattler_shell::shell::{Shell, ShellEnum};
 
@@ -35,6 +36,17 @@ pub(crate) trait NativeShellRunner: Send + Sync {
     fn supports_sandbox(&self) -> bool {
         true
     }
+
+    /// Wraps a non-empty section body in an isolated shell scope so its
+    /// step-local `env` and shell state don't leak into later sections and a
+    /// failure aborts the wrapper. `env` is emitted via [`Shell::set_env_var`]
+    /// for consistent quoting; the scope primitive is shell-specific.
+    fn scope_section(
+        &self,
+        label: Option<&str>,
+        env: &IndexMap<String, String>,
+        body: &str,
+    ) -> Result<String, std::io::Error>;
 
     /// Returns human-readable reproduction instructions shown when execution fails.
     fn debug_info(&self, work_dir: &Path, run_prefix: &Path, build_prefix: Option<&Path>)
@@ -81,8 +93,68 @@ pub(crate) fn quote_arg(shell: &ShellEnum, arg: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{native_runner, quote_arg};
+    use indexmap::IndexMap;
     use rattler_conda_types::Platform;
     use rattler_shell::shell::{self, Shell};
+
+    /// True if any line equals `want` after trimming trailing whitespace.
+    fn has_line(s: &str, want: &str) -> bool {
+        s.lines().any(|l| l.trim_end() == want)
+    }
+
+    /// bash scopes a section in a bare subshell, emits the label comment, and
+    /// quotes env via `set_env_var` (shlex). No errorlevel guard — `set -e`
+    /// from the preamble handles failure.
+    #[test]
+    fn bash_scope_section_subshell_env_and_label() {
+        let runner = native_runner(Platform::Linux64);
+        let mut env = IndexMap::new();
+        env.insert("FOO".to_string(), "a b".to_string());
+        let out = runner
+            .scope_section(Some("uses: configure"), &env, "echo hi")
+            .unwrap();
+        assert!(out.contains("# === uses: configure ==="), "{out}");
+        assert!(has_line(&out, "("), "missing subshell open:\n{out}");
+        assert!(has_line(&out, ")"), "missing subshell close:\n{out}");
+        assert!(
+            out.contains("export FOO='a b'"),
+            "env must be quoted:\n{out}"
+        );
+        assert!(out.contains("echo hi"), "{out}");
+        assert!(!out.contains("errorlevel"), "bash needs no guard:\n{out}");
+    }
+
+    /// No label and empty env => just `( body )`.
+    #[test]
+    fn bash_scope_section_minimal() {
+        let runner = native_runner(Platform::Linux64);
+        let out = runner
+            .scope_section(None, &IndexMap::new(), "echo hi")
+            .unwrap();
+        assert!(!out.contains("# ==="), "no label => no comment:\n{out}");
+        assert!(has_line(&out, "("), "{out}");
+        assert!(has_line(&out, ")"), "{out}");
+    }
+
+    /// cmd scopes via `setlocal`/`endlocal`, sets env via `@SET`, and always
+    /// appends the errorlevel guard (required even for the last section).
+    #[test]
+    fn cmd_scope_section_setlocal_env_and_guard() {
+        let runner = native_runner(Platform::Win64);
+        let mut env = IndexMap::new();
+        env.insert("FOO".to_string(), "bar".to_string());
+        let out = runner
+            .scope_section(Some("step 1"), &env, "echo hi")
+            .unwrap();
+        assert!(out.contains("@rem === step 1 ==="), "{out}");
+        assert!(has_line(&out, "setlocal"), "{out}");
+        assert!(has_line(&out, "endlocal"), "{out}");
+        assert!(
+            has_line(&out, "if %errorlevel% neq 0 exit /b %errorlevel%"),
+            "guard required even when last:\n{out}"
+        );
+        assert!(out.contains(r#"@SET "FOO=bar""#), "{out}");
+    }
 
     #[test]
     fn native_runner_follows_the_platform() {


### PR DESCRIPTION
## What

Generalizes the build-script generator so the platform-native wrapper (`conda_build.sh` / `conda_build.bat`) is composed from an ordered list of sections rather than a single script body.

Each section is an isolated unit of work. It can carry its own interpreter, its own local `env`, and an optional label, and it runs in its own shell scope so its environment and shell state don't leak into later sections. A failure in any section aborts the whole wrapper.

Today exactly one section is built (from `ExecutionArgs`), so the generated build behavior is unchanged for real recipes. This is a structural refactor that makes the wrapper generator able to emit multiple scoped sections.

## Scope

- Internal only, no public API change.
- Single-section recipes keep their existing wrapper filenames and structure.
- Adds cross-platform tests for section scoping and composition.