### PR TITLE
chore: release 0.67.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,50 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.67.0] - 2026-06-22
+### ✨ Highlights
+
+This release introduces support for late-bound build directory variables (e.g., `${{ SRC_DIR }}`, `${{ PREFIX }}`) in recipe fields that are evaluated before build directories exist. This allows patches and license files to reference directories that are only known once the build has started.
+
+The supported variables are:
+
+- `${{ SRC_DIR }}` – the source working directory
+- `${{ RECIPE_DIR }}` – the recipe directory
+- `${{ BUILD_DIR }}` – the top-level build directory
+
+This is useful when a patch ships inside another source. Because sources are
+fetched in order into the shared `SRC_DIR`, a later source can apply a patch
+that was extracted from an earlier one:
+
+```yaml
+source:
+  - url: https://example.com/tool-{{ version }}.tar.gz  # ships patches under src/
+    sha256: "..."
+  - url: https://example.com/lib-{{ version }}.tar.gz
+    sha256: "..."
+    target_directory: lib_src
+    patches:
+      - ${{ SRC_DIR }}/src/patches/0001-fix.patch
+```
+
+
+
+### Added
+
+- Support late-bound build directory variables in patches and license files by @wolfv in [#2554](https://github.com/prefix-dev/rattler-build/pull/2554)
+
+
+### Changed
+
+- Build llamacpp recipe with Ninja generator on Windows by @Hofer-Julian in [#2562](https://github.com/prefix-dev/rattler-build/pull/2562)
+
+
+### Documentation
+
+- Update CLI docs by @Hofer-Julian in [#2568](https://github.com/prefix-dev/rattler-build/pull/2568)
+
+
+
 ## [0.66.2] - 2026-06-17
 ### ✨ Highlights
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4777,7 +4777,7 @@ dependencies = [
 
 [[package]]
 name = "rattler-build"
-version = "0.66.2"
+version = "0.67.0"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler-build"
-version = "0.66.2"
+version = "0.67.0"
 authors = ["rattler-build contributors <hi@prefix.dev>"]
 repository = "https://github.com/prefix-dev/rattler-build"
 edition = "2024"

--- a/py-rattler-build/pyproject.toml
+++ b/py-rattler-build/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "py-rattler-build"
-version = "0.66.2"
+version = "0.67.0"
 requires-python = ">=3.10"
 description = "The fastest way to build conda packages programatically"
 readme = "README.md"

--- a/py-rattler-build/rust/Cargo.lock
+++ b/py-rattler-build/rust/Cargo.lock
@@ -4362,7 +4362,7 @@ dependencies = [
 
 [[package]]
 name = "py-rattler-build"
-version = "0.66.2"
+version = "0.67.0"
 dependencies = [
  "clap",
  "fs-err",
@@ -4726,7 +4726,7 @@ dependencies = [
 
 [[package]]
 name = "rattler-build"
-version = "0.66.2"
+version = "0.67.0"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",

--- a/py-rattler-build/rust/Cargo.toml
+++ b/py-rattler-build/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-rattler-build"
-version = "0.66.2"
+version = "0.67.0"
 edition = "2024"
 license = "BSD-3-Clause"
 publish = false

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/prefix-dev/rattler-build"
 
 [version]
-current = "0.66.2"
+current = "0.67.0"
 
 # Example of a semver regexp.
 # Make sure this matches current_version before


### PR DESCRIPTION
## [0.67.0] - 2026-06-22
### ✨ Highlights

This release introduces support for late-bound build directory variables (e.g., `${{ SRC_DIR }}`, `${{ PREFIX }}`) in recipe fields that are evaluated before build directories exist. This allows patches and license files to reference directories that are only known once the build has started.

The supported variables are:

- `${{ SRC_DIR }}` – the source working directory
- `${{ RECIPE_DIR }}` – the recipe directory
- `${{ BUILD_DIR }}` – the top-level build directory

This is useful when a patch ships inside another source. Because sources are
fetched in order into the shared `SRC_DIR`, a later source can apply a patch
that was extracted from an earlier one:

```yaml
source:
  - url: https://example.com/tool-{{ version }}.tar.gz  # ships patches under src/
    sha256: "..."
  - url: https://example.com/lib-{{ version }}.tar.gz
    sha256: "..."
    target_directory: lib_src
    patches:
      - ${{ SRC_DIR }}/src/patches/0001-fix.patch
```



### Added

- Support late-bound build directory variables in patches and license files by @wolfv in [#2554](https://github.com/prefix-dev/rattler-build/pull/2554)


### Changed

- Build llamacpp recipe with Ninja generator on Windows by @Hofer-Julian in [#2562](https://github.com/prefix-dev/rattler-build/pull/2562)


### Documentation

- Update CLI docs by @Hofer-Julian in [#2568](https://github.com/prefix-dev/rattler-build/pull/2568)