### PR TITLE
feat: warn about problematic entry point configurations

### DIFF
--- a/crates/rattler_build_core/src/packaging.rs
+++ b/crates/rattler_build_core/src/packaging.rs
@@ -584,6 +584,23 @@ fn print_enhanced_file_listing(
         perform_path_checks(output, &pj.paths);
     }
 
+    // Warn if the prefix contains spaces: shebang lines don't support quoted paths on
+    // Linux, so any generated entry point scripts may fail to execute at runtime.
+    let prefix_str = output.prefix().to_string_lossy();
+    if prefix_str.contains(' ') && !output.recipe.build().python.entry_points.is_empty() {
+        tracing::warn!(
+            "The prefix path '{}' contains spaces. Entry point shebang lines do not support \
+            quoted paths on Linux, so the generated scripts may fail to execute.",
+            prefix_str
+        );
+        output.record_warning(&format!(
+            "Prefix path '{}' contains spaces — entry point shebangs may not work on Linux",
+            prefix_str
+        ));
+    }
+
+    let is_noarch_python = output.is_python_version_independent();
+
     // Collect per-file warnings for content files
     let mut path_warnings: HashMap<&Path, Vec<String>> = HashMap::new();
     if let Some(ref pj) = paths_json {
@@ -600,6 +617,16 @@ fn print_enhanced_file_listing(
                 }
                 if path_str.len() > 200 {
                     warnings.push(format!("Path too long ({} > 200)", path_str.len()));
+                }
+                // For noarch: python packages, files under python-scripts/ were placed
+                // there because they are not registered as entry_points. Prefer
+                // entry_points over plain scripts (see issue #1129).
+                if is_noarch_python && path_str.starts_with("python-scripts/") {
+                    warnings.push(
+                        "not registered as an entry_point; consider adding to \
+                        'build.python.entry_points' (e.g. `cmd = pkg.module:main`)"
+                            .to_string(),
+                    );
                 }
             }
 


### PR DESCRIPTION
## Summary

Closes #1129. This re-applies the change from #2197 onto current `main`. The original PR branch (#2197) sits on a divergent/rewritten history with no common merge base with today's `main` (its base commit `b227620` is no longer in `main`), so it can't be merged via normal conflict resolution. This branch relocates the change to `crates/rattler_build_core/`, where the packaging code now lives.

Adds two warnings to help users avoid runtime shebang failures and prefer `entry_points` over plain scripts in `noarch: python` packages:

- **Prefix with spaces**: warns in the file-listing stage when the build prefix contains spaces *and* the recipe defines entry points, since shebang lines don't support quoted paths on Linux and the generated entry point scripts may fail to execute at runtime. The warning is also recorded via `record_warning`.
- **Unregistered Python scripts**: warns when a `noarch: python` package ships executable scripts under `python-scripts/` that aren't registered as entry points, pointing users to `build.python.entry_points` (e.g. `cmd = pkg.module:main`).

## Context

The original report was that `noarch: python` packages contained entry-point scripts with unquoted paths in the shebang. The unquoted paths were traced to `pip` rather than rattler-build, so the remaining ask in #1129 was to *warn* about these situations — both the space-in-prefix shebang hazard and the preference for `entry_points` over plain scripts.

## Testing

- `cargo check -p rattler_build_core` — passes
- `cargo clippy -p rattler_build_core --all-targets` — clean
- `cargo fmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014QPDHFpxLpRX4zA3EssmsT)_