### PR TITLE
fix: preserve explicit empty license_file in output packages

### DIFF
--- a/crates/rattler_build_recipe/src/stage0/evaluate.rs
+++ b/crates/rattler_build_recipe/src/stage0/evaluate.rs
@@ -1616,7 +1616,20 @@ impl Evaluate for Stage0About {
             license_file_globs,
             license_file_late_bound,
         } = match self.license_file.as_ref() {
-            Some(lf) => evaluate_license_files(lf, context)?,
+            Some(lf) => {
+                let mut files = evaluate_license_files(lf, context)?;
+                // The `license_file` key was present in the recipe. If it
+                // evaluated to no ordinary globs and no late-bound entries
+                // (e.g. an explicit empty list `license_file: []`), represent
+                // it as an empty glob set rather than `None`. This preserves
+                // the distinction between "key absent" (inherit the top-level
+                // value during merge) and "key explicitly set to empty"
+                // (override the top-level value and copy no license files).
+                if files.license_file_globs.is_none() && files.license_file_late_bound.is_empty() {
+                    files.license_file_globs = Some(GlobVec::default());
+                }
+                files
+            }
             None => LicenseFiles::default(),
         };
 
@@ -4691,6 +4704,70 @@ outputs:
                     "Custom output summary"
                 ); // Overridden
                 assert!(output2.about.license.is_some()); // Inherited
+            }
+            _ => panic!("Expected MultiOutputRecipe"),
+        }
+    }
+
+    #[test]
+    fn test_output_can_override_license_file_with_empty_list() {
+        use crate::stage0::parser::parse_recipe_or_multi_from_source;
+
+        // Regression test for https://github.com/prefix-dev/rattler-build/issues/2598
+        // An output that sets `license_file: []` should override (clear) the
+        // inherited top-level `license_file` rather than fall back to it.
+        let recipe_yaml = r#"
+schema_version: 1
+
+recipe:
+  name: myproject
+  version: 1.0.0
+
+about:
+  license_file:
+    - LICENSE
+
+outputs:
+  - package:
+      name: output-clears-license
+      version: 1.0.0
+    about:
+      license_file: []
+
+  - package:
+      name: output-inherits-license
+      version: 1.0.0
+"#;
+
+        let parsed = parse_recipe_or_multi_from_source(recipe_yaml).unwrap();
+
+        match parsed {
+            stage0::Recipe::MultiOutput(multi) => {
+                let ctx = EvaluationContext::for_platform(rattler_conda_types::Platform::Linux64);
+
+                let recipes = multi.evaluate(&ctx).unwrap();
+                assert_eq!(recipes.len(), 2);
+
+                // First output explicitly clears the license files with `[]`.
+                // The merge must keep that empty override instead of inheriting
+                // the top-level `[LICENSE]`.
+                let cleared = &recipes[0];
+                assert!(
+                    cleared.about.license_file.is_some(),
+                    "explicit empty license_file should be preserved as Some(empty)"
+                );
+                assert!(cleared.about.license_file.as_ref().unwrap().is_empty());
+                assert!(cleared.about.license_file_late_bound.is_empty());
+
+                // Second output does not mention license_file, so it inherits
+                // the top-level value.
+                let inherited = &recipes[1];
+                let globs = inherited
+                    .about
+                    .license_file
+                    .as_ref()
+                    .expect("license_file should be inherited from top-level");
+                assert!(!globs.is_empty());
             }
             _ => panic!("Expected MultiOutputRecipe"),
         }


### PR DESCRIPTION
## Summary
Fix handling of explicit empty `license_file: []` declarations in output packages so they properly override inherited top-level license files instead of falling back to them.

## Key Changes
- Modified `Stage0About` evaluation to distinguish between "key absent" (inherit top-level value) and "key explicitly set to empty" (override with empty set)
- When `license_file` evaluates to no globs and no late-bound entries, explicitly set `license_file_globs` to an empty `GlobVec` instead of leaving it as `None`
- Added regression test `test_output_can_override_license_file_with_empty_list` to verify the fix

## Implementation Details
The fix addresses issue #2598 where outputs with `license_file: []` were incorrectly inheriting the top-level `license_file` value during merge. By converting the `None` result to `Some(GlobVec::default())` when the key is explicitly present but empty, the merge logic can now properly distinguish between:
- **Absent key**: `None` → inherit top-level value
- **Explicit empty list**: `Some(empty)` → override and copy no license files

The test validates both scenarios: an output that explicitly clears license files and another that inherits them.

https://claude.ai/code/session_01QCuC5RWsV2guGNDbjWNWST