### PR TITLE
feat: allow empty sha256 as all-zeros placeholder for recipe scaffolding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - The `source.filter` field is now also supported for `url` and `git` sources (it was previously only available for `path` sources). The filter is applied to the files copied into the work directory: the contents of the extracted archive for `url` sources (and `path` sources pointing to an archive) and the checked-out tree for `git` sources. This allows large sources to be trimmed down to the parts needed for the build.
-- An empty `sha256` (e.g. `sha256: ""`) is now accepted and treated as an all-zeros placeholder (`0000...0000`). This makes it easier to scaffold a recipe before the real checksum is known: the build downloads the source and reports the actual checksum in the resulting mismatch. (#2524)
+- An empty `sha256` or `md5` (e.g. `sha256: ""`) is now accepted and treated as an all-zeros placeholder (`0000...0000`). This makes it easier to scaffold a recipe before the real checksum is known: the build downloads the source and reports the actual checksum in the resulting mismatch. (#2524)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - The `source.filter` field is now also supported for `url` and `git` sources (it was previously only available for `path` sources). The filter is applied to the files copied into the work directory: the contents of the extracted archive for `url` sources (and `path` sources pointing to an archive) and the checked-out tree for `git` sources. This allows large sources to be trimmed down to the parts needed for the build.
+- An empty `sha256` (e.g. `sha256: ""`) is now accepted and treated as an all-zeros placeholder (`0000...0000`). This makes it easier to scaffold a recipe before the real checksum is known: the build downloads the source and reports the actual checksum in the resulting mismatch. (#2524)
 
 ### Changed
 

--- a/crates/rattler_build_recipe/src/stage0/evaluate.rs
+++ b/crates/rattler_build_recipe/src/stage0/evaluate.rs
@@ -1490,7 +1490,7 @@ fn evaluate_sha256(
         ValueInner::Concrete(hash) => Ok(*hash),
         ValueInner::Template(template) => {
             let s = render_template(template.source(), context, value.span())?;
-            rattler_digest::parse_digest_from_hex::<rattler_digest::Sha256>(&s).ok_or_else(|| {
+            crate::stage0::source::parse_sha256_hex(&s).ok_or_else(|| {
                 ParseError::invalid_value(
                     "SHA256 checksum",
                     format!("Invalid SHA256 checksum: {}", s),

--- a/crates/rattler_build_recipe/src/stage0/evaluate.rs
+++ b/crates/rattler_build_recipe/src/stage0/evaluate.rs
@@ -1510,7 +1510,7 @@ fn evaluate_md5(
         ValueInner::Concrete(hash) => Ok(*hash),
         ValueInner::Template(template) => {
             let s = render_template(template.source(), context, value.span())?;
-            rattler_digest::parse_digest_from_hex::<rattler_digest::Md5>(&s).ok_or_else(|| {
+            crate::stage0::source::parse_md5_hex(&s).ok_or_else(|| {
                 ParseError::invalid_value(
                     "MD5 checksum",
                     format!("Invalid MD5 checksum: {}", s),

--- a/crates/rattler_build_recipe/src/stage0/parser/source.rs
+++ b/crates/rattler_build_recipe/src/stage0/parser/source.rs
@@ -1,6 +1,6 @@
 use marked_yaml::Node;
 use rattler_build_yaml_parser::ParseError;
-use rattler_digest::{Md5, Md5Hash, Sha256, Sha256Hash};
+use rattler_digest::{Md5, Md5Hash, Sha256Hash};
 
 use crate::stage0::{
     parser::helpers::get_span,
@@ -26,8 +26,9 @@ fn parse_sha256_value(node: &Node) -> Result<Value<Sha256Hash>, ParseError> {
             return Ok(Value::new_template(template, Some(span)));
         }
 
-        // Otherwise parse as concrete SHA256 hash
-        let hash = rattler_digest::parse_digest_from_hex::<Sha256>(s).ok_or_else(|| {
+        // Otherwise parse as concrete SHA256 hash (an empty string is treated as
+        // an all-zeros placeholder, see `parse_sha256_hex`)
+        let hash = crate::stage0::source::parse_sha256_hex(s).ok_or_else(|| {
             ParseError::invalid_value("sha256", format!("Invalid SHA256 checksum: {}", s), span)
         })?;
         Ok(Value::new_concrete(hash, Some(span)))

--- a/crates/rattler_build_recipe/src/stage0/parser/source.rs
+++ b/crates/rattler_build_recipe/src/stage0/parser/source.rs
@@ -1,6 +1,6 @@
 use marked_yaml::Node;
 use rattler_build_yaml_parser::ParseError;
-use rattler_digest::{Md5, Md5Hash, Sha256Hash};
+use rattler_digest::{Md5Hash, Sha256Hash};
 
 use crate::stage0::{
     parser::helpers::get_span,
@@ -55,8 +55,9 @@ fn parse_md5_value(node: &Node) -> Result<Value<Md5Hash>, ParseError> {
             return Ok(Value::new_template(template, Some(span)));
         }
 
-        // Otherwise parse as concrete MD5 hash
-        let hash = rattler_digest::parse_digest_from_hex::<Md5>(s).ok_or_else(|| {
+        // Otherwise parse as concrete MD5 hash (an empty string is treated as
+        // an all-zeros placeholder, see `parse_md5_hex`)
+        let hash = crate::stage0::source::parse_md5_hex(s).ok_or_else(|| {
             ParseError::invalid_value("md5", format!("Invalid MD5 checksum: {}", s), span)
         })?;
         Ok(Value::new_concrete(hash, Some(span)))

--- a/crates/rattler_build_recipe/src/stage0/source.rs
+++ b/crates/rattler_build_recipe/src/stage0/source.rs
@@ -5,6 +5,19 @@ use std::path::PathBuf;
 
 use crate::stage0::types::{ConditionalList, IncludeExclude, JinjaTemplate, Value};
 
+/// Parse a concrete SHA256 checksum from a hex string.
+///
+/// An empty string is treated as a placeholder of all zeros
+/// (`0000...0000`), so recipe authors can scaffold a recipe before they have
+/// computed the real checksum. The source download later verifies the hash and
+/// reports a mismatch that includes the actual checksum. See issue #2524.
+pub(crate) fn parse_sha256_hex(s: &str) -> Option<Sha256Hash> {
+    if s.is_empty() {
+        return Some(Sha256Hash::default());
+    }
+    rattler_digest::parse_digest_from_hex::<Sha256>(s)
+}
+
 /// Source information - can be Git, Url, or Path
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -251,7 +264,7 @@ mod sha256_serialization {
             let template = JinjaTemplate::new(s).map_err(serde::de::Error::custom)?;
             Ok(Some(Value::new_template(template, None)))
         } else {
-            let hash = rattler_digest::parse_digest_from_hex::<Sha256>(&s)
+            let hash = parse_sha256_hex(&s)
                 .ok_or_else(|| serde::de::Error::custom(format!("Invalid SHA256 checksum: {s}")))?;
             Ok(Some(Value::new_concrete(hash, None)))
         }

--- a/crates/rattler_build_recipe/src/stage0/source.rs
+++ b/crates/rattler_build_recipe/src/stage0/source.rs
@@ -18,6 +18,18 @@ pub(crate) fn parse_sha256_hex(s: &str) -> Option<Sha256Hash> {
     rattler_digest::parse_digest_from_hex::<Sha256>(s)
 }
 
+/// Parse a concrete MD5 checksum from a hex string.
+///
+/// As with [`parse_sha256_hex`], an empty string is treated as an all-zeros
+/// placeholder (`0000...0000`) so recipes can be scaffolded before the real
+/// checksum is known. See issue #2524.
+pub(crate) fn parse_md5_hex(s: &str) -> Option<Md5Hash> {
+    if s.is_empty() {
+        return Some(Md5Hash::default());
+    }
+    rattler_digest::parse_digest_from_hex::<Md5>(s)
+}
+
 /// Source information - can be Git, Url, or Path
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -303,7 +315,7 @@ mod md5_serialization {
             let template = JinjaTemplate::new(s).map_err(serde::de::Error::custom)?;
             Ok(Some(Value::new_template(template, None)))
         } else {
-            let hash = rattler_digest::parse_digest_from_hex::<Md5>(&s)
+            let hash = parse_md5_hex(&s)
                 .ok_or_else(|| serde::de::Error::custom(format!("Invalid MD5 checksum: {s}")))?;
             Ok(Some(Value::new_concrete(hash, None)))
         }

--- a/crates/rattler_build_recipe/tests/source_parsing_test.rs
+++ b/crates/rattler_build_recipe/tests/source_parsing_test.rs
@@ -95,6 +95,42 @@ build:
 }
 
 #[test]
+fn test_parse_recipe_with_empty_sha256() {
+    // An empty sha256 string is accepted as an all-zeros placeholder so that
+    // recipes can be scaffolded before the real checksum is known (issue #2524).
+    let yaml = r#"
+package:
+  name: test
+  version: 1.0.0
+
+source:
+  url: https://example.com/archive.tar.gz
+  sha256: ""
+
+build:
+  number: 0
+"#;
+
+    let recipe = parse_recipe_from_source(yaml).unwrap();
+    let source = get_concrete_source(&recipe.source.as_slice()[0]).unwrap();
+    match source {
+        Source::Url(url_src) => {
+            let hash = url_src
+                .sha256
+                .as_ref()
+                .expect("sha256 should be present")
+                .as_concrete()
+                .expect("sha256 should be concrete");
+            assert!(
+                hash.iter().all(|&b| b == 0),
+                "empty sha256 should parse to all zeros"
+            );
+        }
+        _ => panic!("Expected URL source"),
+    }
+}
+
+#[test]
 fn test_parse_recipe_with_git_source_filter() {
     let yaml = r#"
 package:

--- a/crates/rattler_build_recipe/tests/source_parsing_test.rs
+++ b/crates/rattler_build_recipe/tests/source_parsing_test.rs
@@ -131,6 +131,42 @@ build:
 }
 
 #[test]
+fn test_parse_recipe_with_empty_md5() {
+    // An empty md5 string is accepted as an all-zeros placeholder, mirroring the
+    // sha256 behavior (issue #2524).
+    let yaml = r#"
+package:
+  name: test
+  version: 1.0.0
+
+source:
+  url: https://example.com/archive.tar.gz
+  md5: ""
+
+build:
+  number: 0
+"#;
+
+    let recipe = parse_recipe_from_source(yaml).unwrap();
+    let source = get_concrete_source(&recipe.source.as_slice()[0]).unwrap();
+    match source {
+        Source::Url(url_src) => {
+            let hash = url_src
+                .md5
+                .as_ref()
+                .expect("md5 should be present")
+                .as_concrete()
+                .expect("md5 should be concrete");
+            assert!(
+                hash.iter().all(|&b| b == 0),
+                "empty md5 should parse to all zeros"
+            );
+        }
+        _ => panic!("Expected URL source"),
+    }
+}
+
+#[test]
 fn test_parse_recipe_with_git_source_filter() {
     let yaml = r#"
 package:

--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -129,11 +129,11 @@ If an extracted archive contains only 1 folder at its top level, its contents
 will be moved 1 level up, so that the extracted package contents sit in the root
 of the work folder.
 
-An empty `sha256` (e.g. `sha256: ""`) is accepted as an all-zeros placeholder
-(`0000...0000`). This is handy while scaffolding a recipe before the real
-checksum is known: the build still downloads the source and reports the actual
-checksum in the resulting mismatch, which you can then paste back into the
-recipe.
+An empty `sha256` or `md5` (e.g. `sha256: ""`) is accepted as an all-zeros
+placeholder (`0000...0000`). This is handy while scaffolding a recipe before the
+real checksum is known: the build still downloads the source and reports the
+actual checksum in the resulting mismatch, which you can then paste back into
+the recipe.
 
 ##### Supported archive formats
 

--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -121,9 +121,10 @@ contain patches.
 source:
   url: https://pypi.python.org/packages/source/b/bsdiff4/bsdiff4-1.1.4.tar.gz
   md5: 29f6089290505fc1a852e176bd276c43
-  sha1: f0a2c9a30073449cfb7d171c57552f3109d93894
   sha256: 5a022ff4c1d1de87232b1c70bde50afbb98212fd246be4a867d8737173cf1f8f
 ```
+
+A source may be verified with `sha256` and/or `md5`; `sha1` is not supported.
 
 If an extracted archive contains only 1 folder at its top level, its contents
 will be moved 1 level up, so that the extracted package contents sit in the root

--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -129,6 +129,12 @@ If an extracted archive contains only 1 folder at its top level, its contents
 will be moved 1 level up, so that the extracted package contents sit in the root
 of the work folder.
 
+An empty `sha256` (e.g. `sha256: ""`) is accepted as an all-zeros placeholder
+(`0000...0000`). This is handy while scaffolding a recipe before the real
+checksum is known: the build still downloads the source and reports the actual
+checksum in the resulting mismatch, which you can then paste back into the
+recipe.
+
 ##### Supported archive formats
 
 When the URL points to one of the archive formats listed below, the file is


### PR DESCRIPTION
## Summary
This PR allows recipe authors to use an empty `sha256` field (e.g., `sha256: ""`) as a placeholder while scaffolding recipes before the actual checksum is known. The empty string is parsed as an all-zeros hash (`0000...0000`), and the build process will later report the actual checksum when a mismatch occurs.

## Key Changes
- **New `parse_sha256_hex()` function** in `crates/rattler_build_recipe/src/stage0/source.rs`: Centralizes SHA256 parsing logic with special handling for empty strings, treating them as all-zeros placeholders
- **Updated deserialization** in `sha256_serialization` module to use the new `parse_sha256_hex()` function instead of directly calling `rattler_digest::parse_digest_from_hex`
- **Updated template evaluation** in `evaluate.rs` to use `parse_sha256_hex()` when rendering SHA256 templates
- **Updated parser** in `crates/rattler_build_recipe/src/stage0/parser/source.rs` to use the new function with clarifying comments
- **Added comprehensive test** `test_parse_recipe_with_empty_sha256()` to verify the empty string is correctly parsed as all zeros
- **Updated documentation** in `docs/reference/recipe_file.md` explaining the empty sha256 placeholder feature and its use case
- **Updated CHANGELOG.md** to document this new feature

## Implementation Details
- The `parse_sha256_hex()` function returns `Sha256Hash::default()` (all zeros) for empty strings, and delegates to the existing `rattler_digest::parse_digest_from_hex` for non-empty strings
- This change is applied consistently across all SHA256 parsing paths: deserialization, template evaluation, and direct parsing
- The feature enables a better developer experience when scaffolding recipes, as the actual checksum is revealed in the build error message

https://claude.ai/code/session_01FRmuPXnDBVXTsVaNXQLH9u