### PR TITLE
docs: package format differences and authentication resolution

### DIFF
--- a/docs/authentication_and_upload.md
+++ b/docs/authentication_and_upload.md
@@ -72,6 +72,27 @@ The following known authentication methods are supported:
 - `BasicHTTP`: artifactory
 - `S3Credentials`: S3 buckets
 
+### How authentication is resolved
+
+Rattler-Build uses the same authentication machinery as `rattler`, `pixi` and
+other tools built on it. When it needs credentials for a host, it consults the
+following storage backends in order and uses the first match:
+
+1. The file pointed to by the `RATTLER_AUTH_FILE` environment variable, if set.
+2. The operating system keyring, where credentials from `rattler-build auth
+   login` are stored (macOS Keychain, Windows Credential Manager, or the
+   Secret Service / `libsecret` on Linux).
+3. The fallback credentials file at `~/.rattler/credentials.json`. This is used
+   when a keyring is not available (for example on headless Linux machines) and
+   has the exact same JSON format as `RATTLER_AUTH_FILE`.
+4. A [`.netrc`](https://everything.curl.dev/usingcurl/netrc.html) file in your
+   home directory (or the file pointed to by the `NETRC` environment variable),
+   which provides `BasicHTTP` credentials.
+
+Because all of these backends share the same JSON format, the credentials
+written by `rattler-build auth login` can also be read by other rattler-based
+tools such as `pixi`, and vice versa.
+
 ## Uploading packages
 
 If you want to upload packages, then Rattler-Build comes with a built-in

--- a/docs/package_spec.md
+++ b/docs/package_spec.md
@@ -215,6 +215,23 @@ in the build recipe:
 : (this field is not used anymore as we rely on SPDX license identifiers)
 
 
+### `info/run_exports.json`
+
+Optional file. Contains the `run_exports` that this package defines (the
+requirements that are automatically added to packages that depend on this one).
+It is only written when the recipe actually defines any run exports.
+
+### `info/link.json`
+
+Contains information used at link (install) time, such as the `noarch` type and
+the version of the tool that created the package.
+
+### `info/hash_input.json`
+
+Contains the variant configuration that was used to compute the build hash of
+the package. This is the same information that conda-build stores and can be
+used to reproduce or inspect why a certain build hash was chosen.
+
 ### `info/recipe/<...>`
 
 A directory containing the full contents of the build recipe. This folder also
@@ -224,3 +241,28 @@ this format is still in flux and can change at any time.
 
 You can also use `--no-include-recipe` to disable the inclusion of the recipe in
 the package.
+
+## Differences from `conda-build` packages
+
+Packages built with Rattler-Build are fully installable with `conda`, `mamba`
+and `pixi`, but the set of files under `info/` differs slightly from what
+`conda-build` produces. Rattler-Build intentionally does **not** write the
+following legacy files:
+
+- `info/files`: a newline-separated list of all files in the package. This
+  information is fully contained in `info/paths.json` (in the `_path` field of
+  each entry), so the file is redundant.
+- `info/has_prefix`: the list of files that contain a build prefix that needs to
+  be replaced at install time. This is also captured in `info/paths.json` (via
+  the `prefix_placeholder` and `file_mode` fields of each entry).
+- `info/git`: information about the git source of the package. Rattler-Build
+  instead records the exact git reference that was used in the rendered recipe
+  (`info/recipe/rendered_recipe.yaml`).
+
+Modern versions of `conda`, `mamba` and `pixi` read `info/paths.json` and do not
+need these files. However, some older tooling still expects them. For example,
+older versions of the [Quetz](https://github.com/mamba-org/quetz) server relied
+on `info/files` when accepting uploads. If you run into a tool that fails on a
+Rattler-Build package because one of these files is missing, updating that tool
+to read `info/paths.json` is the recommended fix (see
+[#335](https://github.com/prefix-dev/rattler-build/issues/335) for background).


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation about Rattler-Build's package format and authentication mechanisms, clarifying how it differs from conda-build and how credentials are resolved.

## Key Changes

### Package Format Documentation (`docs/package_spec.md`)
- Added documentation for three previously undocumented `info/` files:
  - `info/run_exports.json`: Contains run_exports that are automatically added to dependent packages
  - `info/link.json`: Contains link-time information like noarch type and tool version
  - `info/hash_input.json`: Contains variant configuration used to compute the build hash
- Added new "Differences from `conda-build` packages" section explaining:
  - Why Rattler-Build intentionally omits legacy files (`info/files`, `info/has_prefix`, `info/git`)
  - How the information from these files is now captured in `info/paths.json`
  - Guidance for users encountering tools that expect these legacy files
  - Reference to issue #335 for background context

### Authentication Documentation (`docs/authentication_and_upload.md`)
- Added new "How authentication is resolved" subsection detailing the credential resolution order:
  1. `RATTLER_AUTH_FILE` environment variable
  2. Operating system keyring (Keychain, Credential Manager, libsecret)
  3. Fallback credentials file at `~/.rattler/credentials.json`
  4. `.netrc` file for BasicHTTP credentials
- Documented the shared JSON format across rattler-based tools (pixi, rattler, etc.)

## Notable Details
- Documentation emphasizes compatibility with modern conda/mamba/pixi versions while providing migration guidance for older tooling
- Authentication documentation clarifies the unified credential system shared across the rattler ecosystem

https://claude.ai/code/session_016CJTvPTeHhJCA16KV7zdsW