### PR TITLE
docs: add examples for noarch header-only libraries and noarch python variants

### DIFF
--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -708,10 +708,17 @@ build:
 ```
 
 !!! note
-    At the time of this writing, `noarch` packages should not make use
-    of preprocess-selectors: `noarch` packages are built with the directives which
-    evaluate to `true` in the platform it is built on, which probably will result
-    in incorrect/incomplete installation in other platforms.
+    Be careful when combining `noarch` packages with selectors: a `noarch`
+    package is built once, and the selectors are evaluated for the platform it
+    is built on — which probably results in an incorrect or incomplete
+    installation on other platforms.
+
+    That said, selectors can deliberately be combined with `noarch` to build
+    multiple flavors of the same `noarch` package, each restricted to certain
+    platforms or Python versions via virtual packages or version constraints.
+    See [building a header-only library as `noarch: generic`](../tutorials/cpp.md#building-a-header-only-library-as-noarch-generic)
+    and [multiple `noarch: python` variants for different Python versions](../tutorials/python.md#multiple-noarch-python-variants-for-different-python-versions)
+    for examples of this pattern.
 
 ### Include only certain files in the package
 

--- a/docs/scripts/validate_recipes.py
+++ b/docs/scripts/validate_recipes.py
@@ -15,7 +15,9 @@ for recipe_path in sorted(recipes_dir.glob("*.yaml")):
     try:
         recipe = Stage0Recipe.from_file(recipe_path)
         variants_path = variants_dir / recipe_path.name
-        variant_config = VariantConfig.from_file(variants_path) if variants_path.exists() else None
+        variant_config = (
+            VariantConfig.from_file(variants_path) if variants_path.exists() else None
+        )
         recipe.render(variant_config)
         print(f"  OK:   {recipe_path}")
     except Exception as e:

--- a/docs/scripts/validate_recipes.py
+++ b/docs/scripts/validate_recipes.py
@@ -3,15 +3,20 @@
 import sys
 from pathlib import Path
 
-from rattler_build import Stage0Recipe
+from rattler_build import Stage0Recipe, VariantConfig
 
 recipes_dir = Path("docs/snippets/recipes")
+# recipes that need a variant configuration have a file with the same name in
+# the `variants` subdirectory
+variants_dir = recipes_dir / "variants"
 failed = []
 
 for recipe_path in sorted(recipes_dir.glob("*.yaml")):
     try:
         recipe = Stage0Recipe.from_file(recipe_path)
-        recipe.render()
+        variants_path = variants_dir / recipe_path.name
+        variant_config = VariantConfig.from_file(variants_path) if variants_path.exists() else None
+        recipe.render(variant_config)
         print(f"  OK:   {recipe_path}")
     except Exception as e:
         failed.append((recipe_path, str(e)))

--- a/docs/snippets/recipes/botocore.yaml
+++ b/docs/snippets/recipes/botocore.yaml
@@ -1,0 +1,45 @@
+context:
+  version: "1.34.56"
+
+package:
+  name: botocore
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/b/botocore/botocore-${{ version }}.tar.gz
+  sha256: bffeb71ab21d47d4ecf947d9bdb2fbd1b0bbd0c27742cea7cf0b77b701c41d9f
+
+build:
+  number: 0
+  noarch: python
+  string: ${{ "pyge310" if python_geq_310 else "pyge38" }}_${{ hash }}_${{ build_number }} # (1)!
+  script: python -m pip install . --no-deps --no-build-isolation -vv
+
+requirements:
+  host:
+    - if: python_geq_310 # (2)!
+      then: python >=3.10
+      else: python >=3.8
+    - pip
+  run:
+    - if: python_geq_310
+      then:
+        - python >=3.10
+        - urllib3 >=1.25.4,<2.1 # (3)!
+      else:
+        - python >=3.8
+        - urllib3 >=1.25.4,<1.27
+    - jmespath >=0.7.1,<2.0.0
+    - python-dateutil >=2.1,<3.0.0
+
+tests:
+  - python:
+      imports:
+        - botocore
+      pip_check: true
+
+about:
+  homepage: https://aws.amazon.com/sdk-for-python/
+  summary: Low-level, data-driven core of boto 3
+  license: Apache-2.0
+  license_file: LICENSE.txt

--- a/docs/snippets/recipes/libml-dtypes-headers.yaml
+++ b/docs/snippets/recipes/libml-dtypes-headers.yaml
@@ -1,0 +1,41 @@
+context:
+  version: "0.5.4"
+
+package:
+  name: libml_dtypes-headers
+  version: ${{ version }}
+
+source:
+  url: https://github.com/jax-ml/ml_dtypes/archive/v${{ version }}.tar.gz
+  sha256: acaef497b420a15761cb525562b04d880b5c7afacea02d435a5d166fd8a99a16
+
+build:
+  number: 0
+  noarch: generic # (1)!
+  script:
+    - if: unix # (2)!
+      then:
+        - mkdir -p $PREFIX/include/ml_dtypes
+        - cp -r ml_dtypes/include $PREFIX/include/ml_dtypes/
+      else:
+        - md %LIBRARY_PREFIX%\include\ml_dtypes
+        - xcopy /E /I ml_dtypes\include %LIBRARY_PREFIX%\include\ml_dtypes\include
+
+requirements:
+  run:
+    - if: unix # (3)!
+      then: __unix
+      else: __win
+
+tests:
+  - package_contents:
+      files:
+        - if: unix # (4)!
+          then: include/ml_dtypes/include/float8.h
+          else: Library/include/ml_dtypes/include/float8.h
+
+about:
+  homepage: https://github.com/jax-ml/ml_dtypes
+  summary: A stand-alone implementation of several NumPy dtype extensions used in machine learning
+  license: Apache-2.0
+  license_file: LICENSE

--- a/docs/snippets/recipes/variants/botocore.yaml
+++ b/docs/snippets/recipes/variants/botocore.yaml
@@ -1,0 +1,3 @@
+python_geq_310:
+  - true
+  - false

--- a/docs/tutorials/cpp.md
+++ b/docs/tutorials/cpp.md
@@ -52,6 +52,75 @@ But which the package doesn't depend on itself.
 
     For more information please refer to the [conda-forge documentation](https://conda-forge.org/docs/maintainer/knowledge_base/#how-to-enable-cross-compilation).
 
+## Building a header-only library as `noarch: generic`
+
+The `xtensor` recipe above builds one package per platform, even though a
+header-only library contains no compiled code and the packaged files are
+identical on every architecture. To avoid rebuilding the same headers over and
+over, you can package a header-only library as a single, architecture-independent
+[`noarch: generic`](../reference/recipe_file.md#architecture-independent-packages)
+package instead.
+
+There is one wrinkle: the install layout differs between operating systems.
+On Unix systems, headers live in `$PREFIX/include`, while on Windows they are
+expected in `%PREFIX%\Library\include` (i.e. `%LIBRARY_PREFIX%\include`).
+A single `noarch` package cannot place its files in two different locations,
+so the trick is to build *two* flavors of the `noarch: generic` package:
+
+1. One built on Linux or macOS, with the headers in `include/`.
+2. One built on Windows, with the headers in `Library/include/`.
+
+Both flavors share the same package name and version. To make sure that the
+solver installs the correct flavor on each operating system, each flavor
+depends on a *virtual package*: the Unix flavor requires `__unix`, and the
+Windows flavor requires `__win`. Virtual packages are automatically provided by
+the installer based on the running system, so the Windows flavor is simply not
+installable on Unix systems and vice versa.
+
+The following recipe packages the headers of [`ml_dtypes`](https://github.com/jax-ml/ml_dtypes)
+and is based on conda-forge's [`libml_dtypes-headers` feedstock](https://github.com/conda-forge/libml_dtypes-headers-feedstock):
+
+```yaml title="recipe.yaml"
+--8<-- "docs/snippets/recipes/libml-dtypes-headers.yaml"
+```
+
+1. `noarch: generic` makes this a single architecture-independent package that
+   ends up in the `noarch` subdirectory of the channel and can be installed on
+   any platform.
+2. The `if: unix` selector is evaluated for the platform the package is built
+   on, so the build script copies the headers to the correct location for each
+   flavor.
+3. The virtual package (`__unix` or `__win`) restricts on which operating
+   systems this flavor of the package can be installed.
+4. The `package_contents` test checks the correct (platform-dependent) location
+   of the installed headers.
+
+To create both flavors, run `rattler-build` once on a Unix machine and once on
+a Windows machine (for example, in two CI jobs):
+
+```bash
+rattler-build build --recipe ./recipe.yaml
+```
+
+Even though both flavors have the same name and version, they do not clash:
+the `__unix` / `__win` virtual package requirement becomes part of the build
+variant, so each flavor automatically gets a distinct build string hash:
+
+```txt
+noarch/libml_dtypes-headers-0.5.4-h5600cae_0.conda  (depends on __unix)
+noarch/libml_dtypes-headers-0.5.4-h061c3d5_0.conda  (depends on __win)
+```
+
+!!! note "On conda-forge"
+    On conda-forge, this pattern is enabled by setting `noarch_platforms` in
+    the `conda-forge.yml` of the feedstock:
+
+    ```yaml title="conda-forge.yml"
+    noarch_platforms:
+      - linux_64
+      - win_64
+    ```
+
 ## Building A C++ application
 
 In this example, we'll build `poppler`, a C++ application for manipulating PDF files from the command line.

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -4,8 +4,8 @@ This section contains examples for packaging software in different languages wit
 
 | Example | Description |
 |---------|-------------|
-| [Python](python.md) | Build pure Python packages with `noarch: python` and compiled packages like NumPy |
-| [C++](cpp.md) | Package header-only and compiled C++ libraries using CMake |
+| [Python](python.md) | Build pure Python packages with `noarch: python` (including multiple variants per Python version) and compiled packages like NumPy |
+| [C++](cpp.md) | Package header-only (also as `noarch: generic`) and compiled C++ libraries using CMake |
 | [JavaScript](javascript.md) | Create packages for NodeJS applications using NPM |
 | [Rust](rust.md) | Build Rust packages with proper license bundling using `cargo-bundle-licenses` |
 | [Go](go.md) | Package Go applications with `go-cgo` or `go-nocgo` compilers |

--- a/docs/tutorials/python.md
+++ b/docs/tutorials/python.md
@@ -41,6 +41,98 @@ To build this recipe, simply run:
 rattler-build build --recipe ./ipywidgets
 ```
 
+## Multiple `noarch: python` variants for different Python versions
+
+A `noarch: python` package is built only once and works with any Python
+version. But sometimes a pure Python package needs *different requirements
+depending on the Python version* it is installed with.
+
+A good real-world example is `botocore`: the package supports Python 3.8 and
+up, but requires `urllib3 <1.27` on Python 3.8 / 3.9 and allows `urllib3 <2.1`
+on Python 3.10 and up. A single `noarch: python` package cannot express this,
+but you can build **two variants of the same `noarch: python` package** — one
+per Python version range.
+
+To do so, define a custom variant key in the `variants.yaml` file next to your
+recipe:
+
+```yaml title="variants.yaml"
+--8<-- "docs/snippets/recipes/variants/botocore.yaml"
+```
+
+Then use the variant key in [selectors](../selectors.md) to switch the
+requirements between the two variants. The following recipe is based on
+conda-forge's [`botocore` feedstock](https://github.com/conda-forge/botocore-feedstock/blob/0ee2e3cdb522285b93a9897affe668990832f0bf/recipe/meta.yaml):
+
+```yaml title="recipe.yaml"
+--8<-- "docs/snippets/recipes/botocore.yaml"
+```
+
+1. The two variants would normally only differ in their hash. Setting an
+   explicit build string with a readable prefix makes it easy to see which
+   variant of the package you are getting. The `hash` and `build_number`
+   variables are provided by Rattler-Build.
+2. Since `python_geq_310` is a boolean variant key, it can be used directly as
+   a condition in selectors.
+3. This is the reason for building two variants: on Python 3.10+, newer
+   versions of `urllib3` are supported.
+
+Building this recipe produces two `noarch` packages of the same name and
+version:
+
+```txt
+Build variant: botocore-1.34.56-pyge38_c34f5b3_0
+
+╭─────────────────┬──────────╮
+│ Variant         ┆ Version  │
+╞═════════════════╪══════════╡
+│ python_geq_310  ┆ false    │
+│ target_platform ┆ "noarch" │
+╰─────────────────┴──────────╯
+
+Build variant: botocore-1.34.56-pyge310_96c4f1e_0
+
+╭─────────────────┬──────────╮
+│ Variant         ┆ Version  │
+╞═════════════════╪══════════╡
+│ python_geq_310  ┆ true     │
+│ target_platform ┆ "noarch" │
+╰─────────────────┴──────────╯
+```
+
+In an environment with Python 3.8 or 3.9, only the `pyge38` variant is
+installable. With Python 3.10 or newer, both variants can be installed — but
+since the `pyge310` variant allows newer versions of `urllib3` (and the solver
+maximizes dependency versions), it is usually the one that gets picked. If you
+need explicit control over which variant the solver prefers, take a look at
+[prioritizing variants](../variants.md#prioritizing-variants).
+
+!!! tip "Variants based on other dependencies"
+    The same technique works for any dependency, not just Python itself. For
+    example, to ship one variant of your package for `pydantic` v1 and one for
+    `pydantic` v2, you can use the variant values directly in a dependency:
+
+    ```yaml title="variants.yaml"
+    pydantic:
+      - "1.*"
+      - "2.*"
+    ```
+
+    ```yaml title="recipe.yaml (excerpt)"
+    build:
+      noarch: python
+      string: pydantic${{ pydantic[0] }}_${{ hash }}_${{ build_number }}
+
+    requirements:
+      run:
+        - python >=3.9
+        - pydantic ${{ pydantic }}
+    ```
+
+    This builds `my-package-1.0.0-pydantic1_<hash>_0` and
+    `my-package-1.0.0-pydantic2_<hash>_0`, and the solver picks the variant
+    that is compatible with the `pydantic` version in your environment.
+
 ## A Python package with compiled extensions
 
 We will build a package for `numpy` – which contains compiled code.


### PR DESCRIPTION
Fixes #700, fixes #701

## Summary
This PR adds documentation and examples for building multiple variants of `noarch` packages, enabling pure Python packages to support different Python versions with version-specific dependencies, and header-only C++ libraries as platform-specific `noarch: generic` packages. Both examples are translated from real conda-forge feedstocks and were verified with `rattler-build build` / `--render-only`.

## Key Changes

- **New C++ tutorial section** (fixes #700): Added "Building a header-only library as `noarch: generic`", based on conda-forge's [`libml_dtypes-headers` feedstock](https://github.com/conda-forge/libml_dtypes-headers-feedstock)
  - Demonstrates how to package header-only libraries as architecture-independent packages
  - Explains the platform-specific install layout differences (Unix vs Windows) and how to handle them with selectors
  - Shows how virtual packages (`__unix`, `__win`) restrict installation to the appropriate platforms, and how the two flavors automatically get distinct build string hashes
  - Includes a note about conda-forge's `noarch_platforms` configuration

- **New Python tutorial section** (fixes #701): Added "Multiple `noarch: python` variants for different Python versions", based on conda-forge's [`botocore` feedstock](https://github.com/conda-forge/botocore-feedstock/blob/0ee2e3cdb522285b93a9897affe668990832f0bf/recipe/meta.yaml)
  - Shows how to build two variants of the same package with different dependency constraints per Python version range, using a boolean variant key in selectors
  - Shows the resulting build variants and how the solver picks the appropriate one (with a link to variant prioritization)
  - A tip box covers variants based on other dependencies (e.g. `pydantic` v1 vs v2)

- **Updated reference documentation**: Reworked the "noarch packages should not use selectors" note in `recipe_file.md` to link to the new tutorial examples of deliberately combining the two

- **Added example recipe files**:
  - `docs/snippets/recipes/libml-dtypes-headers.yaml`: header-only library as `noarch: generic`
  - `docs/snippets/recipes/botocore.yaml`: `noarch: python` package with Python-version-specific dependencies
  - `docs/snippets/recipes/variants/botocore.yaml`: sidecar variant configuration for the botocore example

- **Updated recipe validation script**: `validate_recipes.py` now loads variant configurations from the `variants/` subdirectory, allowing validation of snippets that require variant definitions (all 25 snippets pass)

- **Updated tutorial index**: Clarified descriptions to mention the new variant and `noarch: generic` examples

## User prompt

> Can you work on https://github.com/prefix-dev/rattler-build/issues/700 and https://github.com/prefix-dev/rattler-build/issues/701 ? ideally find some examples from conda-forge if possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EctHioiHEVbxBKVnpeFXVi