### PR TITLE
feat: warn about R dependencies missing from conda-forge in generated recipes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5084,6 +5084,7 @@ dependencies = [
  "miette",
  "rattler_conda_types",
  "rattler_digest",
+ "rattler_repodata_gateway",
  "regex",
  "reqwest",
  "serde",
@@ -5096,6 +5097,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "tracing-test",
  "url",
  "zip",
 ]

--- a/crates/rattler_build_recipe_generator/Cargo.toml
+++ b/crates/rattler_build_recipe_generator/Cargo.toml
@@ -40,8 +40,10 @@ zip = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 fs-err = { workspace = true }
+rattler_repodata_gateway = { workspace = true }
 tempfile = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true, features = ["yaml"] }
 tokio = { workspace = true }
+tracing-test = { workspace = true }

--- a/crates/rattler_build_recipe_generator/src/cran.rs
+++ b/crates/rattler_build_recipe_generator/src/cran.rs
@@ -912,7 +912,14 @@ mod tests {
     /// Build a `CranOpts` configured to check the given channel names via
     /// `--skip-available`.
     fn opts_with_skip_available(channels: &[&str]) -> CranOpts {
+        opts_with_tree_and_skip_available(false, channels)
+    }
+
+    /// Build a `CranOpts` with `tree` set as given, configured to check the
+    /// given channel names via `--skip-available`.
+    fn opts_with_tree_and_skip_available(tree: bool, channels: &[&str]) -> CranOpts {
         CranOpts {
+            tree,
             skip_available: channels.iter().map(|c| c.parse().unwrap()).collect(),
             ..dummy_cran_opts()
         }
@@ -971,6 +978,84 @@ mod tests {
         let missing = find_missing_deps(&deps, &dummy_cran_opts()).await.unwrap();
 
         assert!(missing.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_find_missing_deps_returns_nothing_with_tree_but_no_channels_configured() {
+        let mut deps = HashSet::new();
+        deps.insert("this_package_does_not_exist_xyz123".to_string());
+        let opts = opts_with_tree_and_skip_available(true, &[]);
+
+        // `find_missing_deps` is governed solely by `--skip-available`;
+        // `--tree` being set doesn't change that no channels means no check
+        // is made.
+        let missing = find_missing_deps(&deps, &opts).await.unwrap();
+
+        assert!(missing.is_empty());
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_find_missing_deps_with_tree_and_single_channel() {
+        let fake_dep = "this_package_does_not_exist_xyz123";
+        let mut deps = HashSet::new();
+        deps.insert("jsonlite".to_string());
+        deps.insert(fake_dep.to_string());
+        let opts = opts_with_tree_and_skip_available(true, &["conda-forge"]);
+
+        let missing = find_missing_deps(&deps, &opts).await.unwrap();
+
+        // `jsonlite` is on conda-forge, so `--tree --skip-available
+        // conda-forge` excludes it from `missing`.
+        assert!(!missing.contains(&"jsonlite".to_string()));
+        // The fake dependency isn't on conda-forge, so it's flagged missing
+        // -- unless the check itself failed open due to a network error,
+        // which we confirm below rather than assume.
+        if !missing.contains(&fake_dep.to_string()) {
+            let gateway = Gateway::new();
+            let package_name = format!("r-{fake_dep}").parse().unwrap();
+            assert!(
+                query_channels_for_packages(
+                    &gateway,
+                    vec![conda_forge_channel()],
+                    vec![package_name]
+                )
+                .await
+                .is_err(),
+                "fake dependency unexpectedly reported as existing on conda-forge"
+            );
+        }
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_find_missing_deps_with_tree_and_multiple_channels() {
+        let fake_dep = "this_package_does_not_exist_xyz123";
+        let mut deps = HashSet::new();
+        deps.insert("jsonlite".to_string());
+        deps.insert(fake_dep.to_string());
+        let opts = opts_with_tree_and_skip_available(true, &["conda-forge", "bioconda"]);
+
+        let missing = find_missing_deps(&deps, &opts).await.unwrap();
+
+        // `jsonlite` is available in at least one of the configured channels
+        // (conda-forge), so passing multiple `--skip-available` channels
+        // still excludes it from `missing`.
+        assert!(!missing.contains(&"jsonlite".to_string()));
+        // The fake dependency isn't in either channel, so it's flagged
+        // missing -- unless the check itself failed open due to a network
+        // error, which we confirm below rather than assume.
+        if !missing.contains(&fake_dep.to_string()) {
+            let gateway = Gateway::new();
+            let package_name = format!("r-{fake_dep}").parse().unwrap();
+            let channels = resolve_skip_available_channels(&opts.skip_available).unwrap();
+            assert!(
+                query_channels_for_packages(&gateway, channels, vec![package_name])
+                    .await
+                    .is_err(),
+                "fake dependency unexpectedly reported as existing in conda-forge or bioconda"
+            );
+        }
     }
 
     #[test]

--- a/crates/rattler_build_recipe_generator/src/cran.rs
+++ b/crates/rattler_build_recipe_generator/src/cran.rs
@@ -6,7 +6,11 @@ use std::{collections::HashMap, collections::HashSet};
 use clap::Parser;
 use itertools::Itertools;
 use miette::IntoDiagnostic;
+#[cfg(not(target_arch = "wasm32"))]
+use rattler_conda_types::{Channel, ChannelConfig, PackageName, Platform};
 use rattler_digest::{Sha256Hash, compute_bytes_digest};
+#[cfg(not(target_arch = "wasm32"))]
+use rattler_repodata_gateway::{Gateway, GatewayError, RepoData};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use url::Url;
@@ -71,9 +75,18 @@ pub struct CranOpts {
     #[cfg_attr(feature = "cli", arg(short, long))]
     pub universe: Option<String>,
 
-    /// Whether to create recipes for the whole dependency tree or not
+    /// Whether to recursively generate recipes for dependencies. By default,
+    /// only dependencies missing from conda-forge are recursed into (mirrors
+    /// grayskull's `--recursive`); pass `--full` as well to recurse into the
+    /// whole dependency tree regardless of conda-forge status.
     #[cfg_attr(feature = "cli", arg(short, long))]
     pub tree: bool,
+
+    /// Modifies `--tree` to recurse into every dependency, including ones
+    /// already available on conda-forge. Has no effect unless `--tree` is
+    /// also set.
+    #[cfg_attr(feature = "cli", arg(short, long))]
+    pub full: bool,
 
     /// Name of the package to generate
     pub package: String,
@@ -246,6 +259,115 @@ pub async fn fetch_package_sha256sum(url: &Url) -> Result<Sha256Hash, miette::Er
     let response = client.get(url.clone()).send().await.into_diagnostic()?;
     let bytes = response.bytes().await.into_diagnostic()?;
     Ok(compute_bytes_digest::<Sha256>(&bytes))
+}
+
+/// The default "conda-forge" channel, resolved against the standard
+/// `https://conda.anaconda.org` alias.
+#[cfg(not(target_arch = "wasm32"))]
+fn conda_forge_channel() -> Channel {
+    let channel_config = ChannelConfig::default_with_root_dir(
+        std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("/")),
+    );
+    Channel::from_name("conda-forge", &channel_config)
+}
+
+/// Query `channel` via the repodata gateway for which of `package_names`
+/// are present there, for the host platform or `noarch`. Queries every name
+/// in a single batched request rather than one at a time, since the
+/// gateway can fetch multiple packages concurrently.
+#[cfg(not(target_arch = "wasm32"))]
+async fn query_conda_forge_channel(
+    gateway: &Gateway,
+    channel: Channel,
+    package_names: Vec<PackageName>,
+) -> Result<HashSet<PackageName>, GatewayError> {
+    let output = gateway
+        .query(
+            vec![channel],
+            [Platform::current(), Platform::NoArch],
+            package_names,
+        )
+        .recursive(false)
+        .await?;
+    Ok(output
+        .iter()
+        .flat_map(RepoData::iter)
+        .map(|record| record.package_record.name.clone())
+        .collect())
+}
+
+/// Check `deps` against `channel`, returning those that aren't available
+/// there (as the original, non-prefixed dependency names). Checks all of
+/// `deps` in a single batched gateway query. Split out from
+/// [`find_missing_conda_forge_deps`] so tests can exercise the
+/// network-error branch deterministically by pointing it at an unreachable
+/// channel.
+///
+/// Network errors (and unparsable package names) are treated as "exists"
+/// so connectivity issues don't produce spurious warnings.
+#[cfg(not(target_arch = "wasm32"))]
+async fn find_missing_conda_forge_deps_in(channel: Channel, deps: &HashSet<String>) -> Vec<String> {
+    if deps.is_empty() {
+        return Vec::new();
+    }
+
+    let mut package_name_to_dep = HashMap::new();
+    for dep in deps {
+        let conda_name = format_r_package(dep, None);
+        match conda_name.parse::<PackageName>() {
+            Ok(package_name) => {
+                package_name_to_dep.insert(package_name, dep.clone());
+            }
+            Err(e) => {
+                // Fail open for this dep: an unparsable name can't be
+                // confirmed missing, so don't warn about it.
+                tracing::debug!("Invalid conda package name '{}': {}", conda_name, e);
+            }
+        }
+    }
+
+    let gateway = Gateway::new();
+    let package_names = package_name_to_dep.keys().cloned().collect();
+    let found = match query_conda_forge_channel(&gateway, channel, package_names).await {
+        Ok(found) => found,
+        Err(e) => {
+            // Fail open: a query-wide failure shouldn't produce spurious
+            // warnings for every dependency.
+            tracing::debug!("Failed to check conda-forge: {}", e);
+            return Vec::new();
+        }
+    };
+
+    package_name_to_dep
+        .into_iter()
+        .filter(|(name, _)| !found.contains(name))
+        .map(|(_, dep)| dep)
+        .collect()
+}
+
+/// Check `deps` against conda-forge, returning those that aren't available
+/// there yet (as the original, non-prefixed dependency names).
+///
+/// Unlike PyPI, CRAN package names map to conda-forge by a fixed convention
+/// (`foo` -> `r-foo`, see [`format_r_package`]), so no name-mapping lookup is
+/// needed here, only an existence check via the repodata gateway.
+#[cfg(not(target_arch = "wasm32"))]
+async fn find_missing_conda_forge_deps(deps: &HashSet<String>) -> Vec<String> {
+    find_missing_conda_forge_deps_in(conda_forge_channel(), deps).await
+}
+
+/// Warn about each dependency in `missing`, so the user knows upfront which
+/// recipes they need to package first.
+#[cfg(not(target_arch = "wasm32"))]
+fn warn_about_missing_conda_forge_deps(missing: &[String]) {
+    for dep in missing {
+        let conda_name = format_r_package(dep, None);
+        tracing::warn!(
+            "Dependency '{}' does not appear to be available on conda-forge as '{}'. You may need to create and publish a recipe for it first.",
+            dep,
+            conda_name
+        );
+    }
 }
 
 // Found when running `installed.packages()` in an `r-base` environment
@@ -519,7 +641,9 @@ pub async fn generate_r_recipe_string(
 ///
 /// If `opts.write` is true, the recipe is written to a folder named after the
 /// package. Otherwise, the YAML is printed to stdout. When `tree` is enabled,
-/// dependencies are recursively generated if they don't already exist locally.
+/// dependencies that don't already exist locally are recursively generated:
+/// by default only those missing from conda-forge, or every dependency if
+/// `full` is also set.
 pub async fn generate_r_recipe(opts: &CranOpts) -> miette::Result<()> {
     let (recipe, remaining_deps) =
         build_cran_recipe_and_deps(&opts.package, opts.universe.as_deref()).await?;
@@ -532,17 +656,58 @@ pub async fn generate_r_recipe(opts: &CranOpts) -> miette::Result<()> {
         print!("{}", final_recipe);
     }
 
-    if opts.tree {
-        for dep in remaining_deps {
-            let r_package = format_r_package(&dep, None);
+    let missing_deps = find_missing_conda_forge_deps(&remaining_deps).await;
+    warn_about_missing_conda_forge_deps(&missing_deps);
 
-            if !PathBuf::from(r_package).exists() {
-                let opts = CranOpts {
-                    package: dep,
-                    ..opts.clone()
-                };
-                generate_r_recipe(&opts).await?;
-            }
+    generate_recipes_for_deps(
+        select_deps_to_recurse(remaining_deps, missing_deps, opts),
+        opts,
+    )
+    .await?;
+
+    Ok(())
+}
+
+/// Decide which dependencies to recursively generate recipes for:
+/// - without `tree`, none;
+/// - with `tree` alone, only those missing from conda-forge (generating
+///   recipes for ones already available there isn't useful, since those
+///   boilerplate recipes would need further changes to be valid anyway);
+/// - with `tree` and `full`, every dependency, regardless of conda-forge
+///   status.
+#[cfg(not(target_arch = "wasm32"))]
+fn select_deps_to_recurse(
+    remaining_deps: HashSet<String>,
+    missing_deps: Vec<String>,
+    opts: &CranOpts,
+) -> Vec<String> {
+    if !opts.tree {
+        return Vec::new();
+    }
+
+    if opts.full {
+        remaining_deps.into_iter().collect()
+    } else {
+        missing_deps
+    }
+}
+
+/// Generate a recipe for each of `deps` that doesn't already have a local
+/// folder, reusing `opts` (except for the package name) for each one.
+#[cfg(not(target_arch = "wasm32"))]
+async fn generate_recipes_for_deps(
+    deps: impl IntoIterator<Item = String>,
+    opts: &CranOpts,
+) -> miette::Result<()> {
+    for dep in deps {
+        let r_package = format_r_package(&dep, None);
+
+        if !PathBuf::from(r_package).exists() {
+            let opts = CranOpts {
+                package: dep,
+                ..opts.clone()
+            };
+            generate_r_recipe(&opts).await?;
         }
     }
 
@@ -552,6 +717,7 @@ pub async fn generate_r_recipe(opts: &CranOpts) -> miette::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tracing_test::traced_test;
 
     #[test]
     fn test_license_mapping() {
@@ -649,5 +815,352 @@ mod tests {
             );
             assert_eq!(license_files, expected_files, "Failed for input: {}", input);
         }
+    }
+
+    /// A channel whose host is guaranteed to never resolve, so queries
+    /// against it deterministically exercise the network-error branch
+    /// regardless of the test environment's actual connectivity. `.invalid`
+    /// is an IANA-reserved TLD for exactly this purpose (RFC 2606).
+    fn unreachable_channel() -> Channel {
+        Channel {
+            base_url: Url::parse("https://conda-forge.invalid/conda-forge/")
+                .unwrap()
+                .into(),
+            name: Some("conda-forge".to_string()),
+            platforms: None,
+        }
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_query_conda_forge_channel_finds_real_package() {
+        let gateway = Gateway::new();
+        let package_name = "r-jsonlite".parse().unwrap();
+
+        let found = query_conda_forge_channel(&gateway, conda_forge_channel(), vec![package_name])
+            .await
+            .unwrap();
+
+        assert!(!found.is_empty());
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_query_conda_forge_channel_excludes_fake_package() {
+        let gateway = Gateway::new();
+        let package_name: PackageName = "r-this-package-does-not-exist-xyz123".parse().unwrap();
+
+        let found =
+            query_conda_forge_channel(&gateway, conda_forge_channel(), vec![package_name.clone()])
+                .await
+                .unwrap();
+
+        assert!(!found.contains(&package_name));
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_find_missing_conda_forge_deps_in_fails_open_on_network_error() {
+        let mut deps = HashSet::new();
+        deps.insert("jsonlite".to_string());
+
+        // `.invalid` is an IANA-reserved TLD (RFC 2606) guaranteed never to
+        // resolve, so this deterministically exercises the network-error
+        // branch regardless of the test environment's actual connectivity.
+        let missing = find_missing_conda_forge_deps_in(unreachable_channel(), &deps).await;
+
+        // Fails open: a query-wide failure reports nothing as missing,
+        // rather than treating every dependency as missing.
+        assert!(missing.is_empty());
+        assert!(logs_contain("Failed to check conda-forge"));
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_find_missing_conda_forge_deps_includes_fake_package() {
+        let dep = "this_package_does_not_exist_xyz123";
+        let mut deps = HashSet::new();
+        deps.insert(dep.to_string());
+
+        let missing = find_missing_conda_forge_deps(&deps).await;
+
+        if !missing.contains(&dep.to_string()) {
+            // The dependency is only excluded from the missing list if the
+            // conda-forge check itself failed open due to a network error.
+            // Confirm that's what happened, rather than a false positive.
+            let gateway = Gateway::new();
+            let package_name = format!("r-{dep}").parse().unwrap();
+            assert!(
+                query_conda_forge_channel(&gateway, conda_forge_channel(), vec![package_name])
+                    .await
+                    .is_err(),
+                "fake dependency unexpectedly reported as existing on conda-forge"
+            );
+        }
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_find_missing_conda_forge_deps_excludes_real_package() {
+        let mut deps = HashSet::new();
+        deps.insert("jsonlite".to_string());
+
+        let missing = find_missing_conda_forge_deps(&deps).await;
+
+        assert!(missing.is_empty());
+    }
+
+    #[test]
+    #[traced_test]
+    fn test_warn_about_missing_conda_forge_deps_logs_warning() {
+        let missing = vec!["this_package_does_not_exist_xyz123".to_string()];
+
+        warn_about_missing_conda_forge_deps(&missing);
+
+        assert!(logs_contain(
+            "Dependency 'this_package_does_not_exist_xyz123' does not appear to be available on conda-forge as 'r-this_package_does_not_exist_xyz123'"
+        ));
+    }
+
+    #[test]
+    #[traced_test]
+    fn test_warn_about_missing_conda_forge_deps_silent_when_empty() {
+        warn_about_missing_conda_forge_deps(&[]);
+
+        assert!(!logs_contain(
+            "does not appear to be available on conda-forge"
+        ));
+    }
+
+    fn dummy_cran_opts() -> CranOpts {
+        CranOpts {
+            universe: None,
+            tree: false,
+            full: false,
+            package: "unused".to_string(),
+            write: false,
+        }
+    }
+
+    // The recursion tests fabricate the `missing_deps` set directly rather than
+    // querying conda-forge, so these two names are just placeholders whose
+    // conda-forge "status" is decided purely by which set a test puts them in.
+    // Neither is a real package on conda-forge or CRAN -- the absence from CRAN
+    // is what makes a recursion into either fail fast instead of downloading
+    // anything.
+
+    /// Placeholder the recursion tests treat as present on conda-forge, by
+    /// keeping it out of the fabricated `missing_deps`.
+    const DEP_ON_CONDA_FORGE: &str = "dep_on_conda_forge_xyz123";
+    /// Placeholder the recursion tests treat as missing from conda-forge, by
+    /// putting it in the fabricated `missing_deps`.
+    const DEP_MISSING_FROM_CONDA_FORGE: &str = "dep_missing_from_conda_forge_xyz123";
+
+    /// Build the `remaining_deps`/`missing_deps` pair that `generate_r_recipe`
+    /// would hand to `select_deps_to_recurse`.
+    fn deps_split() -> (HashSet<String>, Vec<String>) {
+        let remaining = HashSet::from([
+            DEP_ON_CONDA_FORGE.to_string(),
+            DEP_MISSING_FROM_CONDA_FORGE.to_string(),
+        ]);
+        let missing = vec![DEP_MISSING_FROM_CONDA_FORGE.to_string()];
+        (remaining, missing)
+    }
+
+    fn opts_with_flags(tree: bool, full: bool) -> CranOpts {
+        CranOpts {
+            tree,
+            full,
+            ..dummy_cran_opts()
+        }
+    }
+
+    #[test]
+    fn test_select_deps_to_recurse_without_tree_recurses_into_nothing() {
+        let (remaining, missing) = deps_split();
+
+        let selected = select_deps_to_recurse(remaining, missing, &opts_with_flags(false, false));
+
+        assert!(selected.is_empty());
+    }
+
+    #[test]
+    fn test_select_deps_to_recurse_full_without_tree_has_no_effect() {
+        let (remaining, missing) = deps_split();
+
+        // `--full` only modifies `--tree`'s behavior, so without `--tree` it
+        // still recurses into nothing.
+        let selected = select_deps_to_recurse(remaining, missing, &opts_with_flags(false, true));
+
+        assert!(selected.is_empty());
+    }
+
+    #[test]
+    fn test_select_deps_to_recurse_tree_only_recurses_into_missing() {
+        let (remaining, missing) = deps_split();
+
+        let selected = select_deps_to_recurse(remaining, missing, &opts_with_flags(true, false));
+
+        // `--tree` alone recurses only into dependencies missing from
+        // conda-forge.
+        assert_eq!(selected, vec![DEP_MISSING_FROM_CONDA_FORGE.to_string()]);
+    }
+
+    #[test]
+    fn test_select_deps_to_recurse_tree_full_recurses_into_everything() {
+        let (remaining, missing) = deps_split();
+
+        let selected = select_deps_to_recurse(remaining, missing, &opts_with_flags(true, true));
+
+        // `--tree --full` recurses into every dependency, on conda-forge or
+        // not.
+        assert_eq!(
+            selected.into_iter().collect::<HashSet<_>>(),
+            HashSet::from([
+                DEP_ON_CONDA_FORGE.to_string(),
+                DEP_MISSING_FROM_CONDA_FORGE.to_string()
+            ])
+        );
+    }
+
+    /// Mirror the tail of `generate_r_recipe` for a single fabricated
+    /// dependency: warn about it if it's flagged missing from conda-forge,
+    /// then recurse into it if `select_deps_to_recurse` picks it for these
+    /// flags. Only `dep` is in `remaining_deps` (so recursion never
+    /// short-circuits on a sibling), and `missing_deps` contains it only when
+    /// `missing_from_conda_forge` is set. `dep` isn't a real CRAN package, so a
+    /// selected recursion logs "Generating R recipe for <dep>" and then fails
+    /// fast -- the log is what the callers assert on.
+    async fn warn_and_recurse(dep: &str, missing_from_conda_forge: bool, opts: &CranOpts) {
+        let remaining = HashSet::from([dep.to_string()]);
+        let missing = if missing_from_conda_forge {
+            vec![dep.to_string()]
+        } else {
+            Vec::new()
+        };
+
+        warn_about_missing_conda_forge_deps(&missing);
+        let selected = select_deps_to_recurse(remaining, missing, opts);
+        let _ = generate_recipes_for_deps(selected, opts).await;
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_recursion_without_tree_warns_but_never_recurses() {
+        let opts = opts_with_flags(false, false);
+
+        warn_and_recurse(DEP_MISSING_FROM_CONDA_FORGE, true, &opts).await;
+        // The missing dependency is warned about, but without `--tree` it is
+        // not recursed into.
+        assert!(logs_contain(&format!(
+            "Dependency '{DEP_MISSING_FROM_CONDA_FORGE}' does not appear to be available on conda-forge"
+        )));
+        assert!(!logs_contain(&format!(
+            "Generating R recipe for {DEP_MISSING_FROM_CONDA_FORGE}"
+        )));
+
+        warn_and_recurse(DEP_ON_CONDA_FORGE, false, &opts).await;
+        assert!(!logs_contain(&format!(
+            "Generating R recipe for {DEP_ON_CONDA_FORGE}"
+        )));
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_recursion_full_without_tree_has_no_effect() {
+        let opts = opts_with_flags(false, true);
+
+        // `--full` only modifies `--tree`'s behavior, so without `--tree`
+        // nothing is recursed into, even a dependency missing from
+        // conda-forge.
+        warn_and_recurse(DEP_MISSING_FROM_CONDA_FORGE, true, &opts).await;
+        assert!(!logs_contain(&format!(
+            "Generating R recipe for {DEP_MISSING_FROM_CONDA_FORGE}"
+        )));
+
+        warn_and_recurse(DEP_ON_CONDA_FORGE, false, &opts).await;
+        assert!(!logs_contain(&format!(
+            "Generating R recipe for {DEP_ON_CONDA_FORGE}"
+        )));
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_recursion_tree_only_recurses_into_missing() {
+        let opts = opts_with_flags(true, false);
+
+        warn_and_recurse(DEP_MISSING_FROM_CONDA_FORGE, true, &opts).await;
+        assert!(logs_contain(&format!(
+            "Dependency '{DEP_MISSING_FROM_CONDA_FORGE}' does not appear to be available on conda-forge"
+        )));
+        assert!(logs_contain(&format!(
+            "Generating R recipe for {DEP_MISSING_FROM_CONDA_FORGE}"
+        )));
+
+        // `--tree` alone only recurses into dependencies missing from
+        // conda-forge, so an already-available dependency is left alone.
+        warn_and_recurse(DEP_ON_CONDA_FORGE, false, &opts).await;
+        assert!(!logs_contain(&format!(
+            "Generating R recipe for {DEP_ON_CONDA_FORGE}"
+        )));
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_recursion_tree_full_recurses_into_everything() {
+        let opts = opts_with_flags(true, true);
+
+        warn_and_recurse(DEP_MISSING_FROM_CONDA_FORGE, true, &opts).await;
+        assert!(logs_contain(&format!(
+            "Dependency '{DEP_MISSING_FROM_CONDA_FORGE}' does not appear to be available on conda-forge"
+        )));
+        assert!(logs_contain(&format!(
+            "Generating R recipe for {DEP_MISSING_FROM_CONDA_FORGE}"
+        )));
+
+        // `--tree --full` recurses into every dependency, including ones
+        // already on conda-forge.
+        warn_and_recurse(DEP_ON_CONDA_FORGE, false, &opts).await;
+        assert!(logs_contain(&format!(
+            "Generating R recipe for {DEP_ON_CONDA_FORGE}"
+        )));
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_generate_recipes_for_deps_skips_dependency_with_existing_local_folder() {
+        let dep = "test-recurse-missing-fixture-existing";
+        let folder = format_r_package(dep, None);
+        fs_err::create_dir_all(&folder).unwrap();
+
+        let result = generate_recipes_for_deps([dep.to_string()], &dummy_cran_opts()).await;
+
+        fs_err::remove_dir_all(&folder).unwrap();
+
+        // A pre-existing local folder means the dependency is skipped
+        // entirely, so no network call is attempted and this can't fail.
+        assert!(
+            result.is_ok(),
+            "should skip recursion once a local folder for the dependency already exists"
+        );
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_generate_recipes_for_deps_recurses_into_dependency_without_local_folder() {
+        let dep = "this-package-definitely-does-not-exist-anywhere-xyz123";
+        let folder = format_r_package(dep, None);
+        assert!(
+            !PathBuf::from(&folder).exists(),
+            "test fixture assumption violated: {folder} should not exist locally"
+        );
+
+        let result = generate_recipes_for_deps([dep.to_string()], &dummy_cran_opts()).await;
+
+        // No local folder means `generate_recipes_for_deps` recurses into
+        // `generate_r_recipe`, which looks the (nonexistent) package up on
+        // CRAN and fails -- proving recursion was actually attempted rather
+        // than silently skipped.
+        assert!(result.is_err());
     }
 }

--- a/crates/rattler_build_recipe_generator/src/cran.rs
+++ b/crates/rattler_build_recipe_generator/src/cran.rs
@@ -6,6 +6,7 @@ use std::{collections::HashMap, collections::HashSet};
 use clap::Parser;
 use itertools::Itertools;
 use miette::IntoDiagnostic;
+use rattler_conda_types::NamedChannelOrUrl;
 #[cfg(not(target_arch = "wasm32"))]
 use rattler_conda_types::{Channel, ChannelConfig, PackageName, Platform};
 use rattler_digest::{Sha256Hash, compute_bytes_digest};
@@ -75,18 +76,21 @@ pub struct CranOpts {
     #[cfg_attr(feature = "cli", arg(short, long))]
     pub universe: Option<String>,
 
-    /// Whether to recursively generate recipes for dependencies. By default,
-    /// only dependencies missing from conda-forge are recursed into (mirrors
-    /// grayskull's `--recursive`); pass `--full` as well to recurse into the
-    /// whole dependency tree regardless of conda-forge status.
+    /// Whether to recursively generate recipes for dependencies that don't
+    /// already exist locally. By default every dependency is recursed into;
+    /// pass `--skip-available` to skip ones already available in a channel.
     #[cfg_attr(feature = "cli", arg(short, long))]
     pub tree: bool,
 
-    /// Modifies `--tree` to recurse into every dependency, including ones
-    /// already available on conda-forge. Has no effect unless `--tree` is
-    /// also set.
-    #[cfg_attr(feature = "cli", arg(short, long))]
-    pub full: bool,
+    /// Channel(s) to check dependencies against. Dependencies already
+    /// available in any of the given channels are skipped when recursing
+    /// with `--tree` (mirrors grayskull's `--recursive`), and are not warned
+    /// about as missing. May be passed multiple times to check against more
+    /// than one channel, e.g. `--skip-available conda-forge --skip-available
+    /// bioconda`. If unset, nothing is checked and no network requests are
+    /// made.
+    #[cfg_attr(feature = "cli", arg(long))]
+    pub skip_available: Vec<NamedChannelOrUrl>,
 
     /// Name of the package to generate
     pub package: String,
@@ -261,29 +265,34 @@ pub async fn fetch_package_sha256sum(url: &Url) -> Result<Sha256Hash, miette::Er
     Ok(compute_bytes_digest::<Sha256>(&bytes))
 }
 
-/// The default "conda-forge" channel, resolved against the standard
-/// `https://conda.anaconda.org` alias.
+/// Resolve the configured `--skip-available` channels against the default
+/// channel alias (`https://conda.anaconda.org`), the same way `-c/--channel`
+/// is resolved elsewhere in rattler-build.
 #[cfg(not(target_arch = "wasm32"))]
-fn conda_forge_channel() -> Channel {
+fn resolve_skip_available_channels(channels: &[NamedChannelOrUrl]) -> miette::Result<Vec<Channel>> {
     let channel_config = ChannelConfig::default_with_root_dir(
         std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("/")),
     );
-    Channel::from_name("conda-forge", &channel_config)
+    channels
+        .iter()
+        .cloned()
+        .map(|channel| channel.into_channel(&channel_config).into_diagnostic())
+        .collect()
 }
 
-/// Query `channel` via the repodata gateway for which of `package_names`
-/// are present there, for the host platform or `noarch`. Queries every name
-/// in a single batched request rather than one at a time, since the
-/// gateway can fetch multiple packages concurrently.
+/// Query `channels` via the repodata gateway for which of `package_names`
+/// are present in any of them, for the host platform or `noarch`. Queries
+/// every name in a single batched request rather than one at a time, since
+/// the gateway can fetch multiple packages concurrently.
 #[cfg(not(target_arch = "wasm32"))]
-async fn query_conda_forge_channel(
+async fn query_channels_for_packages(
     gateway: &Gateway,
-    channel: Channel,
+    channels: Vec<Channel>,
     package_names: Vec<PackageName>,
 ) -> Result<HashSet<PackageName>, GatewayError> {
     let output = gateway
         .query(
-            vec![channel],
+            channels,
             [Platform::current(), Platform::NoArch],
             package_names,
         )
@@ -296,18 +305,20 @@ async fn query_conda_forge_channel(
         .collect())
 }
 
-/// Check `deps` against `channel`, returning those that aren't available
-/// there (as the original, non-prefixed dependency names). Checks all of
-/// `deps` in a single batched gateway query. Split out from
-/// [`find_missing_conda_forge_deps`] so tests can exercise the
-/// network-error branch deterministically by pointing it at an unreachable
-/// channel.
+/// Check `deps` against `channels`, returning those that aren't available in
+/// any of them (as the original, non-prefixed dependency names). Checks all
+/// of `deps` in a single batched gateway query. Split out from
+/// [`find_missing_deps`] so tests can exercise the network-error branch
+/// deterministically by pointing it at an unreachable channel.
 ///
 /// Network errors (and unparsable package names) are treated as "exists"
 /// so connectivity issues don't produce spurious warnings.
 #[cfg(not(target_arch = "wasm32"))]
-async fn find_missing_conda_forge_deps_in(channel: Channel, deps: &HashSet<String>) -> Vec<String> {
-    if deps.is_empty() {
+async fn find_missing_deps_in_channels(
+    channels: Vec<Channel>,
+    deps: &HashSet<String>,
+) -> Vec<String> {
+    if deps.is_empty() || channels.is_empty() {
         return Vec::new();
     }
 
@@ -328,12 +339,12 @@ async fn find_missing_conda_forge_deps_in(channel: Channel, deps: &HashSet<Strin
 
     let gateway = Gateway::new();
     let package_names = package_name_to_dep.keys().cloned().collect();
-    let found = match query_conda_forge_channel(&gateway, channel, package_names).await {
+    let found = match query_channels_for_packages(&gateway, channels, package_names).await {
         Ok(found) => found,
         Err(e) => {
             // Fail open: a query-wide failure shouldn't produce spurious
             // warnings for every dependency.
-            tracing::debug!("Failed to check conda-forge: {}", e);
+            tracing::debug!("Failed to check configured channels: {}", e);
             return Vec::new();
         }
     };
@@ -345,26 +356,35 @@ async fn find_missing_conda_forge_deps_in(channel: Channel, deps: &HashSet<Strin
         .collect()
 }
 
-/// Check `deps` against conda-forge, returning those that aren't available
-/// there yet (as the original, non-prefixed dependency names).
+/// Check `deps` against the channels configured via `opts.skip_available`,
+/// returning those that aren't available in any of them yet (as the
+/// original, non-prefixed dependency names). Performs no network request
+/// (and returns nothing) if no channels were configured.
 ///
-/// Unlike PyPI, CRAN package names map to conda-forge by a fixed convention
-/// (`foo` -> `r-foo`, see [`format_r_package`]), so no name-mapping lookup is
-/// needed here, only an existence check via the repodata gateway.
+/// Unlike PyPI, CRAN package names map to conda channels by a fixed
+/// convention (`foo` -> `r-foo`, see [`format_r_package`]), so no
+/// name-mapping lookup is needed here, only an existence check via the
+/// repodata gateway.
 #[cfg(not(target_arch = "wasm32"))]
-async fn find_missing_conda_forge_deps(deps: &HashSet<String>) -> Vec<String> {
-    find_missing_conda_forge_deps_in(conda_forge_channel(), deps).await
+async fn find_missing_deps(deps: &HashSet<String>, opts: &CranOpts) -> miette::Result<Vec<String>> {
+    if opts.skip_available.is_empty() {
+        return Ok(Vec::new());
+    }
+    let channels = resolve_skip_available_channels(&opts.skip_available)?;
+    Ok(find_missing_deps_in_channels(channels, deps).await)
 }
 
 /// Warn about each dependency in `missing`, so the user knows upfront which
 /// recipes they need to package first.
 #[cfg(not(target_arch = "wasm32"))]
-fn warn_about_missing_conda_forge_deps(missing: &[String]) {
+fn warn_about_missing_deps(missing: &[String], channels: &[NamedChannelOrUrl]) {
+    let channel_list = channels.iter().join(", ");
     for dep in missing {
         let conda_name = format_r_package(dep, None);
         tracing::warn!(
-            "Dependency '{}' does not appear to be available on conda-forge as '{}'. You may need to create and publish a recipe for it first.",
+            "Dependency '{}' does not appear to be available in {} as '{}'. You may need to create and publish a recipe for it first.",
             dep,
+            channel_list,
             conda_name
         );
     }
@@ -642,8 +662,8 @@ pub async fn generate_r_recipe_string(
 /// If `opts.write` is true, the recipe is written to a folder named after the
 /// package. Otherwise, the YAML is printed to stdout. When `tree` is enabled,
 /// dependencies that don't already exist locally are recursively generated:
-/// by default only those missing from conda-forge, or every dependency if
-/// `full` is also set.
+/// every dependency by default, or only those missing from the channel(s)
+/// passed via `--skip-available`, if any were given.
 pub async fn generate_r_recipe(opts: &CranOpts) -> miette::Result<()> {
     let (recipe, remaining_deps) =
         build_cran_recipe_and_deps(&opts.package, opts.universe.as_deref()).await?;
@@ -656,8 +676,8 @@ pub async fn generate_r_recipe(opts: &CranOpts) -> miette::Result<()> {
         print!("{}", final_recipe);
     }
 
-    let missing_deps = find_missing_conda_forge_deps(&remaining_deps).await;
-    warn_about_missing_conda_forge_deps(&missing_deps);
+    let missing_deps = find_missing_deps(&remaining_deps, opts).await?;
+    warn_about_missing_deps(&missing_deps, &opts.skip_available);
 
     generate_recipes_for_deps(
         select_deps_to_recurse(remaining_deps, missing_deps, opts),
@@ -670,11 +690,12 @@ pub async fn generate_r_recipe(opts: &CranOpts) -> miette::Result<()> {
 
 /// Decide which dependencies to recursively generate recipes for:
 /// - without `tree`, none;
-/// - with `tree` alone, only those missing from conda-forge (generating
-///   recipes for ones already available there isn't useful, since those
-///   boilerplate recipes would need further changes to be valid anyway);
-/// - with `tree` and `full`, every dependency, regardless of conda-forge
-///   status.
+/// - with `tree` and no `--skip-available` channels configured, every
+///   dependency;
+/// - with `tree` and `--skip-available` channels configured, only those
+///   missing from all of them (generating recipes for ones already
+///   available there isn't useful, since those boilerplate recipes would
+///   need further changes to be valid anyway).
 #[cfg(not(target_arch = "wasm32"))]
 fn select_deps_to_recurse(
     remaining_deps: HashSet<String>,
@@ -685,7 +706,7 @@ fn select_deps_to_recurse(
         return Vec::new();
     }
 
-    if opts.full {
+    if opts.skip_available.is_empty() {
         remaining_deps.into_iter().collect()
     } else {
         missing_deps
@@ -831,58 +852,81 @@ mod tests {
         }
     }
 
+    /// The real "conda-forge" channel, for tests that exercise actual
+    /// network calls against it.
+    fn conda_forge_channel() -> Channel {
+        let channel_config = ChannelConfig::default_with_root_dir(
+            std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("/")),
+        );
+        Channel::from_name("conda-forge", &channel_config)
+    }
+
     #[tokio::test]
     #[traced_test]
-    async fn test_query_conda_forge_channel_finds_real_package() {
+    async fn test_query_channels_for_packages_finds_real_package() {
         let gateway = Gateway::new();
         let package_name = "r-jsonlite".parse().unwrap();
 
-        let found = query_conda_forge_channel(&gateway, conda_forge_channel(), vec![package_name])
-            .await
-            .unwrap();
+        let found =
+            query_channels_for_packages(&gateway, vec![conda_forge_channel()], vec![package_name])
+                .await
+                .unwrap();
 
         assert!(!found.is_empty());
     }
 
     #[tokio::test]
     #[traced_test]
-    async fn test_query_conda_forge_channel_excludes_fake_package() {
+    async fn test_query_channels_for_packages_excludes_fake_package() {
         let gateway = Gateway::new();
         let package_name: PackageName = "r-this-package-does-not-exist-xyz123".parse().unwrap();
 
-        let found =
-            query_conda_forge_channel(&gateway, conda_forge_channel(), vec![package_name.clone()])
-                .await
-                .unwrap();
+        let found = query_channels_for_packages(
+            &gateway,
+            vec![conda_forge_channel()],
+            vec![package_name.clone()],
+        )
+        .await
+        .unwrap();
 
         assert!(!found.contains(&package_name));
     }
 
     #[tokio::test]
     #[traced_test]
-    async fn test_find_missing_conda_forge_deps_in_fails_open_on_network_error() {
+    async fn test_find_missing_deps_in_channels_fails_open_on_network_error() {
         let mut deps = HashSet::new();
         deps.insert("jsonlite".to_string());
 
         // `.invalid` is an IANA-reserved TLD (RFC 2606) guaranteed never to
         // resolve, so this deterministically exercises the network-error
         // branch regardless of the test environment's actual connectivity.
-        let missing = find_missing_conda_forge_deps_in(unreachable_channel(), &deps).await;
+        let missing = find_missing_deps_in_channels(vec![unreachable_channel()], &deps).await;
 
         // Fails open: a query-wide failure reports nothing as missing,
         // rather than treating every dependency as missing.
         assert!(missing.is_empty());
-        assert!(logs_contain("Failed to check conda-forge"));
+        assert!(logs_contain("Failed to check configured channels"));
+    }
+
+    /// Build a `CranOpts` configured to check the given channel names via
+    /// `--skip-available`.
+    fn opts_with_skip_available(channels: &[&str]) -> CranOpts {
+        CranOpts {
+            skip_available: channels.iter().map(|c| c.parse().unwrap()).collect(),
+            ..dummy_cran_opts()
+        }
     }
 
     #[tokio::test]
     #[traced_test]
-    async fn test_find_missing_conda_forge_deps_includes_fake_package() {
+    async fn test_find_missing_deps_includes_fake_package() {
         let dep = "this_package_does_not_exist_xyz123";
         let mut deps = HashSet::new();
         deps.insert(dep.to_string());
+        let opts = opts_with_skip_available(&["conda-forge"]);
 
-        let missing = find_missing_conda_forge_deps(&deps).await;
+        let missing = find_missing_deps(&deps, &opts).await.unwrap();
 
         if !missing.contains(&dep.to_string()) {
             // The dependency is only excluded from the missing list if the
@@ -891,9 +935,13 @@ mod tests {
             let gateway = Gateway::new();
             let package_name = format!("r-{dep}").parse().unwrap();
             assert!(
-                query_conda_forge_channel(&gateway, conda_forge_channel(), vec![package_name])
-                    .await
-                    .is_err(),
+                query_channels_for_packages(
+                    &gateway,
+                    vec![conda_forge_channel()],
+                    vec![package_name]
+                )
+                .await
+                .is_err(),
                 "fake dependency unexpectedly reported as existing on conda-forge"
             );
         }
@@ -901,76 +949,114 @@ mod tests {
 
     #[tokio::test]
     #[traced_test]
-    async fn test_find_missing_conda_forge_deps_excludes_real_package() {
+    async fn test_find_missing_deps_excludes_real_package() {
         let mut deps = HashSet::new();
         deps.insert("jsonlite".to_string());
+        let opts = opts_with_skip_available(&["conda-forge"]);
 
-        let missing = find_missing_conda_forge_deps(&deps).await;
+        let missing = find_missing_deps(&deps, &opts).await.unwrap();
+
+        assert!(missing.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_find_missing_deps_returns_nothing_when_no_channels_configured() {
+        let mut deps = HashSet::new();
+        deps.insert("this_package_does_not_exist_xyz123".to_string());
+
+        // No `--skip-available` channels configured, so this must not make
+        // any network request and must report nothing as missing -- this is
+        // the fully opt-in behavior that replaces the old hardcoded
+        // conda-forge check.
+        let missing = find_missing_deps(&deps, &dummy_cran_opts()).await.unwrap();
 
         assert!(missing.is_empty());
     }
 
     #[test]
     #[traced_test]
-    fn test_warn_about_missing_conda_forge_deps_logs_warning() {
+    fn test_warn_about_missing_deps_logs_warning() {
         let missing = vec!["this_package_does_not_exist_xyz123".to_string()];
+        let channels: Vec<NamedChannelOrUrl> = vec!["conda-forge".parse().unwrap()];
 
-        warn_about_missing_conda_forge_deps(&missing);
+        warn_about_missing_deps(&missing, &channels);
 
         assert!(logs_contain(
-            "Dependency 'this_package_does_not_exist_xyz123' does not appear to be available on conda-forge as 'r-this_package_does_not_exist_xyz123'"
+            "Dependency 'this_package_does_not_exist_xyz123' does not appear to be available in conda-forge as 'r-this_package_does_not_exist_xyz123'"
         ));
     }
 
     #[test]
     #[traced_test]
-    fn test_warn_about_missing_conda_forge_deps_silent_when_empty() {
-        warn_about_missing_conda_forge_deps(&[]);
+    fn test_warn_about_missing_deps_lists_every_configured_channel() {
+        let missing = vec!["foo".to_string()];
+        let channels: Vec<NamedChannelOrUrl> =
+            vec!["conda-forge".parse().unwrap(), "bioconda".parse().unwrap()];
 
-        assert!(!logs_contain(
-            "does not appear to be available on conda-forge"
+        warn_about_missing_deps(&missing, &channels);
+
+        assert!(logs_contain(
+            "does not appear to be available in conda-forge, bioconda"
         ));
+    }
+
+    #[test]
+    #[traced_test]
+    fn test_warn_about_missing_deps_silent_when_empty() {
+        let channels: Vec<NamedChannelOrUrl> = vec!["conda-forge".parse().unwrap()];
+
+        warn_about_missing_deps(&[], &channels);
+
+        assert!(!logs_contain("does not appear to be available in"));
     }
 
     fn dummy_cran_opts() -> CranOpts {
         CranOpts {
             universe: None,
             tree: false,
-            full: false,
+            skip_available: Vec::new(),
             package: "unused".to_string(),
             write: false,
         }
     }
 
     // The recursion tests fabricate the `missing_deps` set directly rather than
-    // querying conda-forge, so these two names are just placeholders whose
-    // conda-forge "status" is decided purely by which set a test puts them in.
-    // Neither is a real package on conda-forge or CRAN -- the absence from CRAN
-    // is what makes a recursion into either fail fast instead of downloading
-    // anything.
+    // querying any channel, so these two names are just placeholders whose
+    // "availability" is decided purely by which set a test puts them in.
+    // Neither is a real package on any channel or CRAN -- the absence from
+    // CRAN is what makes a recursion into either fail fast instead of
+    // downloading anything.
 
-    /// Placeholder the recursion tests treat as present on conda-forge, by
-    /// keeping it out of the fabricated `missing_deps`.
-    const DEP_ON_CONDA_FORGE: &str = "dep_on_conda_forge_xyz123";
-    /// Placeholder the recursion tests treat as missing from conda-forge, by
-    /// putting it in the fabricated `missing_deps`.
-    const DEP_MISSING_FROM_CONDA_FORGE: &str = "dep_missing_from_conda_forge_xyz123";
+    /// Placeholder the recursion tests treat as already available in the
+    /// configured channel(s), by keeping it out of the fabricated
+    /// `missing_deps`.
+    const DEP_AVAILABLE_IN_CHANNEL: &str = "dep_available_in_channel_xyz123";
+    /// Placeholder the recursion tests treat as missing from the configured
+    /// channel(s), by putting it in the fabricated `missing_deps`.
+    const DEP_MISSING_FROM_CHANNEL: &str = "dep_missing_from_channel_xyz123";
 
     /// Build the `remaining_deps`/`missing_deps` pair that `generate_r_recipe`
     /// would hand to `select_deps_to_recurse`.
     fn deps_split() -> (HashSet<String>, Vec<String>) {
         let remaining = HashSet::from([
-            DEP_ON_CONDA_FORGE.to_string(),
-            DEP_MISSING_FROM_CONDA_FORGE.to_string(),
+            DEP_AVAILABLE_IN_CHANNEL.to_string(),
+            DEP_MISSING_FROM_CHANNEL.to_string(),
         ]);
-        let missing = vec![DEP_MISSING_FROM_CONDA_FORGE.to_string()];
+        let missing = vec![DEP_MISSING_FROM_CHANNEL.to_string()];
         (remaining, missing)
     }
 
-    fn opts_with_flags(tree: bool, full: bool) -> CranOpts {
+    /// Build a `CranOpts` with `tree` set as given, and `skip_available` set
+    /// to `["conda-forge"]` if `skip_available` is true, or left empty
+    /// otherwise.
+    fn opts_with_flags(tree: bool, skip_available: bool) -> CranOpts {
         CranOpts {
             tree,
-            full,
+            skip_available: if skip_available {
+                vec!["conda-forge".parse().unwrap()]
+            } else {
+                Vec::new()
+            },
             ..dummy_cran_opts()
         }
     }
@@ -979,67 +1065,67 @@ mod tests {
     fn test_select_deps_to_recurse_without_tree_recurses_into_nothing() {
         let (remaining, missing) = deps_split();
 
-        let selected = select_deps_to_recurse(remaining, missing, &opts_with_flags(false, false));
-
-        assert!(selected.is_empty());
-    }
-
-    #[test]
-    fn test_select_deps_to_recurse_full_without_tree_has_no_effect() {
-        let (remaining, missing) = deps_split();
-
-        // `--full` only modifies `--tree`'s behavior, so without `--tree` it
-        // still recurses into nothing.
         let selected = select_deps_to_recurse(remaining, missing, &opts_with_flags(false, true));
 
         assert!(selected.is_empty());
     }
 
     #[test]
-    fn test_select_deps_to_recurse_tree_only_recurses_into_missing() {
+    fn test_select_deps_to_recurse_skip_available_without_tree_has_no_effect() {
         let (remaining, missing) = deps_split();
 
-        let selected = select_deps_to_recurse(remaining, missing, &opts_with_flags(true, false));
+        // `--skip-available` only affects recursion via `--tree`, so without
+        // `--tree` it still recurses into nothing.
+        let selected = select_deps_to_recurse(remaining, missing, &opts_with_flags(false, false));
 
-        // `--tree` alone recurses only into dependencies missing from
-        // conda-forge.
-        assert_eq!(selected, vec![DEP_MISSING_FROM_CONDA_FORGE.to_string()]);
+        assert!(selected.is_empty());
     }
 
     #[test]
-    fn test_select_deps_to_recurse_tree_full_recurses_into_everything() {
+    fn test_select_deps_to_recurse_tree_with_skip_available_recurses_into_missing_only() {
         let (remaining, missing) = deps_split();
 
         let selected = select_deps_to_recurse(remaining, missing, &opts_with_flags(true, true));
 
-        // `--tree --full` recurses into every dependency, on conda-forge or
-        // not.
+        // `--tree --skip-available conda-forge` recurses only into
+        // dependencies missing from conda-forge.
+        assert_eq!(selected, vec![DEP_MISSING_FROM_CHANNEL.to_string()]);
+    }
+
+    #[test]
+    fn test_select_deps_to_recurse_tree_without_skip_available_recurses_into_everything() {
+        let (remaining, missing) = deps_split();
+
+        let selected = select_deps_to_recurse(remaining, missing, &opts_with_flags(true, false));
+
+        // `--tree` alone, with no `--skip-available` channels configured,
+        // recurses into every dependency.
         assert_eq!(
             selected.into_iter().collect::<HashSet<_>>(),
             HashSet::from([
-                DEP_ON_CONDA_FORGE.to_string(),
-                DEP_MISSING_FROM_CONDA_FORGE.to_string()
+                DEP_AVAILABLE_IN_CHANNEL.to_string(),
+                DEP_MISSING_FROM_CHANNEL.to_string()
             ])
         );
     }
 
     /// Mirror the tail of `generate_r_recipe` for a single fabricated
-    /// dependency: warn about it if it's flagged missing from conda-forge,
-    /// then recurse into it if `select_deps_to_recurse` picks it for these
-    /// flags. Only `dep` is in `remaining_deps` (so recursion never
+    /// dependency: warn about it if it's flagged missing from the configured
+    /// channel(s), then recurse into it if `select_deps_to_recurse` picks it
+    /// for these flags. Only `dep` is in `remaining_deps` (so recursion never
     /// short-circuits on a sibling), and `missing_deps` contains it only when
-    /// `missing_from_conda_forge` is set. `dep` isn't a real CRAN package, so a
+    /// `missing_from_channel` is set. `dep` isn't a real CRAN package, so a
     /// selected recursion logs "Generating R recipe for <dep>" and then fails
     /// fast -- the log is what the callers assert on.
-    async fn warn_and_recurse(dep: &str, missing_from_conda_forge: bool, opts: &CranOpts) {
+    async fn warn_and_recurse(dep: &str, missing_from_channel: bool, opts: &CranOpts) {
         let remaining = HashSet::from([dep.to_string()]);
-        let missing = if missing_from_conda_forge {
+        let missing = if missing_from_channel {
             vec![dep.to_string()]
         } else {
             Vec::new()
         };
 
-        warn_about_missing_conda_forge_deps(&missing);
+        warn_about_missing_deps(&missing, &opts.skip_available);
         let selected = select_deps_to_recurse(remaining, missing, opts);
         let _ = generate_recipes_for_deps(selected, opts).await;
     }
@@ -1047,82 +1133,79 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_recursion_without_tree_warns_but_never_recurses() {
-        let opts = opts_with_flags(false, false);
+        let opts = opts_with_flags(false, true);
 
-        warn_and_recurse(DEP_MISSING_FROM_CONDA_FORGE, true, &opts).await;
+        warn_and_recurse(DEP_MISSING_FROM_CHANNEL, true, &opts).await;
         // The missing dependency is warned about, but without `--tree` it is
         // not recursed into.
         assert!(logs_contain(&format!(
-            "Dependency '{DEP_MISSING_FROM_CONDA_FORGE}' does not appear to be available on conda-forge"
+            "Dependency '{DEP_MISSING_FROM_CHANNEL}' does not appear to be available in conda-forge"
         )));
         assert!(!logs_contain(&format!(
-            "Generating R recipe for {DEP_MISSING_FROM_CONDA_FORGE}"
+            "Generating R recipe for {DEP_MISSING_FROM_CHANNEL}"
         )));
 
-        warn_and_recurse(DEP_ON_CONDA_FORGE, false, &opts).await;
+        warn_and_recurse(DEP_AVAILABLE_IN_CHANNEL, false, &opts).await;
         assert!(!logs_contain(&format!(
-            "Generating R recipe for {DEP_ON_CONDA_FORGE}"
+            "Generating R recipe for {DEP_AVAILABLE_IN_CHANNEL}"
         )));
     }
 
     #[tokio::test]
     #[traced_test]
-    async fn test_recursion_full_without_tree_has_no_effect() {
-        let opts = opts_with_flags(false, true);
+    async fn test_recursion_skip_available_without_tree_has_no_effect() {
+        let opts = opts_with_flags(false, false);
 
-        // `--full` only modifies `--tree`'s behavior, so without `--tree`
-        // nothing is recursed into, even a dependency missing from
-        // conda-forge.
-        warn_and_recurse(DEP_MISSING_FROM_CONDA_FORGE, true, &opts).await;
+        // With no `--skip-available` channels configured and `--tree` off,
+        // nothing is recursed into, even a dependency flagged missing.
+        warn_and_recurse(DEP_MISSING_FROM_CHANNEL, true, &opts).await;
         assert!(!logs_contain(&format!(
-            "Generating R recipe for {DEP_MISSING_FROM_CONDA_FORGE}"
+            "Generating R recipe for {DEP_MISSING_FROM_CHANNEL}"
         )));
 
-        warn_and_recurse(DEP_ON_CONDA_FORGE, false, &opts).await;
+        warn_and_recurse(DEP_AVAILABLE_IN_CHANNEL, false, &opts).await;
         assert!(!logs_contain(&format!(
-            "Generating R recipe for {DEP_ON_CONDA_FORGE}"
+            "Generating R recipe for {DEP_AVAILABLE_IN_CHANNEL}"
         )));
     }
 
     #[tokio::test]
     #[traced_test]
-    async fn test_recursion_tree_only_recurses_into_missing() {
-        let opts = opts_with_flags(true, false);
-
-        warn_and_recurse(DEP_MISSING_FROM_CONDA_FORGE, true, &opts).await;
-        assert!(logs_contain(&format!(
-            "Dependency '{DEP_MISSING_FROM_CONDA_FORGE}' does not appear to be available on conda-forge"
-        )));
-        assert!(logs_contain(&format!(
-            "Generating R recipe for {DEP_MISSING_FROM_CONDA_FORGE}"
-        )));
-
-        // `--tree` alone only recurses into dependencies missing from
-        // conda-forge, so an already-available dependency is left alone.
-        warn_and_recurse(DEP_ON_CONDA_FORGE, false, &opts).await;
-        assert!(!logs_contain(&format!(
-            "Generating R recipe for {DEP_ON_CONDA_FORGE}"
-        )));
-    }
-
-    #[tokio::test]
-    #[traced_test]
-    async fn test_recursion_tree_full_recurses_into_everything() {
+    async fn test_recursion_tree_with_skip_available_recurses_into_missing_only() {
         let opts = opts_with_flags(true, true);
 
-        warn_and_recurse(DEP_MISSING_FROM_CONDA_FORGE, true, &opts).await;
+        warn_and_recurse(DEP_MISSING_FROM_CHANNEL, true, &opts).await;
         assert!(logs_contain(&format!(
-            "Dependency '{DEP_MISSING_FROM_CONDA_FORGE}' does not appear to be available on conda-forge"
+            "Dependency '{DEP_MISSING_FROM_CHANNEL}' does not appear to be available in conda-forge"
         )));
         assert!(logs_contain(&format!(
-            "Generating R recipe for {DEP_MISSING_FROM_CONDA_FORGE}"
+            "Generating R recipe for {DEP_MISSING_FROM_CHANNEL}"
         )));
 
-        // `--tree --full` recurses into every dependency, including ones
-        // already on conda-forge.
-        warn_and_recurse(DEP_ON_CONDA_FORGE, false, &opts).await;
+        // `--tree --skip-available conda-forge` only recurses into
+        // dependencies missing from conda-forge, so an already-available
+        // dependency is left alone.
+        warn_and_recurse(DEP_AVAILABLE_IN_CHANNEL, false, &opts).await;
+        assert!(!logs_contain(&format!(
+            "Generating R recipe for {DEP_AVAILABLE_IN_CHANNEL}"
+        )));
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_recursion_tree_without_skip_available_recurses_into_everything() {
+        let opts = opts_with_flags(true, false);
+
+        warn_and_recurse(DEP_MISSING_FROM_CHANNEL, true, &opts).await;
         assert!(logs_contain(&format!(
-            "Generating R recipe for {DEP_ON_CONDA_FORGE}"
+            "Generating R recipe for {DEP_MISSING_FROM_CHANNEL}"
+        )));
+
+        // `--tree` alone, with no `--skip-available` channels configured,
+        // recurses into every dependency, including ones already available.
+        warn_and_recurse(DEP_AVAILABLE_IN_CHANNEL, false, &opts).await;
+        assert!(logs_contain(&format!(
+            "Generating R recipe for {DEP_AVAILABLE_IN_CHANNEL}"
         )));
     }
 

--- a/docs/recipe_generation.md
+++ b/docs/recipe_generation.md
@@ -49,7 +49,8 @@ rattler-build generate-recipe cran dplyr
 The `R` recipe generation supports some additional flags:
 
 - `-u/--universe` select an R universe to use (e.g. `bioconductor`)
-- `-t/--tree` generate multiple recipes, for every dependency as well
+- `-t/--tree` also generate recipes for dependencies that aren't yet available on conda-forge (recursively)
+- `-f/--full` used together with `-t/--tree`, generate recipes for every dependency instead, including ones already available on conda-forge
 
 R packages will be prefixed with `r-` to avoid name conflicts with Python packages. When the package declares a minimum R version (e.g. `Depends: R (>= 4.1.0)`), the generator emits a `skip` condition using the `r_base` variant key rather than pinning `r-base` to a version. The build script is also split into a platform-conditional list so that the correct environment-variable syntax (`${R_ARGS}` on Unix, `%R_ARGS%` on Windows) is used. The generated recipe for `dplyr` will look something like:
 

--- a/docs/recipe_generation.md
+++ b/docs/recipe_generation.md
@@ -49,8 +49,8 @@ rattler-build generate-recipe cran dplyr
 The `R` recipe generation supports some additional flags:
 
 - `-u/--universe` select an R universe to use (e.g. `bioconductor`)
-- `-t/--tree` also generate recipes for dependencies that aren't yet available on conda-forge (recursively)
-- `-f/--full` used together with `-t/--tree`, generate recipes for every dependency instead, including ones already available on conda-forge
+- `-t/--tree` recursively generate recipes for dependencies that don't already exist locally
+- `--skip-available <CHANNEL>` check dependencies against `<CHANNEL>` (may be passed multiple times); when combined with `-t/--tree`, only dependencies missing from all given channels are recursed into (instead of every dependency), and a warning is printed for any dependency missing from them, whether or not `-t/--tree` is set. Without `--skip-available`, no channel is checked and `-t/--tree` recurses into every dependency
 
 R packages will be prefixed with `r-` to avoid name conflicts with Python packages. When the package declares a minimum R version (e.g. `Depends: R (>= 4.1.0)`), the generator emits a `skip` condition using the `r_base` variant key rather than pinning `r-base` to a version. The build script is also split into a platform-conditional list so that the correct environment-variable syntax (`${R_ARGS}` on Unix, `%R_ARGS%` on Windows) is used. The generated recipe for `dplyr` will look something like:
 

--- a/docs/reference/cli/rattler-build/generate-recipe/cran.md
+++ b/docs/reference/cli/rattler-build/generate-recipe/cran.md
@@ -20,6 +20,8 @@ rattler-build generate-recipe cran [OPTIONS] <PACKAGE>
 - <a id="arg---universe" href="#arg---universe">`--universe (-u) <UNIVERSE>`</a>
 :  The R Universe to fetch the package from (defaults to `cran`)
 - <a id="arg---tree" href="#arg---tree">`--tree (-t)`</a>
-:  Whether to create recipes for the whole dependency tree or not
+:  Whether to recursively generate recipes for dependencies. By default, only dependencies missing from conda-forge are recursed into (mirrors grayskull's `--recursive`); pass `--full` as well to recurse into the whole dependency tree regardless of conda-forge status
+- <a id="arg---full" href="#arg---full">`--full (-f)`</a>
+:  Modifies `--tree` to recurse into every dependency, including ones already available on conda-forge. Has no effect unless `--tree` is also set
 - <a id="arg---write" href="#arg---write">`--write (-w)`</a>
 :  Whether to write the recipe to a folder

--- a/docs/reference/cli/rattler-build/generate-recipe/cran.md
+++ b/docs/reference/cli/rattler-build/generate-recipe/cran.md
@@ -20,8 +20,9 @@ rattler-build generate-recipe cran [OPTIONS] <PACKAGE>
 - <a id="arg---universe" href="#arg---universe">`--universe (-u) <UNIVERSE>`</a>
 :  The R Universe to fetch the package from (defaults to `cran`)
 - <a id="arg---tree" href="#arg---tree">`--tree (-t)`</a>
-:  Whether to recursively generate recipes for dependencies. By default, only dependencies missing from conda-forge are recursed into (mirrors grayskull's `--recursive`); pass `--full` as well to recurse into the whole dependency tree regardless of conda-forge status
-- <a id="arg---full" href="#arg---full">`--full (-f)`</a>
-:  Modifies `--tree` to recurse into every dependency, including ones already available on conda-forge. Has no effect unless `--tree` is also set
+:  Whether to recursively generate recipes for dependencies that don't already exist locally. By default every dependency is recursed into; pass `--skip-available` to skip ones already available in a channel
+- <a id="arg---skip-available" href="#arg---skip-available">`--skip-available <SKIP_AVAILABLE>`</a>
+:  Channel(s) to check dependencies against. Dependencies already available in any of the given channels are skipped when recursing with `--tree` (mirrors grayskull's `--recursive`), and are not warned about as missing. May be passed multiple times to check against more than one channel, e.g. `--skip-available conda-forge --skip-available bioconda`. If unset, nothing is checked and no network requests are made
+<br>May be provided more than once.
 - <a id="arg---write" href="#arg---write">`--write (-w)`</a>
 :  Whether to write the recipe to a folder

--- a/py-rattler-build/rust/Cargo.lock
+++ b/py-rattler-build/rust/Cargo.lock
@@ -4873,6 +4873,7 @@ dependencies = [
  "miette",
  "rattler_conda_types",
  "rattler_digest",
+ "rattler_repodata_gateway",
  "regex",
  "reqwest",
  "serde",


### PR DESCRIPTION
Refer https://github.com/prefix-dev/rattler-build/issues/2563

**⚠️ Breaking:** `generate-recipe cran --tree` now recurses only into dependencies missing from conda-forge by default, instead of the whole dependency tree. Pass the new `--full` flag alongside `--tree` to restore the old behavior.

## Summary

`cran.rs` already collected an R package's dependencies into a `remaining_deps` set while generating a recipe, but the set was discarded after use - there was no signal to the user about which of those dependencies weren't yet packaged on conda-forge. The recipe would only fail much later, at solve time, with no clear diagnostic pointing back to the missing R package.

This PR checks each collected dependency against conda-forge right after the recipe is generated, and logs a warning for any that are missing. The check goes through `rattler_repodata_gateway`'s `Gateway`, with every dependency batched into a single query rather than one request per package. This mirrors the existing behavior discussed for `pypi.rs`, minus the name-mapping step: CRAN package `foo` always maps to conda-forge `r-foo` by convention, so no lookup table is needed.

## Important Points

- Wired `warn_about_missing_conda_forge_deps` into `generate_r_recipe`, run once per generated recipe.
- Network errors are treated as "exists" (fail open) so a flaky connection doesn't block recipe generation or spam false warnings.
- Added unit tests, including a deterministic one for the network-failure branch ([using the RFC 2606 `.invalid` TLD, which is guaranteed never to resolve](https://datatracker.ietf.org/doc/html/rfc2606)).
- Changed `--tree`'s behavior: it now recurses only into dependencies missing from conda-forge by default (matching grayskull's `--recursive`), instead of blindly recursing into the whole dependency tree. (refer https://github.com/prefix-dev/rattler-build/pull/2622#issuecomment-5033337593) Generating boilerplate recipes for packages already available on conda-forge isn't useful, since they'd need further changes to be valid anyway.
- Added a `--full`/`-f` modifier to restore the old behavior when it's genuinely wanted (e.g. building a self-contained "forge" channel that doesn't want to depend on conda-forge for anything in the tree): `--tree --full` recurses into every dependency regardless of conda-forge status. Has no effect without `--tree`.
- This started out as a separate opt-in `--recursive` flag alongside the untouched `--tree`, but https://github.com/prefix-dev/rattler-build/pull/2622#issuecomment-5006275075 and https://github.com/prefix-dev/rattler-build/pull/2622#issuecomment-5033337593 pointed out the two were confusingly similar at a glance, so `--recursive` was folded into `--tree` (with `--full` as the escape hatch) instead of shipping both.