### PR TITLE
feat(test): add ABI compatibility check test for shared libraries

### DIFF
--- a/crates/rattler_build_core/src/package_test/abi_check.rs
+++ b/crates/rattler_build_core/src/package_test/abi_check.rs
@@ -1,0 +1,793 @@
+//! Implementation of the `abi_check` package test.
+//!
+//! The test downloads the lowest previously published version of the package that matches
+//! the configured pin expression (e.g. `x.x`, as used in pinnings) and compares the ABI
+//! surface of the shared libraries shipped in both packages. Within the pinned version
+//! range the following are reported as ABI breaks:
+//!
+//! * a shared library that disappeared from the package
+//! * a changed soname (ELF), install name (Mach-O) or DLL name (PE)
+//! * exported symbols that were removed
+//!
+//! Note that this is a *surface* check based on the dynamic symbol tables / export
+//! tables (parsed with `goblin`): changes to function signatures or struct layouts that
+//! do not change the set of exported symbol names cannot be detected.
+
+use std::{
+    cmp,
+    collections::BTreeSet,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+
+use fs_err as fs;
+use goblin::{
+    Object,
+    elf::Elf,
+    mach::{Mach, MachO, SingleArch},
+};
+use rattler::package_cache::CacheKey;
+use rattler_build_recipe::stage1::{GlobVec, tests::AbiCheckTest};
+use rattler_conda_types::{
+    Channel, MatchSpec, PackageName, PackageNameMatcher, Platform, RepoDataRecord, Version,
+    package::CondaArchiveIdentifier,
+};
+
+use super::run_test::{TestConfiguration, TestError};
+
+/// The ABI surface of a single shared library.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LibraryAbi {
+    /// Path of the library relative to the package root
+    pub relative_path: PathBuf,
+    /// The soname (ELF), install name (Mach-O) or DLL name (PE) of the library, if any
+    pub soname: Option<String>,
+    /// All exported (defined, externally visible) symbol names
+    pub exported_symbols: BTreeSet<String>,
+    /// The number of exports without a name (e.g. ordinal-only exports on Windows)
+    pub unnamed_exports: usize,
+}
+
+impl LibraryAbi {
+    /// The name used to pair a library with its counterpart in the other package when the
+    /// relative path does not match exactly (e.g. `libfoo.so.1.2.3` -> `libfoo.so`).
+    fn normalized_name(&self) -> String {
+        let file_name = self
+            .relative_path
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_default();
+        normalized_library_name(&file_name)
+    }
+}
+
+/// Strip version suffixes from a shared library file name so that differently versioned
+/// builds of the same library can be paired with each other.
+fn normalized_library_name(file_name: &str) -> String {
+    // ELF: `libfoo.so.1.2.3` -> `libfoo.so`
+    if file_name.ends_with(".so") {
+        return file_name.to_string();
+    }
+    if let Some(idx) = file_name.find(".so.") {
+        return file_name[..idx + 3].to_string();
+    }
+    // Mach-O: `libfoo.1.2.dylib` -> `libfoo.dylib`
+    if let Some(stem) = file_name.strip_suffix(".dylib") {
+        let base = stem
+            .split('.')
+            .take_while(|part| !part.chars().all(|c| c.is_ascii_digit()))
+            .collect::<Vec<_>>()
+            .join(".");
+        if !base.is_empty() {
+            return format!("{base}.dylib");
+        }
+        return file_name.to_string();
+    }
+    // PE (and everything else): DLL names are case-insensitive
+    file_name.to_lowercase()
+}
+
+/// Extract the ABI surface from a binary, or `None` if the file is not a shared library.
+fn extract_library_abi(bytes: &[u8], relative_path: &Path) -> Option<LibraryAbi> {
+    match Object::parse(bytes).ok()? {
+        Object::Elf(elf) => elf_abi(&elf, relative_path),
+        Object::Mach(Mach::Binary(macho)) => macho_abi(&macho, relative_path),
+        Object::Mach(Mach::Fat(multi_arch)) => {
+            // For fat binaries take the union of the exported symbols of all slices
+            let mut combined: Option<LibraryAbi> = None;
+            for arch in &multi_arch {
+                if let Ok(SingleArch::MachO(macho)) = arch
+                    && let Some(abi) = macho_abi(&macho, relative_path)
+                {
+                    match combined.as_mut() {
+                        None => combined = Some(abi),
+                        Some(existing) => {
+                            existing.exported_symbols.extend(abi.exported_symbols);
+                        }
+                    }
+                }
+            }
+            combined
+        }
+        Object::PE(pe) => {
+            if !pe.is_lib {
+                return None;
+            }
+            let mut exported_symbols = BTreeSet::new();
+            let mut unnamed_exports = 0;
+            for export in &pe.exports {
+                match export.name {
+                    Some(name) if !name.is_empty() => {
+                        exported_symbols.insert(name.to_string());
+                    }
+                    _ => unnamed_exports += 1,
+                }
+            }
+            Some(LibraryAbi {
+                relative_path: relative_path.to_path_buf(),
+                soname: pe.name.map(str::to_lowercase),
+                exported_symbols,
+                unnamed_exports,
+            })
+        }
+        _ => None,
+    }
+}
+
+fn elf_abi(elf: &Elf<'_>, relative_path: &Path) -> Option<LibraryAbi> {
+    use goblin::elf::{
+        header::ET_DYN,
+        section_header::SHN_UNDEF,
+        sym::{STB_GLOBAL, STB_WEAK},
+    };
+
+    // Only shared objects (this includes Python extension modules); skip executables,
+    // including position independent ones (which are ET_DYN but have an interpreter).
+    if elf.header.e_type != ET_DYN || elf.interpreter.is_some() {
+        return None;
+    }
+
+    let mut exported_symbols = BTreeSet::new();
+    for sym in elf.dynsyms.iter() {
+        // Skip undefined symbols (these are imports, not exports)
+        if sym.st_shndx == SHN_UNDEF as usize {
+            continue;
+        }
+        let bind = sym.st_bind();
+        if bind != STB_GLOBAL && bind != STB_WEAK {
+            continue;
+        }
+        if let Some(name) = elf.dynstrtab.get_at(sym.st_name)
+            && !name.is_empty()
+        {
+            exported_symbols.insert(name.to_string());
+        }
+    }
+
+    Some(LibraryAbi {
+        relative_path: relative_path.to_path_buf(),
+        soname: elf.soname.map(str::to_string),
+        exported_symbols,
+        unnamed_exports: 0,
+    })
+}
+
+fn macho_abi(macho: &MachO<'_>, relative_path: &Path) -> Option<LibraryAbi> {
+    use goblin::mach::header::{MH_BUNDLE, MH_DYLIB};
+
+    // Only dylibs and loadable bundles (Python extension modules)
+    if !matches!(macho.header.filetype, MH_DYLIB | MH_BUNDLE) {
+        return None;
+    }
+
+    let mut exported_symbols = BTreeSet::new();
+
+    // The export trie is the authoritative source for exported symbols
+    if let Ok(exports) = macho.exports() {
+        for export in exports {
+            if !export.name.is_empty() {
+                exported_symbols.insert(export.name);
+            }
+        }
+    }
+
+    // Also collect external defined symbols from the symbol table as a fallback for
+    // binaries without (or with an empty) export trie
+    if exported_symbols.is_empty() {
+        for symbol in macho.symbols() {
+            if let Ok((name, nlist)) = symbol
+                && nlist.is_global()
+                && !nlist.is_undefined()
+                && !nlist.is_stab()
+                && !name.is_empty()
+            {
+                exported_symbols.insert(name.to_string());
+            }
+        }
+    }
+
+    // Use the file name portion of the install name as the "soname": the directory part
+    // (e.g. `@rpath/` or an encoded prefix) is not relevant for ABI compatibility
+    let soname = macho.name.map(|id| {
+        Path::new(id)
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| id.to_string())
+    });
+
+    Some(LibraryAbi {
+        relative_path: relative_path.to_path_buf(),
+        soname,
+        exported_symbols,
+        unnamed_exports: 0,
+    })
+}
+
+/// Collect the ABI surface of all shared libraries in an extracted package directory.
+///
+/// If `libraries` is not empty, only libraries whose relative path matches the globs are
+/// collected.
+fn collect_libraries(
+    package_dir: &Path,
+    libraries: &GlobVec,
+) -> Result<Vec<LibraryAbi>, TestError> {
+    let mut result = Vec::new();
+
+    for entry in walkdir::WalkDir::new(package_dir)
+        .into_iter()
+        .filter_entry(|entry| {
+            // Skip the `info/` metadata directory at the package root
+            entry.path().strip_prefix(package_dir) != Ok(Path::new("info"))
+        })
+    {
+        let entry = entry.map_err(|e| {
+            TestError::AbiCheckError(format!("failed to walk package directory: {e}"))
+        })?;
+        // Skip directories and symlinks (the symlink targets are checked instead)
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let relative_path = entry
+            .path()
+            .strip_prefix(package_dir)
+            .expect("entry must be under the package directory")
+            .to_path_buf();
+
+        if !libraries.is_empty() && !libraries.is_match(&relative_path) {
+            continue;
+        }
+
+        let bytes = fs::read(entry.path())?;
+        if let Some(abi) = extract_library_abi(&bytes, &relative_path) {
+            result.push(abi);
+        }
+    }
+
+    result.sort_by(|a, b| a.relative_path.cmp(&b.relative_path));
+    Ok(result)
+}
+
+/// A single detected ABI incompatibility.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum AbiViolation {
+    /// A shared library from the baseline package has no counterpart in the new package
+    LibraryRemoved {
+        path: PathBuf,
+        soname: Option<String>,
+    },
+    /// The soname / install name / DLL name of a library changed
+    SonameChanged {
+        path: PathBuf,
+        old: String,
+        new: String,
+    },
+    /// Exported symbols were removed from a library
+    SymbolsRemoved {
+        path: PathBuf,
+        matched_path: PathBuf,
+        symbols: Vec<String>,
+    },
+    /// The number of unnamed (ordinal-only) exports decreased (PE only)
+    UnnamedExportsRemoved {
+        path: PathBuf,
+        old_count: usize,
+        new_count: usize,
+    },
+}
+
+impl std::fmt::Display for AbiViolation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        /// Number of removed symbols listed per library before truncating the output
+        const MAX_LISTED_SYMBOLS: usize = 25;
+
+        match self {
+            AbiViolation::LibraryRemoved { path, soname } => {
+                write!(f, "{}: shared library was removed", path.display())?;
+                if let Some(soname) = soname {
+                    write!(f, " (soname `{soname}`)")?;
+                }
+                Ok(())
+            }
+            AbiViolation::SonameChanged { path, old, new } => {
+                write!(
+                    f,
+                    "{}: soname changed from `{old}` to `{new}`",
+                    path.display()
+                )
+            }
+            AbiViolation::SymbolsRemoved {
+                path,
+                matched_path,
+                symbols,
+            } => {
+                write!(
+                    f,
+                    "{}: {} exported symbol{} removed",
+                    path.display(),
+                    symbols.len(),
+                    if symbols.len() == 1 { "" } else { "s" },
+                )?;
+                if path != matched_path {
+                    write!(f, " (compared with {})", matched_path.display())?;
+                }
+                for symbol in symbols.iter().take(MAX_LISTED_SYMBOLS) {
+                    write!(f, "\n    - {symbol}")?;
+                }
+                if symbols.len() > MAX_LISTED_SYMBOLS {
+                    write!(
+                        f,
+                        "\n    ... and {} more",
+                        symbols.len() - MAX_LISTED_SYMBOLS
+                    )?;
+                }
+                Ok(())
+            }
+            AbiViolation::UnnamedExportsRemoved {
+                path,
+                old_count,
+                new_count,
+            } => {
+                write!(
+                    f,
+                    "{}: the number of unnamed (ordinal-only) exports decreased from {old_count} to {new_count}",
+                    path.display()
+                )
+            }
+        }
+    }
+}
+
+/// Find the counterpart of `old` in `new_libs`. Match by (in order of preference) exact
+/// relative path, normalized file name in the same directory, soname, and normalized file
+/// name anywhere in the package.
+fn find_matching_library<'a>(
+    old: &LibraryAbi,
+    new_libs: &'a [LibraryAbi],
+) -> Option<&'a LibraryAbi> {
+    if let Some(exact) = new_libs
+        .iter()
+        .find(|lib| lib.relative_path == old.relative_path)
+    {
+        return Some(exact);
+    }
+
+    let normalized = old.normalized_name();
+    if let Some(same_dir) = new_libs.iter().find(|lib| {
+        lib.relative_path.parent() == old.relative_path.parent()
+            && lib.normalized_name() == normalized
+    }) {
+        return Some(same_dir);
+    }
+
+    if old.soname.is_some()
+        && let Some(same_soname) = new_libs.iter().find(|lib| lib.soname == old.soname)
+    {
+        return Some(same_soname);
+    }
+
+    new_libs
+        .iter()
+        .find(|lib| lib.normalized_name() == normalized)
+}
+
+/// Compare the ABI surfaces of the baseline (old) and the new package.
+pub(crate) fn diff_library_abis(
+    old_libs: &[LibraryAbi],
+    new_libs: &[LibraryAbi],
+    ignore_symbols: &GlobVec,
+) -> Vec<AbiViolation> {
+    let mut violations = Vec::new();
+
+    for old in old_libs {
+        let Some(new) = find_matching_library(old, new_libs) else {
+            violations.push(AbiViolation::LibraryRemoved {
+                path: old.relative_path.clone(),
+                soname: old.soname.clone(),
+            });
+            continue;
+        };
+
+        if let (Some(old_soname), Some(new_soname)) = (&old.soname, &new.soname)
+            && old_soname != new_soname
+        {
+            violations.push(AbiViolation::SonameChanged {
+                path: old.relative_path.clone(),
+                old: old_soname.clone(),
+                new: new_soname.clone(),
+            });
+        }
+
+        let removed: Vec<String> = old
+            .exported_symbols
+            .difference(&new.exported_symbols)
+            .filter(|symbol| {
+                ignore_symbols.is_empty() || !ignore_symbols.is_match(Path::new(symbol))
+            })
+            .cloned()
+            .collect();
+        if !removed.is_empty() {
+            violations.push(AbiViolation::SymbolsRemoved {
+                path: old.relative_path.clone(),
+                matched_path: new.relative_path.clone(),
+                symbols: removed,
+            });
+        }
+
+        if old.unnamed_exports > new.unnamed_exports {
+            violations.push(AbiViolation::UnnamedExportsRemoved {
+                path: old.relative_path.clone(),
+                old_count: old.unnamed_exports,
+                new_count: new.unnamed_exports,
+            });
+        }
+    }
+
+    violations
+}
+
+/// The length of the common prefix of two build strings. Used to prefer the baseline
+/// build variant that is closest to the current one (e.g. `py310h1234_0` over
+/// `py39h5678_0` when the current build string is `py310habcd_1`).
+fn common_prefix_len(a: &str, b: &str) -> usize {
+    a.chars().zip(b.chars()).take_while(|(x, y)| x == y).count()
+}
+
+/// From all records matching the pinned version range, select the baseline record: the
+/// lowest version, preferring the build variant closest to the current build string.
+fn select_baseline_record<'a>(
+    candidates: &[&'a RepoDataRecord],
+    current_build_string: &str,
+) -> Option<&'a RepoDataRecord> {
+    let lowest_version = candidates
+        .iter()
+        .map(|record| record.package_record.version.clone())
+        .min()?;
+
+    candidates
+        .iter()
+        .filter(|record| record.package_record.version == lowest_version)
+        .max_by_key(|record| {
+            (
+                common_prefix_len(&record.package_record.build, current_build_string),
+                record.package_record.build_number,
+            )
+        })
+        .copied()
+}
+
+/// Execute the ABI check test: download the baseline package and compare the ABI surface
+/// of its shared libraries with the package under test.
+pub(crate) async fn run_abi_check_test(
+    abi_check: &AbiCheckTest,
+    pkg: &CondaArchiveIdentifier,
+    package_folder: &Path,
+    config: &TestConfiguration,
+) -> Result<(), TestError> {
+    let pkg_id = format!(
+        "{}-{}-{}",
+        pkg.identifier.name, pkg.identifier.version, pkg.identifier.build_string
+    );
+    let span = tracing::info_span!("Running ABI check", span_color = pkg_id);
+    let _guard = span.enter();
+
+    let target_platform = config
+        .target_platform
+        .unwrap_or(config.current_platform.platform);
+    if target_platform == Platform::NoArch {
+        tracing::info!("Skipping ABI check for noarch package");
+        return Ok(());
+    }
+
+    let package_name = PackageName::try_from(pkg.identifier.name.as_str())
+        .map_err(|e| TestError::AbiCheckError(format!("invalid package name: {e}")))?;
+    let current_version = Version::from_str(&pkg.identifier.version)
+        .map_err(|e| TestError::AbiCheckError(format!("invalid package version: {e}")))?;
+
+    // Compute the lower bound of the pinned version range from the pin expression, e.g.
+    // pin `x.x` and version `1.2.3` -> lower bound `1.2` (mirroring `Pin::apply`)
+    let pin_digits = abi_check
+        .pin
+        .to_string()
+        .chars()
+        .filter(|&c| c == 'x')
+        .count();
+    if pin_digits == 0 {
+        return Err(TestError::AbiCheckError(
+            "the pin expression must contain at least one `x`".to_string(),
+        ));
+    }
+    let lower_bound = current_version
+        .with_segments(..cmp::min(pin_digits, current_version.segment_count()))
+        .ok_or_else(|| {
+            TestError::AbiCheckError(format!(
+                "could not apply pin `{}` to version `{current_version}`",
+                abi_check.pin
+            ))
+        })?;
+
+    tracing::info!(
+        "Looking for the lowest published version of `{}` matching `>={lower_bound},<{current_version}` (pin: `{}`)",
+        package_name.as_normalized(),
+        abi_check.pin,
+    );
+
+    // Query the repodata of all test channels for the package
+    let channels = config
+        .channels
+        .iter()
+        .map(|url| Channel::from_url(url.clone()))
+        .collect::<Vec<_>>();
+    let name_only_spec = MatchSpec {
+        name: PackageNameMatcher::Exact(package_name.clone()),
+        ..Default::default()
+    };
+    let repodata = config
+        .tool_configuration
+        .repodata_gateway
+        .query(channels, [target_platform], vec![name_only_spec])
+        .await
+        .map_err(|e| TestError::AbiCheckError(format!("failed to query repodata: {e}")))?;
+
+    let candidates: Vec<&RepoDataRecord> = repodata
+        .iter()
+        .flat_map(|repo_data| repo_data.iter())
+        .filter(|record| record.package_record.name == package_name)
+        .filter(|record| {
+            let version = record.package_record.version.version();
+            version >= &lower_bound && version < &current_version
+        })
+        .filter(|record| {
+            // Respect `--exclude-newer` if configured
+            match (config.exclude_newer, record.package_record.timestamp) {
+                (Some(exclude_newer), Some(timestamp)) => {
+                    timestamp.timestamp_millis() <= exclude_newer.as_millisecond()
+                }
+                _ => true,
+            }
+        })
+        .collect();
+
+    let Some(baseline) = select_baseline_record(&candidates, &pkg.identifier.build_string) else {
+        tracing::warn!(
+            "No previously published version of `{}` matches `>={lower_bound},<{current_version}` — skipping ABI check (this is expected for the first release in a pin range)",
+            package_name.as_normalized(),
+        );
+        return Ok(());
+    };
+
+    tracing::info!(
+        "Comparing ABI with baseline {}={}={}",
+        baseline.package_record.name.as_normalized(),
+        baseline.package_record.version,
+        baseline.package_record.build,
+    );
+
+    // Download (or copy) and extract the baseline package via the package cache
+    let package_cache = &config.tool_configuration.package_cache;
+    let cache_metadata = if baseline.url.scheme() == "file" {
+        let path = baseline
+            .url
+            .to_file_path()
+            .map_err(|_| TestError::AbiCheckError(format!("invalid file URL: {}", baseline.url)))?;
+        package_cache
+            .get_or_fetch_from_path(&path, Some(&baseline.package_record), None)
+            .await
+    } else {
+        package_cache
+            .get_or_fetch_from_url(
+                CacheKey::from(&baseline.package_record),
+                baseline.url.clone(),
+                config
+                    .tool_configuration
+                    .client
+                    .for_host(&baseline.url)
+                    .clone(),
+                None,
+                None,
+            )
+            .await
+    }
+    .map_err(|e| TestError::AbiCheckError(format!("failed to fetch the baseline package: {e}")))?;
+    let baseline_folder = cache_metadata.path().to_path_buf();
+
+    let old_libs = collect_libraries(&baseline_folder, &abi_check.libraries)?;
+    let new_libs = collect_libraries(package_folder, &GlobVec::default())?;
+
+    if old_libs.is_empty() {
+        tracing::warn!(
+            "The baseline package does not contain any shared libraries{} — nothing to check",
+            if abi_check.libraries.is_empty() {
+                String::new()
+            } else {
+                format!(" matching {:?}", abi_check.libraries)
+            }
+        );
+        return Ok(());
+    }
+
+    let violations = diff_library_abis(&old_libs, &new_libs, &abi_check.ignore_symbols);
+
+    if violations.is_empty() {
+        let symbol_count: usize = old_libs.iter().map(|lib| lib.exported_symbols.len()).sum();
+        tracing::info!(
+            "{} ABI check passed: {} librar{} ({} exported symbols) compatible with {}={}={}",
+            console::style(console::Emoji("✔", "")).green(),
+            old_libs.len(),
+            if old_libs.len() == 1 { "y" } else { "ies" },
+            symbol_count,
+            baseline.package_record.name.as_normalized(),
+            baseline.package_record.version,
+            baseline.package_record.build,
+        );
+        Ok(())
+    } else {
+        let mut report = format!(
+            "found {} ABI incompatibilit{} compared to {}={}={}:",
+            violations.len(),
+            if violations.len() == 1 { "y" } else { "ies" },
+            baseline.package_record.name.as_normalized(),
+            baseline.package_record.version,
+            baseline.package_record.build,
+        );
+        for violation in &violations {
+            report.push_str("\n  ✖ ");
+            report.push_str(&violation.to_string());
+        }
+        tracing::error!("{report}");
+        Err(TestError::AbiCheckFailed(report))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lib(path: &str, soname: Option<&str>, symbols: &[&str]) -> LibraryAbi {
+        LibraryAbi {
+            relative_path: PathBuf::from(path),
+            soname: soname.map(str::to_string),
+            exported_symbols: symbols.iter().map(|s| s.to_string()).collect(),
+            unnamed_exports: 0,
+        }
+    }
+
+    #[test]
+    fn test_normalized_library_name() {
+        assert_eq!(normalized_library_name("libfoo.so"), "libfoo.so");
+        assert_eq!(normalized_library_name("libfoo.so.1.2.3"), "libfoo.so");
+        assert_eq!(normalized_library_name("libabsl.so.2308.0.0"), "libabsl.so");
+        assert_eq!(normalized_library_name("libfoo.dylib"), "libfoo.dylib");
+        assert_eq!(normalized_library_name("libfoo.1.2.dylib"), "libfoo.dylib");
+        assert_eq!(
+            normalized_library_name("libfoo.bar.1.dylib"),
+            "libfoo.bar.dylib"
+        );
+        assert_eq!(normalized_library_name("Foo.DLL"), "foo.dll");
+        assert_eq!(
+            normalized_library_name("module.cpython-310-x86_64-linux-gnu.so"),
+            "module.cpython-310-x86_64-linux-gnu.so"
+        );
+    }
+
+    #[test]
+    fn test_diff_no_changes() {
+        let old = vec![lib("lib/libfoo.so.1", Some("libfoo.so.1"), &["a", "b"])];
+        let new = vec![lib(
+            "lib/libfoo.so.1",
+            Some("libfoo.so.1"),
+            &["a", "b", "c"],
+        )];
+        assert!(diff_library_abis(&old, &new, &GlobVec::default()).is_empty());
+    }
+
+    #[test]
+    fn test_diff_removed_symbols() {
+        let old = vec![lib(
+            "lib/libfoo.so.1",
+            Some("libfoo.so.1"),
+            &["a", "b", "c"],
+        )];
+        let new = vec![lib("lib/libfoo.so.1", Some("libfoo.so.1"), &["a"])];
+        let violations = diff_library_abis(&old, &new, &GlobVec::default());
+        assert_eq!(violations.len(), 1);
+        match &violations[0] {
+            AbiViolation::SymbolsRemoved { symbols, .. } => {
+                assert_eq!(symbols, &["b".to_string(), "c".to_string()]);
+            }
+            other => panic!("expected SymbolsRemoved, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_diff_ignored_symbols() {
+        let old = vec![lib(
+            "lib/libfoo.so.1",
+            Some("libfoo.so.1"),
+            &["a", "_internal_x", "_internal_y"],
+        )];
+        let new = vec![lib("lib/libfoo.so.1", Some("libfoo.so.1"), &["a"])];
+        let ignore = GlobVec::from_vec(vec!["_internal_*"], None);
+        assert!(diff_library_abis(&old, &new, &ignore).is_empty());
+    }
+
+    #[test]
+    fn test_diff_version_bumped_file_name() {
+        // The file name changed with the version, but the soname stayed stable
+        let old = vec![lib("lib/libfoo.so.1.2.0", Some("libfoo.so.1"), &["a"])];
+        let new = vec![lib("lib/libfoo.so.1.2.5", Some("libfoo.so.1"), &["a", "b"])];
+        assert!(diff_library_abis(&old, &new, &GlobVec::default()).is_empty());
+    }
+
+    #[test]
+    fn test_diff_soname_changed() {
+        let old = vec![lib("lib/libfoo.so.1.0.0", Some("libfoo.so.1"), &["a"])];
+        let new = vec![lib("lib/libfoo.so.2.0.0", Some("libfoo.so.2"), &["a"])];
+        let violations = diff_library_abis(&old, &new, &GlobVec::default());
+        assert_eq!(violations.len(), 1);
+        assert!(
+            matches!(&violations[0], AbiViolation::SonameChanged { old, new, .. }
+            if old == "libfoo.so.1" && new == "libfoo.so.2")
+        );
+    }
+
+    #[test]
+    fn test_diff_library_removed() {
+        let old = vec![
+            lib("lib/libfoo.so.1", Some("libfoo.so.1"), &["a"]),
+            lib("lib/libbar.so.1", Some("libbar.so.1"), &["b"]),
+        ];
+        let new = vec![lib("lib/libfoo.so.1", Some("libfoo.so.1"), &["a"])];
+        let violations = diff_library_abis(&old, &new, &GlobVec::default());
+        assert_eq!(violations.len(), 1);
+        assert!(
+            matches!(&violations[0], AbiViolation::LibraryRemoved { path, .. }
+            if path == Path::new("lib/libbar.so.1"))
+        );
+    }
+
+    #[test]
+    fn test_diff_unnamed_exports() {
+        let mut old_lib = lib("bin/foo.dll", Some("foo.dll"), &["a"]);
+        old_lib.unnamed_exports = 3;
+        let mut new_lib = lib("bin/foo.dll", Some("foo.dll"), &["a"]);
+        new_lib.unnamed_exports = 1;
+        let violations = diff_library_abis(&[old_lib], &[new_lib], &GlobVec::default());
+        assert_eq!(violations.len(), 1);
+        assert!(matches!(
+            &violations[0],
+            AbiViolation::UnnamedExportsRemoved {
+                old_count: 3,
+                new_count: 1,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_common_prefix_len() {
+        assert_eq!(common_prefix_len("py310h1234_0", "py310h5678_1"), 6);
+        assert_eq!(common_prefix_len("py39h1_0", "py310h1_0"), 3);
+        assert_eq!(common_prefix_len("abc", "abc"), 3);
+        assert_eq!(common_prefix_len("", "abc"), 0);
+    }
+}

--- a/crates/rattler_build_core/src/package_test/mod.rs
+++ b/crates/rattler_build_core/src/package_test/mod.rs
@@ -1,4 +1,5 @@
 //! Tests that are run as part of the package build process.
+mod abi_check;
 mod content_test;
 mod run_test;
 mod serialize_test;

--- a/crates/rattler_build_core/src/package_test/run_test.rs
+++ b/crates/rattler_build_core/src/package_test/run_test.rs
@@ -119,6 +119,12 @@ pub enum TestError {
     #[error("could not determine target platform from package file (no index.json?)")]
     CouldNotDetermineTargetPlatform,
 
+    #[error("ABI check failed: {0}")]
+    AbiCheckFailed(String),
+
+    #[error("failed to run ABI check: {0}")]
+    AbiCheckError(String),
+
     #[error(
         "no tests found in package. Expected `info/test/` (conda-build format) or `info/tests/tests.yaml` (rattler-build format)"
     )]
@@ -653,6 +659,10 @@ pub async fn run_test(
                 }
                 // This test already runs during the build process and we don't need to run it again
                 TestType::PackageContents { .. } => {}
+                TestType::AbiCheck { abi_check } => {
+                    super::abi_check::run_abi_check_test(&abi_check, &pkg, &package_folder, &config)
+                        .await?
+                }
             }
 
             if !config.keep_test_prefix {

--- a/crates/rattler_build_recipe/src/stage0/evaluate.rs
+++ b/crates/rattler_build_recipe/src/stage0/evaluate.rs
@@ -56,7 +56,8 @@ use crate::{
             UrlSource as Stage0UrlSource,
         },
         tests::{
-            CommandsTest as Stage0CommandsTest, CommandsTestFiles as Stage0CommandsTestFiles,
+            AbiCheckTest as Stage0AbiCheckTest, CommandsTest as Stage0CommandsTest,
+            CommandsTestFiles as Stage0CommandsTestFiles,
             CommandsTestRequirements as Stage0CommandsTestRequirements,
             DownstreamTest as Stage0DownstreamTest,
             PackageContentsCheckFiles as Stage0PackageContentsCheckFiles,
@@ -85,7 +86,8 @@ use crate::{
             Source as Stage1Source, UrlSource as Stage1UrlSource, parse_publisher_string,
         },
         tests::{
-            CommandsTest as Stage1CommandsTest, CommandsTestFiles as Stage1CommandsTestFiles,
+            AbiCheckTest as Stage1AbiCheckTest, CommandsTest as Stage1CommandsTest,
+            CommandsTestFiles as Stage1CommandsTestFiles,
             CommandsTestRequirements as Stage1CommandsTestRequirements,
             DownstreamTest as Stage1DownstreamTest,
             PackageContentsCheckFiles as Stage1PackageContentsCheckFiles,
@@ -2554,6 +2556,37 @@ impl Evaluate for Stage0DownstreamTest {
     }
 }
 
+impl Evaluate for Stage0AbiCheckTest {
+    type Output = Stage1AbiCheckTest;
+
+    fn evaluate(&self, context: &EvaluationContext) -> Result<Self::Output, ParseError> {
+        let pin = match &self.pin {
+            None => Stage1AbiCheckTest::default().pin,
+            Some(value) => {
+                let evaluated = evaluate_string_value(value, context)?;
+                evaluated
+                    .parse::<rattler_build_types::PinExpression>()
+                    .map_err(|e| {
+                        ParseError::invalid_value(
+                            "pin",
+                            format!("invalid pin expression '{}': {}", evaluated, e),
+                            value.span().cloned().unwrap_or_else(Span::new_blank),
+                        )
+                        .with_suggestion(
+                            "The pin must use the `x.x` syntax (e.g. `x`, `x.x` or `x.x.x`)",
+                        )
+                    })?
+            }
+        };
+
+        Ok(Stage1AbiCheckTest {
+            pin,
+            libraries: evaluate_glob_vec_simple(&self.libraries, context)?,
+            ignore_symbols: evaluate_glob_vec_simple(&self.ignore_symbols, context)?,
+        })
+    }
+}
+
 // Note: Can't use macro for PackageContentsCheckFiles because fields need GlobVec conversion
 
 impl Evaluate for Stage0PackageContentsCheckFiles {
@@ -2660,6 +2693,9 @@ fn evaluate_test_type(
                 package_contents: package_contents.evaluate(context)?,
             })
         }
+        Stage0TestType::AbiCheck { abi_check } => Ok(Stage1TestType::AbiCheck {
+            abi_check: abi_check.evaluate(context)?,
+        }),
     }
 }
 
@@ -4586,6 +4622,122 @@ outputs:
             }
             _ => panic!("Expected MultiOutputRecipe"),
         }
+    }
+
+    #[test]
+    fn test_evaluate_abi_check_test() {
+        use crate::stage0::parser::parse_recipe_or_multi_from_source;
+
+        let recipe_yaml = r#"
+package:
+  name: test-package
+  version: 1.0.0
+
+tests:
+  - abi_check:
+      pin: x.x.x
+      libraries:
+        - lib/libfoo*
+      ignore_symbols:
+        - _internal_*
+  - abi_check:
+      pin: ${{ abi_pin }}
+  - abi_check: {}
+"#;
+
+        let parsed = parse_recipe_or_multi_from_source(recipe_yaml).unwrap();
+        let stage0::Recipe::SingleOutput(recipe) = parsed else {
+            panic!("Expected single output recipe");
+        };
+
+        let mut ctx = EvaluationContext::new();
+        ctx.insert("abi_pin".to_string(), Variable::from_string("x.x"));
+
+        let tests: Vec<Stage1TestType> = recipe
+            .tests
+            .as_slice()
+            .iter()
+            .flat_map(|item| evaluate_test(item, &ctx).unwrap())
+            .collect();
+        assert_eq!(tests.len(), 3);
+
+        // Fully specified test
+        let Stage1TestType::AbiCheck { abi_check } = &tests[0] else {
+            panic!("Expected AbiCheck test");
+        };
+        assert_eq!(abi_check.pin.to_string(), "x.x.x");
+        assert!(
+            abi_check
+                .libraries
+                .is_match(std::path::Path::new("lib/libfoo.so.1"))
+        );
+        assert!(
+            !abi_check
+                .libraries
+                .is_match(std::path::Path::new("lib/libbar.so.1"))
+        );
+        assert!(
+            abi_check
+                .ignore_symbols
+                .is_match(std::path::Path::new("_internal_free"))
+        );
+
+        // Pin coming from a Jinja variable
+        let Stage1TestType::AbiCheck { abi_check } = &tests[1] else {
+            panic!("Expected AbiCheck test");
+        };
+        assert_eq!(abi_check.pin.to_string(), "x.x");
+
+        // All defaults
+        let Stage1TestType::AbiCheck { abi_check } = &tests[2] else {
+            panic!("Expected AbiCheck test");
+        };
+        assert_eq!(abi_check.pin.to_string(), "x.x");
+        assert!(abi_check.libraries.is_empty());
+        assert!(abi_check.ignore_symbols.is_empty());
+    }
+
+    #[test]
+    fn test_parse_abi_check_test_unknown_field() {
+        use crate::stage0::parser::parse_recipe_or_multi_from_source;
+
+        let recipe_yaml = r#"
+package:
+  name: test-package
+  version: 1.0.0
+
+tests:
+  - abi_check:
+      pin: x.x
+      symbols: foo
+"#;
+
+        let err = parse_recipe_or_multi_from_source(recipe_yaml).unwrap_err();
+        assert!(err.to_string().contains("unknown field 'symbols'"));
+    }
+
+    #[test]
+    fn test_evaluate_abi_check_test_invalid_pin() {
+        use crate::stage0::parser::parse_recipe_or_multi_from_source;
+
+        let recipe_yaml = r#"
+package:
+  name: test-package
+  version: 1.0.0
+
+tests:
+  - abi_check:
+      pin: not-a-pin
+"#;
+
+        let parsed = parse_recipe_or_multi_from_source(recipe_yaml).unwrap();
+        let stage0::Recipe::SingleOutput(recipe) = parsed else {
+            panic!("Expected single output recipe");
+        };
+
+        let ctx = EvaluationContext::new();
+        let err = evaluate_test(&recipe.tests.as_slice()[0], &ctx).unwrap_err();
+        assert!(err.to_string().contains("invalid pin expression"));
     }
 
     #[test]

--- a/crates/rattler_build_recipe/src/stage0/parser/test_parser.rs
+++ b/crates/rattler_build_recipe/src/stage0/parser/test_parser.rs
@@ -11,9 +11,9 @@ use crate::{
         Value,
         parser::helpers::get_span,
         tests::{
-            CommandsTest, CommandsTestFiles, CommandsTestRequirements, DownstreamTest,
-            PackageContentsCheckFiles, PackageContentsTest, PerlTest, PythonTest, PythonVersion,
-            RTest, RubyTest, TestType,
+            AbiCheckTest, CommandsTest, CommandsTestFiles, CommandsTestRequirements,
+            DownstreamTest, PackageContentsCheckFiles, PackageContentsTest, PerlTest, PythonTest,
+            PythonVersion, RTest, RubyTest, TestType,
         },
         types::Script,
     },
@@ -154,10 +154,15 @@ fn parse_single_test(node: &Node) -> Result<TestType, ParseError> {
                 ParseError::expected_type("mapping", "non-mapping", get_span(package_contents_node))
             })?)?;
         Ok(TestType::PackageContents { package_contents })
+    } else if let Some(abi_check_node) = mapping.get("abi_check") {
+        let abi_check = parse_abi_check_test(abi_check_node.as_mapping().ok_or_else(|| {
+            ParseError::expected_type("mapping", "non-mapping", get_span(abi_check_node))
+        })?)?;
+        Ok(TestType::AbiCheck { abi_check })
     } else {
         Err(ParseError::invalid_value(
             "test",
-            "missing test type field (python, perl, r, ruby, script, downstream, package_contents)",
+            "missing test type field (python, perl, r, ruby, script, downstream, package_contents, abi_check)",
             get_span(node),
         ))
     }
@@ -407,6 +412,43 @@ fn parse_downstream_test(
     })?;
 
     Ok(DownstreamTest { downstream })
+}
+
+fn parse_abi_check_test(
+    mapping: &marked_yaml::types::MarkedMappingNode,
+) -> Result<AbiCheckTest, ParseError> {
+    let mut pin = None;
+    let mut libraries = ConditionalList::default();
+    let mut ignore_symbols = ConditionalList::default();
+
+    for (key_node, value_node) in mapping.iter() {
+        let key = key_node.as_str();
+        match key {
+            "pin" => {
+                pin = Some(parse_value(value_node)?);
+            }
+            "libraries" => {
+                libraries = parse_conditional_list(value_node)?;
+            }
+            "ignore_symbols" => {
+                ignore_symbols = parse_conditional_list(value_node)?;
+            }
+            _ => {
+                return Err(ParseError::invalid_value(
+                    "abi_check test",
+                    format!("unknown field '{}'", key),
+                    *key_node.span(),
+                )
+                .with_suggestion("Valid fields are: pin, libraries, ignore_symbols"));
+            }
+        }
+    }
+
+    Ok(AbiCheckTest {
+        pin,
+        libraries,
+        ignore_symbols,
+    })
 }
 
 fn parse_package_contents_test(

--- a/crates/rattler_build_recipe/src/stage0/tests.rs
+++ b/crates/rattler_build_recipe/src/stage0/tests.rs
@@ -102,6 +102,26 @@ pub struct DownstreamTest {
     pub downstream: Value<String>,
 }
 
+/// A test that checks the ABI of the shared libraries in the package against a
+/// previously published version of the same package
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AbiCheckTest {
+    /// The pin expression (`x.x` syntax, as used in pinnings) that selects the range of
+    /// previously published versions that must remain ABI compatible. The lowest published
+    /// version matching the pin is used as the comparison baseline. Defaults to `x.x`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pin: Option<Value<String>>,
+
+    /// Glob patterns that select the libraries to check (defaults to all shared libraries
+    /// found in the package)
+    #[serde(default, skip_serializing_if = "ConditionalList::is_empty")]
+    pub libraries: ConditionalList<String>,
+
+    /// Glob patterns for exported symbol names that should be ignored in the comparison
+    #[serde(default, skip_serializing_if = "ConditionalList::is_empty")]
+    pub ignore_symbols: ConditionalList<String>,
+}
+
 /// Package content test that compares the contents of the package with the expected contents
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PackageContentsTest {
@@ -180,6 +200,12 @@ pub enum TestType {
         /// The package contents to test against
         package_contents: PackageContentsTest,
     },
+    /// A test that checks the ABI of the shared libraries in the package against a
+    /// previously published version of the same package
+    AbiCheck {
+        /// The ABI check to run
+        abi_check: AbiCheckTest,
+    },
 }
 
 impl TestType {
@@ -249,6 +275,13 @@ impl TestType {
                     vars.extend(include.exists.used_variables());
                     vars.extend(include.not_exists.used_variables());
                 }
+            }
+            TestType::AbiCheck { abi_check } => {
+                if let Some(pin) = &abi_check.pin {
+                    vars.extend(pin.used_variables());
+                }
+                vars.extend(abi_check.libraries.used_variables());
+                vars.extend(abi_check.ignore_symbols.used_variables());
             }
         }
         vars.sort();

--- a/crates/rattler_build_recipe/src/stage1/tests.rs
+++ b/crates/rattler_build_recipe/src/stage1/tests.rs
@@ -1,4 +1,5 @@
 use rattler_build_script::Script;
+use rattler_build_types::PinExpression;
 use serde::{Deserialize, Serialize};
 
 use crate::stage1::Dependency;
@@ -229,6 +230,48 @@ fn is_false(value: &bool) -> bool {
     !*value
 }
 
+/// The default pin expression for ABI checks (`x.x`)
+fn default_abi_pin() -> PinExpression {
+    "x.x".parse().expect("`x.x` is a valid pin expression")
+}
+
+fn is_default_abi_pin(pin: &PinExpression) -> bool {
+    pin == &default_abi_pin()
+}
+
+/// A test that checks the ABI of the shared libraries in the package against a
+/// previously published version of the same package (evaluated)
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AbiCheckTest {
+    /// The pin expression (`x.x` syntax, as used in pinnings) that selects the range of
+    /// previously published versions that must remain ABI compatible. The lowest published
+    /// version matching the pin is used as the comparison baseline.
+    #[serde(
+        default = "default_abi_pin",
+        skip_serializing_if = "is_default_abi_pin"
+    )]
+    pub pin: PinExpression,
+
+    /// Globs that select the libraries to check (defaults to all shared libraries found in
+    /// the package)
+    #[serde(default, skip_serializing_if = "GlobVec::is_empty")]
+    pub libraries: GlobVec,
+
+    /// Globs for exported symbol names that should be ignored in the comparison
+    #[serde(default, skip_serializing_if = "GlobVec::is_empty")]
+    pub ignore_symbols: GlobVec,
+}
+
+impl Default for AbiCheckTest {
+    fn default() -> Self {
+        Self {
+            pin: default_abi_pin(),
+            libraries: GlobVec::default(),
+            ignore_symbols: GlobVec::default(),
+        }
+    }
+}
+
 /// The test type enum (evaluated)
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -262,6 +305,12 @@ pub enum TestType {
     PackageContents {
         /// The package contents to test against
         package_contents: PackageContentsTest,
+    },
+    /// A test that checks the ABI of the shared libraries in the package against a
+    /// previously published version of the same package
+    AbiCheck {
+        /// The ABI check to run
+        abi_check: AbiCheckTest,
     },
 }
 
@@ -310,6 +359,31 @@ mod tests {
         script:
           content: echo 'test'
         "###);
+
+        // ABI check test
+        let abi_check = TestType::AbiCheck {
+            abi_check: AbiCheckTest {
+                pin: "x.x.x".parse().unwrap(),
+                libraries: GlobVec::from_vec(vec!["lib/libfoo*"], None),
+                ignore_symbols: GlobVec::from_vec(vec!["_internal_*"], None),
+            },
+        };
+        insta::assert_snapshot!(serde_yaml::to_string(&abi_check).unwrap(), @r###"
+        abi_check:
+          pin: x.x.x
+          libraries:
+          - lib/libfoo*
+          ignore_symbols:
+          - _internal_*
+        "###);
+
+        // ABI check test with all defaults (the default pin is not serialized)
+        let abi_check_default = TestType::AbiCheck {
+            abi_check: AbiCheckTest::default(),
+        };
+        insta::assert_snapshot!(serde_yaml::to_string(&abi_check_default).unwrap(), @r###"
+        abi_check: {}
+        "###);
     }
 
     /// Test deserialization of all test types
@@ -329,6 +403,23 @@ mod tests {
         // Commands
         let commands: TestType = serde_yaml::from_str("script:\n  content: echo test").unwrap();
         assert!(matches!(commands, TestType::Commands(_)));
+
+        // ABI check
+        let abi_check: TestType = serde_yaml::from_str("abi_check:\n  pin: x.x.x").unwrap();
+        match abi_check {
+            TestType::AbiCheck { abi_check } => assert_eq!(abi_check.pin.to_string(), "x.x.x"),
+            _ => panic!("Expected AbiCheck test"),
+        }
+
+        // ABI check with all defaults
+        let abi_check: TestType = serde_yaml::from_str("abi_check: {}").unwrap();
+        match abi_check {
+            TestType::AbiCheck { abi_check } => {
+                assert_eq!(abi_check, AbiCheckTest::default());
+                assert_eq!(abi_check.pin.to_string(), "x.x");
+            }
+            _ => panic!("Expected AbiCheck test"),
+        }
     }
 
     /// Test roundtrip serialization for all test types
@@ -356,6 +447,16 @@ mod tests {
                 },
                 files: CommandsTestFiles::default(),
             }),
+            TestType::AbiCheck {
+                abi_check: AbiCheckTest::default(),
+            },
+            TestType::AbiCheck {
+                abi_check: AbiCheckTest {
+                    pin: "x".parse().unwrap(),
+                    libraries: GlobVec::from_vec(vec!["lib/*"], None),
+                    ignore_symbols: GlobVec::from_vec(vec!["_priv*"], Some(vec!["_privkeep*"])),
+                },
+            },
         ];
 
         for original in test_cases {

--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -1485,6 +1485,49 @@ tests:
   - downstream: numpy
 ```
 
+### ABI check test
+
+The `abi_check` test compares the ABI surface of the shared libraries in the package
+against a previously published version of the same package. It downloads the *lowest*
+published version that matches the given pin expression (the same `x.x` syntax that is
+used for pinnings) and fails if, within that version range:
+
+- a shared library was removed from the package,
+- the soname (ELF), install name (Mach-O) or DLL name (PE) of a library changed, or
+- exported symbols were removed from a library.
+
+This is useful to verify that the ABI promise implied by the `run_exports` of a package
+actually holds: if downstream packages are pinned to e.g. `x.x` of your package, the
+shared libraries of every `x.x` release must stay ABI compatible.
+
+```yaml
+tests:
+  - abi_check:
+      # compare against the lowest published version with the same major.minor
+      # version (this is the default)
+      pin: x.x
+
+      # optionally restrict the check to certain libraries (defaults to all
+      # shared libraries found in the package)
+      libraries:
+        - lib/libfoo*
+
+      # optionally ignore certain exported symbols (glob patterns)
+      ignore_symbols:
+        - _internal_*
+```
+
+The packages to compare against are looked up in the channels used for testing. If no
+previously published version matches the pin (for example for the very first release in
+a new pin range), the check is skipped with a warning. The test is also skipped for
+`noarch` packages.
+
+!!! note
+    The check compares the *exported symbol names* found in the dynamic symbol table
+    (ELF), export trie (Mach-O) or export table (PE) of the libraries. Changes to
+    function signatures or struct layouts that do not change the set of exported symbol
+    names cannot be detected. Added symbols are backwards compatible and never reported.
+
 
 ## Outputs section
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -80,6 +80,12 @@ tests:
         - bin/myapp
       lib:
         - mylib
+
+  # check that the shared libraries in the package are ABI compatible with the
+  # lowest previously published version that matches the pin (`x.x` == same
+  # major.minor version)
+  - abi_check:
+      pin: x.x
 ```
 
 ### Testing package contents
@@ -107,6 +113,30 @@ It has multiple sub-keys that help when building cross-platform packages:
 - **`bin`**: matches files under the `bin` directory in the package. You can specify executable names like `foo` which will match `foo.exe` on Windows and `foo` on Linux and macOS.
 - **`site_packages`**: matches files under the `site-packages` directory in the package. You can specify the import path like `foobar.api` which will match `foobar/api.py` and `foobar/api/__init__.py`.
 - **`strict`**: when set to `true`, enables strict mode. In strict mode, the test will fail if there are any files in the package that don't match any of the specified globs. (default: `false`).
+
+### Checking ABI compatibility
+
+The `abi_check` test verifies that the shared libraries shipped in the package stay ABI
+compatible with previously published versions of the same package. It downloads the
+lowest published version matching the pin expression (using the same `x.x` syntax as
+pinnings) from the test channels and compares the exported symbols, sonames and library
+names of the shared libraries in both packages.
+
+```yaml title="recipe.yaml"
+tests:
+  - abi_check:
+      pin: x.x               # default: lowest version with the same major.minor
+      libraries:             # optional: restrict the check to certain libraries
+        - lib/libfoo*
+      ignore_symbols:        # optional: ignore certain exported symbols
+        - _private_*
+```
+
+The test fails if a shared library was removed, a soname / install name / DLL name
+changed, or exported symbols were removed within the pinned version range. If no
+previously published version matches the pin (e.g. for the first release of a new
+major/minor series) the check is skipped with a warning. See the
+[recipe reference](reference/recipe_file.md#abi-check-test) for details.
 
 ## Testing existing packages
 

--- a/py-rattler-build/rust/src/package.rs
+++ b/py-rattler-build/rust/src/package.rs
@@ -12,8 +12,8 @@ use crate::tracing_subscriber;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use rattler_build_recipe::stage1::tests::{
-    CommandsTest, DownstreamTest, PackageContentsCheckFiles, PackageContentsTest, PerlTest,
-    PythonTest, PythonVersion, RTest, RubyTest, TestType,
+    AbiCheckTest, CommandsTest, DownstreamTest, PackageContentsCheckFiles, PackageContentsTest,
+    PerlTest, PythonTest, PythonVersion, RTest, RubyTest, TestType,
 };
 use rattler_conda_types::{
     NamedChannelOrUrl,
@@ -249,6 +249,13 @@ impl PyPackage {
                     .unbind(),
                     TestType::PackageContents { package_contents } => PyPackageContentsTest {
                         inner: package_contents.clone(),
+                        index,
+                    }
+                    .into_pyobject(py)?
+                    .into_any()
+                    .unbind(),
+                    TestType::AbiCheck { abi_check } => PyAbiCheckTest {
+                        inner: abi_check.clone(),
                         index,
                     }
                     .into_pyobject(py)?
@@ -1020,6 +1027,63 @@ impl PyFileChecks {
     }
 }
 
+/// ABI check test - compares the ABI surface of the shared libraries with a previously
+/// published version of the package
+#[pyclass(name = "AbiCheckTest", from_py_object)]
+#[derive(Clone)]
+pub struct PyAbiCheckTest {
+    inner: AbiCheckTest,
+    index: usize,
+}
+
+#[pymethods]
+impl PyAbiCheckTest {
+    /// Index of this test in the package's test list
+    #[getter]
+    fn index(&self) -> usize {
+        self.index
+    }
+
+    /// The pin expression (`x.x` syntax) selecting the compatible version range
+    #[getter]
+    fn pin(&self) -> String {
+        self.inner.pin.to_string()
+    }
+
+    /// Glob patterns selecting the libraries to check (empty = all shared libraries)
+    #[getter]
+    fn libraries(&self) -> Vec<String> {
+        self.inner
+            .libraries
+            .include_globs()
+            .iter()
+            .map(|g| g.source().to_string())
+            .collect()
+    }
+
+    /// Glob patterns for exported symbol names to ignore in the comparison
+    #[getter]
+    fn ignore_symbols(&self) -> Vec<String> {
+        self.inner
+            .ignore_symbols
+            .include_globs()
+            .iter()
+            .map(|g| g.source().to_string())
+            .collect()
+    }
+
+    fn to_dict(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let json_value = serde_json::to_value(&self.inner).map_err(RattlerBuildError::from)?;
+        pythonize::pythonize(py, &json_value)
+            .map(|obj| obj.into())
+            .map_err(|e| RattlerBuildError::RecipeParse(format!("{}", e)).into())
+    }
+
+    fn __repr__(&self) -> String {
+        format!("AbiCheckTest(pin='{}')", self.inner.pin)
+    }
+}
+
 /// Result of running a test
 #[pyclass(name = "TestResult", from_py_object)]
 #[derive(Clone)]
@@ -1176,6 +1240,7 @@ pub fn register_package_module(
     package_module.add_class::<PyRubyTest>()?;
     package_module.add_class::<PyDownstreamTest>()?;
     package_module.add_class::<PyPackageContentsTest>()?;
+    package_module.add_class::<PyAbiCheckTest>()?;
     package_module.add_class::<PyFileChecks>()?;
     package_module.add_class::<PyTestResult>()?;
     package_module.add_class::<PyPathEntry>()?;

--- a/py-rattler-build/src/rattler_build/__init__.py
+++ b/py-rattler-build/src/rattler_build/__init__.py
@@ -30,6 +30,7 @@ from rattler_build.package_assembler import (
 )
 from rattler_build.jinja_config import JinjaConfig
 from rattler_build.package import (
+    AbiCheckTest,
     CommandsTest,
     DownstreamTest,
     FileChecks,
@@ -119,6 +120,7 @@ __all__ = [
     "RubyTest",
     "DownstreamTest",
     "PackageContentsTest",
+    "AbiCheckTest",
     "FileChecks",
     "TestResult",
     "PathEntry",

--- a/py-rattler-build/src/rattler_build/package.py
+++ b/py-rattler-build/src/rattler_build/package.py
@@ -51,6 +51,7 @@ PackageTestType = Union[
     "RubyTest",
     "DownstreamTest",
     "PackageContentsTest",
+    "AbiCheckTest",
 ]
 
 
@@ -422,6 +423,8 @@ def _wrap_test(inner: Any) -> PackageTestType:
         return DownstreamTest(inner)
     elif isinstance(inner, _package.PackageContentsTest):
         return PackageContentsTest(inner)
+    elif isinstance(inner, _package.AbiCheckTest):
+        return AbiCheckTest(inner)
     else:
         raise TypeError(f"Unknown test type: {type(inner)}")
 
@@ -713,6 +716,48 @@ class PackageContentsTest:
 
     def __repr__(self) -> str:
         return f"PackageContentsTest(strict={self.strict})"
+
+
+class AbiCheckTest:
+    """ABI check test - compares the ABI surface of the shared libraries with a previously
+    published version of the package.
+
+    Attributes:
+        index: Index of this test in the package's test list
+        pin: The pin expression (`x.x` syntax) selecting the compatible version range
+        libraries: Glob patterns selecting the libraries to check (empty = all shared libraries)
+        ignore_symbols: Glob patterns for exported symbol names to ignore in the comparison
+    """
+
+    def __init__(self, inner: _package.AbiCheckTest) -> None:
+        self._inner = inner
+
+    @property
+    def index(self) -> int:
+        """Index of this test in the package's test list."""
+        return self._inner.index
+
+    @property
+    def pin(self) -> str:
+        """The pin expression (`x.x` syntax) selecting the compatible version range."""
+        return self._inner.pin
+
+    @property
+    def libraries(self) -> list[str]:
+        """Glob patterns selecting the libraries to check (empty = all shared libraries)."""
+        return self._inner.libraries
+
+    @property
+    def ignore_symbols(self) -> list[str]:
+        """Glob patterns for exported symbol names to ignore in the comparison."""
+        return self._inner.ignore_symbols
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to a dictionary."""
+        return self._inner.to_dict()
+
+    def __repr__(self) -> str:
+        return f"AbiCheckTest(pin='{self.pin}')"
 
 
 class FileChecks:


### PR DESCRIPTION
## Summary

This PR adds a new `abi_check` package test that verifies shared libraries in a package remain ABI compatible with previously published versions. The test downloads the lowest published version matching a pin expression (e.g., `x.x` for same major.minor) and compares the exported symbols, sonames, and library presence.

## Key Changes

- **New ABI check implementation** (`crates/rattler_build_core/src/package_test/abi_check.rs`):
  - Extracts ABI surface from shared libraries using `goblin` for ELF, Mach-O, and PE formats
  - Parses exported symbols from dynamic symbol tables (ELF), export tries (Mach-O), and export tables (PE)
  - Detects ABI violations: removed libraries, changed sonames/install names, and removed symbols
  - Implements intelligent library matching across version bumps (e.g., `libfoo.so.1.2.3` → `libfoo.so.1.2.5`)
  - Selects baseline record by lowest version with closest build string match

- **Recipe parsing and evaluation**:
  - Added `AbiCheckTest` struct to stage0 and stage1 recipe types with configurable pin, libraries, and ignore_symbols
  - Implemented evaluation logic to parse pin expressions and glob patterns
  - Added comprehensive tests for parsing and evaluation

- **Test infrastructure**:
  - Added `AbiCheckFailed` and `AbiCheckError` variants to `TestError` enum
  - Integrated ABI check test execution into the test runner

- **Documentation**:
  - Added reference documentation explaining the ABI check test syntax and behavior
  - Added testing guide section on ABI compatibility checking

## Implementation Details

- The test uses the `x.x` pin syntax (same as version pinnings) to define the compatibility range
- Libraries are matched across versions using multiple strategies: exact path, normalized name in same directory, soname, and normalized name anywhere
- Symbol comparison filters out ignored patterns (glob-based)
- Supports platform-specific binary formats: ELF (Linux), Mach-O (macOS), and PE (Windows)
- Gracefully skips testing for `noarch` packages and when no baseline version is found

https://claude.ai/code/session_01FtZdiZvbdfcisDw4xk3ap3