### PR TITLE
ci: scope Deploy Docs concurrency per-ref

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,9 +30,11 @@ on:
 
 permissions: {}
 
-# Allow one concurrent deployment
+# Serialize runs per ref: a new commit on a branch/PR cancels its own
+# in-progress run, but runs for different refs (other PRs, main deploys)
+# no longer cancel each other.
 concurrency:
-  group: "pages"
+  group: pages-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Problem

The `Deploy Docs` workflow uses a single global concurrency group:

```yaml
concurrency:
  group: "pages"
  cancel-in-progress: true
```

Because this group is shared across **every** PR and `main`, any new docs run cancels all other in-progress ones. In practice this means PR `build-docs` / `generate-cli-docs` checks routinely show up as **failed** with `The operation was canceled.` — either because `main` advanced (a push to main starts a `pages` run that cancels the PR's) or because several PRs get pushed close together and cancel each other. This is a false red that has hit many recent PRs (#2624, #2627, #2628, #2630, #2635, …), and the same cancellations are visible on `main`'s own Deploy Docs runs.

## Fix

Scope the concurrency group per ref:

```yaml
concurrency:
  group: pages-${{ github.ref }}
  cancel-in-progress: true
```

Now each ref only serializes against itself — a new commit on a branch still supersedes its own in-progress run (saving CI), but different PRs and `main` deploys no longer cancel one another.

🤖 Generated with [Claude Code](https://claude.com/claude-code)