### PR TITLE
fix: don't resolve the native wrapper shell as a build-env interpreter

### DIFF
--- a/crates/rattler_build_script/src/execution.rs
+++ b/crates/rattler_build_script/src/execution.rs
@@ -430,8 +430,10 @@ impl Decoder for CrLfNormalizer {
 /// Returns the path to the generated native build wrapper script.
 ///
 /// If `args.interpreter` is set, or if the resolved script path has a known
-/// interpreter extension, inline script text is written to a separate file and
-/// the native wrapper invokes the resolved interpreter with that file. Otherwise
+/// interpreter extension, and that interpreter differs from the wrapper shell,
+/// inline script text is written to a separate file and the native wrapper
+/// invokes the resolved interpreter with that file. Otherwise — no interpreter,
+/// or one that is the wrapper shell itself (`cmd` on Windows, `bash` on Unix) —
 /// the script contents are appended directly to the native wrapper.
 pub(crate) async fn generate_build_script(
     args: &ExecutionArgs,
@@ -470,6 +472,17 @@ pub(crate) async fn generate_build_script(
     let interpreter = crate::interpreter::SelectedInterpreter::from_recipe_name(&interpreter_name)
         .ok_or_else(|| crate::InterpreterError::UnsupportedInterpreter(interpreter_name.clone()))?;
 
+    // Whether the content needs a specialized interpreter invocation. An
+    // interpreter that matches the wrapper shell itself (`cmd` on Windows,
+    // `bash` on Unix) is *not* specialized: the wrapper is already executed by
+    // that shell, so its body is inlined directly rather than resolving the
+    // interpreter executable from the build environment and re-invoking it.
+    // This matters most for `cmd`, which is a system shell rather than a
+    // conda-provided executable and would otherwise fail to resolve.
+    let needs_specialized_interpreter = explicit_or_inferred
+        .as_deref()
+        .is_some_and(|name| name != runner.default_interpreter());
+
     // Assemble the rendered content; the interpreter joins a command list.
     let script_text = match &args.script {
         ResolvedScriptContents::Commands(commands) => interpreter.join_commands(commands),
@@ -478,7 +491,7 @@ pub(crate) async fn generate_build_script(
         ResolvedScriptContents::Missing => String::new(),
     };
 
-    let body = if explicit_or_inferred.is_some() {
+    let body = if needs_specialized_interpreter {
         // Specialized interpreter: invoke a script file (the original path, or
         // one written next to the wrapper).
         let script_path = match &args.script {
@@ -518,7 +531,8 @@ pub(crate) async fn generate_build_script(
             .map_err(std::io::Error::other)?;
         body
     } else {
-        // No interpreter: the content is the native wrapper body.
+        // No interpreter, or one that matches the wrapper shell: the content is
+        // the native wrapper body, run directly by the wrapper shell.
         script_text
     };
 

--- a/crates/rattler_build_script/src/interpreter/mod.rs
+++ b/crates/rattler_build_script/src/interpreter/mod.rs
@@ -451,6 +451,45 @@ mod tests {
         assert!(!build_script.contains("print('from file')"));
     }
 
+    /// An interpreter that matches the wrapper shell (`cmd` on Windows, `bash`
+    /// on Unix) is inlined into the wrapper rather than resolved from the build
+    /// environment and re-invoked. This must succeed even with an empty prefix:
+    /// `cmd` in particular is a system shell, not a conda-provided executable,
+    /// so resolving it from the build environment used to fail with
+    /// "interpreter 'cmd' was not found in the build environment".
+    /// Regression test for the `file: build` -> `build.bat` path on Windows.
+    #[tokio::test]
+    async fn interpreter_matching_wrapper_shell_is_native_body() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Empty prefix: no interpreter executable is resolvable from it.
+        let prefix = tmp.path().join("prefix");
+        fs::create_dir_all(&prefix).unwrap();
+
+        // The recipe interpreter that equals the native wrapper shell.
+        let native = if cfg!(windows) { "cmd" } else { "bash" };
+        let marker = "echo wrapper-shell-body";
+
+        let args = execution_args(
+            tmp.path().to_path_buf(),
+            prefix,
+            ResolvedScriptContents::Inline(marker.to_string()),
+            Some(native),
+        );
+
+        crate::execution::generate_build_script(&args)
+            .await
+            .expect("native wrapper shell must not be resolved from the build environment");
+
+        let build_script = fs::read_to_string(native_build_script_path(tmp.path())).unwrap();
+        assert!(
+            build_script.contains(marker),
+            "wrapper should inline the script body, got:\n{build_script}"
+        );
+        // No separate interpreter script file is written for the native shell.
+        assert!(!tmp.path().join("conda_build_script.bat").exists());
+        assert!(!tmp.path().join("conda_build_script.sh").exists());
+    }
+
     #[tokio::test]
     async fn unknown_file_extension_without_interpreter_is_native_body() {
         let tmp = tempfile::tempdir().unwrap();


### PR DESCRIPTION
A `file: build` script resolves to `build.bat` on Windows, whose `.bat` extension makes `infer_interpreter()` return `cmd`. Since #2535 that sent script generation down the specialized-interpreter path, which resolves a `cmd.exe` from the build prefix / host prefix / system PATH and re-invokes it. But `cmd` is the native wrapper shell itself (the wrapper is already run by `cmd.exe`), not a conda-provided executable, so the lookup failed with "interpreter 'cmd' was not found in the build environment".

When the resolved interpreter equals the native runner's own `default_interpreter()` (`cmd` on Windows, `bash` on Unix), inline the script body into the wrapper instead — the historical conda-build behavior — rather than resolving and re-invoking the shell.

## Alternative

Never search for `cmd.exe` in the build environment?