### PR TITLE
fix: use `skip` condition and platform-split script in generated R recipes

### DIFF
--- a/crates/rattler_build_recipe_generator/src/cran.rs
+++ b/crates/rattler_build_recipe_generator/src/cran.rs
@@ -275,6 +275,30 @@ const R_BUILTINS: &[&str] = &[
 /// keeps the post-processing match simple.
 const CROSS_R_BASE_MARKER: &str = "CROSS_R_BASE_PLACEHOLDER";
 
+/// Placeholder stored in `build.script`. Expanded by
+/// [`format_cran_recipe_with_suggests`] into a platform-conditional list that
+/// uses `${R_ARGS}` on Unix and `%R_ARGS%` on Windows.
+const CRAN_R_SCRIPT_MARKER: &str = "CRAN_R_SCRIPT_PLACEHOLDER";
+
+/// Convert an R `Depends: R (>= x.y.z)` version string into a rattler-build
+/// `skip` expression. Only `>=` constraints are handled; returns `None` for
+/// anything else.
+fn r_dep_version_to_skip(version: &str) -> Option<String> {
+    let num = version
+        .trim()
+        .trim_start_matches(">=")
+        .trim_start_matches('>')
+        .trim();
+    let parts: Vec<&str> = num.splitn(3, '.').collect();
+    match parts.as_slice() {
+        [major, minor, ..] if !major.is_empty() => {
+            Some(format!("match(r_base, \"<{}.{}\")", major, minor))
+        }
+        [major] if !major.is_empty() => Some(format!("match(r_base, \"<{}\")", major)),
+        _ => None,
+    }
+}
+
 fn format_cran_recipe_with_suggests(recipe: &serialize::Recipe) -> String {
     let recipe_str = format!("{}", recipe);
     let mut final_recipe = String::new();
@@ -289,6 +313,20 @@ fn format_cran_recipe_with_suggests(recipe: &serialize::Recipe) -> String {
                 "{indent}- if: build_platform != target_platform\n\
                  {indent}  then:\n\
                  {indent}    - cross-r-base ${{{{ r_base }}}}\n"
+            ));
+        } else if line
+            .trim_start()
+            .starts_with(&format!("script: {CRAN_R_SCRIPT_MARKER}"))
+        {
+            // Expand into a platform-conditional script list.
+            let indent_len = line.len() - line.trim_start().len();
+            let indent = &line[..indent_len];
+            final_recipe.push_str(&format!(
+                "{indent}script:\n\
+                 {indent}  - if: unix\n\
+                 {indent}    then: R CMD INSTALL --build . ${{R_ARGS}}\n\
+                 {indent}  - if: win\n\
+                 {indent}    then: R CMD INSTALL --build . %R_ARGS%\n"
             ));
         } else if line.contains("SUGGEST") {
             final_recipe.push_str(&format!(
@@ -366,10 +404,9 @@ async fn build_cran_recipe_and_deps(
     recipe.source.push(source.into());
 
     recipe.build.number = "${{ build_number }}".to_string();
-    // `${R_ARGS}` lets the recipe author pass extra flags (e.g.
-    // `--configure-args=...`) through to `R CMD INSTALL`, matching the
-    // convention used by conda-forge's R build scripts.
-    recipe.build.script = "R CMD INSTALL --build . ${R_ARGS}".to_string();
+    // Expanded by `format_cran_recipe_with_suggests` into a platform-specific
+    // list (${R_ARGS} on Unix, %R_ARGS% on Windows).
+    recipe.build.script = CRAN_R_SCRIPT_MARKER.to_string();
 
     let build_tools = vec![
         "${{ compiler('c') }}".to_string(),
@@ -382,18 +419,19 @@ async fn build_cran_recipe_and_deps(
     // they need a compiler even if `NeedsCompilation` is not set to `yes`.
     let mut needs_compilation = package_info.NeedsCompilation == "yes";
 
-    // `r-base` itself, possibly carrying the version constraint from a
-    // `Depends: R (>= x.y.z)` entry. It is the first requirement in both `host`
-    // and `run`.
-    let mut r_base = "r-base".to_string();
+    // `r-base` is always listed without a version pin; instead a minimum-R
+    // constraint from `Depends: R (>= x.y.z)` is expressed as a `skip`
+    // condition so variant selectors (r_base) control it at solve time.
+    let r_base = "r-base".to_string();
     let mut host = Vec::new();
     let mut run = Vec::new();
 
     let mut remaining_deps = HashSet::new();
     for dep in package_info._dependencies.iter() {
         if dep.package == "R" {
-            // The R version constraint pins `r-base` in both host and run.
-            r_base = format_r_package("base", dep.version.as_ref());
+            if let Some(ver) = &dep.version {
+                recipe.build.skip = r_dep_version_to_skip(ver);
+            }
             continue;
         }
 

--- a/crates/rattler_build_recipe_generator/src/cran.rs
+++ b/crates/rattler_build_recipe_generator/src/cran.rs
@@ -323,10 +323,9 @@ fn format_cran_recipe_with_suggests(recipe: &serialize::Recipe) -> String {
             let indent = &line[..indent_len];
             final_recipe.push_str(&format!(
                 "{indent}script:\n\
-                 {indent}  - if: unix\n\
-                 {indent}    then: R CMD INSTALL --build . ${{R_ARGS}}\n\
                  {indent}  - if: win\n\
-                 {indent}    then: R CMD INSTALL --build . %R_ARGS%\n"
+                 {indent}    then: R CMD INSTALL --build . %R_ARGS%\n\
+                 {indent}    else: R CMD INSTALL --build . ${{R_ARGS}}\n"
             ));
         } else if line.contains("SUGGEST") {
             final_recipe.push_str(&format!(

--- a/crates/rattler_build_recipe_generator/src/luarocks/mod.rs
+++ b/crates/rattler_build_recipe_generator/src/luarocks/mod.rs
@@ -406,6 +406,7 @@ fn rockspec_to_recipe(rockspec: &LuarocksRockspec) -> miette::Result<Recipe> {
         source: vec![source_element],
         build: Build {
             number: "${{ build_number }}".to_string(),
+            skip: None,
             script: "# Take the first `rockspec` we find (in non-deterministic places unfortunately)\nROCK=$(find . -name \"*.rockspec\" | sort -n -r | head -n 1)\nluarocks install ${ROCK} --tree=${{ PREFIX }}".to_string(),
             python: Python::default(),
             noarch: None,

--- a/crates/rattler_build_recipe_generator/src/serialize.rs
+++ b/crates/rattler_build_recipe_generator/src/serialize.rs
@@ -49,6 +49,8 @@ pub struct GitSourceElement {
 #[derive(Default, Debug, Serialize)]
 pub struct Build {
     pub number: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub skip: Option<String>,
     pub script: String,
     #[serde(skip_serializing_if = "Python::is_default")]
     pub python: Python,

--- a/docs/recipe_generation.md
+++ b/docs/recipe_generation.md
@@ -51,7 +51,7 @@ The `R` recipe generation supports some additional flags:
 - `-u/--universe` select an R universe to use (e.g. `bioconductor`)
 - `-t/--tree` generate multiple recipes, for every dependency as well
 
-R packages will be prefixed with `r-` to avoid name conflicts with Python packages. The generated recipe for `dplyr` will look something like:
+R packages will be prefixed with `r-` to avoid name conflicts with Python packages. When the package declares a minimum R version (e.g. `Depends: R (>= 4.1.0)`), the generator emits a `skip` condition using the `r_base` variant key rather than pinning `r-base` to a version. The build script is also split into a platform-conditional list so that the correct environment-variable syntax (`${R_ARGS}` on Unix, `%R_ARGS%` on Windows) is used. The generated recipe for `dplyr` will look something like:
 
 ```yaml title="recipe.yaml"
 --8<-- "docs/snippets/recipes/r-dplyr-generated.yaml"

--- a/docs/snippets/recipes/r-dplyr-generated.yaml
+++ b/docs/snippets/recipes/r-dplyr-generated.yaml
@@ -15,10 +15,9 @@ build:
   number: ${{ build_number }}
   skip: match(r_base, "<4.1")
   script:
-    - if: unix
-      then: R CMD INSTALL --build . ${R_ARGS}
     - if: win
       then: R CMD INSTALL --build . %R_ARGS%
+      else: R CMD INSTALL --build . ${R_ARGS}
   dynamic_linking:
     rpaths:
       - lib/R/lib/

--- a/docs/snippets/recipes/r-dplyr-generated.yaml
+++ b/docs/snippets/recipes/r-dplyr-generated.yaml
@@ -13,7 +13,12 @@ source:
 
 build:
   number: ${{ build_number }}
-  script: R CMD INSTALL --build . ${R_ARGS}
+  skip: match(r_base, "<4.1")
+  script:
+    - if: unix
+      then: R CMD INSTALL --build . ${R_ARGS}
+    - if: win
+      then: R CMD INSTALL --build . %R_ARGS%
   dynamic_linking:
     rpaths:
       - lib/R/lib/
@@ -28,7 +33,7 @@ requirements:
     - ${{ compiler('cxx') }}
     - make
   host:
-    - r-base >=4.1.0
+    - r-base
     - r-cli >=3.6.2
     - r-generics
     - r-glue >=1.3.2
@@ -41,7 +46,7 @@ requirements:
     - r-tidyselect >=1.2.0
     - r-vctrs >=0.7.1
   run:
-    - r-base >=4.1.0
+    - r-base
     - r-cli >=3.6.2
     - r-generics
     - r-glue >=1.3.2


### PR DESCRIPTION
## Summary

Refer - https://github.com/prefix-dev/rattler-build/pull/2597#pullrequestreview-4592776976 and https://github.com/prefix-dev/rattler-build/pull/2597#pullrequestreview-4593527853

This PR addresses review feedback recieved on the https://github.com/prefix-dev/rattler-build/pull/2597. Two related improvements are made to the output of `rattler-build generate-recipe cran`:

- **Platform-specific build script.** The single-line `R CMD INSTALL --build . ${R_ARGS}` is replaced with a platform-conditional list that uses `${R_ARGS}` on Unix and `%R_ARGS%` on Windows, matching the environment-variable quoting each shell expects.

- **`skip` condition instead of a pinned `r-base`.** When an R package declares a minimum R version (e.g. `Depends: R (>= 4.1.0)`), the generator previously embedded that constraint directly in the `r-base` requirement (`r-base >=4.1.0`). It now emits an unversioned `r-base` together with a `skip: match(r_base, "<x.y")` condition.

The documentation snippet (`r-dplyr-generated.yaml`) and the `recipe_generation.md` prose are updated to reflect the new generator output.

## Acknowledgements

Many thanks to @isuruf for the review comments on https://github.com/prefix-dev/rattler-build/pull/2597 that motivated these improvements!

@isuruf @wolfv, would you mind taking another look when you get a chance? I'd really appreciate your feedback on whether this aligns with your comments/expectations. TYSM. <3.

