### PR TITLE
fix: Empty license_file output overrides

### DIFF
--- a/crates/rattler_build_recipe/src/stage0/evaluate.rs
+++ b/crates/rattler_build_recipe/src/stage0/evaluate.rs
@@ -1630,6 +1630,7 @@ impl Evaluate for Stage0About {
                 .map(|v| v.evaluate(context))
                 .transpose()?,
             license_file: license_file_globs,
+            license_file_specified: self.license_file.is_some(),
             license_file_late_bound,
             license_family: evaluate_optional_string_value(&self.license_family, context)?,
             summary: evaluate_optional_string_value(&self.summary, context)?,
@@ -2989,9 +2990,11 @@ fn merge_stage1_build(
 fn merge_stage1_about(toplevel: stage1::About, output: stage1::About) -> stage1::About {
     // `license_file` and `license_file_late_bound` are both derived from the
     // single `license_file` recipe key, so they are merged as a unit: if the
-    // output specified any license files, its values win entirely.
-    let use_output_license =
-        output.license_file.is_some() || !output.license_file_late_bound.is_empty();
+    // output specified `license_file`, its values win entirely, including an
+    // explicit empty list.
+    let use_output_license = output.license_file_specified
+        || output.license_file.is_some()
+        || !output.license_file_late_bound.is_empty();
 
     stage1::About {
         homepage: if output.homepage.is_some() {
@@ -3023,6 +3026,11 @@ fn merge_stage1_about(toplevel: stage1::About, output: stage1::About) -> stage1:
             output.license_file
         } else {
             toplevel.license_file
+        },
+        license_file_specified: if use_output_license {
+            true
+        } else {
+            toplevel.license_file_specified
         },
         license_file_late_bound: if use_output_license {
             output.license_file_late_bound
@@ -4691,6 +4699,47 @@ outputs:
                     "Custom output summary"
                 ); // Overridden
                 assert!(output2.about.license.is_some()); // Inherited
+            }
+            _ => panic!("Expected MultiOutputRecipe"),
+        }
+    }
+
+    #[test]
+    fn test_multi_output_empty_license_file_overrides_top_level() {
+        use crate::stage0::parser::parse_recipe_or_multi_from_source;
+
+        let recipe_yaml = r#"
+schema_version: 1
+
+recipe:
+  name: myproject
+  version: 1.0.0
+
+about:
+  license_file:
+    - LICENSE
+
+outputs:
+  - package:
+      name: output-no-license-file
+      version: 1.0.0
+    about:
+      license_file: []
+"#;
+
+        let parsed = parse_recipe_or_multi_from_source(recipe_yaml).unwrap();
+
+        match parsed {
+            stage0::Recipe::MultiOutput(multi) => {
+                let ctx = EvaluationContext::for_platform(rattler_conda_types::Platform::Linux64);
+
+                let recipes = multi.evaluate(&ctx).unwrap();
+                assert_eq!(recipes.len(), 1);
+
+                let output = &recipes[0];
+                assert!(output.about.license_file_specified);
+                assert!(output.about.license_file.is_none());
+                assert!(output.about.license_file_late_bound.is_empty());
             }
             _ => panic!("Expected MultiOutputRecipe"),
         }

--- a/crates/rattler_build_recipe/src/stage1/about.rs
+++ b/crates/rattler_build_recipe/src/stage1/about.rs
@@ -29,6 +29,12 @@ pub struct About {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub license_file: Option<GlobVec>,
 
+    /// Whether `license_file` was explicitly present in the source recipe.
+    /// This preserves an explicit empty list so outputs can override inherited
+    /// top-level license files.
+    #[serde(default, skip)]
+    pub license_file_specified: bool,
+
     /// License file paths that reference late-bound build directory variables
     /// (e.g. `${{ PREFIX }}/share/licenses/LICENSE`). These are resolved during
     /// packaging once the build directories are known.
@@ -61,6 +67,7 @@ impl About {
             && self.documentation.is_none()
             && self.license.is_none()
             && self.license_file.is_none()
+            && !self.license_file_specified
             && self.license_file_late_bound.is_empty()
             && self.license_family.is_none()
             && self.summary.is_none()


### PR DESCRIPTION
## Summary

Fixes #2598 by preserving whether `about.license_file` was explicitly present during recipe evaluation. This lets an output-level `license_file: []` override inherited top-level license files instead of being treated the same as an omitted field.

## Root Cause

Evaluation collapsed both omitted `license_file` and an explicitly empty list into `None` plus no late-bound license entries. The multi-output merge logic then interpreted the output as not specifying license files and inherited the top-level value.

## Changes

- Added a non-serialized `license_file_specified` flag to evaluated `About` metadata.
- Updated multi-output about merging to respect explicit empty `license_file` overrides.
- Added a regression test for top-level `license_file` with output-level `license_file: []`.

## Validation

- `cargo test -p rattler_build_recipe test_multi_output_empty_license_file_overrides_top_level`
- `cargo test -p rattler_build_core copy_license_files --lib` compile check
- `cargo fmt --check`
- Verified the issue reproducer with `cargo run -- build -r /private/tmp/rb-2598-repro/recipe --output-dir /private/tmp/rb-2598-repro/out --test skip --log-style plain --color never`