### PR TITLE
fix: treat empty/null-like `noarch` as absent; hint `default` filter for undefined variant keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Conditional `build.noarch` and `build.variant.down_prioritize_variant` expressions no longer fail when they reference a variant key that is only defined on some platforms. A `noarch` expression that renders to an empty or null-like value (e.g. `noarch: ${{ "python" if use_noarch }}` when `use_noarch` is false, or `noarch: null`/`~`) is now treated as "not a noarch package", identical to omitting the key. Likewise, a `down_prioritize_variant` expression that references an undefined variant key (e.g. `${{ 0 if my_level == 1 else 1 }}` on a platform where `my_level` is not set) now falls back to no down-prioritization instead of erroring. Invalid noarch types and genuine template errors are still reported. (#2291, #2544)
+- A conditional `build.noarch` expression that renders to an empty or null-like value (e.g. `noarch: ${{ "python" if use_noarch }}` when `use_noarch` is false, or `noarch: null`/`~`/`${{ "python" if use_noarch else none }}`) is now treated as "not a noarch package", identical to omitting the key, instead of failing with `Invalid noarch type ''`. Invalid noarch types are still rejected. (#2291)
+- `build.noarch` and `build.variant.down_prioritize_variant` expressions that reference an undefined variable (e.g. a variant key that is only defined on some platforms) now report an error with a suggestion to use the `default` filter as an explicit fallback, e.g. `${{ 0 if (my_level | default(1)) == 1 else 1 }}`. (#2544)
 
 
 ## [0.67.0] - 2026-06-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Package content test failures now report the fully expanded glob(s) that were actually matched against the package (including automatically prepended platform prefixes such as `include/` or `Library/include/`), instead of only the raw user-provided pattern. This applies to all package content sections (`include`, `bin`, `lib`, `site_packages`, `files`), making it clearer why a pattern did not match. (#2584)
 - Improve CRAN (R) recipe generation: pass `${R_ARGS}` to `R CMD INSTALL`, add `cross-r-base` for cross-compilation, set `rpaths` for compiled packages, mark pure-R packages as `noarch: generic`, reference `r-base`'s bundled license files, and fix the `r-base` version constraint so it is applied to both `host` and `run` without duplication.
 
+### Fixed
+
+- Conditional `build.noarch` and `build.variant.down_prioritize_variant` expressions no longer fail when they reference a variant key that is only defined on some platforms. A `noarch` expression that renders to an empty or null-like value (e.g. `noarch: ${{ "python" if use_noarch }}` when `use_noarch` is false, or `noarch: null`/`~`) is now treated as "not a noarch package", identical to omitting the key. Likewise, a `down_prioritize_variant` expression that references an undefined variant key (e.g. `${{ 0 if my_level == 1 else 1 }}` on a platform where `my_level` is not set) now falls back to no down-prioritization instead of erroring. Invalid noarch types and genuine template errors are still reported. (#2291, #2544)
+
 
 ## [0.67.0] - 2026-06-22
 ### ✨ Highlights

--- a/crates/rattler_build_recipe/src/stage0/evaluate.rs
+++ b/crates/rattler_build_recipe/src/stage0/evaluate.rs
@@ -641,11 +641,13 @@ fn render_optional_variant_template(
         Ok(s) => Ok(Some(s)),
         Err(e) if is_undefined_variable_error(&e) => {
             let span = *e.span();
-            Err(ParseError::invalid_value(field, e.to_string(), span).with_suggestion(
-                "If this expression references a variant key that is only defined on some \
+            Err(
+                ParseError::invalid_value(field, e.to_string(), span).with_suggestion(
+                    "If this expression references a variant key that is only defined on some \
                  platforms, provide an explicit fallback with the `default` filter, e.g. \
                  `${{ my_key | default(0) }}`.",
-            ))
+                ),
+            )
         }
         Err(e) => Err(e),
     }
@@ -669,7 +671,10 @@ fn parse_noarch_string(s: &str, span: Option<&Span>) -> Result<Option<NoArchType
         .map_err(|_| {
             ParseError::invalid_value(
                 "noarch type",
-                format!("Invalid noarch type '{}'. Expected 'python' or 'generic'", s),
+                format!(
+                    "Invalid noarch type '{}'. Expected 'python' or 'generic'",
+                    s
+                ),
                 span.copied().unwrap_or_else(Span::new_blank),
             )
         })
@@ -4130,8 +4135,14 @@ requirements:
         let cond = "${{ 0 if my_level == 1 else 1 }}";
 
         // Key defined: evaluated normally.
-        assert_eq!(eval(cond, &[("my_level", Variable::from(1i64))]).unwrap(), Some(0));
-        assert_eq!(eval(cond, &[("my_level", Variable::from(3i64))]).unwrap(), Some(1));
+        assert_eq!(
+            eval(cond, &[("my_level", Variable::from(1i64))]).unwrap(),
+            Some(0)
+        );
+        assert_eq!(
+            eval(cond, &[("my_level", Variable::from(3i64))]).unwrap(),
+            Some(1)
+        );
         // Key absent (e.g. osx-arm64): strict undefined error with a fix-it hint.
         assert_undefined_with_default_hint(&eval(cond, &[]).unwrap_err());
         // The documented `| default(...)` fallback renders with the key absent.

--- a/crates/rattler_build_recipe/src/stage0/evaluate.rs
+++ b/crates/rattler_build_recipe/src/stage0/evaluate.rs
@@ -573,6 +573,19 @@ fn track_template_variables(value: &Value<String>, context: &EvaluationContext) 
     }
 }
 
+/// Whether a [`ParseError`] was caused by referencing an undefined Jinja variable.
+///
+/// Since the v0.58 parser rewrite, undefined variables are a hard error. A few
+/// contexts want to react to that specific failure rather than propagate it
+/// (e.g. preserving build-time templates, or falling back to a field default for
+/// variant keys that only exist on some platforms).
+fn is_undefined_variable_error(error: &ParseError) -> bool {
+    let error_msg = error.to_string();
+    error_msg.contains("undefined value")
+        || error_msg.contains("undefined variable")
+        || error_msg.contains("not defined in the evaluation context")
+}
+
 /// Try to evaluate a template string, but preserve it if there are undefined variables
 /// This is specifically for build script content where environment variables like ${{ PYTHON }}
 /// are only available at build time.
@@ -589,12 +602,7 @@ fn evaluate_or_preserve_template(
     match evaluate_string_value(value, context) {
         Ok(result) => Ok(result),
         Err(e) => {
-            // Check if this error was due to undefined variables
-            // The error message will contain "undefined value" or we can check the tracked undefined vars
-            let error_msg = e.to_string();
-            if error_msg.contains("undefined value")
-                || error_msg.contains("not defined in the evaluation context")
-            {
+            if is_undefined_variable_error(&e) {
                 // This is an undefined variable error - preserve the template
                 Ok(extract_template_source(value).unwrap_or_default())
             } else {
@@ -603,6 +611,63 @@ fn evaluate_or_preserve_template(
             }
         }
     }
+}
+
+/// Render an optional, templated build field that may reference variant keys
+/// which only exist on *some* target platforms.
+///
+/// Both `build.noarch` (`${{ "python" if use_noarch }}`) and
+/// `build.variant.down_prioritize_variant` (`${{ 0 if my_level == 1 else 1 }}`)
+/// routinely reference variant keys that are conditionally defined in
+/// `variants.yaml` (the standard conda-forge pattern). Before the v0.58
+/// strict-undefined change these rendered leniently; afterwards an undefined
+/// reference became a hard error, breaking every platform where the key is
+/// absent (see prefix-dev/rattler-build#2291 and #2544).
+///
+/// Both fields have a well-defined "absent" meaning (no noarch / no
+/// down-prioritization), so this helper collapses a missing value to `None`:
+/// - a template that references an undefined variable → `Ok(None)`
+/// - a template that renders to an empty string → `Ok(None)`
+/// - anything else → `Ok(Some(rendered))`, for the caller to parse/validate.
+///
+/// Only *undefined-variable* failures are swallowed; genuine template errors
+/// (syntax errors, failing function calls, ...) are still propagated. Concrete
+/// (non-template) values are handled by the callers, since their types differ.
+fn render_optional_variant_template(
+    template_source: &str,
+    span: Option<&Span>,
+    context: &EvaluationContext,
+) -> Result<Option<String>, ParseError> {
+    match render_template(template_source, context, span) {
+        Ok(s) if s.trim().is_empty() => Ok(None),
+        Ok(s) => Ok(Some(s)),
+        Err(e) if is_undefined_variable_error(&e) => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
+/// Interpret a rendered `noarch` string, treating "null-like" values as *no
+/// noarch* (`None`).
+///
+/// This lets `noarch: null`/`~` and conditional templates such as
+/// `${{ "python" if use_noarch else "~" }}` behave the same as omitting the
+/// `noarch` key entirely (see prefix-dev/rattler-build#2291). Valid noarch
+/// types (`python`, `generic`) are parsed via serde.
+fn parse_noarch_string(s: &str, span: Option<&Span>) -> Result<Option<NoArchType>, ParseError> {
+    let trimmed = s.trim();
+    if matches!(trimmed, "" | "~" | "null" | "none" | "None") {
+        return Ok(None);
+    }
+
+    serde_json::from_value::<NoArchType>(serde_json::Value::String(trimmed.to_string()))
+        .map(|nt| if nt.is_none() { None } else { Some(nt) })
+        .map_err(|_| {
+            ParseError::invalid_value(
+                "noarch type",
+                format!("Invalid noarch type '{}'. Expected 'python' or 'generic'", s),
+                span.copied().unwrap_or_else(Span::new_blank),
+            )
+        })
 }
 
 /// Evaluate an optional Value<T: ToString> into an Option<T> by parsing the string result
@@ -1804,20 +1869,32 @@ impl Evaluate for Stage0VariantKeyUsage {
     type Output = Stage1VariantKeyUsage;
 
     fn evaluate(&self, context: &EvaluationContext) -> Result<Self::Output, ParseError> {
+        // A `down_prioritize_variant` expression frequently compares against a
+        // variant key that is only defined on some platforms, e.g.
+        // `${{ 0 if my_level == 1 else 1 }}`. On platforms where the key is
+        // absent there is only a single variant, so the priority is irrelevant:
+        // treat an undefined reference (or an empty render) as "no
+        // down-prioritization" instead of a hard error (#2544).
         let down_prioritize_variant = match &self.down_prioritize_variant {
             None => None,
             Some(val) => {
-                let s = evaluate_value_to_string(val, context)?;
-                if s.is_empty() {
-                    None
+                let rendered = if let Some(n) = val.as_concrete() {
+                    Some(n.to_string())
+                } else if let Some(template) = val.as_template() {
+                    render_optional_variant_template(template.source(), val.span(), context)?
                 } else {
-                    Some(s.parse::<i32>().map_err(|_| {
+                    unreachable!("Value must be either concrete or template")
+                };
+
+                match rendered {
+                    None => None,
+                    Some(s) => Some(s.trim().parse::<i32>().map_err(|_| {
                         ParseError::invalid_value(
                             "down_prioritize_variant",
                             format!("Invalid integer value for down_prioritize_variant: '{}'", s),
-                            Span::new_blank(),
+                            val.span().copied().unwrap_or_else(Span::new_blank),
                         )
-                    })?)
+                    })?),
                 }
             }
         };
@@ -2039,28 +2116,24 @@ impl Evaluate for Stage0Build {
         let script = evaluate_script(&self.script, context)?;
 
         // Evaluate noarch
+        //
+        // A conditional template such as `${{ "python" if use_noarch }}` renders
+        // to an empty string when the condition is false; `noarch: null`/`~`
+        // renders to a null-like token. Both mean "no noarch" and must behave the
+        // same as omitting the key, rather than erroring (#2291). References to
+        // variant keys that only exist on some platforms are likewise treated as
+        // "no noarch" instead of a hard undefined-variable error.
         let noarch = match &self.noarch {
             None => None,
             Some(v) => {
-                // NoArchType is already validated during parsing, we just need to evaluate templates
                 if let Some(value) = v.as_concrete() {
-                    Some(*value)
+                    // NoArchType is already validated during parsing.
+                    if value.is_none() { None } else { Some(*value) }
                 } else if let Some(template) = v.as_template() {
-                    // If it's a template, we need to render it and parse as NoArchType
-                    let s = render_template(template.source(), context, v.span())?;
-                    // Parse the string as NoArchType using serde
-                    serde_json::from_value::<NoArchType>(serde_json::Value::String(s.clone()))
-                        .map(Some)
-                        .map_err(|_| {
-                            ParseError::invalid_value(
-                                "noarch type",
-                                format!(
-                                    "Invalid noarch type '{}'. Expected 'python' or 'generic'",
-                                    s
-                                ),
-                                v.span().copied().unwrap_or(Span::new_blank()),
-                            )
-                        })?
+                    match render_optional_variant_template(template.source(), v.span(), context)? {
+                        None => None,
+                        Some(s) => parse_noarch_string(&s, v.span())?,
+                    }
                 } else {
                     unreachable!("Value must be either concrete or template")
                 }
@@ -3954,6 +4027,172 @@ requirements:
             }
             _ => panic!("Expected single recipe"),
         }
+    }
+
+    /// Evaluate a single-output recipe with the given variant variables set,
+    /// returning the stage1 recipe (or the evaluation error).
+    fn evaluate_recipe_with_vars(
+        recipe_yaml: &str,
+        vars: &[(&str, Variable)],
+    ) -> Result<Stage1Recipe, ParseError> {
+        use crate::stage0::parser::parse_recipe_or_multi_from_source;
+
+        let parsed = parse_recipe_or_multi_from_source(recipe_yaml).expect("recipe should parse");
+        match parsed {
+            stage0::Recipe::SingleOutput(recipe) => {
+                let mut ctx = EvaluationContext::new();
+                for (key, value) in vars {
+                    ctx.insert((*key).to_string(), value.clone());
+                }
+                recipe.evaluate(&ctx)
+            }
+            _ => panic!("Expected single recipe"),
+        }
+    }
+
+    /// #2291: `noarch: ${{ "python" if use_noarch }}` must render to "no noarch"
+    /// (rather than erroring on the empty string) when the condition is false,
+    /// while still producing `python` when true.
+    #[test]
+    fn test_conditional_noarch_toggles_with_variant() {
+        let recipe_yaml = r#"schema_version: 1
+
+package:
+  name: coverage
+  version: "1.0"
+
+build:
+  number: 1
+  noarch: ${{ "python" if use_noarch }}
+"#;
+
+        let noarch_on = evaluate_recipe_with_vars(recipe_yaml, &[("use_noarch", Variable::from(true))])
+            .unwrap()
+            .build
+            .noarch;
+        assert_eq!(noarch_on, Some(NoArchType::python()));
+
+        let noarch_off =
+            evaluate_recipe_with_vars(recipe_yaml, &[("use_noarch", Variable::from(false))])
+                .unwrap()
+                .build
+                .noarch;
+        assert_eq!(noarch_off, None, "false condition means no noarch");
+    }
+
+    /// #2291: a conditional `noarch` that references a variant key which is not
+    /// defined on this platform must fall back to "no noarch" instead of failing
+    /// with an undefined-variable error.
+    #[test]
+    fn test_conditional_noarch_undefined_key_is_none() {
+        let recipe_yaml = r#"schema_version: 1
+
+package:
+  name: coverage
+  version: "1.0"
+
+build:
+  noarch: ${{ "python" if use_noarch }}
+"#;
+        // `use_noarch` intentionally not set.
+        let noarch = evaluate_recipe_with_vars(recipe_yaml, &[])
+            .unwrap()
+            .build
+            .noarch;
+        assert_eq!(noarch, None);
+    }
+
+    /// #2291 (wolfv's suggestion): `noarch: null`/`~` and a `"~"` fallback in a
+    /// template are accepted and mean "no noarch".
+    #[test]
+    fn test_noarch_null_like_values() {
+        for literal in ["null", "~", "none"] {
+            let recipe_yaml = format!(
+                "schema_version: 1\n\npackage:\n  name: p\n  version: \"1.0\"\n\nbuild:\n  noarch: {literal}\n"
+            );
+            let noarch = evaluate_recipe_with_vars(&recipe_yaml, &[])
+                .unwrap()
+                .build
+                .noarch;
+            assert_eq!(noarch, None, "`noarch: {literal}` should mean no noarch");
+        }
+
+        // `${{ "python" if use_noarch else "~" }}` — the `~` else-branch is a
+        // null-like token that means "no noarch".
+        let recipe_yaml = r#"schema_version: 1
+
+package:
+  name: p
+  version: "1.0"
+
+build:
+  noarch: ${{ "python" if use_noarch else "~" }}
+"#;
+        let noarch =
+            evaluate_recipe_with_vars(recipe_yaml, &[("use_noarch", Variable::from(false))])
+                .unwrap()
+                .build
+                .noarch;
+        assert_eq!(noarch, None);
+    }
+
+    /// An invalid (non-null-like) noarch value must still be rejected.
+    #[test]
+    fn test_invalid_noarch_still_errors() {
+        let recipe_yaml = r#"schema_version: 1
+
+package:
+  name: p
+  version: "1.0"
+
+build:
+  noarch: ${{ "banana" }}
+"#;
+        assert!(evaluate_recipe_with_vars(recipe_yaml, &[]).is_err());
+    }
+
+    /// #2544: `down_prioritize_variant` referencing a variant key that only
+    /// exists on some platforms must not error where the key is absent; where it
+    /// is defined, the expression is evaluated normally.
+    #[test]
+    fn test_down_prioritize_variant_undefined_key() {
+        let recipe_yaml = r#"schema_version: 1
+
+package:
+  name: repro
+  version: "1.0"
+
+build:
+  number: 0
+  variant:
+    use_keys:
+      - my_level
+    down_prioritize_variant: ${{ 0 if my_level == 1 else 1 }}
+"#;
+
+        // Key absent (e.g. osx-arm64): no down-prioritization, no error.
+        let absent = evaluate_recipe_with_vars(recipe_yaml, &[])
+            .unwrap()
+            .build
+            .variant
+            .down_prioritize_variant;
+        assert_eq!(absent, None);
+
+        // Key defined and matching → 0.
+        let matching = evaluate_recipe_with_vars(recipe_yaml, &[("my_level", Variable::from(1i64))])
+            .unwrap()
+            .build
+            .variant
+            .down_prioritize_variant;
+        assert_eq!(matching, Some(0));
+
+        // Key defined and not matching → 1.
+        let other = evaluate_recipe_with_vars(recipe_yaml, &[("my_level", Variable::from(3i64))])
+            .unwrap()
+            .build
+            .variant
+            .down_prioritize_variant;
+        assert_eq!(other, Some(1));
     }
 
     #[test]

--- a/crates/rattler_build_recipe/src/stage0/evaluate.rs
+++ b/crates/rattler_build_recipe/src/stage0/evaluate.rs
@@ -613,27 +613,25 @@ fn evaluate_or_preserve_template(
     }
 }
 
-/// Render an optional, templated build field that may reference variant keys
-/// which only exist on *some* target platforms.
+/// Render an optional, templated build field where an empty render means
+/// "field absent".
 ///
 /// Both `build.noarch` (`${{ "python" if use_noarch }}`) and
-/// `build.variant.down_prioritize_variant` (`${{ 0 if my_level == 1 else 1 }}`)
-/// routinely reference variant keys that are conditionally defined in
-/// `variants.yaml` (the standard conda-forge pattern). Before the v0.58
-/// strict-undefined change these rendered leniently; afterwards an undefined
-/// reference became a hard error, breaking every platform where the key is
-/// absent (see prefix-dev/rattler-build#2291 and #2544).
+/// `build.variant.down_prioritize_variant` (`${{ 0 if cuda else 1 }}`) are
+/// commonly written as conditional expressions that render to an empty string
+/// when the condition is false. Both fields have a well-defined "absent"
+/// meaning (no noarch / no down-prioritization), so an empty render collapses
+/// to `Ok(None)` instead of failing validation on the empty string
+/// (see prefix-dev/rattler-build#2291).
 ///
-/// Both fields have a well-defined "absent" meaning (no noarch / no
-/// down-prioritization), so this helper collapses a missing value to `None`:
-/// - a template that references an undefined variable → `Ok(None)`
-/// - a template that renders to an empty string → `Ok(None)`
-/// - anything else → `Ok(Some(rendered))`, for the caller to parse/validate.
-///
-/// Only *undefined-variable* failures are swallowed; genuine template errors
-/// (syntax errors, failing function calls, ...) are still propagated. Concrete
-/// (non-template) values are handled by the callers, since their types differ.
+/// Undefined variables remain a hard error, consistent with strict-undefined
+/// checking everywhere else. Since these fields often reference variant keys
+/// that are only defined on some platforms (see prefix-dev/rattler-build#2544),
+/// the error is enriched with a suggestion to use the `default` filter as an
+/// explicit fallback. Concrete (non-template) values are handled by the
+/// callers, since their types differ.
 fn render_optional_variant_template(
+    field: &str,
     template_source: &str,
     span: Option<&Span>,
     context: &EvaluationContext,
@@ -641,7 +639,14 @@ fn render_optional_variant_template(
     match render_template(template_source, context, span) {
         Ok(s) if s.trim().is_empty() => Ok(None),
         Ok(s) => Ok(Some(s)),
-        Err(e) if is_undefined_variable_error(&e) => Ok(None),
+        Err(e) if is_undefined_variable_error(&e) => {
+            let span = *e.span();
+            Err(ParseError::invalid_value(field, e.to_string(), span).with_suggestion(
+                "If this expression references a variant key that is only defined on some \
+                 platforms, provide an explicit fallback with the `default` filter, e.g. \
+                 `${{ my_key | default(0) }}`.",
+            ))
+        }
         Err(e) => Err(e),
     }
 }
@@ -1869,19 +1874,22 @@ impl Evaluate for Stage0VariantKeyUsage {
     type Output = Stage1VariantKeyUsage;
 
     fn evaluate(&self, context: &EvaluationContext) -> Result<Self::Output, ParseError> {
-        // A `down_prioritize_variant` expression frequently compares against a
-        // variant key that is only defined on some platforms, e.g.
-        // `${{ 0 if my_level == 1 else 1 }}`. On platforms where the key is
-        // absent there is only a single variant, so the priority is irrelevant:
-        // treat an undefined reference (or an empty render) as "no
-        // down-prioritization" instead of a hard error (#2544).
+        // An empty render (e.g. `${{ 1 if cuda }}` with `cuda` false) means "no
+        // down-prioritization". Undefined variant keys are a hard error with a
+        // hint to use `| default(...)` for keys that are only defined on some
+        // platforms (#2544).
         let down_prioritize_variant = match &self.down_prioritize_variant {
             None => None,
             Some(val) => {
                 let rendered = if let Some(n) = val.as_concrete() {
                     Some(n.to_string())
                 } else if let Some(template) = val.as_template() {
-                    render_optional_variant_template(template.source(), val.span(), context)?
+                    render_optional_variant_template(
+                        "variant.down_prioritize_variant",
+                        template.source(),
+                        val.span(),
+                        context,
+                    )?
                 } else {
                     unreachable!("Value must be either concrete or template")
                 };
@@ -2120,9 +2128,7 @@ impl Evaluate for Stage0Build {
         // A conditional template such as `${{ "python" if use_noarch }}` renders
         // to an empty string when the condition is false; `noarch: null`/`~`
         // renders to a null-like token. Both mean "no noarch" and must behave the
-        // same as omitting the key, rather than erroring (#2291). References to
-        // variant keys that only exist on some platforms are likewise treated as
-        // "no noarch" instead of a hard undefined-variable error.
+        // same as omitting the key, rather than erroring (#2291).
         let noarch = match &self.noarch {
             None => None,
             Some(v) => {
@@ -2130,7 +2136,12 @@ impl Evaluate for Stage0Build {
                     // NoArchType is already validated during parsing.
                     if value.is_none() { None } else { Some(*value) }
                 } else if let Some(template) = v.as_template() {
-                    match render_optional_variant_template(template.source(), v.span(), context)? {
+                    match render_optional_variant_template(
+                        "noarch",
+                        template.source(),
+                        v.span(),
+                        context,
+                    )? {
                         None => None,
                         Some(s) => parse_noarch_string(&s, v.span())?,
                     }
@@ -4080,11 +4091,10 @@ build:
         assert_eq!(noarch_off, None, "false condition means no noarch");
     }
 
-    /// #2291: a conditional `noarch` that references a variant key which is not
-    /// defined on this platform must fall back to "no noarch" instead of failing
-    /// with an undefined-variable error.
+    /// A conditional `noarch` that references an undefined variable is still a
+    /// hard error (strict-undefined checking), with a hint to use `| default()`.
     #[test]
-    fn test_conditional_noarch_undefined_key_is_none() {
+    fn test_conditional_noarch_undefined_key_errors_with_hint() {
         let recipe_yaml = r#"schema_version: 1
 
 package:
@@ -4095,11 +4105,8 @@ build:
   noarch: ${{ "python" if use_noarch }}
 "#;
         // `use_noarch` intentionally not set.
-        let noarch = evaluate_recipe_with_vars(recipe_yaml, &[])
-            .unwrap()
-            .build
-            .noarch;
-        assert_eq!(noarch, None);
+        let err = evaluate_recipe_with_vars(recipe_yaml, &[]).unwrap_err();
+        assert_undefined_with_default_hint(&err);
     }
 
     /// #2291 (wolfv's suggestion): `noarch: null`/`~` and a `"~"` fallback in a
@@ -4151,9 +4158,32 @@ build:
         assert!(evaluate_recipe_with_vars(recipe_yaml, &[]).is_err());
     }
 
-    /// #2544: `down_prioritize_variant` referencing a variant key that only
-    /// exists on some platforms must not error where the key is absent; where it
-    /// is defined, the expression is evaluated normally.
+    /// Assert that an error is an undefined-variable `InvalidValue` carrying the
+    /// `| default(...)` suggestion.
+    fn assert_undefined_with_default_hint(err: &ParseError) {
+        match err {
+            ParseError::InvalidValue {
+                reason, suggestion, ..
+            } => {
+                assert!(
+                    reason.contains("undefined"),
+                    "expected an undefined-variable reason, got: {reason}"
+                );
+                let suggestion = suggestion
+                    .as_deref()
+                    .expect("undefined-variable error should carry a suggestion");
+                assert!(
+                    suggestion.contains("default"),
+                    "suggestion should point at the `default` filter, got: {suggestion}"
+                );
+            }
+            other => panic!("expected InvalidValue with suggestion, got: {other:?}"),
+        }
+    }
+
+    /// #2544: `down_prioritize_variant` referencing a variant key that is not
+    /// defined on this platform errors with a hint to use `| default(...)`;
+    /// where the key is defined, the expression is evaluated normally.
     #[test]
     fn test_down_prioritize_variant_undefined_key() {
         let recipe_yaml = r#"schema_version: 1
@@ -4170,13 +4200,9 @@ build:
     down_prioritize_variant: ${{ 0 if my_level == 1 else 1 }}
 "#;
 
-        // Key absent (e.g. osx-arm64): no down-prioritization, no error.
-        let absent = evaluate_recipe_with_vars(recipe_yaml, &[])
-            .unwrap()
-            .build
-            .variant
-            .down_prioritize_variant;
-        assert_eq!(absent, None);
+        // Key absent (e.g. osx-arm64): strict undefined error with a fix-it hint.
+        let err = evaluate_recipe_with_vars(recipe_yaml, &[]).unwrap_err();
+        assert_undefined_with_default_hint(&err);
 
         // Key defined and matching → 0.
         let matching = evaluate_recipe_with_vars(recipe_yaml, &[("my_level", Variable::from(1i64))])
@@ -4193,6 +4219,31 @@ build:
             .variant
             .down_prioritize_variant;
         assert_eq!(other, Some(1));
+    }
+
+    /// The documented `| default(...)` fallback works for variant keys that are
+    /// only defined on some platforms.
+    #[test]
+    fn test_down_prioritize_variant_default_filter_fallback() {
+        let recipe_yaml = r#"schema_version: 1
+
+package:
+  name: repro
+  version: "1.0"
+
+build:
+  variant:
+    use_keys:
+      - my_level
+    down_prioritize_variant: ${{ 0 if (my_level | default(1)) == 1 else 1 }}
+"#;
+        // `my_level` intentionally not set: the default(1) fallback kicks in.
+        let value = evaluate_recipe_with_vars(recipe_yaml, &[])
+            .unwrap()
+            .build
+            .variant
+            .down_prioritize_variant;
+        assert_eq!(value, Some(0));
     }
 
     #[test]

--- a/crates/rattler_build_recipe/src/stage0/evaluate.rs
+++ b/crates/rattler_build_recipe/src/stage0/evaluate.rs
@@ -4061,103 +4061,6 @@ requirements:
         }
     }
 
-    /// #2291: `noarch: ${{ "python" if use_noarch }}` must render to "no noarch"
-    /// (rather than erroring on the empty string) when the condition is false,
-    /// while still producing `python` when true.
-    #[test]
-    fn test_conditional_noarch_toggles_with_variant() {
-        let recipe_yaml = r#"schema_version: 1
-
-package:
-  name: coverage
-  version: "1.0"
-
-build:
-  number: 1
-  noarch: ${{ "python" if use_noarch }}
-"#;
-
-        let noarch_on = evaluate_recipe_with_vars(recipe_yaml, &[("use_noarch", Variable::from(true))])
-            .unwrap()
-            .build
-            .noarch;
-        assert_eq!(noarch_on, Some(NoArchType::python()));
-
-        let noarch_off =
-            evaluate_recipe_with_vars(recipe_yaml, &[("use_noarch", Variable::from(false))])
-                .unwrap()
-                .build
-                .noarch;
-        assert_eq!(noarch_off, None, "false condition means no noarch");
-    }
-
-    /// A conditional `noarch` that references an undefined variable is still a
-    /// hard error (strict-undefined checking), with a hint to use `| default()`.
-    #[test]
-    fn test_conditional_noarch_undefined_key_errors_with_hint() {
-        let recipe_yaml = r#"schema_version: 1
-
-package:
-  name: coverage
-  version: "1.0"
-
-build:
-  noarch: ${{ "python" if use_noarch }}
-"#;
-        // `use_noarch` intentionally not set.
-        let err = evaluate_recipe_with_vars(recipe_yaml, &[]).unwrap_err();
-        assert_undefined_with_default_hint(&err);
-    }
-
-    /// #2291 (wolfv's suggestion): `noarch: null`/`~` and a `"~"` fallback in a
-    /// template are accepted and mean "no noarch".
-    #[test]
-    fn test_noarch_null_like_values() {
-        for literal in ["null", "~", "none"] {
-            let recipe_yaml = format!(
-                "schema_version: 1\n\npackage:\n  name: p\n  version: \"1.0\"\n\nbuild:\n  noarch: {literal}\n"
-            );
-            let noarch = evaluate_recipe_with_vars(&recipe_yaml, &[])
-                .unwrap()
-                .build
-                .noarch;
-            assert_eq!(noarch, None, "`noarch: {literal}` should mean no noarch");
-        }
-
-        // `${{ "python" if use_noarch else "~" }}` — the `~` else-branch is a
-        // null-like token that means "no noarch".
-        let recipe_yaml = r#"schema_version: 1
-
-package:
-  name: p
-  version: "1.0"
-
-build:
-  noarch: ${{ "python" if use_noarch else "~" }}
-"#;
-        let noarch =
-            evaluate_recipe_with_vars(recipe_yaml, &[("use_noarch", Variable::from(false))])
-                .unwrap()
-                .build
-                .noarch;
-        assert_eq!(noarch, None);
-    }
-
-    /// An invalid (non-null-like) noarch value must still be rejected.
-    #[test]
-    fn test_invalid_noarch_still_errors() {
-        let recipe_yaml = r#"schema_version: 1
-
-package:
-  name: p
-  version: "1.0"
-
-build:
-  noarch: ${{ "banana" }}
-"#;
-        assert!(evaluate_recipe_with_vars(recipe_yaml, &[]).is_err());
-    }
-
     /// Assert that an error is an undefined-variable `InvalidValue` carrying the
     /// `| default(...)` suggestion.
     fn assert_undefined_with_default_hint(err: &ParseError) {
@@ -4181,69 +4084,61 @@ build:
         }
     }
 
-    /// #2544: `down_prioritize_variant` referencing a variant key that is not
-    /// defined on this platform errors with a hint to use `| default(...)`;
-    /// where the key is defined, the expression is evaluated normally.
+    /// #2291: conditional `noarch` expressions.
     #[test]
-    fn test_down_prioritize_variant_undefined_key() {
-        let recipe_yaml = r#"schema_version: 1
+    fn test_conditional_noarch() {
+        let eval = |noarch: &str, vars: &[(&str, Variable)]| {
+            let recipe = format!(
+                "schema_version: 1\n\npackage:\n  name: p\n  version: \"1.0\"\n\nbuild:\n  noarch: {noarch}\n"
+            );
+            evaluate_recipe_with_vars(&recipe, vars).map(|r| r.build.noarch)
+        };
+        let cond = r#"${{ "python" if use_noarch }}"#;
+        let on = &[("use_noarch", Variable::from(true))][..];
+        let off = &[("use_noarch", Variable::from(false))][..];
 
-package:
-  name: repro
-  version: "1.0"
-
-build:
-  number: 0
-  variant:
-    use_keys:
-      - my_level
-    down_prioritize_variant: ${{ 0 if my_level == 1 else 1 }}
-"#;
-
-        // Key absent (e.g. osx-arm64): strict undefined error with a fix-it hint.
-        let err = evaluate_recipe_with_vars(recipe_yaml, &[]).unwrap_err();
-        assert_undefined_with_default_hint(&err);
-
-        // Key defined and matching → 0.
-        let matching = evaluate_recipe_with_vars(recipe_yaml, &[("my_level", Variable::from(1i64))])
-            .unwrap()
-            .build
-            .variant
-            .down_prioritize_variant;
-        assert_eq!(matching, Some(0));
-
-        // Key defined and not matching → 1.
-        let other = evaluate_recipe_with_vars(recipe_yaml, &[("my_level", Variable::from(3i64))])
-            .unwrap()
-            .build
-            .variant
-            .down_prioritize_variant;
-        assert_eq!(other, Some(1));
+        assert_eq!(eval(cond, on).unwrap(), Some(NoArchType::python()));
+        // A false condition renders empty → same as omitting the key.
+        assert_eq!(eval(cond, off).unwrap(), None);
+        // Null-like literals and template renders also mean "no noarch".
+        for expr in [
+            "null",
+            "~",
+            "none",
+            r#"${{ "python" if use_noarch else none }}"#,
+            r#"${{ "python" if use_noarch else "~" }}"#,
+        ] {
+            assert_eq!(eval(expr, off).unwrap(), None, "`noarch: {expr}`");
+        }
+        // Undefined variables are still a hard error, with a `default` hint.
+        assert_undefined_with_default_hint(&eval(cond, &[]).unwrap_err());
+        // Invalid noarch types are still rejected.
+        assert!(eval(r#"${{ "banana" }}"#, &[]).is_err());
     }
 
-    /// The documented `| default(...)` fallback works for variant keys that are
-    /// only defined on some platforms.
+    /// #2544: `down_prioritize_variant` referencing a variant key that is only
+    /// defined on some platforms.
     #[test]
-    fn test_down_prioritize_variant_default_filter_fallback() {
-        let recipe_yaml = r#"schema_version: 1
+    fn test_down_prioritize_variant_conditional_key() {
+        let eval = |expr: &str, vars: &[(&str, Variable)]| {
+            let recipe = format!(
+                "schema_version: 1\n\npackage:\n  name: p\n  version: \"1.0\"\n\nbuild:\n  variant:\n    use_keys:\n      - my_level\n    down_prioritize_variant: {expr}\n"
+            );
+            evaluate_recipe_with_vars(&recipe, vars)
+                .map(|r| r.build.variant.down_prioritize_variant)
+        };
+        let cond = "${{ 0 if my_level == 1 else 1 }}";
 
-package:
-  name: repro
-  version: "1.0"
-
-build:
-  variant:
-    use_keys:
-      - my_level
-    down_prioritize_variant: ${{ 0 if (my_level | default(1)) == 1 else 1 }}
-"#;
-        // `my_level` intentionally not set: the default(1) fallback kicks in.
-        let value = evaluate_recipe_with_vars(recipe_yaml, &[])
-            .unwrap()
-            .build
-            .variant
-            .down_prioritize_variant;
-        assert_eq!(value, Some(0));
+        // Key defined: evaluated normally.
+        assert_eq!(eval(cond, &[("my_level", Variable::from(1i64))]).unwrap(), Some(0));
+        assert_eq!(eval(cond, &[("my_level", Variable::from(3i64))]).unwrap(), Some(1));
+        // Key absent (e.g. osx-arm64): strict undefined error with a fix-it hint.
+        assert_undefined_with_default_hint(&eval(cond, &[]).unwrap_err());
+        // The documented `| default(...)` fallback renders with the key absent.
+        assert_eq!(
+            eval("${{ 0 if (my_level | default(1)) == 1 else 1 }}", &[]).unwrap(),
+            Some(0)
+        );
     }
 
     #[test]

--- a/crates/rattler_build_recipe/src/stage0/parser/build.rs
+++ b/crates/rattler_build_recipe/src/stage0/parser/build.rs
@@ -138,6 +138,8 @@ fn parse_bool_or_patterns<T>(
 ///
 /// Noarch can be either:
 /// - A scalar string: "python" or "generic"
+/// - A null-like value (`null`, `~`, `none`, empty) meaning "no noarch", which
+///   behaves the same as omitting the key (see prefix-dev/rattler-build#2291)
 /// - A template: "${{ noarch_type }}"
 fn parse_noarch(node: &Node) -> Result<Value<NoArchType>, ParseError> {
     let scalar = node.as_scalar().ok_or_else(|| {
@@ -158,6 +160,9 @@ fn parse_noarch(node: &Node) -> Result<Value<NoArchType>, ParseError> {
     let noarch = match str_val {
         "python" => NoArchType::python(),
         "generic" => NoArchType::generic(),
+        // `noarch: null` / `~` / `none` (and the empty scalar) explicitly mean
+        // "not a noarch package", identical to leaving the key out entirely.
+        "" | "~" | "null" | "none" | "None" => NoArchType::none(),
         _ => {
             return Err(ParseError::invalid_value(
                 "noarch",

--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -729,9 +729,10 @@ build:
 
 An expression that renders to an empty or null-like value (`none`, `null`,
 `~`, or the empty string) — as well as a literal `noarch: null` — is treated
-the same as omitting the `noarch` key entirely. If the expression references a
-variant key that is not defined for the current platform, the package is also
-treated as non-`noarch` rather than failing to render.
+the same as omitting the `noarch` key entirely. Referencing an undefined
+variable is still an error: if the variable is only defined on some platforms,
+provide an explicit fallback with the `default` filter, e.g.
+`${{ "python" if use_noarch | default(false) }}`.
 
 ### Include only certain files in the package
 

--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -713,6 +713,26 @@ build:
     evaluate to `true` in the platform it is built on, which probably will result
     in incorrect/incomplete installation in other platforms.
 
+#### Conditional `noarch`
+
+The `noarch` key can be set conditionally from a variant variable, which is
+useful for recipes that build a `noarch: python` package in some variants and
+an arch-specific package in others:
+
+```yaml
+build:
+  # no noarch when `use_noarch` is false or undefined
+  noarch: ${{ "python" if use_noarch }}
+  # or, with an explicit else branch:
+  noarch: ${{ "python" if use_noarch else none }}
+```
+
+An expression that renders to an empty or null-like value (`none`, `null`,
+`~`, or the empty string) — as well as a literal `noarch: null` — is treated
+the same as omitting the `noarch` key entirely. If the expression references a
+variant key that is not defined for the current platform, the package is also
+treated as non-`noarch` rather than failing to render.
+
 ### Include only certain files in the package
 
 Sometimes you may want to include only a subset of the files installed by the

--- a/docs/variants.md
+++ b/docs/variants.md
@@ -235,12 +235,11 @@ build:
 !!! note "Variant keys that only exist on some platforms"
     The `down_prioritize_variant` expression may reference a variant key that
     is only defined for some platforms in the variant configuration (e.g. a
-    microarchitecture level that only exists on `linux` + `x86_64`). On
-    platforms where the key is undefined there is only a single variant and
-    nothing to prioritize between, so the expression is skipped and no
-    down-prioritization is applied — the recipe still renders. If you prefer
-    an explicit fallback, `${{ 0 if (my_level | default(1)) == 1 else 1 }}`
-    works as well.
+    microarchitecture level that only exists on `linux` + `x86_64`). Since
+    referencing an undefined variable is an error, provide an explicit
+    fallback with the `default` filter:
+    `${{ 0 if (my_level | default(1)) == 1 else 1 }}`. On platforms where the
+    key is absent there is only a single variant, so any fallback value works.
 
 ???+ example "Example: CUDA / CPU variant with automatic fallback"
 

--- a/docs/variants.md
+++ b/docs/variants.md
@@ -232,6 +232,16 @@ build:
     down_prioritize_variant: ${{ 1 if cuda else 0 }}
 ```
 
+!!! note "Variant keys that only exist on some platforms"
+    The `down_prioritize_variant` expression may reference a variant key that
+    is only defined for some platforms in the variant configuration (e.g. a
+    microarchitecture level that only exists on `linux` + `x86_64`). On
+    platforms where the key is undefined there is only a single variant and
+    nothing to prioritize between, so the expression is skipped and no
+    down-prioritization is applied — the recipe still renders. If you prefer
+    an explicit fallback, `${{ 0 if (my_level | default(1)) == 1 else 1 }}`
+    works as well.
+
 ???+ example "Example: CUDA / CPU variant with automatic fallback"
 
     A common pattern is to build both GPU and CPU variants, where the solver


### PR DESCRIPTION
Fixes #2291
Closes #2544

Both issues are fallout from the v0.58 parser rewrite that made undefined Jinja variables a hard error, hitting `build` fields that reference variant keys defined only on *some* platforms (the standard conda-forge pattern):

- **#2291** — `noarch: ${{ "python" if use_noarch }}` renders to an empty string when the condition is false and failed with *"Invalid noarch type ''"*.
- **#2544** — `down_prioritize_variant: ${{ 0 if my_level == 1 else 1 }}` failed with a bare *"undefined value"* on platforms where `my_level` is not defined in the variant config.

## Design

One rule for both fields, keeping strict-undefined checking intact everywhere:

> An expression that **renders empty or null-like** means "field absent" (no noarch / no down-prioritization). An expression that **references an undefined variable** is always an error — the error now carries a fix-it hint to use the `default` filter.

This deliberately does **not** silently skip expressions referencing undefined keys: a typo'd variable name should error loudly, not quietly render every variant unprioritized. The explicit fallback (working since #2232) is the supported pattern:

```yaml
down_prioritize_variant: ${{ 0 if (my_level | default(1)) == 1 else 1 }}
```

and the error for the unguarded form now renders as:

```
Error:   × Failed to render recipe with variants
  ╰─▶ invalid value for 'variant.down_prioritize_variant': Jinja template
      error: Template rendering failed: undefined value ...
  help: If this expression references a variant key that is only defined on
        some platforms, provide an explicit fallback with the `default`
        filter, e.g. `${{ my_key | default(0) }}`.
```

For `noarch`, per @wolfv's suggestion in #2291, null-like values now explicitly mean "not a noarch package", identical to omitting the key:

```yaml
build:
  noarch: ${{ "python" if use_noarch }}              # empty render when false → no noarch
  noarch: ${{ "python" if use_noarch else none }}    # explicit, via minijinja's `none` literal
  noarch: null                                       # or ~ / none
```

Invalid noarch types (e.g. `noarch: banana`) and genuine template errors are still rejected.

## Changes

- `stage0/evaluate.rs`: shared `render_optional_variant_template` helper used by both fields — collapses an empty/whitespace render to `None`, and re-wraps undefined-variable errors as `InvalidValue` with the `default`-filter suggestion (plain `JinjaError` cannot carry a suggestion); `is_undefined_variable_error` refactored out of the existing build-script template-preservation logic; `parse_noarch_string` maps null-like renders to `NoArchType::none()`; the `down_prioritize_variant` parse error now carries the field's span instead of a blank one.
- `stage0/parser/build.rs`: `parse_noarch` accepts null-like scalars (`null`, `~`, `none`, empty) as `NoArchType::none()`.
- Docs: new "Conditional `noarch`" section in `docs/reference/recipe_file.md`; note in `docs/variants.md` about platform-conditional keys and the `default` filter.
- Changelog entries under `Fixed`.

## Testing

- Two table-style unit tests, one per field: `test_conditional_noarch` covers the conditional toggling, the null-like forms (`null`/`~`/`none`, `else none`, `else "~"`), the undefined-variable error with the `default` hint, and invalid types still erroring; `test_down_prioritize_variant_conditional_key` covers defined-key evaluation (0/1), the absent-key error with the hint, and the documented `| default(1)` fallback rendering correctly.
- Full `rattler_build_recipe` test suite passes.
- Verified end-to-end with `--render-only` using the reproducers from both issues: #2291 renders with `use_noarch` true (noarch python, subdir `noarch`) and false (no noarch); #2544's unguarded form shows the help text above, the `| default(1)` form renders on `osx-arm64`, and `linux-64` still produces two variants with priorities 0/1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9iPvod9MHTeZqaLaDQx4M