### PR TITLE
feat: display optional dependency groups (extras) in dependency tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `SHLIB_EXT` variable (shared library extension for the target platform, e.g. `.so`, `.dylib`, `.dll`) is now available in Jinja templates, so it can be used in fields such as `build.files` (e.g. `foo${{ SHLIB_EXT }}`). It previously was only set as a build-script environment variable. (#2532)
 - The `source.filter` field is now also supported for `url` and `git` sources (it was previously only available for `path` sources). The filter is applied to the files copied into the work directory: the contents of the extracted archive for `url` sources (and `path` sources pointing to an archive) and the checked-out tree for `git` sources. This allows large sources to be trimmed down to the parts needed for the build.
 - An empty `sha256` or `md5` (e.g. `sha256: ""`) is now accepted and treated as an all-zeros placeholder (`0000...0000`). This makes it easier to scaffold a recipe before the real checksum is known: the build downloads the source and reports the actual checksum in the resulting mismatch. (#2524)
+- The build summary now prints a section for each `requirements.extras` group (optional dependency group) in the run dependencies table, so the resolved contents of each extra are visible. The section is omitted when the recipe defines no extras.
 
 ### Changed
 

--- a/crates/rattler_build_core/src/render/resolved_dependencies.rs
+++ b/crates/rattler_build_core/src/render/resolved_dependencies.rs
@@ -475,6 +475,20 @@ impl FinalizedRunDependencies {
             has_previous_section = true;
         }
 
+        // Add a section for each extra (optional dependency group)
+        for (extra_name, extra_deps) in &self.extra_depends {
+            let extra_rendered = render_grouped_dependencies(extra_deps, long);
+            if extra_rendered.is_empty() {
+                continue;
+            }
+            if has_previous_section {
+                table.add_row(vec!["", ""]);
+            }
+            add_section_header(&mut table, &format!("Extra ({extra_name})"));
+            add_grouped_items(&mut table, &extra_rendered);
+            has_previous_section = true;
+        }
+
         // Add run exports sections if not empty
         if !self.run_exports.is_empty() {
             let sections = [
@@ -1258,5 +1272,34 @@ mod tests {
                 ("scipy".to_string(), r#"[when="python>=3.10"]"#.to_string()),
             ]
         );
+    }
+
+    #[test]
+    fn test_to_table_renders_extras() {
+        let source_dep = |spec: &str| -> DependencyInfo {
+            SourceDependency {
+                spec: MatchSpec::from_str(spec, ParseStrictness::Strict).unwrap(),
+            }
+            .into()
+        };
+
+        let mut extra_depends = BTreeMap::new();
+        extra_depends.insert("science".to_string(), vec![source_dep("numpy")]);
+        extra_depends.insert("plot".to_string(), vec![source_dep("matplotlib")]);
+
+        let run = FinalizedRunDependencies {
+            depends: vec![source_dep("python")],
+            constraints: vec![],
+            extra_depends,
+            run_exports: Default::default(),
+        };
+
+        let table = comfy_table::Table::new();
+        let rendered = run.to_table(table, false).to_string();
+
+        assert!(rendered.contains("Extra (science)"));
+        assert!(rendered.contains("numpy"));
+        assert!(rendered.contains("Extra (plot)"));
+        assert!(rendered.contains("matplotlib"));
     }
 }

--- a/crates/rattler_build_core/src/types/build_output.rs
+++ b/crates/rattler_build_core/src/types/build_output.rs
@@ -355,7 +355,11 @@ impl BuildOutput {
                 writeln!(f, "{}\n", host.to_table(template(), long))?;
             }
 
-            if !finalized_dependencies.run.depends.is_empty() {
+            let run = &finalized_dependencies.run;
+            if !run.depends.is_empty()
+                || !run.constraints.is_empty()
+                || !run.extra_depends.is_empty()
+            {
                 writeln!(f, "Run dependencies:")?;
                 writeln!(
                     f,


### PR DESCRIPTION
## Summary
This PR adds support for rendering optional dependency groups (extras) in the dependency output tables. When a package has extra dependencies defined, they are now displayed in separate sections in the formatted output.

Renders as:

```
Run dependencies:
╭──────────────────┬──────────────────────────────╮
│ Name             ┆ Spec                         │
╞══════════════════╪══════════════════════════════╡
│ Run dependencies ┆                              │
│ python           ┆ *                            │
│                  ┆                              │
│ Extra (all)      ┆                              │
│ foobar           ┆ [extras=[science, plot]]     │
│                  ┆                              │
│ Extra (plot)     ┆                              │
│ matplotlib       ┆ *                            │
│                  ┆                              │
│ Extra (science)  ┆                              │
│ numpy            ┆ *                            │
╰──────────────────┴──────────────────────────────╯
```

## Key Changes
- **Dependency rendering**: Added a new section in `FinalizedRunDependencies::to_table()` that iterates through extra dependencies and renders each extra as a separate table section with the format "Extra ({extra_name})"
- **Output condition**: Updated the run dependencies display logic to show the "Run dependencies:" header when there are extra dependencies present, even if the main `depends` list is empty
- **Test coverage**: Added `test_to_table_renders_extras()` to verify that extras are properly rendered in the output table with correct section headers and dependency names

## Implementation Details
- Extra dependencies are rendered using the existing `render_grouped_dependencies()` and `add_grouped_items()` helper functions, maintaining consistency with other dependency sections
- Empty extra sections are skipped to avoid cluttering the output
- Proper spacing is maintained between sections using the existing `has_previous_section` flag
- The implementation follows the same pattern as other dependency sections (run exports, constraints, etc.)

https://claude.ai/code/session_01VBhHJGao4Bc1LjbiNcn3PC