### PR TITLE
docs: fix down_prioritize_variant documentation and example value

### DIFF
--- a/crates/rattler_build_recipe/examples/README.md
+++ b/crates/rattler_build_recipe/examples/README.md
@@ -149,7 +149,7 @@ The `build` section supports the following fields:
 **Variant Configuration:**
 - `variant.use_keys`: Variant keys to use
 - `variant.ignore_keys`: Variant keys to ignore
-- `variant.down_prioritize_variant`: Down-prioritize variant (negative integer)
+- `variant.down_prioritize_variant`: Down-prioritize variant (integer; higher is less preferred)
 
 **Prefix Detection:**
 - `prefix_detection.force_file_type.text`: Force files to be treated as text (glob patterns)

--- a/crates/rattler_build_recipe/src/stage0/build.rs
+++ b/crates/rattler_build_recipe/src/stage0/build.rs
@@ -17,7 +17,8 @@ pub struct VariantKeyUsage {
     #[serde(default)]
     pub ignore_keys: ConditionalList<String>,
 
-    /// Down-prioritize variant by setting priority to a negative value
+    /// Down-prioritize this variant. Higher values make the variant less
+    /// preferred; the magnitude of the value is used (the sign is ignored).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub down_prioritize_variant: Option<Value<i32>>,
 }

--- a/crates/rattler_build_recipe/src/stage1/build.rs
+++ b/crates/rattler_build_recipe/src/stage1/build.rs
@@ -173,7 +173,8 @@ pub struct VariantKeyUsage {
     /// Variant keys to ignore
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub ignore_keys: Vec<String>,
-    /// Down-prioritize variant (negative priority value)
+    /// Down-prioritize this variant. Higher values make the variant less
+    /// preferred; the magnitude of the value is used (the sign is ignored).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub down_prioritize_variant: Option<i32>,
 }

--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -911,7 +911,7 @@ build:
       - numpy
     ignore_keys:
       - python
-    down_prioritize_variant: -1
+    down_prioritize_variant: 1
 ```
 
 - **`use_keys`** - Variant keys that must be part of this build's variant
@@ -920,8 +920,10 @@ build:
   build's variant even if they are referenced. Packages built with
   `ignore_keys` will not get a separate output per value of that key.
 - **`down_prioritize_variant`** - Integer priority offset applied to this
-  variant during solving. Negative values make the variant less preferred
-  when multiple variants satisfy a dependency.
+  variant during solving (defaults to `0`). Higher values make the variant
+  less preferred when multiple variants satisfy a dependency. This is
+  implemented via `track_features`, so it is the magnitude of the value that
+  matters (the sign is ignored).
 
 ## Include build recipe
 


### PR DESCRIPTION
## Summary
This PR corrects the documentation and example usage of the `down_prioritize_variant` field to accurately reflect how it works. The field uses magnitude-based prioritization via `track_features`, not sign-based prioritization.

## Key Changes
- **Documentation update**: Changed the example value from `-1` to `1` in the recipe file reference, since the sign is ignored and only magnitude matters
- **Clarified behavior**: Updated all docstrings to explain that higher values make variants less preferred, and that the magnitude (not sign) is what matters
- **Implementation notes**: Added clarification that this is implemented via `track_features`, which uses absolute values
- **Examples updated**: Fixed the README example to indicate that the field accepts integers where higher values are less preferred

## Notable Details
The `down_prioritize_variant` field applies a priority offset during dependency solving. Previously, the documentation suggested using negative values, but the actual implementation uses the magnitude of the value. This change ensures users understand the correct semantics: provide a positive integer where larger numbers result in lower priority for that variant.

https://claude.ai/code/session_01JSqoj15Wc8E72cWZQCFuEW