### PR TITLE
fix: stdout/stderr interleaving in build output (issue #2511)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4159,6 +4159,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5157,6 +5167,7 @@ dependencies = [
  "insta",
  "itertools 0.14.0",
  "minijinja",
+ "os_pipe",
  "rattler_conda_types",
  "rattler_shell",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ libc = "0.2"
 md-5 = "0.11"
 lazy_static = "1.5.0"
 miette = "7.6.0"
+os_pipe = "1.2.3"
 minijinja = { version = "2.18.0", features = [
   "unstable_machinery",
   "custom_syntax",

--- a/crates/rattler_build_script/Cargo.toml
+++ b/crates/rattler_build_script/Cargo.toml
@@ -23,6 +23,7 @@ execution = [
   "which",
   "minijinja",
   "strsim",
+  "os_pipe",
 ]
 
 [dependencies]
@@ -51,6 +52,7 @@ fs-err = { workspace = true, optional = true }
 which = { workspace = true, optional = true }
 minijinja = { workspace = true, optional = true }
 strsim = { workspace = true, optional = true }
+os_pipe = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "macros", "fs"] }

--- a/crates/rattler_build_script/src/execution.rs
+++ b/crates/rattler_build_script/src/execution.rs
@@ -767,6 +767,17 @@ pub(crate) async fn run_process_with_replacements(
 
     configure_subprocess_env(&mut command, env_vars, secrets, env_isolation, runtime);
 
+    // Point both stdout and stderr of the child at a single OS pipe so that the
+    // two streams are interleaved by the kernel in the exact order the process
+    // wrote them. Reading them as two separate pipes (and picking whichever has
+    // a line ready) cannot recover the true ordering, because the streams are
+    // buffered independently — the lines racing in `tokio::select!` is what made
+    // the build output appear in random order (issue #2511). Merging is the
+    // same thing the documented `exec 2>&1` workaround does, applied uniformly
+    // regardless of the interpreter running inside the wrapper.
+    let (pipe_reader, pipe_writer) = os_pipe::pipe()?;
+    let pipe_writer_clone = pipe_writer.try_clone()?;
+
     command
         .current_dir(cwd)
         // when using `pixi global install bash` the current work dir
@@ -774,44 +785,46 @@ pub(crate) async fn run_process_with_replacements(
         .env("PWD", cwd)
         .args(&args[1..])
         .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
+        .stdout(Stdio::from(pipe_writer))
+        .stderr(Stdio::from(pipe_writer_clone));
 
-    let mut child = command.spawn()?;
+    let child = command.spawn();
 
-    let stdout = child.stdout.take().expect("Failed to take stdout");
-    let stderr = child.stderr.take().expect("Failed to take stderr");
+    // Drop the parent's copies of the pipe's write end (held by `command`)
+    // *before* reading from it. If any writer is left open on our side the read
+    // end never observes EOF and the loop below would hang forever.
+    drop(command);
+    let mut child = child?;
 
-    let stdout_wrapped = normalize_crlf(stdout);
-    let stderr_wrapped = normalize_crlf(stderr);
+    // Wrap the read end of the merged pipe as an async reader. `tokio::fs::File`
+    // performs the (blocking) pipe reads on the blocking thread pool, which
+    // keeps this cross-platform without a dedicated async pipe abstraction.
+    let merged_std: std::fs::File = {
+        #[cfg(unix)]
+        {
+            use std::os::unix::io::OwnedFd;
+            OwnedFd::from(pipe_reader).into()
+        }
+        #[cfg(windows)]
+        {
+            use std::os::windows::io::OwnedHandle;
+            OwnedHandle::from(pipe_reader).into()
+        }
+    };
+    let merged = normalize_crlf(tokio::fs::File::from_std(merged_std));
+    let mut lines = tokio::io::BufReader::new(merged).lines();
 
-    let mut stdout_lines = tokio::io::BufReader::new(stdout_wrapped).lines();
-    let mut stderr_lines = tokio::io::BufReader::new(stderr_wrapped).lines();
-
-    let mut stdout_log = String::new();
-    let mut stderr_log = String::new();
-    let mut closed = (false, false);
+    let mut output_log = String::new();
 
     loop {
-        let (line, is_stderr) = tokio::select! {
-            line = stdout_lines.next_line() => (line, false),
-            line = stderr_lines.next_line() => (line, true),
-            else => break,
-        };
-
-        match line {
+        match lines.next_line().await {
             Ok(Some(line)) => {
                 let filtered_line = replacements
                     .iter()
                     .fold(line, |acc, (from, to)| acc.replace(from, to));
 
-                if is_stderr {
-                    stderr_log.push_str(&filtered_line);
-                    stderr_log.push('\n');
-                } else {
-                    stdout_log.push_str(&filtered_line);
-                    stdout_log.push('\n');
-                }
+                output_log.push_str(&filtered_line);
+                output_log.push('\n');
 
                 // Write to log file
                 if let Err(e) = log_file.write_all(filtered_line.as_bytes()).await {
@@ -823,17 +836,11 @@ pub(crate) async fn run_process_with_replacements(
 
                 tracing::info!("{}", filtered_line);
             }
-            Ok(None) if !is_stderr => closed.0 = true,
-            Ok(None) if is_stderr => closed.1 = true,
-            Ok(None) => unreachable!(),
+            Ok(None) => break,
             Err(e) => {
                 tracing::warn!("Error reading output: {:?}", e);
                 break;
             }
-        };
-        // make sure we close the loop when both stdout and stderr are closed
-        if closed == (true, true) {
-            break;
         }
     }
 
@@ -846,8 +853,8 @@ pub(crate) async fn run_process_with_replacements(
 
     Ok(std::process::Output {
         status,
-        stdout: stdout_log.into_bytes(),
-        stderr: stderr_log.into_bytes(),
+        stdout: output_log.into_bytes(),
+        stderr: Vec::new(),
     })
 }
 
@@ -856,6 +863,43 @@ mod tests {
     use super::*;
     use rattler_conda_types::Platform;
     use tokio_util::bytes::BytesMut;
+
+    /// Regression test for <https://github.com/prefix-dev/rattler-build/issues/2511>
+    ///
+    /// stdout and stderr must be interleaved in the order the process wrote
+    /// them. Reading them as two separate pipes raced the streams and produced
+    /// random ordering; merging them into a single OS pipe preserves order.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_stdout_stderr_interleaved_in_write_order() {
+        let tmp = tempfile::tempdir().unwrap();
+        let script = "echo 1 err >&2; echo 2 out; echo 3 err >&2; echo 4 out";
+        let args = ["bash", "-c", script];
+
+        // Run repeatedly: the previous select!-based reader produced a different
+        // (random) order across runs, so a single pass could pass by luck.
+        for _ in 0..20 {
+            let output = run_process_with_replacements(
+                &args,
+                tmp.path(),
+                &HashMap::new(),
+                &IndexMap::new(),
+                &IndexMap::new(),
+                EnvironmentIsolation::None,
+                None,
+                &RuntimeEnv::current(),
+            )
+            .await
+            .unwrap();
+
+            assert!(output.status.success());
+            assert_eq!(
+                String::from_utf8_lossy(&output.stdout),
+                "1 err\n2 out\n3 err\n4 out\n",
+                "stdout/stderr must stay interleaved in write order"
+            );
+        }
+    }
 
     /// `CONDA_BUILD=1` must live inside the sourced activation script so that
     /// nested shells inherit it while the outer subprocess starts without it.

--- a/py-rattler-build/rust/Cargo.lock
+++ b/py-rattler-build/rust/Cargo.lock
@@ -3957,6 +3957,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4939,6 +4949,7 @@ dependencies = [
  "indexmap 2.14.0",
  "itertools 0.14.0",
  "minijinja",
+ "os_pipe",
  "rattler_conda_types",
  "rattler_shell",
  "serde",


### PR DESCRIPTION
## Summary
This PR fixes a critical issue where stdout and stderr from build processes were appearing in random order in the output logs. The problem was caused by reading stdout and stderr as separate streams and racing them with `tokio::select!`, which couldn't recover the true ordering due to independent buffering.

## Key Changes
- **Merged stdout and stderr into a single OS pipe**: Both streams now write to the same pipe, preserving the kernel's ordering of writes
- **Simplified output handling**: Removed the dual-stream reading logic with `tokio::select!` in favor of reading from a single merged pipe
- **Cross-platform pipe handling**: Added platform-specific code to convert OS pipe handles to `std::fs::File` for both Unix and Windows
- **Updated output structure**: Changed from separate `stdout_log` and `stderr_log` to a single `output_log`, with stderr now empty (all output merged into stdout)
- **Added regression test**: Implemented `test_stdout_stderr_interleaved_in_write_order()` that runs 20 iterations to verify consistent ordering

## Implementation Details
- Uses the `os_pipe` crate to create OS-level pipes that preserve write ordering
- Drops the parent's write end of the pipe before reading to ensure EOF is properly detected
- Wraps the pipe's read end as a `tokio::fs::File` to perform async reads on the blocking thread pool
- The merged pipe approach is equivalent to the documented `exec 2>&1` workaround but applied uniformly regardless of the shell interpreter
- All output filtering and log file writing logic remains unchanged, just operating on the merged stream

https://claude.ai/code/session_01TTZZd4NWFdMcEnGyWwyefx