### PR TITLE
chore: bump 0.66.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.66.1] - 2026-06-13
+
+### Fixed
+
+- Don't resolve the native wrapper shell as a build-env interpreter by @wolfv in [#2545](https://github.com/prefix-dev/rattler-build/pull/2545)
+
 ## [0.66.0] - 2026-06-11
 ### ✨ Highlights
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4769,7 +4769,7 @@ dependencies = [
 
 [[package]]
 name = "rattler-build"
-version = "0.66.0"
+version = "0.66.1"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler-build"
-version = "0.66.0"
+version = "0.66.1"
 authors = ["rattler-build contributors <hi@prefix.dev>"]
 repository = "https://github.com/prefix-dev/rattler-build"
 edition = "2024"

--- a/py-rattler-build/pyproject.toml
+++ b/py-rattler-build/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "py-rattler-build"
-version = "0.66.0"
+version = "0.66.1"
 requires-python = ">=3.10"
 description = "The fastest way to build conda packages programatically"
 readme = "README.md"

--- a/py-rattler-build/rust/Cargo.lock
+++ b/py-rattler-build/rust/Cargo.lock
@@ -4306,7 +4306,7 @@ dependencies = [
 
 [[package]]
 name = "py-rattler-build"
-version = "0.66.0"
+version = "0.66.1"
 dependencies = [
  "clap",
  "fs-err",
@@ -4670,7 +4670,7 @@ dependencies = [
 
 [[package]]
 name = "rattler-build"
-version = "0.66.0"
+version = "0.66.1"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",

--- a/py-rattler-build/rust/Cargo.toml
+++ b/py-rattler-build/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-rattler-build"
-version = "0.66.0"
+version = "0.66.1"
 edition = "2024"
 license = "BSD-3-Clause"
 publish = false

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/prefix-dev/rattler-build"
 
 [version]
-current = "0.66.0"
+current = "0.66.1"
 
 # Example of a semver regexp.
 # Make sure this matches current_version before


### PR DESCRIPTION
Release bump to **0.66.1**.

### Fixed

- Don't resolve the native wrapper shell as a build-env interpreter by @wolfv in [#2545](https://github.com/prefix-dev/rattler-build/pull/2545)

🤖 Generated with [Claude Code](https://claude.com/claude-code)