### PR TITLE
feat: make SHLIB_EXT available in Jinja templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The `SHLIB_EXT` variable (shared library extension for the target platform, e.g. `.so`, `.dylib`, `.dll`) is now available in Jinja templates, so it can be used in fields such as `build.files` (e.g. `foo${{ SHLIB_EXT }}`). It previously was only set as a build-script environment variable. (#2532)
 - The `source.filter` field is now also supported for `url` and `git` sources (it was previously only available for `path` sources). The filter is applied to the files copied into the work directory: the contents of the extracted archive for `url` sources (and `path` sources pointing to an archive) and the checked-out tree for `git` sources. This allows large sources to be trimmed down to the parts needed for the build.
 
 ### Changed

--- a/crates/rattler_build_core/src/env_vars.rs
+++ b/crates/rattler_build_core/src/env_vars.rs
@@ -233,17 +233,11 @@ pub fn os_vars(
         }
     }
 
-    let shlib_ext = if target_platform.is_windows() {
-        ".dll"
-    } else if target_platform.is_osx() {
-        ".dylib"
-    } else if target_platform.is_linux() {
-        ".so"
-    } else {
-        ".not_implemented"
-    };
-
-    insert!(vars, "SHLIB_EXT", shlib_ext);
+    insert!(
+        vars,
+        "SHLIB_EXT",
+        rattler_build_types::shlib_ext(target_platform)
+    );
     vars.insert(path_var.to_string(), env::var(path_var).ok());
 
     if target_platform.is_windows() {

--- a/crates/rattler_build_jinja/src/jinja.rs
+++ b/crates/rattler_build_jinja/src/jinja.rs
@@ -180,6 +180,14 @@ impl Jinja {
             Value::from(config.host_platform.is_unix()),
         );
 
+        // Shared library extension for the target platform (e.g. `.so`, `.dylib`,
+        // `.dll`). Mirrors the `SHLIB_EXT` build-script environment variable so it
+        // can be used in templated fields such as `build.files`.
+        context.insert(
+            "SHLIB_EXT".to_string(),
+            Value::from(rattler_build_types::shlib_ext(&config.target_platform)),
+        );
+
         // Derive the host platform's family name (e.g., "linux" from "linux-64",
         // "emscripten" from "emscripten-wasm32")
         let host_family = config.host_platform.only_platform();
@@ -1504,6 +1512,34 @@ mod tests {
         assert!(!jinja.eval("linux").expect("host is not linux").is_true());
         assert!(!jinja.eval("osx").expect("host is not osx").is_true());
         assert!(jinja.eval("x86_64").expect("host is x86_64").is_true());
+    }
+
+    #[test]
+    fn eval_shlib_ext() {
+        // `SHLIB_EXT` should be available in the Jinja context and resolve to the
+        // target platform's shared library extension (see issue #2532).
+        let cases = [
+            (Platform::Linux64, ".so"),
+            (Platform::LinuxAarch64, ".so"),
+            (Platform::OsxArm64, ".dylib"),
+            (Platform::Osx64, ".dylib"),
+            (Platform::Win64, ".dll"),
+        ];
+        for (target_platform, expected) in cases {
+            let jinja = Jinja::new(JinjaConfig {
+                target_platform,
+                host_platform: target_platform,
+                build_platform: target_platform,
+                ..Default::default()
+            });
+            assert_eq!(
+                jinja
+                    .render_str("foo${{ SHLIB_EXT }}")
+                    .expect("SHLIB_EXT should be defined"),
+                format!("foo{expected}"),
+                "unexpected SHLIB_EXT for {target_platform}"
+            );
+        }
     }
 
     #[test]

--- a/crates/rattler_build_types/src/lib.rs
+++ b/crates/rattler_build_types/src/lib.rs
@@ -11,6 +11,23 @@ pub use late_bound_path::{LICENSE_VARS, LateBoundPath, PATCH_VARS};
 pub use pin::*;
 pub use variant_config::NormalizedKey;
 
+use rattler_conda_types::Platform;
+
+/// Returns the shared library extension for the given platform (e.g. `.so` for
+/// Linux, `.dylib` for macOS, and `.dll` for Windows). Returns
+/// `.not_implemented` for platforms without a known extension (e.g. `noarch`).
+pub fn shlib_ext(platform: &Platform) -> &'static str {
+    if platform.is_windows() {
+        ".dll"
+    } else if platform.is_osx() {
+        ".dylib"
+    } else if platform.is_linux() {
+        ".so"
+    } else {
+        ".not_implemented"
+    }
+}
+
 /// Extract the first `length` dot-separated parts of a version string and
 /// concatenate them without separators. For example, `"3.11.2"` with length 2
 /// gives `"311"`.


### PR DESCRIPTION
## Summary
This PR makes the `SHLIB_EXT` variable (shared library extension for the target platform) available in Jinja templates, allowing it to be used in templated fields such as `build.files`. Previously, `SHLIB_EXT` was only set as a build-script environment variable.

## Key Changes
- **Extracted shared logic**: Created a new `shlib_ext()` function in `rattler_build_types` that returns the appropriate shared library extension (`.so`, `.dylib`, `.dll`, or `.not_implemented`) based on the target platform
- **Updated Jinja context**: Added `SHLIB_EXT` to the Jinja template context in `rattler_build_jinja` so it can be used in templated fields like `foo${{ SHLIB_EXT }}`
- **Refactored environment variables**: Updated `rattler_build_core` to use the new shared `shlib_ext()` function instead of duplicating the platform detection logic
- **Added comprehensive tests**: Included test cases covering Linux, macOS, and Windows platforms to verify correct extension resolution

## Implementation Details
- The `shlib_ext()` function is platform-agnostic and returns the correct extension for Windows (`.dll`), macOS (`.dylib`), Linux (`.so`), and unknown platforms (`.not_implemented`)
- The implementation eliminates code duplication by centralizing the platform-to-extension mapping in a single location
- The Jinja template integration allows users to reference `SHLIB_EXT` directly in recipe files, enabling more flexible build configurations

https://claude.ai/code/session_01RBrnKwvBd9JQH2LWh1EVCf