### PR TITLE
fix: report YAML parse error location for malformed Jinja

### DIFF
--- a/crates/rattler_build_recipe/src/stage0/parser/error_tests.rs
+++ b/crates/rattler_build_recipe/src/stage0/parser/error_tests.rs
@@ -210,3 +210,37 @@ fn test_error_multi_output_empty_outputs() {
     let error_with_source = ParseErrorWithSource::new(source, err);
     assert_miette_snapshot!(error_with_source);
 }
+
+// ============================================================================
+// YAML load error location tests
+//
+// These guard against regressing the location reported for low-level YAML
+// load errors. A common mistake is writing `{{ var }}` instead of `${{ var }}`,
+// which YAML parses as a flow mapping and rejects with "Keys in mappings must
+// be scalar". The reported span must point at the offending line, not at the
+// top of the file (see https://github.com/prefix-dev/rattler-build/issues/2580).
+// ============================================================================
+
+#[test]
+fn test_error_missing_dollar_jinja_multi_output() {
+    let source = load_error_test("missing_dollar_jinja.yaml");
+    let result = parse_recipe_or_multi_from_source(source.as_ref());
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+
+    let error_with_source = ParseErrorWithSource::new(source, err);
+    assert_miette_snapshot!(error_with_source);
+}
+
+#[test]
+fn test_error_missing_dollar_jinja_single_output() {
+    let source = load_error_test("missing_dollar_jinja_single.yaml");
+    let result = parse_recipe_from_source(source.as_ref());
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+
+    let error_with_source = ParseErrorWithSource::new(source, err);
+    assert_miette_snapshot!(error_with_source);
+}

--- a/crates/rattler_build_recipe/src/stage0/parser/mod.rs
+++ b/crates/rattler_build_recipe/src/stage0/parser/mod.rs
@@ -26,11 +26,9 @@ mod unit_tests;
 use marked_yaml::{Node as MarkedNode, types::MarkedScalarNode};
 use rattler_build_jinja::Variable;
 use rattler_build_yaml_parser::{
-    ParseError, ParseResult, helpers::contains_jinja_template, parse_yaml,
+    ParseError, ParseResult, helpers::contains_jinja_template, parse_yaml, yaml::load_error_span,
 };
 use rattler_conda_types::RepodataRevision;
-
-use crate::Span;
 
 // Re-export parsing functions
 pub use about::parse_about;
@@ -65,7 +63,7 @@ pub fn parse_recipe_or_multi_from_source_with_config(
     config: ParseConfig,
 ) -> ParseResult<crate::stage0::Recipe> {
     let yaml = parse_yaml(source).map_err(|e| {
-        ParseError::generic(format!("Failed to parse YAML: {}", e), Span::new_blank())
+        ParseError::generic(format!("Failed to parse YAML: {}", e), load_error_span(&e))
     })?;
 
     parse_recipe_or_multi_with_config(&yaml, config)
@@ -86,7 +84,7 @@ pub fn parse_recipe_from_source_with_config(
     config: ParseConfig,
 ) -> ParseResult<crate::stage0::Stage0Recipe> {
     let yaml = parse_yaml(source).map_err(|e| {
-        ParseError::generic(format!("Failed to parse YAML: {}", e), Span::new_blank())
+        ParseError::generic(format!("Failed to parse YAML: {}", e), load_error_span(&e))
     })?;
 
     parse_recipe_with_config(&yaml, config)

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__error_tests__error_missing_dollar_jinja_multi_output.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__error_tests__error_missing_dollar_jinja_multi_output.snap
@@ -1,0 +1,13 @@
+---
+source: crates/rattler_build_recipe/src/stage0/parser/error_tests.rs
+assertion_line: 233
+expression: error_with_source
+---
+  × parse error: Failed to parse YAML: 15:12: Keys in mappings must be scalar
+    ╭─[missing_dollar_jinja.yaml:15:12]
+ 14 │ build:
+ 15 │   number: {{ build_number }}
+    ·            ┬
+    ·            ╰── Failed to parse YAML: 15:12: Keys in mappings must be scalar
+ 16 │ 
+    ╰────

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__error_tests__error_missing_dollar_jinja_single_output.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__error_tests__error_missing_dollar_jinja_single_output.snap
@@ -1,0 +1,12 @@
+---
+source: crates/rattler_build_recipe/src/stage0/parser/error_tests.rs
+assertion_line: 245
+expression: error_with_source
+---
+  × parse error: Failed to parse YAML: 10:12: Keys in mappings must be scalar
+    ╭─[missing_dollar_jinja_single.yaml:10:12]
+  9 │ build:
+ 10 │   number: {{ build_number }}
+    ·            ┬
+    ·            ╰── Failed to parse YAML: 10:12: Keys in mappings must be scalar
+    ╰────

--- a/crates/rattler_build_recipe/test-data/errors/missing_dollar_jinja.yaml
+++ b/crates/rattler_build_recipe/test-data/errors/missing_dollar_jinja.yaml
@@ -1,0 +1,19 @@
+context:
+  version: "22.1.8"
+  build_number: "3"
+  major_version: "22"
+
+recipe:
+  name: llvm-project
+  version: ${{ version }}
+
+source:
+  url: https://example.com/llvm-${{ version }}.tar.gz
+  folder: llvm-project
+
+build:
+  number: {{ build_number }}
+
+outputs:
+  - package:
+      name: libllvm

--- a/crates/rattler_build_recipe/test-data/errors/missing_dollar_jinja_single.yaml
+++ b/crates/rattler_build_recipe/test-data/errors/missing_dollar_jinja_single.yaml
@@ -1,0 +1,10 @@
+context:
+  version: "1.0.0"
+  build_number: "3"
+
+package:
+  name: mypackage
+  version: ${{ version }}
+
+build:
+  number: {{ build_number }}

--- a/crates/rattler_build_yaml_parser/src/yaml.rs
+++ b/crates/rattler_build_yaml_parser/src/yaml.rs
@@ -3,7 +3,7 @@
 //! This module provides a wrapper around marked_yaml that enables `prevent_coercion(true)`
 //! to ensure that quoted values like "123" and "true" are treated as strings, not integers/booleans.
 
-use marked_yaml::{LoadError, LoaderOptions, Node, parse_yaml_with_options};
+use marked_yaml::{LoadError, LoaderOptions, Node, Span, parse_yaml_with_options};
 
 /// Parse YAML from a string with proper quote handling
 ///
@@ -20,4 +20,28 @@ pub fn parse_yaml(source: &str) -> Result<Node, LoadError> {
         .prevent_coercion(true);
 
     parse_yaml_with_options(0, source, options)
+}
+
+/// Extract the source [`Span`] from a marked_yaml [`LoadError`].
+///
+/// Every `LoadError` variant carries location information describing *where* in
+/// the source the problem occurred (a [`marked_yaml::Marker`], or, for duplicate
+/// keys, the offending scalar node). This converts that location into a `Span`
+/// so the error can be reported at the offending line/column instead of
+/// defaulting to the top of the file.
+///
+/// This is particularly important for errors triggered by malformed Jinja, e.g.
+/// a `{{ var }}` that should have been `${{ var }}` parses as a YAML flow
+/// mapping and yields a "Keys in mappings must be scalar" error whose marker
+/// points at the actual mistake.
+pub fn load_error_span(error: &LoadError) -> Span {
+    match error {
+        LoadError::TopLevelMustBeMapping(marker)
+        | LoadError::TopLevelMustBeSequence(marker)
+        | LoadError::UnexpectedAnchor(marker)
+        | LoadError::MappingKeyMustBeScalar(marker)
+        | LoadError::UnexpectedTag(marker)
+        | LoadError::ScanError(marker, _) => Span::new_start(*marker),
+        LoadError::DuplicateKey(inner) => *inner.key.span(),
+    }
 }


### PR DESCRIPTION
## Summary
This PR fixes error location reporting for YAML parse errors, ensuring that errors are reported at the actual location of the problem rather than defaulting to the top of the file. This is particularly important for catching common mistakes like using `{{ var }}` instead of `${{ var }}` in recipe files.

## Key Changes
- **Added `load_error_span()` function** in `rattler_build_yaml_parser/src/yaml.rs` to extract the source span from `marked_yaml::LoadError` variants, converting marker information into proper span locations
- **Updated error handling** in `rattler_build_recipe/src/stage0/parser/mod.rs` to use `load_error_span()` instead of blank spans when reporting YAML parse errors
- **Added comprehensive test cases** for the missing dollar sign in Jinja templates:
  - `test_error_missing_dollar_jinja_multi_output()` - tests multi-output recipes
  - `test_error_missing_dollar_jinja_single_output()` - tests single-output recipes
- **Added test data files** with example YAML files that trigger the error condition
- **Added snapshot tests** that verify errors are reported at the correct line and column (line 15 and 10 respectively, not at the top of the file)

## Implementation Details
The `load_error_span()` function handles all `LoadError` variants from `marked_yaml`:
- For most variants (TopLevelMustBeMapping, MappingKeyMustBeScalar, etc.), it extracts the marker and converts it to a span
- For DuplicateKey errors, it extracts the span directly from the key node
- This ensures that when a user writes `{{ build_number }}` instead of `${{ build_number }}`, the error points to that exact location where YAML interprets it as a malformed flow mapping

Fixes https://github.com/prefix-dev/rattler-build/issues/2580

https://claude.ai/code/session_01JW3oBhVWJsQMMnqRsGqk7e