### PR TITLE
feat: Add `PATHS_JSON`/`INDEX_JSON` env vars at test-time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -308,6 +308,7 @@ Feel free to find out more details by looking at the linked PRs below.
 - An empty `sha256` or `md5` (e.g. `sha256: ""`) is now accepted and treated as an all-zeros placeholder (`0000...0000`). This makes it easier to scaffold a recipe before the real checksum is known: the build downloads the source and reports the actual checksum in the resulting mismatch. (#2524)
 - The build summary now prints a section for each `requirements.extras` group (optional dependency group) in the run dependencies table, so the resolved contents of each extra are visible. The section is omitted when the recipe defines no extras.
 - Patches that are already fully applied to the source (e.g. because the change was merged upstream) are now detected, reported with a warning, and skipped instead of being silently "applied". This makes it easy to spot patches that can be removed from the recipe. (#1953)
+- `PATHS_JSON` and `INDEX_JSON` environment variables are now set during the test phase, pointing at the tested package's `info/paths.json` and `info/index.json` respectively. Test scripts can use these to inspect the package's installed files without having to load its `PrefixRecord` from `conda-meta` themselves. (#1263)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,7 @@ Feel free to find out more details by looking at the linked PRs below.
 - An empty `sha256` or `md5` (e.g. `sha256: ""`) is now accepted and treated as an all-zeros placeholder (`0000...0000`). This makes it easier to scaffold a recipe before the real checksum is known: the build downloads the source and reports the actual checksum in the resulting mismatch. (#2524)
 - The build summary now prints a section for each `requirements.extras` group (optional dependency group) in the run dependencies table, so the resolved contents of each extra are visible. The section is omitted when the recipe defines no extras.
 - Patches that are already fully applied to the source (e.g. because the change was merged upstream) are now detected, reported with a warning, and skipped instead of being silently "applied". This makes it easy to spot patches that can be removed from the recipe. (#1953)
+- `PATHS_JSON` and `INDEX_JSON` environment variables are now set during the test phase, pointing at the tested package's `info/paths.json` and `info/index.json` respectively. Test scripts can use these to inspect the package's installed files without having to load its `PrefixRecord` from `conda-meta` themselves. (#1263)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -308,7 +308,6 @@ Feel free to find out more details by looking at the linked PRs below.
 - An empty `sha256` or `md5` (e.g. `sha256: ""`) is now accepted and treated as an all-zeros placeholder (`0000...0000`). This makes it easier to scaffold a recipe before the real checksum is known: the build downloads the source and reports the actual checksum in the resulting mismatch. (#2524)
 - The build summary now prints a section for each `requirements.extras` group (optional dependency group) in the run dependencies table, so the resolved contents of each extra are visible. The section is omitted when the recipe defines no extras.
 - Patches that are already fully applied to the source (e.g. because the change was merged upstream) are now detected, reported with a warning, and skipped instead of being silently "applied". This makes it easy to spot patches that can be removed from the recipe. (#1953)
-- `PATHS_JSON` and `INDEX_JSON` environment variables are now set during the test phase, pointing at the tested package's `info/paths.json` and `info/index.json` respectively. Test scripts can use these to inspect the package's installed files without having to load its `PrefixRecord` from `conda-meta` themselves. (#1263)
 
 ### Changed
 

--- a/crates/rattler_build_core/src/package_test/run_test.rs
+++ b/crates/rattler_build_core/src/package_test/run_test.rs
@@ -19,7 +19,7 @@ use rattler_build_script::{
 use rattler_build_types::NormalizedKey;
 use rattler_conda_types::{
     Channel, ChannelUrl, MatchSpec, PackageName, PackageNameMatcher, ParseStrictness, Platform,
-    StringMatcher, Version, VersionSpec,
+    PrefixRecord, StringMatcher, Version, VersionSpec,
     compression_level::CompressionLevel,
     package::{ArchiveIdentifier, CondaArchiveIdentifier, IndexJson, PackageFile},
     version_spec::EqualityOperator,
@@ -406,6 +406,56 @@ fn env_vars_from_package(index_json: &IndexJson) -> HashMap<String, String> {
     res
 }
 
+/// Once the tested package has been linked into `prefix`, locate its
+/// `conda-meta/<name>-<version>-<build>.json` (the `PrefixRecord`) and derive
+/// the `PATHS_JSON` and `INDEX_JSON` env vars from its `extracted_package_dir`.
+///
+/// This spares test scripts from having to load the `PrefixRecord` themselves
+/// to find these files (see <https://github.com/prefix-dev/rattler-build/issues/1263>).
+fn env_vars_from_prefix_record(
+    prefix: &Path,
+    pkg: &CondaArchiveIdentifier,
+) -> HashMap<String, String> {
+    let mut res = HashMap::new();
+
+    let conda_meta_file = prefix.join("conda-meta").join(format!(
+        "{}-{}-{}.json",
+        pkg.identifier.name, pkg.identifier.version, pkg.identifier.build_string
+    ));
+
+    let prefix_record = match PrefixRecord::from_path(&conda_meta_file) {
+        Ok(record) => record,
+        Err(e) => {
+            tracing::debug!(
+                "could not read prefix record at '{}': {e}",
+                conda_meta_file.display()
+            );
+            return res;
+        }
+    };
+
+    let Some(extracted_package_dir) = &prefix_record.extracted_package_dir else {
+        return res;
+    };
+
+    res.insert(
+        "PATHS_JSON".to_string(),
+        extracted_package_dir
+            .join("info/paths.json")
+            .to_string_lossy()
+            .to_string(),
+    );
+    res.insert(
+        "INDEX_JSON".to_string(),
+        extracted_package_dir
+            .join("info/index.json")
+            .to_string_lossy()
+            .to_string(),
+    );
+
+    res
+}
+
 /// Read variant environment variables from `info/hash_input.json` in the
 /// package directory.  This file contains the full variant map that was used
 /// to build the package.  We expose every key as an environment variable
@@ -637,9 +687,18 @@ pub async fn run_test(
         // These are the legacy tests
         let (test_folder, tests) = legacy_tests_from_folder(&package_folder).await?;
 
+        let mut legacy_env = env.clone();
+        legacy_env.extend(env_vars_from_prefix_record(&prefix, &pkg));
+
         for test in tests {
-            test.run(&prefix, &test_folder, &env, &resolved_records, &config)
-                .await?;
+            test.run(
+                &prefix,
+                &test_folder,
+                &legacy_env,
+                &resolved_records,
+                &config,
+            )
+            .await?;
         }
 
         tracing::info!(
@@ -783,6 +842,7 @@ async fn run_python_test(
     for (python_version, dependencies) in dependencies_map {
         run_python_test_inner(
             python_test,
+            pkg,
             python_version,
             dependencies,
             path,
@@ -797,6 +857,7 @@ async fn run_python_test(
 
 async fn run_python_test_inner(
     python_test: &PythonTest,
+    pkg: &CondaArchiveIdentifier,
     python_version: String,
     dependencies: Vec<MatchSpec>,
     path: &Path,
@@ -843,7 +904,7 @@ async fn run_python_test_inner(
     let (target_platform, build_platform, host_platform) = configured_test_platforms(config);
     let test_dir = prefix.join("test");
     fs::create_dir_all(&test_dir)?;
-    let test_env_vars = env_vars::os_vars(
+    let mut test_env_vars = env_vars::os_vars(
         &test_prefix,
         &target_platform,
         &host_platform,
@@ -851,6 +912,11 @@ async fn run_python_test_inner(
         config.env_isolation,
         &test_dir,
         &RuntimeEnv::current(),
+    );
+    test_env_vars.extend(
+        env_vars_from_prefix_record(&test_prefix, pkg)
+            .into_iter()
+            .map(|(k, v)| (k, Some(v))),
     );
 
     let context = shared_test_context(&test_prefix, host_platform);
@@ -956,7 +1022,7 @@ async fn run_perl_test(
     fs::create_dir_all(&test_folder)?;
 
     let (target_platform, build_platform, host_platform) = configured_test_platforms(config);
-    let test_env_vars = env_vars::os_vars(
+    let mut test_env_vars = env_vars::os_vars(
         &test_prefix,
         &target_platform,
         &host_platform,
@@ -964,6 +1030,11 @@ async fn run_perl_test(
         config.env_isolation,
         &test_folder,
         &RuntimeEnv::current(),
+    );
+    test_env_vars.extend(
+        env_vars_from_prefix_record(&test_prefix, pkg)
+            .into_iter()
+            .map(|(k, v)| (k, Some(v))),
     );
     let context = shared_test_context(&test_prefix, host_platform);
 
@@ -1095,6 +1166,11 @@ async fn run_commands_test(
         host_platform,
     ));
     env_vars.extend(pkg_vars.iter().map(|(k, v)| (k.clone(), Some(v.clone()))));
+    env_vars.extend(
+        env_vars_from_prefix_record(&run_prefix, pkg)
+            .into_iter()
+            .map(|(k, v)| (k, Some(v))),
+    );
     env_vars.insert(
         "PREFIX".to_string(),
         Some(run_prefix.to_string_lossy().to_string()),
@@ -1286,7 +1362,7 @@ async fn run_r_test(
     fs::create_dir_all(&test_folder)?;
 
     let (target_platform, build_platform, host_platform) = configured_test_platforms(config);
-    let test_env_vars = env_vars::os_vars(
+    let mut test_env_vars = env_vars::os_vars(
         &test_prefix,
         &target_platform,
         &host_platform,
@@ -1294,6 +1370,11 @@ async fn run_r_test(
         config.env_isolation,
         &test_folder,
         &RuntimeEnv::current(),
+    );
+    test_env_vars.extend(
+        env_vars_from_prefix_record(&test_prefix, pkg)
+            .into_iter()
+            .map(|(k, v)| (k, Some(v))),
     );
     let context = shared_test_context(&test_prefix, host_platform);
 
@@ -1370,7 +1451,7 @@ async fn run_ruby_test(
     fs::create_dir_all(&test_folder)?;
 
     let (target_platform, build_platform, host_platform) = configured_test_platforms(config);
-    let test_env_vars = env_vars::os_vars(
+    let mut test_env_vars = env_vars::os_vars(
         &test_prefix,
         &target_platform,
         &host_platform,
@@ -1378,6 +1459,11 @@ async fn run_ruby_test(
         config.env_isolation,
         &test_folder,
         &RuntimeEnv::current(),
+    );
+    test_env_vars.extend(
+        env_vars_from_prefix_record(&test_prefix, pkg)
+            .into_iter()
+            .map(|(k, v)| (k, Some(v))),
     );
     let context = shared_test_context(&test_prefix, host_platform);
 

--- a/crates/rattler_build_core/src/package_test/run_test.rs
+++ b/crates/rattler_build_core/src/package_test/run_test.rs
@@ -19,7 +19,7 @@ use rattler_build_script::{
 use rattler_build_types::NormalizedKey;
 use rattler_conda_types::{
     Channel, ChannelUrl, MatchSpec, PackageName, PackageNameMatcher, ParseStrictness, Platform,
-    StringMatcher, Version, VersionSpec,
+    PrefixRecord, StringMatcher, Version, VersionSpec,
     compression_level::CompressionLevel,
     package::{ArchiveIdentifier, CondaArchiveIdentifier, IndexJson, PackageFile},
     version_spec::EqualityOperator,
@@ -415,6 +415,56 @@ fn env_vars_from_package(index_json: &IndexJson) -> HashMap<String, String> {
     res
 }
 
+/// Once the tested package has been linked into `prefix`, locate its
+/// `conda-meta/<name>-<version>-<build>.json` (the `PrefixRecord`) and derive
+/// the `PATHS_JSON` and `INDEX_JSON` env vars from its `extracted_package_dir`.
+///
+/// This spares test scripts from having to load the `PrefixRecord` themselves
+/// to find these files (see <https://github.com/prefix-dev/rattler-build/issues/1263>).
+fn env_vars_from_prefix_record(
+    prefix: &Path,
+    pkg: &CondaArchiveIdentifier,
+) -> HashMap<String, String> {
+    let mut res = HashMap::new();
+
+    let conda_meta_file = prefix.join("conda-meta").join(format!(
+        "{}-{}-{}.json",
+        pkg.identifier.name, pkg.identifier.version, pkg.identifier.build_string
+    ));
+
+    let prefix_record = match PrefixRecord::from_path(&conda_meta_file) {
+        Ok(record) => record,
+        Err(e) => {
+            tracing::debug!(
+                "could not read prefix record at '{}': {e}",
+                conda_meta_file.display()
+            );
+            return res;
+        }
+    };
+
+    let Some(extracted_package_dir) = &prefix_record.extracted_package_dir else {
+        return res;
+    };
+
+    res.insert(
+        "PATHS_JSON".to_string(),
+        extracted_package_dir
+            .join("info/paths.json")
+            .to_string_lossy()
+            .to_string(),
+    );
+    res.insert(
+        "INDEX_JSON".to_string(),
+        extracted_package_dir
+            .join("info/index.json")
+            .to_string_lossy()
+            .to_string(),
+    );
+
+    res
+}
+
 /// Read variant environment variables from `info/hash_input.json` in the
 /// package directory.  This file contains the full variant map that was used
 /// to build the package.  We expose every key as an environment variable
@@ -647,9 +697,18 @@ pub async fn run_test(
         let (test_folder, tests) =
             legacy_tests_from_folder(&package_folder, config.current_platform.platform).await?;
 
+        let mut legacy_env = env.clone();
+        legacy_env.extend(env_vars_from_prefix_record(&prefix, &pkg));
+
         for test in tests {
-            test.run(&prefix, &test_folder, &env, &resolved_records, &config)
-                .await?;
+            test.run(
+                &prefix,
+                &test_folder,
+                &legacy_env,
+                &resolved_records,
+                &config,
+            )
+            .await?;
         }
 
         tracing::info!(
@@ -812,6 +871,7 @@ async fn run_python_test(
     for (python_version, dependencies) in dependencies_map {
         run_python_test_inner(
             python_test,
+            pkg,
             python_version,
             dependencies,
             path,
@@ -826,6 +886,7 @@ async fn run_python_test(
 
 async fn run_python_test_inner(
     python_test: &PythonTest,
+    pkg: &CondaArchiveIdentifier,
     python_version: String,
     dependencies: Vec<MatchSpec>,
     path: &Path,
@@ -872,7 +933,7 @@ async fn run_python_test_inner(
     let (target_platform, build_platform, host_platform) = configured_test_platforms(config);
     let test_dir = prefix.join("test");
     fs::create_dir_all(&test_dir)?;
-    let test_env_vars = env_vars::os_vars(
+    let mut test_env_vars = env_vars::os_vars(
         &test_prefix,
         &target_platform,
         &host_platform,
@@ -880,6 +941,11 @@ async fn run_python_test_inner(
         config.env_isolation,
         &test_dir,
         &RuntimeEnv::current(),
+    );
+    test_env_vars.extend(
+        env_vars_from_prefix_record(&test_prefix, pkg)
+            .into_iter()
+            .map(|(k, v)| (k, Some(v))),
     );
 
     let context = shared_test_context(&test_prefix, host_platform);
@@ -985,7 +1051,7 @@ async fn run_perl_test(
     fs::create_dir_all(&test_folder)?;
 
     let (target_platform, build_platform, host_platform) = configured_test_platforms(config);
-    let test_env_vars = env_vars::os_vars(
+    let mut test_env_vars = env_vars::os_vars(
         &test_prefix,
         &target_platform,
         &host_platform,
@@ -993,6 +1059,11 @@ async fn run_perl_test(
         config.env_isolation,
         &test_folder,
         &RuntimeEnv::current(),
+    );
+    test_env_vars.extend(
+        env_vars_from_prefix_record(&test_prefix, pkg)
+            .into_iter()
+            .map(|(k, v)| (k, Some(v))),
     );
     let context = shared_test_context(&test_prefix, host_platform);
 
@@ -1125,6 +1196,11 @@ async fn run_commands_test(
         host_platform,
     ));
     env_vars.extend(pkg_vars.iter().map(|(k, v)| (k.clone(), Some(v.clone()))));
+    env_vars.extend(
+        env_vars_from_prefix_record(&run_prefix, pkg)
+            .into_iter()
+            .map(|(k, v)| (k, Some(v))),
+    );
     env_vars.insert(
         "PREFIX".to_string(),
         Some(run_prefix.to_string_lossy().to_string()),
@@ -1316,7 +1392,7 @@ async fn run_r_test(
     fs::create_dir_all(&test_folder)?;
 
     let (target_platform, build_platform, host_platform) = configured_test_platforms(config);
-    let test_env_vars = env_vars::os_vars(
+    let mut test_env_vars = env_vars::os_vars(
         &test_prefix,
         &target_platform,
         &host_platform,
@@ -1324,6 +1400,11 @@ async fn run_r_test(
         config.env_isolation,
         &test_folder,
         &RuntimeEnv::current(),
+    );
+    test_env_vars.extend(
+        env_vars_from_prefix_record(&test_prefix, pkg)
+            .into_iter()
+            .map(|(k, v)| (k, Some(v))),
     );
     let context = shared_test_context(&test_prefix, host_platform);
 
@@ -1400,7 +1481,7 @@ async fn run_ruby_test(
     fs::create_dir_all(&test_folder)?;
 
     let (target_platform, build_platform, host_platform) = configured_test_platforms(config);
-    let test_env_vars = env_vars::os_vars(
+    let mut test_env_vars = env_vars::os_vars(
         &test_prefix,
         &target_platform,
         &host_platform,
@@ -1408,6 +1489,11 @@ async fn run_ruby_test(
         config.env_isolation,
         &test_folder,
         &RuntimeEnv::current(),
+    );
+    test_env_vars.extend(
+        env_vars_from_prefix_record(&test_prefix, pkg)
+            .into_iter()
+            .map(|(k, v)| (k, Some(v))),
     );
     let context = shared_test_context(&test_prefix, host_platform);
 

--- a/crates/rattler_build_core/src/package_test/run_test.rs
+++ b/crates/rattler_build_core/src/package_test/run_test.rs
@@ -19,7 +19,7 @@ use rattler_build_script::{
 use rattler_build_types::NormalizedKey;
 use rattler_conda_types::{
     Channel, ChannelUrl, MatchSpec, PackageName, PackageNameMatcher, ParseStrictness, Platform,
-    PrefixRecord, StringMatcher, Version, VersionSpec,
+    RepoDataRecord, StringMatcher, Version, VersionSpec,
     compression_level::CompressionLevel,
     package::{ArchiveIdentifier, CondaArchiveIdentifier, IndexJson, PackageFile},
     version_spec::EqualityOperator,
@@ -203,19 +203,13 @@ impl Tests {
         &self,
         environment: &Path,
         cwd: &Path,
-        pkg_vars: &HashMap<String, String>,
-        resolved_records: &[rattler_conda_types::RepoDataRecord],
+        package_folder: &Path,
+        resolved_records: &[RepoDataRecord],
         config: &TestConfiguration,
     ) -> Result<(), TestError> {
         tracing::info!("Testing commands:");
 
-        let target_platform = config.target_platform.unwrap_or(Platform::current());
-        let build_platform = config.current_platform.platform;
-        let host_platform = config
-            .host_platform
-            .as_ref()
-            .map(|p| p.platform)
-            .unwrap_or(target_platform);
+        let (_, _, host_platform) = configured_test_platforms(config);
 
         let tmp_dir = tempfile::tempdir()?;
 
@@ -228,34 +222,13 @@ impl Tests {
             )))
         })?;
 
-        let mut env_vars = env_vars::os_vars(
+        let env_vars = test_env_vars(
             environment,
-            &target_platform,
-            &host_platform,
-            &build_platform,
-            config.env_isolation,
             tmp_dir.path(),
-            &RuntimeEnv::current(),
-        );
-        if config.env_isolation == EnvironmentIsolation::None {
-            env_vars.retain(|key, _| key != ShellEnum::default().path_var(&build_platform));
-        }
-        env_vars.extend(env_vars::test_vars(
-            target_platform,
-            build_platform,
-            host_platform,
-            tmp_dir.path(),
-        ));
-        env_vars.extend(env_vars::python_vars_from_records(
+            package_folder,
             resolved_records,
-            environment,
-            host_platform,
-        ));
-        env_vars.extend(pkg_vars.iter().map(|(k, v)| (k.clone(), Some(v.clone()))));
-        env_vars.insert(
-            "PREFIX".to_string(),
-            Some(environment.to_string_lossy().to_string()),
-        );
+            config,
+        )?;
 
         let context = shared_test_context(environment, host_platform);
 
@@ -415,54 +388,64 @@ fn env_vars_from_package(index_json: &IndexJson) -> HashMap<String, String> {
     res
 }
 
-/// Once the tested package has been linked into `prefix`, locate its
-/// `conda-meta/<name>-<version>-<build>.json` (the `PrefixRecord`) and derive
-/// the `PATHS_JSON` and `INDEX_JSON` env vars from its `extracted_package_dir`.
-///
-/// This spares test scripts from having to load the `PrefixRecord` themselves
-/// to find these files (see <https://github.com/prefix-dev/rattler-build/issues/1263>).
-fn env_vars_from_prefix_record(
+/// Assemble the environment shared by legacy, script, and language tests.
+fn test_env_vars(
     prefix: &Path,
-    pkg: &CondaArchiveIdentifier,
-) -> HashMap<String, String> {
-    let mut res = HashMap::new();
-
-    let conda_meta_file = prefix.join("conda-meta").join(format!(
-        "{}-{}-{}.json",
-        pkg.identifier.name, pkg.identifier.version, pkg.identifier.build_string
+    cwd: &Path,
+    package_folder: &Path,
+    resolved_records: &[RepoDataRecord],
+    config: &TestConfiguration,
+) -> Result<HashMap<String, Option<String>>, TestError> {
+    let (target_platform, build_platform, host_platform) = configured_test_platforms(config);
+    let mut vars = env_vars::os_vars(
+        prefix,
+        &target_platform,
+        &host_platform,
+        &build_platform,
+        config.env_isolation,
+        cwd,
+        &RuntimeEnv::current(),
+    );
+    if config.env_isolation == EnvironmentIsolation::None {
+        vars.retain(|key, _| key != ShellEnum::default().path_var(&build_platform));
+    }
+    vars.extend(env_vars::test_vars(
+        target_platform,
+        build_platform,
+        host_platform,
+        cwd,
     ));
-
-    let prefix_record = match PrefixRecord::from_path(&conda_meta_file) {
-        Ok(record) => record,
-        Err(e) => {
-            tracing::debug!(
-                "could not read prefix record at '{}': {e}",
-                conda_meta_file.display()
-            );
-            return res;
-        }
-    };
-
-    let Some(extracted_package_dir) = &prefix_record.extracted_package_dir else {
-        return res;
-    };
-
-    res.insert(
-        "PATHS_JSON".to_string(),
-        extracted_package_dir
-            .join("info/paths.json")
-            .to_string_lossy()
-            .to_string(),
+    vars.extend(env_vars::python_vars_from_records(
+        resolved_records,
+        prefix,
+        host_platform,
+    ));
+    let index_json = IndexJson::from_package_directory(package_folder)?;
+    vars.extend(
+        env_vars_from_package(&index_json)
+            .into_iter()
+            .map(|(k, v)| (k, Some(v))),
     );
-    res.insert(
-        "INDEX_JSON".to_string(),
-        extracted_package_dir
-            .join("info/index.json")
-            .to_string_lossy()
-            .to_string(),
+    vars.extend(env_vars_from_hash_input(package_folder));
+    vars.insert(
+        "PREFIX".to_string(),
+        Some(prefix.to_string_lossy().into_owned()),
     );
 
-    res
+    // The package is already extracted for reading its tests; reuse that metadata.
+    for (key, file) in [("PATHS_JSON", "paths.json"), ("INDEX_JSON", "index.json")] {
+        vars.insert(
+            key.to_string(),
+            Some(
+                package_folder
+                    .join("info")
+                    .join(file)
+                    .to_string_lossy()
+                    .into_owned(),
+            ),
+        );
+    }
+    Ok(vars)
 }
 
 /// Read variant environment variables from `info/hash_input.json` in the
@@ -644,14 +627,6 @@ pub async fn run_test(
 
     tracing::info!("Collecting tests from '{}'", package_folder.display());
 
-    let index_json = IndexJson::from_package_directory(&package_folder)?;
-    let mut env = env_vars_from_package(&index_json);
-    env.extend(
-        env_vars_from_hash_input(&package_folder)
-            .into_iter()
-            .filter_map(|(k, v)| v.map(|v| (k, v))),
-    );
-
     let has_legacy_tests = package_folder.join("info/test").exists();
     let has_modern_tests = package_folder.join("info/tests/tests.yaml").exists();
 
@@ -697,14 +672,11 @@ pub async fn run_test(
         let (test_folder, tests) =
             legacy_tests_from_folder(&package_folder, config.current_platform.platform).await?;
 
-        let mut legacy_env = env.clone();
-        legacy_env.extend(env_vars_from_prefix_record(&prefix, &pkg));
-
         for test in tests {
             test.run(
                 &prefix,
                 &test_folder,
-                &legacy_env,
+                &package_folder,
                 &resolved_records,
                 &config,
             )
@@ -749,8 +721,7 @@ pub async fn run_test(
             .keep();
             match test {
                 TestType::Commands(c) => {
-                    run_commands_test(&c, &pkg, &package_folder, &test_prefix, &config, &env)
-                        .await?
+                    run_commands_test(&c, &pkg, &package_folder, &test_prefix, &config).await?
                 }
                 TestType::Python { python } => {
                     // A downstream package's Python test matrix describes the Python
@@ -871,7 +842,6 @@ async fn run_python_test(
     for (python_version, dependencies) in dependencies_map {
         run_python_test_inner(
             python_test,
-            pkg,
             python_version,
             dependencies,
             path,
@@ -886,7 +856,6 @@ async fn run_python_test(
 
 async fn run_python_test_inner(
     python_test: &PythonTest,
-    pkg: &CondaArchiveIdentifier,
     python_version: String,
     dependencies: Vec<MatchSpec>,
     path: &Path,
@@ -901,7 +870,7 @@ async fn run_python_test_inner(
     let _guard = span.enter();
 
     let test_prefix = prefix.join("test_env");
-    create_environment(
+    let resolved_records = create_environment(
         "test",
         &dependencies,
         config
@@ -930,23 +899,10 @@ async fn run_python_test_inner(
         ..Script::default()
     };
 
-    let (target_platform, build_platform, host_platform) = configured_test_platforms(config);
+    let (_, _, host_platform) = configured_test_platforms(config);
     let test_dir = prefix.join("test");
     fs::create_dir_all(&test_dir)?;
-    let mut test_env_vars = env_vars::os_vars(
-        &test_prefix,
-        &target_platform,
-        &host_platform,
-        &build_platform,
-        config.env_isolation,
-        &test_dir,
-        &RuntimeEnv::current(),
-    );
-    test_env_vars.extend(
-        env_vars_from_prefix_record(&test_prefix, pkg)
-            .into_iter()
-            .map(|(k, v)| (k, Some(v))),
-    );
+    let test_env_vars = test_env_vars(&test_prefix, &test_dir, path, &resolved_records, config)?;
 
     let context = shared_test_context(&test_prefix, host_platform);
 
@@ -1014,7 +970,7 @@ async fn run_perl_test(
     let dependencies = vec!["perl".parse().unwrap(), match_spec];
 
     let test_prefix = prefix.join("test_env");
-    create_environment(
+    let resolved_records = create_environment(
         "test",
         &dependencies,
         config
@@ -1050,21 +1006,8 @@ async fn run_perl_test(
     let test_folder = prefix.join("test_files");
     fs::create_dir_all(&test_folder)?;
 
-    let (target_platform, build_platform, host_platform) = configured_test_platforms(config);
-    let mut test_env_vars = env_vars::os_vars(
-        &test_prefix,
-        &target_platform,
-        &host_platform,
-        &build_platform,
-        config.env_isolation,
-        &test_folder,
-        &RuntimeEnv::current(),
-    );
-    test_env_vars.extend(
-        env_vars_from_prefix_record(&test_prefix, pkg)
-            .into_iter()
-            .map(|(k, v)| (k, Some(v))),
-    );
+    let (_, _, host_platform) = configured_test_platforms(config);
+    let test_env_vars = test_env_vars(&test_prefix, &test_folder, path, &resolved_records, config)?;
     let context = shared_test_context(&test_prefix, host_platform);
 
     script
@@ -1090,7 +1033,6 @@ async fn run_commands_test(
     path: &Path,
     test_directory: &Path,
     config: &TestConfiguration,
-    pkg_vars: &HashMap<String, String>,
 ) -> Result<(), TestError> {
     let deps = commands_test.requirements.clone();
 
@@ -1154,13 +1096,7 @@ async fn run_commands_test(
     .wrap_err("failed to setup test environment")
     .map_err(TestError::TestEnvironmentSetup)?;
 
-    let target_platform = config.target_platform.unwrap_or(Platform::current());
-    let build_platform = config.current_platform.platform;
-    let host_platform = config
-        .host_platform
-        .as_ref()
-        .map(|p| p.platform)
-        .unwrap_or(target_platform);
+    let (_, build_platform, host_platform) = configured_test_platforms(config);
 
     // copy all test files to a temporary directory and set it as the working
     // directory
@@ -1172,39 +1108,7 @@ async fn run_commands_test(
         )))
     })?;
 
-    let mut env_vars = env_vars::os_vars(
-        &run_prefix,
-        &target_platform,
-        &host_platform,
-        &build_platform,
-        config.env_isolation,
-        &test_dir,
-        &RuntimeEnv::current(),
-    );
-    if config.env_isolation == EnvironmentIsolation::None {
-        env_vars.retain(|key, _| key != ShellEnum::default().path_var(&build_platform));
-    }
-    env_vars.extend(env_vars::test_vars(
-        target_platform,
-        build_platform,
-        host_platform,
-        &test_dir,
-    ));
-    env_vars.extend(env_vars::python_vars_from_records(
-        &resolved_records,
-        &run_prefix,
-        host_platform,
-    ));
-    env_vars.extend(pkg_vars.iter().map(|(k, v)| (k.clone(), Some(v.clone()))));
-    env_vars.extend(
-        env_vars_from_prefix_record(&run_prefix, pkg)
-            .into_iter()
-            .map(|(k, v)| (k, Some(v))),
-    );
-    env_vars.insert(
-        "PREFIX".to_string(),
-        Some(run_prefix.to_string_lossy().to_string()),
-    );
+    let env_vars = test_env_vars(&run_prefix, &test_dir, path, &resolved_records, config)?;
 
     let context = if let Some(build_prefix) = build_prefix {
         ExecutionContext::separate(
@@ -1355,7 +1259,7 @@ async fn run_r_test(
 
     let dependencies = vec!["r-base".parse().unwrap(), match_spec];
     let test_prefix = prefix.join("test_env");
-    create_environment(
+    let resolved_records = create_environment(
         "test",
         &dependencies,
         config
@@ -1391,21 +1295,8 @@ async fn run_r_test(
     let test_folder = prefix.join("test_files");
     fs::create_dir_all(&test_folder)?;
 
-    let (target_platform, build_platform, host_platform) = configured_test_platforms(config);
-    let mut test_env_vars = env_vars::os_vars(
-        &test_prefix,
-        &target_platform,
-        &host_platform,
-        &build_platform,
-        config.env_isolation,
-        &test_folder,
-        &RuntimeEnv::current(),
-    );
-    test_env_vars.extend(
-        env_vars_from_prefix_record(&test_prefix, pkg)
-            .into_iter()
-            .map(|(k, v)| (k, Some(v))),
-    );
+    let (_, _, host_platform) = configured_test_platforms(config);
+    let test_env_vars = test_env_vars(&test_prefix, &test_folder, path, &resolved_records, config)?;
     let context = shared_test_context(&test_prefix, host_platform);
 
     script
@@ -1444,7 +1335,7 @@ async fn run_ruby_test(
     let dependencies = vec!["ruby".parse().unwrap(), match_spec];
 
     let test_prefix = prefix.join("test_env");
-    create_environment(
+    let resolved_records = create_environment(
         "test",
         &dependencies,
         config
@@ -1480,21 +1371,8 @@ async fn run_ruby_test(
     let test_folder = prefix.join("test_files");
     fs::create_dir_all(&test_folder)?;
 
-    let (target_platform, build_platform, host_platform) = configured_test_platforms(config);
-    let mut test_env_vars = env_vars::os_vars(
-        &test_prefix,
-        &target_platform,
-        &host_platform,
-        &build_platform,
-        config.env_isolation,
-        &test_folder,
-        &RuntimeEnv::current(),
-    );
-    test_env_vars.extend(
-        env_vars_from_prefix_record(&test_prefix, pkg)
-            .into_iter()
-            .map(|(k, v)| (k, Some(v))),
-    );
+    let (_, _, host_platform) = configured_test_platforms(config);
+    let test_env_vars = test_env_vars(&test_prefix, &test_folder, path, &resolved_records, config)?;
     let context = shared_test_context(&test_prefix, host_platform);
 
     script

--- a/docs/build_script.md
+++ b/docs/build_script.md
@@ -485,6 +485,19 @@ noted, no variables are inherited from the shell environment in which you invoke
 : Represents the hash of the package being built, excluding the
   leading 'h' (e.g. 21422ab).
 
+`PATHS_JSON`
+
+: Only set during the test phase. The path to the `info/paths.json` file of
+  the package under test, resolved from its `conda-meta` `PrefixRecord` once
+  the package has been linked into the test prefix. Lets test scripts inspect
+  the exact list of files the package installed without having to locate and
+  parse the `PrefixRecord` themselves.
+
+`INDEX_JSON`
+
+: Only set during the test phase. The path to the `info/index.json` file of
+  the package under test, resolved the same way as `PATHS_JSON`.
+
 `PYTHON`
 
 : The path to the Python executable in the host prefix. Python is

--- a/docs/build_script.md
+++ b/docs/build_script.md
@@ -487,16 +487,15 @@ noted, no variables are inherited from the shell environment in which you invoke
 
 `PATHS_JSON`
 
-: Only set during the test phase. The path to the `info/paths.json` file of
-  the package under test, resolved from its `conda-meta` `PrefixRecord` once
-  the package has been linked into the test prefix. Lets test scripts inspect
-  the exact list of files the package installed without having to locate and
-  parse the `PrefixRecord` themselves.
+: Only set during the test phase. The path to `info/paths.json` in the
+  extracted package under test. This describes paths in the package archive,
+  which can differ from installed paths (for example, for noarch Python
+  packages).
 
 `INDEX_JSON`
 
-: Only set during the test phase. The path to the `info/index.json` file of
-  the package under test, resolved the same way as `PATHS_JSON`.
+: Only set during the test phase. The path to `info/index.json` in the
+  extracted package under test.
 
 `PYTHON`
 

--- a/test-data/recipes/test-execution/recipe-test-succeed.yaml
+++ b/test-data/recipes/test-execution/recipe-test-succeed.yaml
@@ -49,3 +49,14 @@ tests:
           - if not "%PKG_BUILDNUM%" == "0" (exit 1)
           # make sure that the build string is not empty
           - if "%PKG_BUILD_STRING%" == "" (exit 1)
+  - script:
+      # PATHS_JSON and INDEX_JSON should point at the `info/paths.json` and
+      # `info/index.json` of the package that was just installed for testing.
+      - if: unix
+        then:
+          - test -f "$PATHS_JSON"
+          - test -f "$INDEX_JSON"
+          - grep -q "test-execution" "$INDEX_JSON"
+        else:
+          - if not exist "%PATHS_JSON%" (exit 1)
+          - if not exist "%INDEX_JSON%" (exit 1)

--- a/test-data/recipes/test-execution/recipe-test-succeed.yaml
+++ b/test-data/recipes/test-execution/recipe-test-succeed.yaml
@@ -57,6 +57,9 @@ tests:
           - test -f "$PATHS_JSON"
           - test -f "$INDEX_JSON"
           - grep -q "test-execution" "$INDEX_JSON"
+          - grep -Fq "test-execution.txt" "$PATHS_JSON"
         else:
           - if not exist "%PATHS_JSON%" (exit 1)
           - if not exist "%INDEX_JSON%" (exit 1)
+          - findstr /L /C:"test-execution" "%INDEX_JSON%" || exit /b 1
+          - findstr /L /C:"test-execution.txt" "%PATHS_JSON%" || exit /b 1


### PR DESCRIPTION
## Summary

- Test scripts previously had no easy way to find a package's `info/paths.json` or `info/index.json` - the only path was to load the `PrefixRecord` from `conda-meta` and locate where the package was linked from. This adds `PATHS_JSON` and `INDEX_JSON` environment variables during the test phase so test scripts can reference these files directly.
- Documented both variables in `docs/build_script.md` and added a `CHANGELOG.md` entry.

Closes https://github.com/prefix-dev/rattler-build/issues/1263

cc: @wolfv 