### PR TITLE
chore: release 0.68.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,55 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.68.0] - 2026-07-06
+### ✨ Highlights
+
+This release adds a lot of exciting features and bugfixes. Here a few highlights:
+- A lot of R and CRAN improvements
+- New, mobile-friendly design for https://playground.rattler.build/
+- Fixes for many sharp edges
+
+Feel free to find out more details by looking at the linked PRs below.
+
+
+### Added
+
+- Add PyPI/CRAN/CPAN recipe generator to https://playground.rattler.build by @wolfv in [#2538](https://github.com/prefix-dev/rattler-build/pull/2538)
+- Improve CRAN recipe generation for R packages by @wolfv in [#2597](https://github.com/prefix-dev/rattler-build/pull/2597)
+- Display v3 package variant flags in build output by @wolfv in [#2601](https://github.com/prefix-dev/rattler-build/pull/2601)
+- Improve package content test failure messages with expanded globs by @wolfv in [#2602](https://github.com/prefix-dev/rattler-build/pull/2602)
+- Support `source.filter` for URL and archive path sources by @wolfv in [#2608](https://github.com/prefix-dev/rattler-build/pull/2608)
+- Redesign UI with themes, layouts and CodeMirror editor by @wolfv in [#2604](https://github.com/prefix-dev/rattler-build/pull/2604)
+- Make SHLIB_EXT available in Jinja templates by @wolfv in [#2612](https://github.com/prefix-dev/rattler-build/pull/2612)
+- Allow empty sha256 as all-zeros placeholder for recipe scaffolding by @wolfv in [#2610](https://github.com/prefix-dev/rattler-build/pull/2610)
+- Adds support to publish --to cloudsmith by @jmayes-rx in [#2516](https://github.com/prefix-dev/rattler-build/pull/2516)
+- Display optional dependency groups (extras) in dependency tables by @wolfv in [#2621](https://github.com/prefix-dev/rattler-build/pull/2621)
+- Warn about problematic entry point configurations by @wolfv in [#2623](https://github.com/prefix-dev/rattler-build/pull/2623)
+- Show executed commands for failing test scripts by @mohitdebian in [#2266](https://github.com/prefix-dev/rattler-build/pull/2266)
+
+
+### Documentation
+
+- Fix down_prioritize_variant documentation and example value by @wolfv in [#2606](https://github.com/prefix-dev/rattler-build/pull/2606)
+
+
+### Fixed
+
+- Report YAML parse error location for malformed Jinja by @wolfv in [#2603](https://github.com/prefix-dev/rattler-build/pull/2603)
+- Preserve explicit empty license_file in output packages by @wolfv in [#2600](https://github.com/prefix-dev/rattler-build/pull/2600)
+- Switch PyPI sources to use `files.pythonhosted.org` by @mgorny in [#2586](https://github.com/prefix-dev/rattler-build/pull/2586)
+- Write github output to stderr by @pavelzw in [#2550](https://github.com/prefix-dev/rattler-build/pull/2550)
+- Build test MatchSpec from typed components to support trailing-underscore versions by @XhstormR in [#2618](https://github.com/prefix-dev/rattler-build/pull/2618)
+- Use `skip` condition and platform-split script in generated R recipes by @pb01ka in [#2609](https://github.com/prefix-dev/rattler-build/pull/2609)
+- Don't treat non-exact run_constraints pins as build-order edges by @baszalmstra in [#2537](https://github.com/prefix-dev/rattler-build/pull/2537)
+- `--render-only --with-solve` panic when output dir missing by @wolfv in [#2631](https://github.com/prefix-dev/rattler-build/pull/2631)
+- CRAN recipe generation by @Hofer-Julian in [#2637](https://github.com/prefix-dev/rattler-build/pull/2637)
+
+
+### New Contributors
+* @jmayes-rx made their first contribution in [#2516](https://github.com/prefix-dev/rattler-build/pull/2516)
+* @XhstormR made their first contribution in [#2618](https://github.com/prefix-dev/rattler-build/pull/2618)
+
 ## [Unreleased]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4838,7 +4838,7 @@ dependencies = [
 
 [[package]]
 name = "rattler-build"
-version = "0.67.0"
+version = "0.68.0"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler-build"
-version = "0.67.0"
+version = "0.68.0"
 authors = ["rattler-build contributors <hi@prefix.dev>"]
 repository = "https://github.com/prefix-dev/rattler-build"
 edition = "2024"

--- a/py-rattler-build/pyproject.toml
+++ b/py-rattler-build/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "py-rattler-build"
-version = "0.67.0"
+version = "0.68.0"
 requires-python = ">=3.10"
 description = "The fastest way to build conda packages programatically"
 readme = "README.md"

--- a/py-rattler-build/rust/Cargo.lock
+++ b/py-rattler-build/rust/Cargo.lock
@@ -4302,7 +4302,7 @@ dependencies = [
 
 [[package]]
 name = "py-rattler-build"
-version = "0.67.0"
+version = "0.68.0"
 dependencies = [
  "clap",
  "fs-err",
@@ -4665,7 +4665,7 @@ dependencies = [
 
 [[package]]
 name = "rattler-build"
-version = "0.67.0"
+version = "0.68.0"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",

--- a/py-rattler-build/rust/Cargo.toml
+++ b/py-rattler-build/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-rattler-build"
-version = "0.67.0"
+version = "0.68.0"
 edition = "2024"
 license = "BSD-3-Clause"
 publish = false

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/prefix-dev/rattler-build"
 
 [version]
-current = "0.67.0"
+current = "0.68.0"
 
 # Example of a semver regexp.
 # Make sure this matches current_version before


### PR DESCRIPTION
## [0.68.0] - 2026-07-06
### ✨ Highlights

This release adds a lot of exciting features and bugfixes. Here a few highlights:
- A lot of R and CRAN improvements
- New, mobile-friendly design for https://playground.rattler.build/
- Fixes for many sharp edges

Feel free to find out more details by looking at the linked PRs below.


### Added

- Add PyPI/CRAN/CPAN recipe generator to https://playground.rattler.build by @wolfv in [#2538](https://github.com/prefix-dev/rattler-build/pull/2538)
- Improve CRAN recipe generation for R packages by @wolfv in [#2597](https://github.com/prefix-dev/rattler-build/pull/2597)
- Display v3 package variant flags in build output by @wolfv in [#2601](https://github.com/prefix-dev/rattler-build/pull/2601)
- Improve package content test failure messages with expanded globs by @wolfv in [#2602](https://github.com/prefix-dev/rattler-build/pull/2602)
- Support `source.filter` for URL and archive path sources by @wolfv in [#2608](https://github.com/prefix-dev/rattler-build/pull/2608)
- Redesign UI with themes, layouts and CodeMirror editor by @wolfv in [#2604](https://github.com/prefix-dev/rattler-build/pull/2604)
- Make SHLIB_EXT available in Jinja templates by @wolfv in [#2612](https://github.com/prefix-dev/rattler-build/pull/2612)
- Allow empty sha256 as all-zeros placeholder for recipe scaffolding by @wolfv in [#2610](https://github.com/prefix-dev/rattler-build/pull/2610)
- Adds support to publish --to cloudsmith by @jmayes-rx in [#2516](https://github.com/prefix-dev/rattler-build/pull/2516)
- Display optional dependency groups (extras) in dependency tables by @wolfv in [#2621](https://github.com/prefix-dev/rattler-build/pull/2621)
- Warn about problematic entry point configurations by @wolfv in [#2623](https://github.com/prefix-dev/rattler-build/pull/2623)
- Show executed commands for failing test scripts by @mohitdebian in [#2266](https://github.com/prefix-dev/rattler-build/pull/2266)


### Documentation

- Fix down_prioritize_variant documentation and example value by @wolfv in [#2606](https://github.com/prefix-dev/rattler-build/pull/2606)


### Fixed

- Report YAML parse error location for malformed Jinja by @wolfv in [#2603](https://github.com/prefix-dev/rattler-build/pull/2603)
- Preserve explicit empty license_file in output packages by @wolfv in [#2600](https://github.com/prefix-dev/rattler-build/pull/2600)
- Switch PyPI sources to use `files.pythonhosted.org` by @mgorny in [#2586](https://github.com/prefix-dev/rattler-build/pull/2586)
- Write github output to stderr by @pavelzw in [#2550](https://github.com/prefix-dev/rattler-build/pull/2550)
- Build test MatchSpec from typed components to support trailing-underscore versions by @XhstormR in [#2618](https://github.com/prefix-dev/rattler-build/pull/2618)
- Use `skip` condition and platform-split script in generated R recipes by @pb01ka in [#2609](https://github.com/prefix-dev/rattler-build/pull/2609)
- Don't treat non-exact run_constraints pins as build-order edges by @baszalmstra in [#2537](https://github.com/prefix-dev/rattler-build/pull/2537)
- `--render-only --with-solve` panic when output dir missing by @wolfv in [#2631](https://github.com/prefix-dev/rattler-build/pull/2631)
- CRAN recipe generation by @Hofer-Julian in [#2637](https://github.com/prefix-dev/rattler-build/pull/2637)


### New Contributors
* @jmayes-rx made their first contribution in [#2516](https://github.com/prefix-dev/rattler-build/pull/2516)
* @XhstormR made their first contribution in [#2618](https://github.com/prefix-dev/rattler-build/pull/2618)