### PR TITLE
feat: detect and warn when patches are already applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `source.filter` field is now also supported for `url` and `git` sources (it was previously only available for `path` sources). The filter is applied to the files copied into the work directory: the contents of the extracted archive for `url` sources (and `path` sources pointing to an archive) and the checked-out tree for `git` sources. This allows large sources to be trimmed down to the parts needed for the build.
 - An empty `sha256` or `md5` (e.g. `sha256: ""`) is now accepted and treated as an all-zeros placeholder (`0000...0000`). This makes it easier to scaffold a recipe before the real checksum is known: the build downloads the source and reports the actual checksum in the resulting mismatch. (#2524)
 - The build summary now prints a section for each `requirements.extras` group (optional dependency group) in the run dependencies table, so the resolved contents of each extra are visible. The section is omitted when the recipe defines no extras.
+- Patches that are already fully applied to the source (e.g. because the change was merged upstream) are now detected, reported with a warning, and skipped instead of being silently "applied". This makes it easy to spot patches that can be removed from the recipe. (#1953)
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,9 +183,9 @@ checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "arwen-codesign"
@@ -428,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -439,14 +439,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1192,9 +1193,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.5"
+version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
+checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
 dependencies = [
  "clap",
 ]
@@ -1340,9 +1341,9 @@ checksum = "b46dec724fd22199ebde05033a0cbae453bc3b1ecff11eb6a6bb3eec4b90c6a4"
 
 [[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -1710,9 +1711,9 @@ dependencies = [
 
 [[package]]
 name = "dbus"
-version = "0.9.11"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
+checksum = "3ab69f03cc8c4340c9c8e315114e1658e6775a9b16a04357973aa21cec22b32e"
 dependencies = [
  "libc",
  "libdbus-sys",
@@ -1750,9 +1751,9 @@ dependencies = [
 
 [[package]]
 name = "defmt"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
 dependencies = [
  "bitflags 1.3.2",
  "defmt-macros",
@@ -1760,12 +1761,11 @@ dependencies = [
 
 [[package]]
 name = "defmt-macros"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
 dependencies = [
  "defmt-parser",
- "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn",
@@ -2294,9 +2294,9 @@ dependencies = [
 
 [[package]]
 name = "fs-err"
-version = "3.3.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
+checksum = "b91aa448ca50d7e79433bdf3ee8d99215430d2ec02ade5aefab2a073a1822e8a"
 dependencies = [
  "autocfg",
  "tokio",
@@ -2475,11 +2475,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2816,15 +2814,15 @@ dependencies = [
 
 [[package]]
 name = "humantime"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
 ]
@@ -3042,9 +3040,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d"
+checksum = "fe112b004901c62c2faa11f4f75e9864e0cc5af8da71c9115d184a3aa888749f"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -3081,9 +3079,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.18.4"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
 dependencies = [
  "console",
  "portable-atomic",
@@ -3190,9 +3188,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.29"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
+checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
 dependencies = [
  "defmt",
  "jiff-static",
@@ -3208,9 +3206,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.29"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
+checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3219,9 +3217,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-tzdb"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+checksum = "6142247df1a93c2b3587402a19710be3e6e942f1581a1702e76408f2c21d6590"
 
 [[package]]
 name = "jiff-tzdb-platform"
@@ -3423,9 +3421,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "libc",
 ]
@@ -3749,9 +3747,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -3954,13 +3952,12 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "open"
-version = "5.3.5"
+version = "5.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fbaa89d2ddc8473c78a3adf69eea8cffa28c483b8e02a971ef31527cd0fc92c"
+checksum = "cd8d3b65c44123a56e0133d2cd06ce4361bd3ca99d41198b2f25e3c3db9b8b4a"
 dependencies = [
  "is-wsl",
  "libc",
- "pathdiff",
 ]
 
 [[package]]
@@ -4406,13 +4403,13 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml 0.39.4",
+ "quick-xml 0.41.0",
  "serde",
  "time",
 ]
@@ -4519,28 +4516,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4616,6 +4591,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4637,15 +4621,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.15"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -4659,16 +4644,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4721,9 +4706,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
@@ -4773,6 +4758,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "rand_xorshift"
@@ -6014,7 +6008,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc05fbf560421a0357a750cbe78c7ca19d4923918490daabba313d5dbc871e47"
 dependencies = [
- "rand 0.10.1",
+ "rand 0.10.2",
 ]
 
 [[package]]
@@ -6139,9 +6133,9 @@ checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -6206,9 +6200,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "web-time",
  "zeroize",
@@ -7420,9 +7414,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.51"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
  "js-sys",
@@ -7441,9 +7435,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.30"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
@@ -7934,7 +7928,7 @@ checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
- "rand 0.10.1",
+ "rand 0.10.2",
  "serde_core",
  "wasm-bindgen",
 ]
@@ -8444,15 +8438,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -8484,28 +8469,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link 0.2.1",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -8539,12 +8507,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8555,12 +8517,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8575,22 +8531,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -8605,12 +8549,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8621,12 +8559,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -8641,12 +8573,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8657,12 +8583,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -8904,9 +8824,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "977347db8caa080403f6b6b7c1cda9479a8e869316f7e13a59b19076a40f94e3"
+checksum = "5431d5661c32445236631278f27946e444ddafe4684cac70b185272d4f9c52d5"
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2232,9 +2232,9 @@ dependencies = [
 
 [[package]]
 name = "flickzeug"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c95ac51c7950d711fb128681fccb1dddd41c81eb230d78251e600a0296fdd30c"
+checksum = "c80b84a6c2a0750383008cd384de902d69b4a9c5009f784e092259b98803bc45"
 dependencies = [
  "nu-ansi-term",
  "strsim",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ unicode-normalization = "0.1.25"
 # Dependencies used in subcrates (workspace-level)
 clap-verbosity-flag = "3.0.4"
 comfy-table = "7.2.2"
-flickzeug = "0.5.1"
+flickzeug = "0.5.2"
 goblin = "0.10.5"
 ignore = "0.4.25"
 num_cpus = "1.17.0"

--- a/crates/rattler_build_core/src/source/patch.rs
+++ b/crates/rattler_build_core/src/source/patch.rs
@@ -252,6 +252,77 @@ fn custom_patch_stripped_paths(
     normalize_backup_paths(original_path, modified_path, work_dir)
 }
 
+/// Determine whether a single diff already appears to be applied to the work
+/// directory.
+///
+/// This is the same idea GNU `patch` uses when it reports "Reversed (or
+/// previously applied) patch detected":
+///
+/// * For an in-place modification, the diff is considered already applied when
+///   reversing it produces a different pre-image that, patched forward again,
+///   reproduces the current content exactly (a reverse round-trip).
+/// * For a file creation, it is already applied when the target already exists
+///   with exactly the content the patch would produce.
+/// * For a deletion, it is already applied when the file is already gone.
+/// * For a rename, it is already applied when the source is gone and the
+///   destination exists.
+fn diff_already_applied(diff: &Diff<'_, [u8]>, strip_level: usize, work_dir: &Path) -> bool {
+    let (orig, modif) = custom_patch_stripped_paths(diff, strip_level, work_dir);
+    match (orig, modif) {
+        // Nothing references an on-disk file; we cannot tell, so assume not applied.
+        (None, None) => false,
+        // New file creation: applied if the target exists with the exact
+        // content the patch produces from an empty base.
+        (None, Some(m)) => {
+            let Ok(existing) = fs_err::read(work_dir.join(&m)) else {
+                return false;
+            };
+            apply(&[], diff)
+                .map(|produced| produced == existing)
+                .unwrap_or(false)
+        }
+        // Deletion: applied if the file is already gone.
+        (Some(o), None) => !work_dir.join(&o).exists(),
+        (Some(o), Some(m)) => {
+            let orig_abs = work_dir.join(&o);
+            if o != m {
+                // Rename: applied if the source is gone and the destination exists.
+                return !orig_abs.exists() && work_dir.join(&m).exists();
+            }
+            // In-place modification. Fuzzy matching means a forward apply can
+            // succeed as a no-op on already-patched content, so a forward
+            // failure is not a reliable signal. Instead we round-trip through
+            // the reverse patch: if reversing the diff produces a *different*
+            // pre-image and forward-applying that pre-image reproduces the
+            // current content exactly, then the current content already is the
+            // patched state.
+            let Ok(current) = fs_err::read(&orig_abs) else {
+                return false;
+            };
+            match apply(&current, &diff.reverse()) {
+                Ok(pre) if pre != current => {
+                    apply(&pre, diff).map(|re| re == current).unwrap_or(false)
+                }
+                _ => false,
+            }
+        }
+    }
+}
+
+/// Determine whether every diff in a patch already appears to be applied to the
+/// work directory. Returns `false` for an empty patch (there is nothing that
+/// could have been applied).
+fn patch_already_applied(patch: &Patch<[u8]>, strip_level: usize, work_dir: &Path) -> bool {
+    let mut saw_diff = false;
+    for diff in patch {
+        if !diff_already_applied(diff, strip_level, work_dir) {
+            return false;
+        }
+        saw_diff = true;
+    }
+    saw_diff
+}
+
 fn write_patch_content(content: &[u8], path: &Path) -> Result<(), SourceError> {
     if let Some(parent) = path.parent() {
         fs_err::create_dir_all(parent).map_err(SourceError::Io)?;
@@ -358,6 +429,16 @@ pub fn apply_patch_custom(work_dir: &Path, patch_file_path: &Path) -> Result<(),
     let patch = patch_from_bytes(&patch_file_content)
         .map_err(|_| SourceError::PatchParseFailed(patch_file_path.to_path_buf()))?;
     let strip_level = guess_strip_level(&patch, work_dir)?;
+
+    // Skip patches that are already fully applied (e.g. the change has been
+    // merged upstream) instead of silently claiming to apply them.
+    if patch_already_applied(&patch, strip_level, work_dir) {
+        tracing::warn!(
+            "Patch '{}' appears to be already applied; skipping. It may no longer be necessary and can likely be removed from the recipe.",
+            patch_file_path.display()
+        );
+        return Ok(());
+    }
 
     for diff in patch {
         let file_paths = custom_patch_stripped_paths(&diff, strip_level, work_dir);
@@ -561,6 +642,80 @@ mod tests {
         let text_md = tempdir.path().join("workdir/text.md");
         let text_md = fs_err::read_to_string(&text_md).unwrap();
         assert!(text_md.contains("Oh, wow, I was patched! Thank you soooo much!"));
+    }
+
+    #[test]
+    fn test_already_applied_patch_is_skipped() {
+        // Applying the same patch a second time should be detected as
+        // already-applied and skipped, leaving the file untouched rather than
+        // corrupting it or erroring out.
+        let (tempdir, _) = setup_patch_test_dir();
+        let work_dir = tempdir.path().join("workdir");
+        let patches_dir = tempdir.path().join("patches");
+
+        apply_patches(
+            &[LateBoundPath::new(
+                "0001-increase-minimum-cmake-version.patch",
+            )],
+            &work_dir,
+            &patches_dir,
+            &patches_dir,
+            &patches_dir,
+            apply_patch_custom,
+        )
+        .expect("first application should succeed");
+
+        let cmake_list = work_dir.join("CMakeLists.txt");
+        let after_first = fs_err::read_to_string(&cmake_list).unwrap();
+        assert!(after_first.contains("cmake_minimum_required(VERSION 3.12)"));
+
+        // The patch is now fully applied: it should be detected and skipped.
+        let patch_content =
+            fs_err::read(patches_dir.join("0001-increase-minimum-cmake-version.patch")).unwrap();
+        let patch = patch_from_bytes(&patch_content).unwrap();
+        let strip_level = guess_strip_level(&patch, &work_dir).unwrap();
+        assert!(
+            patch_already_applied(&patch, strip_level, &work_dir),
+            "patch should be detected as already applied"
+        );
+
+        apply_patches(
+            &[LateBoundPath::new(
+                "0001-increase-minimum-cmake-version.patch",
+            )],
+            &work_dir,
+            &patches_dir,
+            &patches_dir,
+            &patches_dir,
+            apply_patch_custom,
+        )
+        .expect("re-applying an already-applied patch should not error");
+
+        // The file must be byte-for-byte identical after the second (skipped)
+        // application.
+        let after_second = fs_err::read_to_string(&cmake_list).unwrap();
+        assert_eq!(
+            after_first, after_second,
+            "already-applied patch must not modify the file again"
+        );
+    }
+
+    #[test]
+    fn test_not_yet_applied_patch_is_not_flagged() {
+        // A patch that has not been applied yet must not be treated as
+        // already-applied.
+        let (tempdir, _) = setup_patch_test_dir();
+        let work_dir = tempdir.path().join("workdir");
+        let patches_dir = tempdir.path().join("patches");
+
+        let patch_content =
+            fs_err::read(patches_dir.join("0001-increase-minimum-cmake-version.patch")).unwrap();
+        let patch = patch_from_bytes(&patch_content).unwrap();
+        let strip_level = guess_strip_level(&patch, &work_dir).unwrap();
+        assert!(
+            !patch_already_applied(&patch, strip_level, &work_dir),
+            "a fresh patch should not be detected as already applied"
+        );
     }
 
     #[test]

--- a/crates/rattler_build_core/src/source/patch.rs
+++ b/crates/rattler_build_core/src/source/patch.rs
@@ -12,8 +12,9 @@ use std::{
 };
 
 use flickzeug::{
-    ApplyConfig, ApplyError, Diff, FuzzyConfig, HunkRangeStrategy, ParsePatchError, ParserConfig,
-    Patch, apply_bytes_with_config, patch_from_bytes_with_config,
+    ApplyConfig, ApplyError, ApplyOutcome, Diff, FuzzyConfig, HunkRangeStrategy, ParsePatchError,
+    ParserConfig, Patch, apply_bytes_reporting, apply_bytes_with_config,
+    patch_from_bytes_with_config,
 };
 use fs_err::File;
 use itertools::Itertools;
@@ -166,20 +167,21 @@ fn patch_from_bytes_raw(input: &[u8]) -> Result<Patch<'_, [u8]>, ParsePatchError
     )
 }
 
-fn apply(base_image: &[u8], diff: &Diff<'_, [u8]>) -> Result<Vec<u8>, ApplyError> {
-    apply_bytes_with_config(
-        base_image,
-        diff,
-        &ApplyConfig {
-            fuzzy_config: FuzzyConfig {
-                max_fuzz: 2,
-                ignore_whitespace: true,
-                ignore_case: false,
-            },
-            ..Default::default()
+/// The fuzzy-matching configuration used for all patch application. Shared by
+/// `apply` and the already-applied detection so both agree on what "applies".
+fn apply_config() -> ApplyConfig {
+    ApplyConfig {
+        fuzzy_config: FuzzyConfig {
+            max_fuzz: 2,
+            ignore_whitespace: true,
+            ignore_case: false,
         },
-    )
-    .map(|(content, _stats)| content)
+        ..Default::default()
+    }
+}
+
+fn apply(base_image: &[u8], diff: &Diff<'_, [u8]>) -> Result<Vec<u8>, ApplyError> {
+    apply_bytes_with_config(base_image, diff, &apply_config()).map(|(content, _stats)| content)
 }
 
 // Returns number by which all patch paths must be stripped to be
@@ -250,77 +252,6 @@ fn custom_patch_stripped_paths(
     let modified_path = diff.modified().and_then(strip_path);
 
     normalize_backup_paths(original_path, modified_path, work_dir)
-}
-
-/// Determine whether a single diff already appears to be applied to the work
-/// directory.
-///
-/// This is the same idea GNU `patch` uses when it reports "Reversed (or
-/// previously applied) patch detected":
-///
-/// * For an in-place modification, the diff is considered already applied when
-///   reversing it produces a different pre-image that, patched forward again,
-///   reproduces the current content exactly (a reverse round-trip).
-/// * For a file creation, it is already applied when the target already exists
-///   with exactly the content the patch would produce.
-/// * For a deletion, it is already applied when the file is already gone.
-/// * For a rename, it is already applied when the source is gone and the
-///   destination exists.
-fn diff_already_applied(diff: &Diff<'_, [u8]>, strip_level: usize, work_dir: &Path) -> bool {
-    let (orig, modif) = custom_patch_stripped_paths(diff, strip_level, work_dir);
-    match (orig, modif) {
-        // Nothing references an on-disk file; we cannot tell, so assume not applied.
-        (None, None) => false,
-        // New file creation: applied if the target exists with the exact
-        // content the patch produces from an empty base.
-        (None, Some(m)) => {
-            let Ok(existing) = fs_err::read(work_dir.join(&m)) else {
-                return false;
-            };
-            apply(&[], diff)
-                .map(|produced| produced == existing)
-                .unwrap_or(false)
-        }
-        // Deletion: applied if the file is already gone.
-        (Some(o), None) => !work_dir.join(&o).exists(),
-        (Some(o), Some(m)) => {
-            let orig_abs = work_dir.join(&o);
-            if o != m {
-                // Rename: applied if the source is gone and the destination exists.
-                return !orig_abs.exists() && work_dir.join(&m).exists();
-            }
-            // In-place modification. Fuzzy matching means a forward apply can
-            // succeed as a no-op on already-patched content, so a forward
-            // failure is not a reliable signal. Instead we round-trip through
-            // the reverse patch: if reversing the diff produces a *different*
-            // pre-image and forward-applying that pre-image reproduces the
-            // current content exactly, then the current content already is the
-            // patched state.
-            let Ok(current) = fs_err::read(&orig_abs) else {
-                return false;
-            };
-            match apply(&current, &diff.reverse()) {
-                Ok(pre) if pre != current => {
-                    apply(&pre, diff).map(|re| re == current).unwrap_or(false)
-                }
-                _ => false,
-            }
-        }
-    }
-}
-
-/// Determine whether every diff in a patch already appears to be applied to the
-/// work directory. Returns `false` for an empty patch (there is nothing that
-/// could have been applied).
-fn patch_already_applied(patch: &Patch<[u8]>, strip_level: usize, work_dir: &Path) -> bool {
-    let mut saw_diff = false;
-    for diff in patch {
-        if !diff_already_applied(diff, strip_level, work_dir) {
-            return false;
-        }
-        saw_diff = true;
-    }
-    saw_diff
 }
 
 fn write_patch_content(content: &[u8], path: &Path) -> Result<(), SourceError> {
@@ -430,15 +361,12 @@ pub fn apply_patch_custom(work_dir: &Path, patch_file_path: &Path) -> Result<(),
         .map_err(|_| SourceError::PatchParseFailed(patch_file_path.to_path_buf()))?;
     let strip_level = guess_strip_level(&patch, work_dir)?;
 
-    // Skip patches that are already fully applied (e.g. the change has been
-    // merged upstream) instead of silently claiming to apply them.
-    if patch_already_applied(&patch, strip_level, work_dir) {
-        tracing::warn!(
-            "Patch '{}' appears to be already applied; skipping. It may no longer be necessary and can likely be removed from the recipe.",
-            patch_file_path.display()
-        );
-        return Ok(());
-    }
+    // Track whether every diff in the patch turned out to be a no-op because it
+    // was already applied (e.g. the change was merged upstream). If so, we warn
+    // that the patch can likely be dropped from the recipe rather than silently
+    // claiming to have applied it.
+    let mut saw_diff = false;
+    let mut all_already_applied = true;
 
     for diff in patch {
         let file_paths = custom_patch_stripped_paths(&diff, strip_level, work_dir);
@@ -456,33 +384,66 @@ pub fn apply_patch_custom(work_dir: &Path, patch_file_path: &Path) -> Result<(),
         match absolute_file_paths {
             (None, None) => continue,
             (None, Some(m)) => {
+                saw_diff = true;
                 let new_file_content = apply(&[], &diff).map_err(SourceError::PatchApplyError)?;
+                // Already applied if the target already holds the produced content.
+                if fs_err::read(&m).is_ok_and(|existing| existing == new_file_content) {
+                    continue;
+                }
+                all_already_applied = false;
                 write_patch_content(&new_file_content, &m)?;
             }
             (Some(o), None) => {
-                fs_err::remove_file(work_dir.join(o)).map_err(SourceError::Io)?;
+                saw_diff = true;
+                // Already applied if the file to delete is already gone.
+                if o.exists() {
+                    all_already_applied = false;
+                    fs_err::remove_file(&o).map_err(SourceError::Io)?;
+                }
             }
             (Some(o), Some(m)) => {
+                saw_diff = true;
                 // Check if the original file exists
                 // If it doesn't, treat this as creating a new file
                 if !o.exists() {
+                    // A rename whose source is already gone and whose
+                    // destination exists is already applied; otherwise create
+                    // the new file from scratch.
+                    if o != m && m.exists() {
+                        continue;
+                    }
+                    all_already_applied = false;
                     let new_file_content =
                         apply(&[], &diff).map_err(SourceError::PatchApplyError)?;
                     write_patch_content(&new_file_content, &m)?;
                 } else {
                     let old_file_content = fs_err::read(&o).map_err(SourceError::Io)?;
 
-                    let new_file_content =
-                        apply(&old_file_content, &diff).map_err(SourceError::PatchApplyError)?;
-
-                    if o != m {
-                        fs_err::remove_file(&o).map_err(SourceError::Io)?;
+                    // `apply_bytes_reporting` reports whether the file already
+                    // reflects the patched state, which is reliable even under
+                    // the fuzzy matching we enable (a plain forward apply can
+                    // silently succeed as a no-op on already-patched content).
+                    match apply_bytes_reporting(&old_file_content, &diff, &apply_config()) {
+                        ApplyOutcome::AlreadyApplied(_) => continue,
+                        ApplyOutcome::Applied(new_file_content, _stats) => {
+                            all_already_applied = false;
+                            if o != m {
+                                fs_err::remove_file(&o).map_err(SourceError::Io)?;
+                            }
+                            write_patch_content(&new_file_content, &m)?;
+                        }
+                        ApplyOutcome::Failed(e) => return Err(SourceError::PatchApplyError(e)),
                     }
-
-                    write_patch_content(&new_file_content, &m)?;
                 }
             }
         }
+    }
+
+    if saw_diff && all_already_applied {
+        tracing::warn!(
+            "Patch '{}' appears to be already applied; skipping. It may no longer be necessary and can likely be removed from the recipe.",
+            patch_file_path.display()
+        );
     }
 
     Ok(())
@@ -669,16 +630,8 @@ mod tests {
         let after_first = fs_err::read_to_string(&cmake_list).unwrap();
         assert!(after_first.contains("cmake_minimum_required(VERSION 3.12)"));
 
-        // The patch is now fully applied: it should be detected and skipped.
-        let patch_content =
-            fs_err::read(patches_dir.join("0001-increase-minimum-cmake-version.patch")).unwrap();
-        let patch = patch_from_bytes(&patch_content).unwrap();
-        let strip_level = guess_strip_level(&patch, &work_dir).unwrap();
-        assert!(
-            patch_already_applied(&patch, strip_level, &work_dir),
-            "patch should be detected as already applied"
-        );
-
+        // The patch is now fully applied. Re-applying it must be detected as a
+        // no-op and skipped rather than corrupting the file or erroring.
         apply_patches(
             &[LateBoundPath::new(
                 "0001-increase-minimum-cmake-version.patch",
@@ -697,24 +650,6 @@ mod tests {
         assert_eq!(
             after_first, after_second,
             "already-applied patch must not modify the file again"
-        );
-    }
-
-    #[test]
-    fn test_not_yet_applied_patch_is_not_flagged() {
-        // A patch that has not been applied yet must not be treated as
-        // already-applied.
-        let (tempdir, _) = setup_patch_test_dir();
-        let work_dir = tempdir.path().join("workdir");
-        let patches_dir = tempdir.path().join("patches");
-
-        let patch_content =
-            fs_err::read(patches_dir.join("0001-increase-minimum-cmake-version.patch")).unwrap();
-        let patch = patch_from_bytes(&patch_content).unwrap();
-        let strip_level = guess_strip_level(&patch, &work_dir).unwrap();
-        assert!(
-            !patch_already_applied(&patch, strip_level, &work_dir),
-            "a fresh patch should not be detected as already applied"
         );
     }
 

--- a/py-rattler-build/rust/Cargo.lock
+++ b/py-rattler-build/rust/Cargo.lock
@@ -2098,9 +2098,9 @@ dependencies = [
 
 [[package]]
 name = "flickzeug"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c95ac51c7950d711fb128681fccb1dddd41c81eb230d78251e600a0296fdd30c"
+checksum = "c80b84a6c2a0750383008cd384de902d69b4a9c5009f784e092259b98803bc45"
 dependencies = [
  "nu-ansi-term",
  "strsim",


### PR DESCRIPTION
## Summary
This change improves patch application handling by detecting when patches have already been applied (e.g., when changes were merged upstream) and warning users that the patch may no longer be necessary, rather than silently succeeding or corrupting files.

## Key Changes
- **Extract shared apply configuration**: Created `apply_config()` function to centralize the fuzzy-matching configuration used for patch application, ensuring consistency across all patch operations
- **Detect already-applied patches**: Implemented detection logic for each diff scenario:
  - For new files: Check if the target already contains the expected content
  - For file deletions: Skip if the file is already gone
  - For renames: Detect when source is gone and destination exists
  - For modifications: Use the new `apply_bytes_reporting` function from flickzeug to reliably detect already-applied state
- **Add user warning**: When all diffs in a patch are detected as already-applied, emit a warning suggesting the patch can likely be removed from the recipe
- **Update flickzeug dependency**: Bumped to version 0.5.2 to access the new `ApplyOutcome` and `apply_bytes_reporting` APIs
- **Add test coverage**: New test `test_already_applied_patch_is_skipped` verifies that re-applying an already-applied patch is correctly detected as a no-op and doesn't modify files

## Implementation Details
- The detection uses `apply_bytes_reporting` which provides reliable feedback even under fuzzy matching conditions, preventing silent no-op successes from being misinterpreted as actual applications
- Tracking variables (`saw_diff` and `all_already_applied`) distinguish between patches with no diffs and patches where all diffs are already applied
- The warning is only shown when at least one diff exists but all are already applied, avoiding false positives on empty patches

https://claude.ai/code/session_015pSKoJTxsgMxxLKJy7Zmba