### PR TITLE
chore: release 0.67.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.67.0] - 2026-06-19
+### ✨ Highlights
+
+Test
+
+### Added
+
+- Support late-bound build directory variables in patches and license files by @wolfv in [#2554](https://github.com/prefix-dev/rattler-build/pull/2554)
+
+
+### Changed
+
+- Build llamacpp recipe with Ninja generator on Windows by @Hofer-Julian in [#2562](https://github.com/prefix-dev/rattler-build/pull/2562)
+
+
+
 ## [0.66.2] - 2026-06-17
 ### ✨ Highlights
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4809,7 +4809,7 @@ dependencies = [
 
 [[package]]
 name = "rattler-build"
-version = "0.66.2"
+version = "0.67.0"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler-build"
-version = "0.66.2"
+version = "0.67.0"
 authors = ["rattler-build contributors <hi@prefix.dev>"]
 repository = "https://github.com/prefix-dev/rattler-build"
 edition = "2024"

--- a/py-rattler-build/pyproject.toml
+++ b/py-rattler-build/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "py-rattler-build"
-version = "0.66.2"
+version = "0.67.0"
 requires-python = ">=3.10"
 description = "The fastest way to build conda packages programatically"
 readme = "README.md"

--- a/py-rattler-build/rust/Cargo.lock
+++ b/py-rattler-build/rust/Cargo.lock
@@ -4303,7 +4303,7 @@ dependencies = [
 
 [[package]]
 name = "py-rattler-build"
-version = "0.66.2"
+version = "0.67.0"
 dependencies = [
  "clap",
  "fs-err",
@@ -4667,7 +4667,7 @@ dependencies = [
 
 [[package]]
 name = "rattler-build"
-version = "0.66.2"
+version = "0.67.0"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",

--- a/py-rattler-build/rust/Cargo.toml
+++ b/py-rattler-build/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-rattler-build"
-version = "0.66.2"
+version = "0.67.0"
 edition = "2024"
 license = "BSD-3-Clause"
 publish = false

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/prefix-dev/rattler-build"
 
 [version]
-current = "0.66.2"
+current = "0.67.0"
 
 # Example of a semver regexp.
 # Make sure this matches current_version before


### PR DESCRIPTION
## [0.67.0] - 2026-06-19
### ✨ Highlights

Test

### Added

- Support late-bound build directory variables in patches and license files by @wolfv in [#2554](https://github.com/prefix-dev/rattler-build/pull/2554)


### Changed

- Build llamacpp recipe with Ninja generator on Windows by @Hofer-Julian in [#2562](https://github.com/prefix-dev/rattler-build/pull/2562)