### PR TITLE
fix(jinja): negative indexing and slicing on split filter results

### DIFF
--- a/crates/rattler_build_jinja/src/jinja.rs
+++ b/crates/rattler_build_jinja/src/jinja.rs
@@ -1922,6 +1922,40 @@ mod tests {
         );
     }
 
+    /// The other sequence-producing filters we register already return
+    /// indexable sequences in the current minijinja version. This test guards
+    /// against a future minijinja update turning any of them into a lazy
+    /// iterable (which would break negative indexing / slicing, see
+    /// https://github.com/prefix-dev/rattler-build/issues/2582). If it does,
+    /// wrap the affected filter with `materialize_iterable` like `split`.
+    #[test]
+    fn test_sequence_filters_support_negative_indexing() {
+        let jinja = Jinja::new(JinjaConfig::default());
+
+        // `reverse` on a sequence
+        assert_eq!(
+            jinja.eval("([1, 2, 3] | reverse)[-1]").unwrap().to_string(),
+            "1"
+        );
+        // `reverse` on a string still yields a reversed string
+        assert_eq!(jinja.eval("'abc' | reverse").unwrap().to_string(), "cba");
+        // `unique`
+        assert_eq!(
+            jinja
+                .eval("([1, 2, 2, 3] | unique)[-1]")
+                .unwrap()
+                .to_string(),
+            "3"
+        );
+        // `sort`
+        assert_eq!(
+            jinja.eval("([3, 1, 2] | sort)[-1]").unwrap().to_string(),
+            "3"
+        );
+        // `list`
+        assert_eq!(jinja.eval("('abc' | list)[-1]").unwrap().to_string(), "c");
+    }
+
     #[test]
     fn eval_env() {
         let options = JinjaConfig {

--- a/crates/rattler_build_jinja/src/jinja.rs
+++ b/crates/rattler_build_jinja/src/jinja.rs
@@ -591,7 +591,29 @@ fn default_filters(env: &mut Environment) {
     env.add_filter("sort", minijinja::filters::sort);
     env.add_filter("trim", minijinja::filters::trim);
     env.add_filter("unique", minijinja::filters::unique);
-    env.add_filter("split", minijinja::filters::split);
+    // Reimplement `split` so that it returns an eagerly materialized sequence
+    // instead of the lazy iterable that upstream minijinja produces. The lazy
+    // iterable does not support (negative) indexing or slicing, so expressions
+    // like `(version | split('.'))[-1]` fail. Materializing into a real list
+    // restores regular Python-style indexing on the result.
+    // See https://github.com/prefix-dev/rattler-build/issues/2582 (remove once
+    // fixed upstream in minijinja).
+    env.add_filter(
+        "split",
+        |s: Arc<str>,
+         sep: Option<Arc<str>>,
+         maxsplits: Option<i64>|
+         -> Result<Value, minijinja::Error> {
+            materialize_iterable(minijinja::filters::split(s, sep, maxsplits))
+        },
+    );
+}
+
+/// Collect a (potentially lazy) iterable [`Value`] into a real sequence so that
+/// indexing (including negative indices) and slicing work as expected.
+fn materialize_iterable(value: Value) -> Result<Value, minijinja::Error> {
+    let items = value.try_iter()?.collect::<Vec<Value>>();
+    Ok(Value::from(items))
 }
 
 fn parse_platform(platform: &str) -> Result<Platform, minijinja::Error> {
@@ -1870,6 +1892,32 @@ mod tests {
 
         assert_eq!(
             jinja.eval("(var | split('.'))[2]").unwrap().to_string(),
+            "3"
+        );
+
+        // Regression test for https://github.com/prefix-dev/rattler-build/issues/2582:
+        // negative indexing and slicing must work on the result of `split`.
+        assert_eq!(
+            jinja.eval("(var | split('.'))[-1]").unwrap().to_string(),
+            "3"
+        );
+        assert_eq!(
+            jinja.eval("(var | split('.'))[-2]").unwrap().to_string(),
+            "2"
+        );
+        assert_eq!(
+            jinja.eval("(var | split('.'))[-1:]").unwrap().to_string(),
+            "[\"3\"]"
+        );
+        assert_eq!(
+            jinja.eval("(var | split('.'))[1:]").unwrap().to_string(),
+            "[\"2\", \"3\"]"
+        );
+        assert_eq!(
+            jinja
+                .eval("(var | split('.'))[-1] | int")
+                .unwrap()
+                .to_string(),
             "3"
         );
     }


### PR DESCRIPTION
## Summary
This PR fixes an issue where negative indexing and slicing operations failed on the results of the `split` filter in Jinja templates. The root cause was that the upstream minijinja `split` filter returns a lazy iterable that doesn't support negative indices or slicing operations.

## Changes
- **Reimplemented the `split` filter** to materialize the lazy iterable into a real sequence (Vec), enabling full Python-style indexing including negative indices and slicing
- **Added `materialize_iterable` helper function** to convert lazy iterables into eagerly-evaluated sequences that support all indexing operations
- **Added comprehensive regression tests** for negative indexing and slicing on `split` results (e.g., `(version | split('.'))[-1]`)
- **Added guard tests** for other sequence-producing filters (`reverse`, `unique`, `sort`, `list`) to detect if future minijinja updates introduce lazy iterables that would break negative indexing

## Implementation Details
The fix wraps the upstream `minijinja::filters::split` function with a custom implementation that:
1. Calls the original split filter
2. Collects the resulting lazy iterable into a `Vec<Value>`
3. Returns the materialized sequence as a minijinja `Value`

This approach maintains backward compatibility while restoring expected Python-like sequence behavior for template expressions like `(version | split('.'))[-1]`.

Fixes #2582

https://claude.ai/code/session_01CKz9vQ6P2cuxs1ySgdW4Qn