### PR TITLE
fix: inherit all top-level build settings for cache outputs

### DIFF
--- a/crates/rattler_build_recipe/src/stage0/evaluate.rs
+++ b/crates/rattler_build_recipe/src/stage0/evaluate.rs
@@ -3118,48 +3118,22 @@ fn evaluate_package_output_to_recipe(
         let output_build = output.build.evaluate(context)?;
         merge_stage1_build(toplevel_build, output_build)
     } else {
-        // Cache inheritance: only merge non-script build settings
+        // Cache inheritance: inherit all top-level build settings that the
+        // output does not set itself, EXCEPT the script (the cache has its own
+        // script; a cache-inheriting output packages the restored files and
+        // does not need to re-run the top-level script).
+        //
+        // We reuse `merge_stage1_build` as the single source of truth for which
+        // build fields are inheritable, then restore the output's own script.
+        // Maintaining a separate hand-written field list here caused top-level
+        // settings (build number, `files`, ...) to be silently dropped whenever
+        // a new field was added but not mirrored into this branch (see #2497).
         let toplevel_build = recipe.build.evaluate(context)?;
-        let mut output_build = output.build.evaluate(context)?;
-
-        // Only inherit specific build settings from top-level, not the script
-        if output_build.dynamic_linking.is_default() {
-            output_build.dynamic_linking = toplevel_build.dynamic_linking;
-        }
-        if output_build.prefix_detection.is_default() {
-            output_build.prefix_detection = toplevel_build.prefix_detection;
-        }
-        if output_build.variant.is_default() {
-            output_build.variant = toplevel_build.variant;
-        }
-        if matches!(output_build.string, BuildString::Default) {
-            output_build.string = toplevel_build.string;
-        }
-        if output_build.number.is_none() {
-            output_build.number = toplevel_build.number;
-        }
-        if output_build.noarch.is_none() {
-            output_build.noarch = toplevel_build.noarch;
-        }
-        if output_build.python.is_default() {
-            output_build.python = toplevel_build.python;
-        }
-        if output_build.always_copy_files.is_empty() {
-            output_build.always_copy_files = toplevel_build.always_copy_files;
-        }
-        if output_build.always_include_files.is_empty() {
-            output_build.always_include_files = toplevel_build.always_include_files;
-        }
-        if !toplevel_build.merge_build_and_host_envs && output_build.merge_build_and_host_envs {
-            output_build.merge_build_and_host_envs = toplevel_build.merge_build_and_host_envs;
-        }
-        if output_build.post_process.is_empty() {
-            output_build.post_process = toplevel_build.post_process;
-        }
-        // Combine skip with OR logic
-        output_build.skip = output_build.skip || toplevel_build.skip;
-
-        output_build
+        let output_build = output.build.evaluate(context)?;
+        let output_script = output_build.script.clone();
+        let mut merged = merge_stage1_build(toplevel_build, output_build);
+        merged.script = output_script;
+        merged
     };
 
     // Multi-output recipes do not auto-discover `build.sh`/`build.bat`: a single

--- a/crates/rattler_build_recipe/src/stage0/evaluate.rs
+++ b/crates/rattler_build_recipe/src/stage0/evaluate.rs
@@ -3122,12 +3122,6 @@ fn evaluate_package_output_to_recipe(
         // output does not set itself, EXCEPT the script (the cache has its own
         // script; a cache-inheriting output packages the restored files and
         // does not need to re-run the top-level script).
-        //
-        // We reuse `merge_stage1_build` as the single source of truth for which
-        // build fields are inheritable, then restore the output's own script.
-        // Maintaining a separate hand-written field list here caused top-level
-        // settings (build number, `files`, ...) to be silently dropped whenever
-        // a new field was added but not mirrored into this branch (see #2497).
         let toplevel_build = recipe.build.evaluate(context)?;
         let output_build = output.build.evaluate(context)?;
         let output_script = output_build.script.clone();

--- a/crates/rattler_build_recipe/src/variant_render.rs
+++ b/crates/rattler_build_recipe/src/variant_render.rs
@@ -1699,6 +1699,67 @@ outputs:
         );
     }
 
+    /// Regression test for https://github.com/prefix-dev/rattler-build/issues/2497
+    ///
+    /// A package output that has its own `build` section and inherits from a
+    /// staging cache must still inherit top-level build settings (build number,
+    /// `files`, ...) that it does not override itself. Previously the
+    /// cache-inheritance merge only copied a hand-maintained subset of build
+    /// fields, so top-level settings such as `build.files` were silently lost.
+    #[test]
+    fn test_cache_inherited_output_inherits_top_level_build_settings() {
+        let recipe_yaml = r#"
+recipe:
+  name: libgdal-split
+  version: 3.21.3
+
+build:
+  number: 1
+  files:
+    - "*.txt"
+
+outputs:
+  - staging:
+      name: core-build
+    requirements:
+      build:
+    build:
+      script: build
+
+  - package:
+      name: libgdal-core
+    inherit: core-build
+    requirements:
+      build:
+    build:
+      script: build
+"#;
+
+        let stage0_recipe = stage0::parse_recipe_or_multi_from_source(recipe_yaml).unwrap();
+        let variant_config = VariantConfig::from_yaml_str("{}").unwrap();
+
+        let rendered =
+            render_recipe_with_variant_config(&stage0_recipe, &variant_config, RenderConfig::new())
+                .unwrap();
+
+        assert_eq!(rendered.len(), 1);
+        let output = &rendered[0].recipe;
+        assert_eq!(output.package.name.as_normalized(), "libgdal-core");
+        // The top-level build number must be inherited.
+        assert_eq!(output.build.number, Some(1));
+        // The build string must end with the inherited build number.
+        let build_string = output.build.string.as_resolved().unwrap();
+        assert!(
+            build_string.ends_with("_1"),
+            "cache-inherited output should resolve its build string with the inherited build number, got {build_string}"
+        );
+        // Other top-level build settings (e.g. `files`) must be inherited too.
+        assert!(
+            !output.build.files.is_empty(),
+            "cache-inherited output should inherit the top-level build.files glob"
+        );
+    }
+
     #[test]
     fn test_render_multi_output_with_pin_subpackage() {
         let recipe_yaml = r#"


### PR DESCRIPTION
## Summary

Fixes prefix-dev/rattler-build#2497.

A package output that inherits from a staging cache and has its own `build` section only inherited a **hand-maintained subset** of top-level build fields. That subset was a partial copy of `merge_stage1_build`, and whenever a new build field was added but not mirrored into it, the field was silently dropped for cache-inheriting outputs.

This is what caused the top-level `build.number` to get lost for such outputs (the symptom reported in the issue). [#2460](<https://github.com/prefix-dev/rattler-build/issues/2460>) patched `number` and `string` reactively, but the underlying duplication remained — for example `build.files` and the v3 package `flags` were still dropped.

## Change

Reuse `merge_stage1_build` as the single source of truth for which build fields are inheritable, then restore the output's own script. Cache inheritance intentionally does **not** inherit the top-level script (the cache has its own script; a cache-inheriting output packages the restored files), so that one field is overridden back to the output's value after the merge.

This also incidentally fixes a latent bug in the old branch where `merge_build_and_host_envs` could be reset from `true` back to `false`.

## Reproducer (from the issue)

```yaml
recipe:
  name: libgdal-split
  version: 3.21.3
build:
  number: 1
  files: ["*.txt"]
outputs:
  - staging:
      name: core-build
    build:
      script: build
  - package:
      name: libgdal-core
    inherit: core-build
    build:
      script: build
```

Before: `libgdal-core` renders with build number `0` and no `files`.<br>After: it renders with build number `1` and inherits `files: ["*.txt"]`.

## Tests

* Added `test_cache_inherited_output_inherits_top_level_build_settings` in `variant_render.rs`, covering the issue reproducer and asserting that both the build number **and** `build.files` are inherited.
* The existing `test_cache_inherited_output_inherits_top_level_build_number_before_build_string` continues to pass.
* Full `rattler_build_recipe` test suite is green.

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)

[https://claude.ai/code/session_01128Z1F2koWdxC5VKYfW7wr](<https://claude.ai/code/session_01128Z1F2koWdxC5VKYfW7wr>)

---

*Generated by [Claude Code](<https://claude.ai/code/session_01128Z1F2koWdxC5VKYfW7wr>)*