### PR TITLE
feat: improve package content test failure messages with expanded globs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Package content test failures now report the fully expanded glob(s) that were actually matched against the package (including automatically prepended platform prefixes such as `include/` or `Library/include/`), instead of only the raw user-provided pattern. This applies to all package content sections (`include`, `bin`, `lib`, `site_packages`, `files`), making it clearer why a pattern did not match. (#2584)
 - Improve CRAN (R) recipe generation: pass `${R_ARGS}` to `R CMD INSTALL`, add `cross-r-base` for cross-compilation, set `rpaths` for compiled packages, mark pure-R packages as `noarch: generic`, reference `r-base`'s bundled license files, and fix the `r-base` version constraint so it is applied to both `host` and `run` without duplication.
 
 

--- a/crates/rattler_build_core/src/package_test/content_test.rs
+++ b/crates/rattler_build_core/src/package_test/content_test.rs
@@ -12,6 +12,22 @@ fn build_glob(glob: String) -> Result<Glob, globset::Error> {
     GlobBuilder::new(&glob).empty_alternates(true).build()
 }
 
+/// Build a single glob entry from one or more expanded patterns.
+///
+/// The patterns are combined into a [`GlobSet`] (so the entry matches if *any*
+/// pattern matches) and joined into a human-readable string used in the
+/// success/failure messages. Using the expanded patterns for display - rather
+/// than the raw user-provided source - makes it clear which paths are actually
+/// being checked, including any platform-specific prefixes (e.g. `include/` or
+/// `Library/include/`) that are prepended automatically.
+fn build_entry(patterns: Vec<String>) -> Result<(String, GlobSet), globset::Error> {
+    let mut builder = GlobSet::builder();
+    for pattern in &patterns {
+        builder.add(build_glob(pattern.clone())?);
+    }
+    Ok((patterns.join(", "), builder.build()?))
+}
+
 fn display_success(matches: &[&PathBuf], glob: &str, section: &str) {
     tracing::info!(
         "{} {section}: \"{}\" matched:",
@@ -193,8 +209,7 @@ impl PackageContentsTestExt for PackageContentsTest {
                     } else {
                         format!("include/{}", source)
                     };
-                    let globset = GlobSet::builder().add(build_glob(pattern)?).build()?;
-                    Ok(vec![(source.to_string(), globset)])
+                    Ok(vec![build_entry(vec![pattern])?])
                 })
             }
             Section::Bin => {
@@ -204,27 +219,22 @@ impl PackageContentsTestExt for PackageContentsTest {
                     self.bin.not_exists.include_globs()
                 };
                 Self::match_files(raws, |bin_raw| {
-                    let globset = if target_platform.is_windows() {
+                    let patterns = if target_platform.is_windows() {
                         let ext = "{,.exe,.bat,.cmd,.com,.ps1}";
-                        GlobSet::builder()
-                            .add(build_glob(format!("Library/bin/{bin_raw}{ext}"))?)
-                            .add(build_glob(format!("Scripts/{bin_raw}{ext}"))?)
-                            .add(build_glob(format!("bin/{bin_raw}{ext}"))?)
-                            .add(build_glob(format!("Library/mingw-w64/bin/{bin_raw}{ext}"))?)
-                            .add(build_glob(format!("Library/usr/bin/{bin_raw}{ext}"))?)
-                            .add(build_glob(format!("{bin_raw}{ext}"))?)
-                            .build()
+                        vec![
+                            format!("Library/bin/{bin_raw}{ext}"),
+                            format!("Scripts/{bin_raw}{ext}"),
+                            format!("bin/{bin_raw}{ext}"),
+                            format!("Library/mingw-w64/bin/{bin_raw}{ext}"),
+                            format!("Library/usr/bin/{bin_raw}{ext}"),
+                            format!("{bin_raw}{ext}"),
+                        ]
                     } else if matches!(target_platform, &Platform::EmscriptenWasm32) {
-                        GlobSet::builder()
-                            .add(build_glob(format!("bin/{bin_raw}.js"))?)
-                            .add(build_glob(format!("bin/{bin_raw}.wasm"))?)
-                            .build()
+                        vec![format!("bin/{bin_raw}.js"), format!("bin/{bin_raw}.wasm")]
                     } else {
-                        GlobSet::builder()
-                            .add(Glob::new(&format!("bin/{bin_raw}"))?)
-                            .build()
-                    }?;
-                    Ok(vec![(bin_raw.to_string(), globset)])
+                        vec![format!("bin/{bin_raw}")]
+                    };
+                    Ok(vec![build_entry(patterns)?])
                 })
             }
             Section::Lib => {
@@ -237,61 +247,36 @@ impl PackageContentsTestExt for PackageContentsTest {
                     Self::match_files(raws, |raw| {
                         let mut res = Vec::new();
                         if raw.ends_with(".dll") {
-                            res.push((
-                                raw.to_string(),
-                                GlobSet::builder()
-                                    .add(Glob::new(&format!("Library/bin/{raw}"))?)
-                                    .build()?,
-                            ));
+                            res.push(build_entry(vec![format!("Library/bin/{raw}")])?);
                         } else if raw.ends_with(".lib") {
-                            res.push((
-                                raw.to_string(),
-                                GlobSet::builder()
-                                    .add(Glob::new(&format!("Library/lib/{raw}"))?)
-                                    .build()?,
-                            ));
+                            res.push(build_entry(vec![format!("Library/lib/{raw}")])?);
                         } else {
-                            res.push((
-                                raw.to_string(),
-                                GlobSet::builder()
-                                    .add(Glob::new(&format!("Library/bin/{raw}.dll"))?)
-                                    .build()?,
-                            ));
-                            res.push((
-                                raw.to_string(),
-                                GlobSet::builder()
-                                    .add(Glob::new(&format!("Library/lib/{raw}.lib"))?)
-                                    .build()?,
-                            ));
+                            res.push(build_entry(vec![format!("Library/bin/{raw}.dll")])?);
+                            res.push(build_entry(vec![format!("Library/lib/{raw}.lib")])?);
                         }
                         Ok(res)
                     })
                 } else {
                     Self::match_files(raws, |raw| {
-                        let globset = if target_platform.is_osx() {
+                        let patterns = if target_platform.is_osx() {
                             if raw.ends_with(".dylib") || raw.ends_with(".a") {
-                                GlobSet::builder()
-                                    .add(Glob::new(&format!("lib/{raw}"))?)
-                                    .build()
+                                vec![format!("lib/{raw}")]
                             } else {
-                                GlobSet::builder()
-                                    .add(build_glob(format!("lib/{{,lib}}{raw}.dylib"))?)
-                                    .add(build_glob(format!("lib/{{,lib}}{raw}.*.dylib"))?)
-                                    .build()
+                                vec![
+                                    format!("lib/{{,lib}}{raw}.dylib"),
+                                    format!("lib/{{,lib}}{raw}.*.dylib"),
+                                ]
                             }
+                        } else if raw.ends_with(".so") || raw.contains(".so.") || raw.ends_with(".a")
+                        {
+                            vec![format!("lib/{raw}")]
                         } else {
-                            if raw.ends_with(".so") || raw.contains(".so.") || raw.ends_with(".a") {
-                                GlobSet::builder()
-                                    .add(Glob::new(&format!("lib/{raw}"))?)
-                                    .build()
-                            } else {
-                                GlobSet::builder()
-                                    .add(build_glob(format!("lib/{{,lib}}{raw}.so"))?)
-                                    .add(build_glob(format!("lib/{{,lib}}{raw}.so.*"))?)
-                                    .build()
-                            }
-                        }?;
-                        Ok(vec![(raw.to_string(), globset)])
+                            vec![
+                                format!("lib/{{,lib}}{raw}.so"),
+                                format!("lib/{{,lib}}{raw}.so.*"),
+                            ]
+                        };
+                        Ok(vec![build_entry(patterns)?])
                     })
                 }
             }
@@ -309,9 +294,8 @@ impl PackageContentsTestExt for PackageContentsTest {
                     } else {
                         "lib/python*/site-packages"
                     };
-                    let mut builder = GlobSet::builder();
-                    if source.contains('/') {
-                        builder.add(build_glob(format!("{base}/{source}"))?);
+                    let patterns = if source.contains('/') {
+                        vec![format!("{base}/{source}")]
                     } else {
                         let mut parts = source.split('.').collect::<Vec<_>>();
                         let last = parts.pop().unwrap_or_default();
@@ -319,11 +303,12 @@ impl PackageContentsTestExt for PackageContentsTest {
                         if !path.is_empty() {
                             path.push('/');
                         }
-                        builder.add(build_glob(format!("{base}/{path}{last}.py"))?);
-                        builder.add(build_glob(format!("{base}/{path}{last}/__init__.py"))?);
-                    }
-                    let final_set = builder.build()?;
-                    Ok(vec![(source.to_string(), final_set)])
+                        vec![
+                            format!("{base}/{path}{last}.py"),
+                            format!("{base}/{path}{last}/__init__.py"),
+                        ]
+                    };
+                    Ok(vec![build_entry(patterns)?])
                 })
             }
             Section::Files => {
@@ -332,11 +317,7 @@ impl PackageContentsTestExt for PackageContentsTest {
                 } else {
                     self.files.not_exists.include_globs()
                 };
-                Self::match_files(raws, |source| {
-                    let g = Glob::new(source)?;
-                    let set = GlobSet::builder().add(g).build()?;
-                    Ok(vec![(source.to_string(), set)])
-                })
+                Self::match_files(raws, |source| Ok(vec![build_entry(vec![source.to_string()])?]))
             }
         }
     }
@@ -572,6 +553,21 @@ mod tests {
             .get_globs_for_section(Section::Include, true, &Platform::Linux64, false)
             .unwrap();
 
+        // The display string should reflect the *expanded* pattern (with the
+        // `include/` prefix that is prepended automatically), not just the raw
+        // user-provided source. See https://github.com/prefix-dev/rattler-build/issues/2584
+        let display: Vec<&str> = globs.iter().map(|(g, _)| g.as_str()).collect();
+        assert_eq!(display, vec!["include/foo", "include/bar"]);
+
+        let win_globs = package_contents
+            .get_globs_for_section(Section::Include, true, &Platform::Win64, false)
+            .unwrap();
+        let win_display: Vec<&str> = win_globs.iter().map(|(g, _)| g.as_str()).collect();
+        assert_eq!(
+            win_display,
+            vec!["Library/include/foo", "Library/include/bar"]
+        );
+
         let paths = &["include/foo".to_string(), "include/bar".to_string()];
         test_glob_matches(&globs, paths).unwrap();
 
@@ -598,6 +594,14 @@ mod tests {
         let globs = package_contents
             .get_globs_for_section(Section::Bin, true, &Platform::EmscriptenWasm32, false)
             .unwrap();
+
+        // For sections that expand into multiple candidate patterns, the display
+        // string joins them so the failure message shows every path that was tried.
+        let display: Vec<&str> = globs.iter().map(|(g, _)| g.as_str()).collect();
+        assert_eq!(
+            display,
+            vec!["bin/foo.js, bin/foo.wasm", "bin/bar.js, bin/bar.wasm"]
+        );
 
         let paths = &[
             "bin/foo.js".to_string(),

--- a/crates/rattler_build_core/src/package_test/content_test.rs
+++ b/crates/rattler_build_core/src/package_test/content_test.rs
@@ -267,7 +267,9 @@ impl PackageContentsTestExt for PackageContentsTest {
                                     format!("lib/{{,lib}}{raw}.*.dylib"),
                                 ]
                             }
-                        } else if raw.ends_with(".so") || raw.contains(".so.") || raw.ends_with(".a")
+                        } else if raw.ends_with(".so")
+                            || raw.contains(".so.")
+                            || raw.ends_with(".a")
                         {
                             vec![format!("lib/{raw}")]
                         } else {
@@ -317,7 +319,9 @@ impl PackageContentsTestExt for PackageContentsTest {
                 } else {
                     self.files.not_exists.include_globs()
                 };
-                Self::match_files(raws, |source| Ok(vec![build_entry(vec![source.to_string()])?]))
+                Self::match_files(raws, |source| {
+                    Ok(vec![build_entry(vec![source.to_string()])?])
+                })
             }
         }
     }


### PR DESCRIPTION
## Summary
This PR refactors the package content test glob handling to improve failure messages by displaying the fully expanded glob patterns that are actually matched against packages, rather than just the raw user-provided source. This makes it clear which paths are being checked, including any platform-specific prefixes that are automatically prepended.

## Key Changes
- **New `build_entry()` function**: Consolidates the pattern of building a `GlobSet` from one or more patterns and creating a human-readable display string by joining the patterns together
- **Simplified glob construction**: Replaced repetitive `GlobSet::builder()` chains throughout the codebase with calls to the new `build_entry()` function
- **Improved display strings**: The display strings now show the expanded patterns (e.g., `include/foo` instead of just `foo`, or `bin/foo.js, bin/foo.wasm` for multi-pattern matches) so users can see exactly what paths were checked
- **Better error context**: When a package content test fails, the error message now clearly shows the platform-specific prefixes and all candidate patterns that were attempted

## Implementation Details
- The `build_entry()` function takes a `Vec<String>` of patterns, builds them into a `GlobSet`, and returns both the joined display string and the compiled glob set
- All sections (Include, Bin, Lib, Python, Files) now use this unified approach, reducing code duplication
- Added test cases to verify that display strings correctly reflect expanded patterns with platform-specific prefixes (e.g., `Library/include/` on Windows, `include/` on Linux)
- The change is backward compatible and only affects the display/error messages, not the actual matching logic

https://claude.ai/code/session_01T3MZx8joGvJCPV5yerqWWx