### PR TITLE
fix(ci): rattler-build binary detection

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -137,14 +137,14 @@ jobs:
       - name: Build rich package
         run: |
           mkdir -p output
-          ./target-pixi/release/rattler-build build --recipe ./examples/rich
+          ./target-pixi/$CARGO_BUILD_TARGET/release/rattler-build build --recipe ./examples/rich
           echo "Built packages:"
           ls -la ./output/noarch/
       - name: Rebuild rich package
         run: |
           PACKAGE=$(find ./output/noarch/rich-*.conda | head -n1)
           echo "Rebuilding package: $PACKAGE"
-          ./target-pixi/release/rattler-build rebuild --package-file "$PACKAGE"
+          ./target-pixi/$CARGO_BUILD_TARGET/release/rattler-build rebuild --package-file "$PACKAGE"
           echo "Rebuild completed successfully"
       - name: Compare original and rebuilt packages
         run: |

--- a/scripts/activate.bat
+++ b/scripts/activate.bat
@@ -1,3 +1,3 @@
 @echo off
 set CARGO_TARGET_DIR=target-pixi
-set RATTLER_BUILD_PATH="%PIXI_PROJECT_ROOT%\target-pixi\release\rattler-build.exe"
+set RATTLER_BUILD_PATH="%PIXI_PROJECT_ROOT%\target-pixi\%CARGO_BUILD_TARGET%\release\rattler-build.exe"

--- a/scripts/activate.sh
+++ b/scripts/activate.sh
@@ -8,4 +8,4 @@ export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS="-C link-arg=-fuse-ld=$CO
 export CARGO_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS="-C link-arg=-Wl,-rpath,$CONDA_PREFIX/lib"
 export CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS="-C link-arg=-Wl,-rpath,$CONDA_PREFIX/lib"
 
-export RATTLER_BUILD_PATH="$PIXI_PROJECT_ROOT/target-pixi/release/rattler-build"
+export RATTLER_BUILD_PATH="$PIXI_PROJECT_ROOT/target-pixi/$CARGO_BUILD_TARGET/release/rattler-build"

--- a/test/end-to-end/conftest.py
+++ b/test/end-to-end/conftest.py
@@ -20,8 +20,10 @@ def rattler_build():
         possible_paths = [
             base_path / f"target/release/{executable_name}",
             base_path / f"target/debug/{executable_name}",
-            base_path / f"target-pixi/release/{executable_name}",
-            base_path / f"target-pixi/debug/{executable_name}",
+            base_path
+            / f"target-pixi/{os.environ.get('CARGO_BUILD_TARGET')}/release/{executable_name}",
+            base_path
+            / f"target-pixi/{os.environ.get('CARGO_BUILD_TARGET')}/debug/{executable_name}",
         ]
 
         # Use the most recently modified binary


### PR DESCRIPTION
We moved to the Pixi Build `dev` feature to build rattler-build, but that also means we got more environment variables from the rust activation package: https://github.com/conda-forge/rust-activation-feedstock/blob/790b767c19ceb4caa6a5454141f835fec32ac227/recipe/activate.sh#L11

This PR adapts our test code so it still works