### PR TITLE
feat: Allow $schema top-level field in recipe.yaml

### DIFF
--- a/crates/rattler_build_recipe/src/stage0/parser/mod.rs
+++ b/crates/rattler_build_recipe/src/stage0/parser/mod.rs
@@ -254,7 +254,8 @@ fn parse_single_output_recipe_with_config(
         let key_str = key.as_str();
         if !matches!(
             key_str,
-            "package"
+            "$schema"
+                | "package"
                 | "build"
                 | "about"
                 | "requirements"

--- a/test-data/recipes/test-parsing/single_output.yaml
+++ b/test-data/recipes/test-parsing/single_output.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+$schema: https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
 schema_version: 1
 # a recipe with all possible fields
 package:


### PR DESCRIPTION
## References
- https://github.com/prefix-dev/recipe-format/pull/82

## Changes

- [x] accept top-level `$schema`, otherwise not used
- [x] replace magic comment with  `$schema` in a test file (presumably it gets parsed) 

## Motivation

`$schema` allows for explicitly describing the contract a file meets without magic comments.

 This convention is now supported by most third-party tools, most recently `yaml-language-server 1.24.0`.

## Future Work

- add `yaml-language-server` to playground via [`@codemirror/lsp-client`](https://code.haverbeke.berlin/codemirror/lsp-client)