### PR TITLE
fix: trailing spaces in format_requirement for packages without versions

### DIFF
--- a/crates/rattler_build_recipe_generator/src/pypi.rs
+++ b/crates/rattler_build_recipe_generator/src/pypi.rs
@@ -252,14 +252,24 @@ fn format_requirement(req: &str) -> String {
 
     // Handle markers separately
     if let Some((version, marker)) = version.split_once(';') {
-        format!(
-            "{} {} ;MARKER; {}",
-            name.to_lowercase(),
-            version.trim(),
-            marker.trim()
-        )
+        let version = version.trim();
+        if version.is_empty() {
+            format!("{} ;MARKER; {}", name.to_lowercase(), marker.trim())
+        } else {
+            format!(
+                "{} {} ;MARKER; {}",
+                name.to_lowercase(),
+                version,
+                marker.trim()
+            )
+        }
     } else {
-        format!("{} {}", name.to_lowercase(), version.trim())
+        let version = version.trim();
+        if version.is_empty() {
+            name.to_lowercase()
+        } else {
+            format!("{} {}", name.to_lowercase(), version)
+        }
     }
 }
 
@@ -977,6 +987,20 @@ pub async fn generate_pypi_recipe(opts: &PyPIOpts) -> miette::Result<()> {
 mod tests {
     use super::*;
     use insta::assert_yaml_snapshot;
+
+    #[test]
+    fn test_format_requirement_no_trailing_space() {
+        assert_eq!(format_requirement("docopt"), "docopt");
+        assert_eq!(format_requirement("numpy>=2.0.0"), "numpy >=2.0.0");
+        assert_eq!(
+            format_requirement("requests; extra == 'foo'"),
+            "requests ;MARKER; extra == 'foo'"
+        );
+        assert_eq!(
+            format_requirement("numpy>=2.0.0; extra == 'foo'"),
+            "numpy >=2.0.0 ;MARKER; extra == 'foo'"
+        );
+    }
 
     #[tokio::test]
     async fn test_recipe_generation() {

--- a/crates/rattler_build_recipe_generator/src/snapshots/rattler_build_recipe_generator__pypi__tests__flask_noarch_recipe_generation.snap
+++ b/crates/rattler_build_recipe_generator/src/snapshots/rattler_build_recipe_generator__pypi__tests__flask_noarch_recipe_generation.snap
@@ -32,7 +32,7 @@ requirements:
     - blinker >=1.9
     - "importlib-metadata >=3.6 ;MARKER; python_version < \"3.10\""
     - "asgiref >=3.2 ;MARKER; extra == \"async\""
-    - "python-dotenv  ;MARKER; extra == \"dotenv\""
+    - "python-dotenv ;MARKER; extra == \"dotenv\""
 tests:
   - python:
       imports:


### PR DESCRIPTION
## Summary
Fixed the `format_requirement` function to avoid adding trailing spaces when formatting package requirements that have no version specifier.

## Key Changes
- Modified `format_requirement` to check if the version string is empty after trimming
- When version is empty, return only the package name (with or without markers) instead of appending an extra space
- Added comprehensive test cases to verify the fix handles:
  - Packages with no version specifier
  - Packages with version specifiers
  - Packages with markers but no version
  - Packages with both version and markers

## Implementation Details
The function now conditionally formats the output based on whether a version specifier exists:
- For requirements with markers: returns `name ;MARKER; marker` (no version) or `name version ;MARKER; marker` (with version)
- For requirements without markers: returns `name` (no version) or `name version` (with version)

This prevents the generation of malformed requirement strings like `"docopt "` with trailing whitespace.

https://claude.ai/code/session_01HKP4pjfmtTRWhGivxDaDcH