### PR TITLE
feat: display V3 package variant flags in build output

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -433,6 +433,14 @@ pub async fn get_build_output(
             skipped
         );
 
+        // Display V3 package variant flags, if any. These are not variant keys,
+        // so they are shown below the build string rather than in the table.
+        let flags = &discovered_output.recipe.build().flags;
+        if !flags.is_empty() {
+            let flags = flags.iter().map(|flag| flag.as_str()).collect::<Vec<_>>();
+            tracing::info!("Flags: {}", flags.join(", "));
+        }
+
         let mut table = comfy_table::Table::new();
         table
             .load_preset(comfy_table::presets::UTF8_FULL_CONDENSED)
@@ -440,12 +448,6 @@ pub async fn get_build_output(
             .set_header(["Variant", "Version"]);
         for (key, value) in discovered_output.used_vars.iter() {
             table.add_row([key.normalize(), format!("{:?}", value)]);
-        }
-        // Display V3 package variant flags, if any.
-        let flags = &discovered_output.recipe.build().flags;
-        if !flags.is_empty() {
-            let flags = flags.iter().map(|flag| flag.as_str()).collect::<Vec<_>>();
-            table.add_row(["flags".to_string(), format!("{:?}", flags)]);
         }
         tracing::info!("\n{}\n", table);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -441,6 +441,12 @@ pub async fn get_build_output(
         for (key, value) in discovered_output.used_vars.iter() {
             table.add_row([key.normalize(), format!("{:?}", value)]);
         }
+        // Display V3 package variant flags, if any.
+        let flags = &discovered_output.recipe.build().flags;
+        if !flags.is_empty() {
+            let flags = flags.iter().map(|flag| flag.as_str()).collect::<Vec<_>>();
+            table.add_row(["flags".to_string(), format!("{:?}", flags)]);
+        }
         tracing::info!("\n{}\n", table);
     }
     drop(enter);


### PR DESCRIPTION
## Summary
Added display of V3 package variant flags in the build output table when flags are present.

## Key Changes
- Added conditional display of `flags` from the recipe's build configuration in the build output table
- Flags are only shown if the collection is non-empty
- Flag values are formatted as a debug string for consistency with other output variables

## Implementation Details
- Retrieves flags from `discovered_output.recipe.build().flags`
- Converts flag references to string slices and collects them into a vector for formatting
- Adds a new row to the output table with key "flags" and the formatted flag values
- Follows the existing pattern used for displaying `used_vars` in the output table

https://claude.ai/code/session_0145Ufa9FQVbb2XmAHeD4jS5