### PR TITLE
ci: trigger CLI docs check on dependency bumps

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,6 +19,8 @@ on:
       - "pixi.*"
       - "src/opt.rs"
       - "crates/rattler_build_docs/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
One of the reasons why we sometimes have to update CLI docs after the fact