### PR TITLE
feat: add experimental build steps

### DIFF
--- a/crates/rattler_build_core/src/build.rs
+++ b/crates/rattler_build_core/src/build.rs
@@ -184,8 +184,19 @@ pub async fn run_build(
             }
         });
 
+    let interpreter_field = if output.recipe.build().plan.steps().is_some() {
+        "build.steps[].interpreter"
+    } else {
+        "build.script.interpreter"
+    };
+
     match output.run_build_script().await {
         Ok(_) => {}
+        Err(InterpreterError::ExecutionFailed(err))
+            if err.kind() == std::io::ErrorKind::InvalidInput =>
+        {
+            return Err(miette::miette!("{err}"));
+        }
         Err(InterpreterError::ExecutionFailed(_)) => {
             return Err(miette::miette!("Script failed to execute"));
         }
@@ -210,10 +221,10 @@ pub async fn run_build(
                 match rattler_build_script::closest_interpreter(&interpreter) {
                     Some(suggestion) => miette::miette!(
                         help = format!("Did you mean `{suggestion}`?"),
-                        "unsupported interpreter `{interpreter}` in `build.script.interpreter`"
+                        "unsupported interpreter `{interpreter}` in `{interpreter_field}`"
                     ),
                     None => miette::miette!(
-                        "unsupported interpreter `{interpreter}` in `build.script.interpreter`"
+                        "unsupported interpreter `{interpreter}` in `{interpreter_field}`"
                     ),
                 },
             );

--- a/crates/rattler_build_core/src/script.rs
+++ b/crates/rattler_build_core/src/script.rs
@@ -9,14 +9,16 @@ use rattler_build_jinja::Jinja;
 
 // Re-export from rattler_build_script
 pub use rattler_build_script::{
-    ExecutionArgs, ExecutionContext, InterpreterError, ResolvedScriptContents, RuntimeEnv,
-    SandboxArguments, SandboxConfiguration, Script, ScriptContent, platform_script_extensions,
+    BuildScriptSection, ExecutionArgs, ExecutionContext, InterpreterError, ResolvedScriptContents,
+    RuntimeEnv, SandboxArguments, SandboxConfiguration, Script, ScriptContent,
+    platform_script_extensions,
 };
 
 use crate::{
     env_vars::{self},
     metadata::Output,
 };
+use rattler_build_recipe::stage1::build::BuildPlan;
 
 impl Output {
     /// Helper function to get a jinja renderer for the output's recipe context.
@@ -26,13 +28,24 @@ impl Output {
         move |template: &str| jinja.render_str(template).map_err(|e| e.to_string())
     }
 
-    /// Helper method to prepare build script execution arguments
+    /// Helper method to prepare build script execution arguments.
+    ///
+    /// The build script is always expressed as an ordered list of sections: a
+    /// `build.script` is a single section, and `build.steps` are one section per
+    /// step. Both go through the same execution path.
     async fn prepare_build_script(&self) -> Result<ExecutionArgs, std::io::Error> {
         let host_prefix = self.build_configuration.directories.host_prefix.clone();
         let target_platform = self.build_configuration.target_platform;
         let host_platform = self.host_platform().platform;
         let env_isolation = self.build_configuration.env_isolation;
-        let context = if self.recipe.build().merge_build_and_host_envs {
+        let build = self.recipe.build();
+        if matches!(&build.plan, BuildPlan::Steps(_)) && !self.build_configuration.experimental {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "`build.steps` is an experimental feature: provide the `--experimental` flag to enable it",
+            ));
+        }
+        let context = if build.merge_build_and_host_envs {
             ExecutionContext::shared(
                 RuntimeEnv::current(),
                 &host_prefix,
@@ -72,22 +85,78 @@ impl Output {
             );
         }
 
-        let jinja_renderer = self.jinja_renderer();
-        let work_dir = &self.build_configuration.directories.work_dir;
-        Ok(ExecutionArgs {
-            interpreter: self.recipe.build().script.interpreter.clone(),
-            script: self.recipe.build().script.resolve_content(
-                &self.build_configuration.directories.recipe_dir,
-                Some(jinja_renderer),
-                platform_script_extensions(),
-            )?,
-            env_vars: env_vars
-                .into_iter()
-                .filter_map(|(k, v)| v.map(|v| (k, v)))
+        let mut env_vars: IndexMap<String, String> = env_vars
+            .into_iter()
+            .filter_map(|(k, v)| v.map(|v| (k, v)))
+            .collect();
+        if let BuildPlan::Script(script) = &build.plan {
+            env_vars.extend(script.env().clone());
+        }
+
+        let recipe_dir = &self.build_configuration.directories.recipe_dir;
+        let scripts: Vec<(Script, Option<usize>)> = match &build.plan {
+            BuildPlan::Steps(steps) => steps
+                .iter()
+                .enumerate()
+                .map(|(index, step)| (step.to_script(), Some(index)))
                 .collect(),
-            secrets: IndexMap::new(),
+            BuildPlan::Script(script) => vec![(script.clone(), None)],
+        };
+
+        let mut secrets = IndexMap::new();
+        let work_dir = self.build_configuration.directories.work_dir.clone();
+        let mut sections = Vec::with_capacity(scripts.len());
+
+        for (script, step_index) in scripts {
+            let mut section_jinja = Jinja::new(self.build_configuration.selector_config())
+                .with_context(&self.recipe.context);
+            for (key, value) in env_vars.iter().chain(script.env()) {
+                section_jinja
+                    .context_mut()
+                    .insert(key.clone(), Value::from_safe_string(value.clone()));
+            }
+            let section_jinja_renderer = |template: &str| {
+                section_jinja
+                    .render_str(template)
+                    .map_err(|err| err.to_string())
+            };
+            let content = script.resolve_content(
+                recipe_dir,
+                Some(&section_jinja_renderer),
+                platform_script_extensions(),
+            )?;
+
+            for name in script.secrets() {
+                if let Some(value) = context.runtime().var(name) {
+                    secrets.insert(name.to_string(), value.to_string());
+                } else {
+                    tracing::warn!("Secret {} not found in environment", name);
+                }
+            }
+
+            let cwd = script
+                .cwd
+                .as_ref()
+                .map(|cwd| context.host().path().join(cwd));
+            sections.push(BuildScriptSection {
+                interpreter: script.interpreter.clone(),
+                content,
+                env: if step_index.is_some() {
+                    script.env().clone()
+                } else {
+                    Default::default()
+                },
+                cwd,
+                label: step_index.map(|index| format!("step {index}")),
+            });
+        }
+
+        Ok(ExecutionArgs {
+            sections,
+            env_vars,
+            secrets,
             context,
-            work_dir: work_dir.clone(),
+            work_dir,
             sandbox_config: self.build_configuration.sandbox_config().cloned(),
             env_isolation,
         })
@@ -123,40 +192,7 @@ impl Output {
         }
 
         let exec_args = self.prepare_build_script().await?;
-        let context = exec_args.context.clone();
-
-        // Create Jinja context with environment variables
-        let mut jinja = Jinja::new(self.build_configuration.selector_config())
-            .with_context(&self.recipe.context);
-
-        // Add env vars to jinja context
-        for (k, v) in &exec_args.env_vars {
-            jinja
-                .context_mut()
-                .insert(k.clone(), Value::from_safe_string(v.clone()));
-        }
-
-        let jinja_renderer = |template: &str| -> Result<String, String> {
-            jinja.render_str(template).map_err(|e| e.to_string())
-        };
-
-        self.recipe
-            .build()
-            .script
-            .run_script(
-                exec_args
-                    .env_vars
-                    .into_iter()
-                    .map(|(k, v)| (k, Some(v)))
-                    .collect(),
-                &self.build_configuration.directories.work_dir,
-                &self.build_configuration.directories.recipe_dir,
-                context,
-                Some(jinja_renderer),
-                self.build_configuration.sandbox_config(),
-                self.build_configuration.env_isolation,
-            )
-            .await?;
+        rattler_build_script::run_script(exec_args).await?;
 
         Ok(())
     }

--- a/crates/rattler_build_core/src/staging.rs
+++ b/crates/rattler_build_core/src/staging.rs
@@ -13,7 +13,7 @@ use fs_err as fs;
 use miette::{Context, IntoDiagnostic};
 use minijinja::Value;
 use rattler_build_jinja::{Jinja, Variable};
-use rattler_build_recipe::stage1::{InheritsFrom, StagingCache};
+use rattler_build_recipe::stage1::{BuildPlan, InheritsFrom, StagingCache};
 use rattler_build_script::{ExecutionContext, RuntimeEnv};
 use rattler_build_types::NormalizedKey;
 use serde::{Deserialize, Serialize};
@@ -81,6 +81,18 @@ pub struct StagingCacheMetadata {
     /// physically installed in the host prefix.
     #[serde(default)]
     pub library_name_map: LibraryNameMap,
+}
+
+fn staging_build_script(
+    staging: &StagingCache,
+) -> Result<&rattler_build_script::Script, miette::Error> {
+    match &staging.build.plan {
+        BuildPlan::Script(script) => Ok(script),
+        BuildPlan::Steps(_) => Err(miette::miette!(
+            "staging cache `{}` uses `build.steps`, but staging builds only support `build.script`",
+            staging.name
+        )),
+    }
 }
 
 impl Output {
@@ -343,9 +355,7 @@ impl Output {
             )
         };
 
-        staging
-            .build
-            .script
+        staging_build_script(staging)?
             .run_script(
                 env_vars,
                 &self.build_configuration.directories.work_dir,
@@ -581,4 +591,31 @@ pub fn get_staging_cache_name(inherits: &InheritsFrom) -> &str {
 /// Check if run_exports should be inherited from the staging cache
 pub fn should_inherit_run_exports(inherits: &InheritsFrom) -> bool {
     inherits.inherit_run_exports
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rattler_build_recipe::stage1::{Build, Requirements};
+
+    #[test]
+    fn staging_build_steps_returns_error_instead_of_panicking() {
+        let staging = StagingCache::new(
+            "compile".to_string(),
+            Build {
+                plan: BuildPlan::Steps(Vec::new()),
+                ..Default::default()
+            },
+            Requirements::default(),
+            Vec::new(),
+            BTreeMap::new(),
+        );
+
+        let err = staging_build_script(&staging).unwrap_err();
+
+        assert!(
+            err.to_string().contains("staging builds only support"),
+            "unexpected error: {err}"
+        );
+    }
 }

--- a/crates/rattler_build_core/src/types/build_configuration.rs
+++ b/crates/rattler_build_core/src/types/build_configuration.rs
@@ -56,6 +56,10 @@ pub struct BuildConfiguration {
     #[serde(skip_serializing, default = "default_true")]
     pub force_colors: bool,
 
+    /// Whether experimental features are enabled for this build invocation.
+    #[serde(skip_serializing, default)]
+    pub experimental: bool,
+
     /// The environment isolation mode for build scripts
     #[serde(skip_serializing, default)]
     pub env_isolation: EnvironmentIsolation,
@@ -89,7 +93,7 @@ impl BuildConfiguration {
             host_platform: self.host_platform.platform,
             build_platform: self.build_platform.platform,
             variant: self.variant.clone(),
-            experimental: false,
+            experimental: self.experimental,
             undefined_behavior: rattler_build_jinja::UndefinedBehavior::Lenient,
             recipe_path: None,
         }

--- a/crates/rattler_build_core/src/utils.rs
+++ b/crates/rattler_build_core/src/utils.rs
@@ -121,7 +121,7 @@ fn try_remove_with_retry(path: &Path, last_err: Option<std::io::Error>) -> std::
     // This frees the original path immediately; the actual deletion can
     // then proceed on the renamed path without blocking the caller.
     let trash_path = pending_removal_path(path);
-    let (target, renamed) = match std::fs::rename(path, &trash_path) {
+    let (target, renamed) = match fs::rename(path, &trash_path) {
         Ok(()) => {
             tracing::debug!(
                 "Renamed {:?} → {:?} for deferred deletion",

--- a/crates/rattler_build_jinja/src/ast_variables.rs
+++ b/crates/rattler_build_jinja/src/ast_variables.rs
@@ -20,7 +20,7 @@ pub struct JinjaTemplate {
 impl JinjaTemplate {
     /// Create a new JinjaTemplate, validating that it parses correctly
     pub fn new(source: String) -> Result<Self, String> {
-        let variables = extract_variables_from_template(&source)
+        let variables = catch_minijinja_panic(|| extract_variables_from_template(&source))
             .map_err(|e| format!("Failed to parse Jinja template: {}", e))?;
         Ok(Self { source, variables })
     }
@@ -78,8 +78,9 @@ pub struct JinjaExpression {
 impl JinjaExpression {
     /// Create a new JinjaExpression, validating that it parses correctly
     pub fn new(source: String) -> Result<Self, String> {
-        let variables = extract_variables_from_expression_checked(&source)
-            .map_err(|e| format!("Failed to parse Jinja expression: {}", e))?;
+        let variables =
+            catch_minijinja_panic(|| extract_variables_from_expression_checked(&source))
+                .map_err(|e| format!("Failed to parse Jinja expression: {}", e))?;
         Ok(Self { source, variables })
     }
 
@@ -117,6 +118,30 @@ impl<'de> Deserialize<'de> for JinjaExpression {
     {
         let source = String::deserialize(deserializer)?;
         JinjaExpression::new(source).map_err(serde::de::Error::custom)
+    }
+}
+
+fn catch_minijinja_panic<T>(
+    f: impl FnOnce() -> Result<T, minijinja::Error>,
+) -> Result<T, minijinja::Error> {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)).unwrap_or_else(|payload| {
+        Err(minijinja::Error::new(
+            minijinja::ErrorKind::SyntaxError,
+            format!(
+                "failed to parse Jinja without panicking: {}",
+                panic_payload_message(payload.as_ref())
+            ),
+        ))
+    })
+}
+
+fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(message) = payload.downcast_ref::<&'static str>() {
+        (*message).to_string()
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "unknown panic".to_string()
     }
 }
 
@@ -484,6 +509,14 @@ mod tests {
     fn test_expression_simple() {
         let expr = JinjaExpression::new("linux".to_string()).unwrap();
         assert_eq!(expr.used_variables(), &["linux"]);
+    }
+
+    #[test]
+    fn test_expression_malformed_errors_without_panic() {
+        let err = JinjaExpression::new("target_platform }}".to_string())
+            .expect_err("malformed expression should return an error");
+
+        assert!(err.contains("Failed to parse Jinja expression"), "{err}");
     }
 
     #[test]

--- a/crates/rattler_build_jinja/src/jinja.rs
+++ b/crates/rattler_build_jinja/src/jinja.rs
@@ -300,8 +300,19 @@ impl Jinja {
         let tracking_context =
             TrackingContext::new(self.context.clone(), self.accessed_variables.clone());
 
-        let expr = self.env.compile_expression(str)?;
-        expr.eval(Value::from_object(tracking_context))
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let expr = self.env.compile_expression(str)?;
+            expr.eval(Value::from_object(tracking_context))
+        }))
+        .unwrap_or_else(|payload| {
+            Err(minijinja::Error::new(
+                minijinja::ErrorKind::SyntaxError,
+                format!(
+                    "failed to evaluate Jinja expression without panicking: {}",
+                    panic_payload_message(payload.as_ref())
+                ),
+            ))
+        })
     }
 
     /// Get the set of variables that were accessed during rendering
@@ -336,6 +347,16 @@ impl Jinja {
         if let Ok(mut accessed) = self.accessed_variables.lock() {
             accessed.clear();
         }
+    }
+}
+
+fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(message) = payload.downcast_ref::<&'static str>() {
+        (*message).to_string()
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "unknown panic".to_string()
     }
 }
 
@@ -1420,7 +1441,22 @@ mod tests {
     }
 
     #[test]
+    fn eval_malformed_expression_errors_without_panic() {
+        let jinja = Jinja::new(JinjaConfig::default());
 
+        let err = jinja
+            .eval("target_platform }}")
+            .expect_err("malformed expression should return an error");
+
+        assert!(
+            err.to_string()
+                .contains("failed to evaluate Jinja expression")
+                || err.to_string().contains("unexpected"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
     fn eval() {
         let options = JinjaConfig {
             target_platform: Platform::Linux64,

--- a/crates/rattler_build_recipe/src/stage0/build.rs
+++ b/crates/rattler_build_recipe/src/stage0/build.rs
@@ -1,10 +1,11 @@
 use std::fmt::Display;
 
 use itertools::Itertools as _;
+use marked_yaml::Span;
 use rattler_conda_types::{Flag, NoArchType, package::EntryPoint};
 use serde::{Deserialize, Serialize};
 
-use crate::stage0::types::{ConditionalList, IncludeExclude, Item, Script, Value};
+use crate::stage0::types::{ConditionalList, IncludeExclude, Item, JinjaExpression, Script, Value};
 
 /// Variant key usage configuration
 #[derive(Debug, Serialize, Deserialize, Default, Clone, PartialEq)]
@@ -23,8 +24,153 @@ pub struct VariantKeyUsage {
     pub down_prioritize_variant: Option<Value<i32>>,
 }
 
-/// Stage0 Build configuration - contains templates and conditionals
+/// A single build step.
+///
+/// Steps are an ordered, GitHub-Actions-style alternative to a monolithic
+/// `build.script`. A step is an inline `run` script.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(untagged)]
+pub enum Step {
+    /// An inline script step.
+    Run(RunStep),
+}
+
+/// An inline `run` step that executes script content as part of the build.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
+pub struct RunStep {
+    /// The script content to execute for this step.
+    pub run: ConditionalList<String>,
+
+    /// Optional selector expression gating whether this step runs (e.g. `unix`).
+    #[serde(default, rename = "if", skip_serializing_if = "Option::is_none")]
+    pub condition: Option<JinjaExpression>,
+
+    /// Optional span for the condition expression (for error reporting).
+    #[serde(default, skip)]
+    pub condition_span: Option<Span>,
+
+    /// Optional interpreter override for this step (e.g. `bash`, `cmd.exe`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub interpreter: Option<Value<String>>,
+
+    /// Optional working directory for this step, relative to the host prefix.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<Value<String>>,
+
+    /// Environment variables scoped to this step only.
+    #[serde(default, skip_serializing_if = "indexmap::IndexMap::is_empty")]
+    pub env: indexmap::IndexMap<String, Value<String>>,
+}
+
+impl Step {
+    /// Collect all variables used in this step.
+    pub fn used_variables(&self) -> Vec<String> {
+        match self {
+            Step::Run(run) => run.used_variables(),
+        }
+    }
+}
+
+impl RunStep {
+    /// Collect all variables used in this run step.
+    pub fn used_variables(&self) -> Vec<String> {
+        let RunStep {
+            run,
+            condition,
+            condition_span: _,
+            interpreter,
+            cwd,
+            env,
+        } = self;
+
+        let mut vars = run.used_variables();
+
+        if let Some(condition) = condition {
+            vars.extend(condition.used_variables().iter().cloned());
+        }
+        if let Some(interpreter) = interpreter {
+            vars.extend(interpreter.used_variables());
+        }
+        if let Some(cwd) = cwd {
+            vars.extend(cwd.used_variables());
+        }
+        for value in env.values() {
+            vars.extend(value.used_variables());
+        }
+
+        vars.sort();
+        vars.dedup();
+        vars
+    }
+}
+
+/// The executable build plan before evaluation.
+#[derive(Debug, Serialize, Clone, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum BuildPlan {
+    /// Legacy `build.script` mode. `Script::default()` preserves default
+    /// `build.sh` / `build.bat` discovery.
+    Script(Box<Script>),
+    /// Explicit `build.steps` mode. An empty vector is meaningful: it disables
+    /// legacy default script discovery.
+    Steps(Vec<Step>),
+}
+
+impl Default for BuildPlan {
+    fn default() -> Self {
+        Self::Script(Box::default())
+    }
+}
+
+impl BuildPlan {
+    /// Returns the script in legacy script mode.
+    pub fn script(&self) -> Option<&Script> {
+        match self {
+            Self::Script(script) => Some(script),
+            Self::Steps(_) => None,
+        }
+    }
+
+    /// Returns a mutable script in legacy script mode.
+    pub fn script_mut(&mut self) -> Option<&mut Script> {
+        match self {
+            Self::Script(script) => Some(script),
+            Self::Steps(_) => None,
+        }
+    }
+
+    /// Returns the steps in explicit steps mode.
+    pub fn steps(&self) -> Option<&[Step]> {
+        match self {
+            Self::Script(_) => None,
+            Self::Steps(steps) => Some(steps.as_slice()),
+        }
+    }
+
+    /// Returns true if this is default legacy script discovery.
+    pub fn is_default(&self) -> bool {
+        matches!(self, Self::Script(script) if script.is_default())
+    }
+
+    /// Collect all variables used in the build plan.
+    pub fn used_variables(&self) -> Vec<String> {
+        let mut vars = Vec::new();
+        match self {
+            Self::Script(script) => vars.extend(script.used_variables()),
+            Self::Steps(steps) => {
+                for step in steps {
+                    vars.extend(step.used_variables());
+                }
+            }
+        }
+        vars.sort();
+        vars.dedup();
+        vars
+    }
+}
+
+/// Stage0 Build configuration - contains templates and conditionals
+#[derive(Debug, Serialize, Clone, PartialEq)]
 pub struct Build {
     /// Build number (increments with each rebuild)
     /// None means inherit from top-level, Some(n) means use n (even if n is 0)
@@ -35,10 +181,9 @@ pub struct Build {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub string: Option<Value<String>>,
 
-    /// Build script - contains script content, interpreter, environment variables, etc.
-    /// Default is `build.sh` on Unix, `build.bat` on Windows
-    #[serde(default)]
-    pub script: Script,
+    /// Executable build plan: either a single legacy script or explicit steps.
+    #[serde(default, flatten)]
+    pub plan: BuildPlan,
 
     /// Noarch type - python or generic
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -94,7 +239,7 @@ impl Default for Build {
         Self {
             number: None,
             string: None,
-            script: Script::default(),
+            plan: BuildPlan::default(),
             noarch: None,
             flags: ConditionalList::default(),
             python: PythonBuild::default(),
@@ -259,7 +404,10 @@ impl Display for Build {
                 .map(|v| format!("{}", v))
                 .unwrap_or_else(|| "inherited".to_string()),
             self.string.as_ref().into_iter().format(", "),
-            self.script,
+            match &self.plan {
+                BuildPlan::Script(script) => script.to_string(),
+                BuildPlan::Steps(steps) => format!("{} steps", steps.len()),
+            },
             self.noarch
                 .as_ref()
                 .map(|v| format!("{:?}", v))
@@ -275,7 +423,7 @@ impl Build {
         let Build {
             number,
             string,
-            script,
+            plan,
             noarch,
             flags,
             python,
@@ -300,7 +448,7 @@ impl Build {
             vars.extend(string.used_variables());
         }
 
-        vars.extend(script.used_variables());
+        vars.extend(plan.used_variables());
 
         if let Some(noarch) = noarch {
             vars.extend(noarch.used_variables());

--- a/crates/rattler_build_recipe/src/stage0/evaluate.rs
+++ b/crates/rattler_build_recipe/src/stage0/evaluate.rs
@@ -41,10 +41,11 @@ use crate::{
         Package as Stage0Package, Requirements as Stage0Requirements, Source as Stage0Source,
         Stage0Recipe, TestType as Stage0TestType,
         build::{
-            BinaryRelocation as Stage0BinaryRelocation, DynamicLinking as Stage0DynamicLinking,
-            ForceFileType as Stage0ForceFileType, PostProcess as Stage0PostProcess,
-            PrefixDetection as Stage0PrefixDetection, PrefixIgnore as Stage0PrefixIgnore,
-            PythonBuild as Stage0PythonBuild, VariantKeyUsage as Stage0VariantKeyUsage,
+            BinaryRelocation as Stage0BinaryRelocation, BuildPlan as Stage0BuildPlan,
+            DynamicLinking as Stage0DynamicLinking, ForceFileType as Stage0ForceFileType,
+            PostProcess as Stage0PostProcess, PrefixDetection as Stage0PrefixDetection,
+            PrefixIgnore as Stage0PrefixIgnore, PythonBuild as Stage0PythonBuild,
+            Step as Stage0Step, VariantKeyUsage as Stage0VariantKeyUsage,
         },
         match_spec::matchspec_parse_options,
         requirements::{
@@ -71,9 +72,10 @@ use crate::{
         Extra as Stage1Extra, GlobVec, Package as Stage1Package, Recipe as Stage1Recipe,
         Requirements as Stage1Requirements, Rpaths,
         build::{
-            Build as Stage1Build, BuildString, DynamicLinking as Stage1DynamicLinking,
-            ForceFileType as Stage1ForceFileType, PostProcess as Stage1PostProcess,
-            PrefixDetection as Stage1PrefixDetection, PythonBuild as Stage1PythonBuild,
+            Build as Stage1Build, BuildPlan as Stage1BuildPlan, BuildString,
+            DynamicLinking as Stage1DynamicLinking, ForceFileType as Stage1ForceFileType,
+            PostProcess as Stage1PostProcess, PrefixDetection as Stage1PrefixDetection,
+            PythonBuild as Stage1PythonBuild, Step as Stage1Step,
             VariantKeyUsage as Stage1VariantKeyUsage,
         },
         requirements::{
@@ -1277,14 +1279,7 @@ pub fn evaluate_script(
         None
     };
 
-    // Evaluate environment variables
-    let mut env = indexmap::IndexMap::new();
-    for (key, val) in &script.env {
-        let evaluated_val = evaluate_string_value(val, context)?;
-        if !evaluated_val.is_empty() {
-            env.insert(key.clone(), evaluated_val);
-        }
-    }
+    let env = evaluate_env_map("script.env", &script.env, context)?;
 
     // Copy secrets as-is
     let secrets = script.secrets.clone();
@@ -1349,6 +1344,84 @@ pub fn evaluate_script(
         cwd,
         content_explicit: script.content_explicit,
     })
+}
+
+/// Evaluate an ordered list of build [`steps`](Stage0Step) into one
+/// [`Step`](Stage1Step) per included recipe step.
+///
+/// Each step's `if` condition is evaluated here, where the target platform and
+/// selectors are known, and excluded steps are dropped. `run` content keeps its
+/// templates so they render at build time, exactly like `build.script`.
+pub fn evaluate_steps(
+    steps: &[Stage0Step],
+    context: &EvaluationContext,
+) -> Result<Vec<Stage1Step>, ParseError> {
+    let mut scripts = Vec::new();
+
+    for step in steps {
+        match step {
+            Stage0Step::Run(run) => {
+                for var in run.used_variables() {
+                    context.track_access(&var);
+                }
+
+                if let Some(condition) = &run.condition
+                    && !evaluate_condition(condition, context, run.condition_span.as_ref())?
+                {
+                    continue;
+                }
+
+                let commands = preserve_string_list(&run.run, context)?;
+                if commands.is_empty() {
+                    continue;
+                }
+
+                let interpreter = match &run.interpreter {
+                    Some(interpreter) => Some(evaluate_string_value(interpreter, context)?),
+                    None => None,
+                };
+                let cwd = match &run.cwd {
+                    Some(cwd) => Some(PathBuf::from(evaluate_string_value(cwd, context)?)),
+                    None => None,
+                };
+
+                scripts.push(Stage1Step::new(rattler_build_script::Script {
+                    interpreter,
+                    env: evaluate_env_map("steps.env", &run.env, context)?,
+                    content: ScriptContent::Commands(commands),
+                    cwd,
+                    ..Default::default()
+                }));
+            }
+        }
+    }
+
+    Ok(scripts)
+}
+
+fn evaluate_env_map(
+    field_name: &str,
+    env: &indexmap::IndexMap<String, Value<String>>,
+    context: &EvaluationContext,
+) -> Result<IndexMap<String, String>, ParseError> {
+    let mut evaluated = IndexMap::new();
+    for (key, value) in env {
+        let evaluated_value = evaluate_string_value(value, context)?;
+        if evaluated_value.contains(['\n', '\r']) {
+            return Err(ParseError::invalid_value(
+                field_name,
+                format!(
+                    "environment variable '{}' contains a newline, which cannot be represented safely in build scripts",
+                    key
+                ),
+                value.span().copied().unwrap_or_else(Span::new_blank),
+            ));
+        }
+        if !evaluated_value.is_empty() {
+            evaluated.insert(key.clone(), evaluated_value);
+        }
+    }
+    Ok(evaluated)
 }
 
 /// Parse a boolean from a string (case-insensitive)
@@ -2083,7 +2156,26 @@ impl Evaluate for Stage0Build {
         // like ${{ PYTHON }} or ${{ PREFIX }} that are only available at build time.
         // Track the variables used in the script to count towards "actually used" variables,
         // but defer actual evaluation until build time.
-        let script = evaluate_script(&self.script, context)?;
+        //
+        // The build plan is either legacy script mode or explicit steps mode
+        // (enforced during parsing). Steps mode is preserved even if the list is
+        // empty or all steps filter out, so outputs don't accidentally inherit a
+        // top-level script.
+        let plan = match &self.plan {
+            Stage0BuildPlan::Steps(steps) => {
+                if !context.jinja_config().experimental {
+                    return Err(ParseError::invalid_value(
+                        "build.steps",
+                        "`build.steps` is an experimental feature: provide the `--experimental` flag to enable it",
+                        Span::new_blank(),
+                    ));
+                }
+                Stage1BuildPlan::Steps(evaluate_steps(steps, context)?)
+            }
+            Stage0BuildPlan::Script(script) => {
+                Stage1BuildPlan::Script(evaluate_script(script, context)?)
+            }
+        };
 
         // Evaluate noarch
         //
@@ -2188,7 +2280,7 @@ impl Evaluate for Stage0Build {
         Ok(Stage1Build {
             number,
             string,
-            script,
+            plan,
             noarch,
             flags,
             python,
@@ -2931,17 +3023,35 @@ impl Evaluate for Stage0Recipe {
     }
 }
 
+fn build_plan_inherits_from_toplevel(toplevel: &Stage1BuildPlan, output: &Stage1BuildPlan) -> bool {
+    matches!(
+        output,
+        Stage1BuildPlan::Script(script)
+            if script.content.is_default()
+                && script.interpreter.is_none()
+                && script.env.is_empty()
+                && script.secrets.is_empty()
+                && (script.cwd.is_none() || matches!(toplevel, Stage1BuildPlan::Script(_)))
+    )
+}
+
 /// Merge two Stage1 Build configurations
 /// The output build takes precedence, but if output has default/empty values, use top-level
 fn merge_stage1_build(
     toplevel: crate::stage1::Build,
     output: crate::stage1::Build,
 ) -> crate::stage1::Build {
-    // Script: use output if not default, otherwise inherit from top-level
-    let script = if output.script.is_default() {
-        toplevel.script
+    // Build-authoring mode (`script` vs `steps`) is mutually exclusive and is
+    // determined per build unit. If the output specifies either, it fully owns
+    // the mode; only a legacy script-discovery plan with no executable content
+    // inherits from top-level. A cwd-only script object still counts as unset
+    // when inheriting a top-level script, matching the historical multi-output
+    // behavior. It does not inherit a top-level steps plan because there is no
+    // whole-plan `cwd` to apply to steps without silently dropping it.
+    let plan = if build_plan_inherits_from_toplevel(&toplevel.plan, &output.plan) {
+        toplevel.plan
     } else {
-        output.script
+        output.plan
     };
 
     // Build string: use output unless it's Default, then inherit from top-level
@@ -3027,7 +3137,7 @@ fn merge_stage1_build(
     };
 
     stage1::Build {
-        script,
+        plan,
         number,
         string,
         noarch,
@@ -3146,24 +3256,24 @@ fn evaluate_package_output_to_recipe(
 
     // Evaluate build section
     // Merging strategy depends on what the output inherits from:
-    // - Top-level inheritance: merge everything including script
-    // - Cache inheritance: merge build settings (dynamic_linking, etc.) but NOT script
-    //   (the cache has its own script, and the output doesn't need one for filtering files)
+    // - Top-level inheritance: merge everything including the build plan
+    // - Cache inheritance: merge build settings (dynamic_linking, etc.) but NOT the plan
+    //   (the cache has its own plan, and the output doesn't need one for filtering files)
     let build = if inherits_from_toplevel {
-        // Full merge including script
+        // Full merge including the build plan
         let toplevel_build = recipe.build.evaluate(context)?;
         let output_build = output.build.evaluate(context)?;
         merge_stage1_build(toplevel_build, output_build)
     } else {
         // Cache inheritance: inherit all top-level build settings that the
-        // output does not set itself, EXCEPT the script (the cache has its own
-        // script; a cache-inheriting output packages the restored files and
-        // does not need to re-run the top-level script).
+        // output does not set itself, EXCEPT the build plan (the cache has its
+        // own plan; a cache-inheriting output packages the restored files and
+        // does not need to re-run the top-level plan).
         let toplevel_build = recipe.build.evaluate(context)?;
         let output_build = output.build.evaluate(context)?;
-        let output_script = output_build.script.clone();
+        let output_plan = output_build.plan.clone();
         let mut merged = merge_stage1_build(toplevel_build, output_build);
-        merged.script = output_script;
+        merged.plan = output_plan;
         merged
     };
 
@@ -3173,8 +3283,10 @@ fn evaluate_package_output_to_recipe(
     // as a no-op; users must set `build.script` explicitly on the output or
     // top-level to run anything.
     let mut build = build;
-    if build.script.content.is_default() {
-        build.script.content = ScriptContent::Commands(Vec::new());
+    if let Stage1BuildPlan::Script(script) = &mut build.plan
+        && script.content.is_default()
+    {
+        script.content = ScriptContent::Commands(Vec::new());
     }
 
     // Check if this output is skipped (already eagerly evaluated during Build::evaluate).
@@ -3384,7 +3496,7 @@ impl Evaluate for crate::stage0::MultiOutputRecipe {
                 // Evaluate staging output components
                 let script = evaluate_script(&staging_output.build.script, &context_with_vars)?;
                 let build = crate::stage1::Build {
-                    script,
+                    plan: Stage1BuildPlan::Script(script),
                     ..crate::stage1::Build::default()
                 };
 
@@ -3577,9 +3689,11 @@ mod tests {
     use super::*;
     use crate::stage0::{
         self,
+        build::RunStep as Stage0RunStep,
         parser::parse_recipe_or_multi_from_source,
         types::{Conditional, ConditionalList, Item, JinjaTemplate, NestedItemList, Value},
     };
+    use crate::stage1::build::StepRun as Stage1StepRun;
 
     #[test]
     fn test_evaluate_condition_simple() {
@@ -4995,7 +5109,7 @@ outputs:
                 // multi-output outputs never auto-discover `build.sh`/`build.bat`,
                 // so the resolved script is an explicit no-op.
                 assert_eq!(
-                    cache_output.build.script.content,
+                    cache_output.build.plan.script().unwrap().content,
                     ScriptContent::Commands(Vec::new())
                 );
 
@@ -5015,7 +5129,92 @@ outputs:
 
                 // Build section: should inherit everything including script
                 assert!(!toplevel_output.build.dynamic_linking.is_default()); // Inherited
-                assert!(!toplevel_output.build.script.is_default()); // Inherited (top-level has script)
+                assert!(!toplevel_output.build.plan.is_default()); // Inherited (top-level has script)
+            }
+            _ => panic!("Expected MultiOutputRecipe"),
+        }
+    }
+
+    #[test]
+    fn test_multi_output_cwd_only_script_inherits_top_level_script() {
+        let recipe_yaml = r#"
+schema_version: 1
+
+recipe:
+  name: myproject
+  version: 1.0.0
+
+build:
+  script: echo top-level
+
+outputs:
+  - package:
+      name: output
+      version: 1.0.0
+    build:
+      script:
+        cwd: subdir
+"#;
+
+        let parsed = parse_recipe_or_multi_from_source(recipe_yaml).unwrap();
+
+        match parsed {
+            stage0::Recipe::MultiOutput(multi) => {
+                let ctx = EvaluationContext::for_platform(rattler_conda_types::Platform::Linux64);
+                let recipes = multi.evaluate(&ctx).unwrap();
+                assert_eq!(recipes.len(), 1);
+
+                let script = recipes[0].build.plan.script().expect("script mode");
+                assert_eq!(
+                    script.content,
+                    ScriptContent::CommandOrPath("echo top-level".to_string())
+                );
+            }
+            _ => panic!("Expected MultiOutputRecipe"),
+        }
+    }
+
+    #[test]
+    fn test_multi_output_cwd_only_script_does_not_inherit_top_level_steps() {
+        let recipe_yaml = r#"
+schema_version: 1
+
+recipe:
+  name: myproject
+  version: 1.0.0
+
+build:
+  steps:
+    - run: echo top-level-step
+
+outputs:
+  - package:
+      name: output
+      version: 1.0.0
+    build:
+      script:
+        cwd: subdir
+"#;
+
+        let parsed = parse_recipe_or_multi_from_source(recipe_yaml).unwrap();
+
+        match parsed {
+            stage0::Recipe::MultiOutput(multi) => {
+                let jinja_config = JinjaConfig {
+                    target_platform: rattler_conda_types::Platform::Linux64,
+                    build_platform: rattler_conda_types::Platform::Linux64,
+                    host_platform: rattler_conda_types::Platform::Linux64,
+                    experimental: true,
+                    ..Default::default()
+                };
+                let ctx =
+                    EvaluationContext::with_variables_and_config(IndexMap::new(), jinja_config);
+                let recipes = multi.evaluate(&ctx).unwrap();
+                assert_eq!(recipes.len(), 1);
+
+                let script = recipes[0].build.plan.script().expect("script mode");
+                assert_eq!(script.content, ScriptContent::Commands(Vec::new()));
+                assert_eq!(script.cwd.as_deref(), Some(std::path::Path::new("subdir")));
             }
             _ => panic!("Expected MultiOutputRecipe"),
         }
@@ -5050,7 +5249,7 @@ outputs:
                 assert_eq!(recipes.len(), 2);
                 for recipe in &recipes {
                     assert_eq!(
-                        recipe.build.script.content,
+                        recipe.build.plan.script().unwrap().content,
                         ScriptContent::Commands(Vec::new()),
                         "multi-output recipe must not default script to build.sh/build.bat (output: {})",
                         recipe.package.name.as_normalized()
@@ -5747,6 +5946,355 @@ package:
             !result.content.is_default(),
             "Empty conditional script must not fall back to Default (which discovers build.sh)"
         );
+    }
+
+    fn run_step(cmd: &str) -> Stage0Step {
+        Stage0Step::Run(Stage0RunStep {
+            run: ConditionalList::new(vec![Item::Value(Value::new_concrete(
+                cmd.to_string(),
+                None,
+            ))]),
+            ..Default::default()
+        })
+    }
+
+    fn step_condition(expr: &str) -> JinjaExpression {
+        JinjaExpression::new(expr.to_string()).unwrap()
+    }
+
+    #[test]
+    fn test_evaluate_steps_basic_desugar() {
+        let steps = vec![run_step("echo a"), run_step("echo b")];
+        let ctx = EvaluationContext::new();
+
+        let scripts = evaluate_steps(&steps, &ctx).unwrap();
+
+        assert_eq!(scripts.len(), 2);
+        assert_eq!(
+            scripts[0].run,
+            Stage1StepRun::Commands(vec!["echo a".to_string()])
+        );
+        assert_eq!(
+            scripts[1].run,
+            Stage1StepRun::Commands(vec!["echo b".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_evaluate_steps_if_filters_step() {
+        let win_step = Stage0Step::Run(Stage0RunStep {
+            run: ConditionalList::new(vec![Item::Value(Value::new_concrete(
+                "echo windows".to_string(),
+                None,
+            ))]),
+            condition: Some(step_condition("win")),
+            ..Default::default()
+        });
+        let steps = vec![run_step("echo always"), win_step];
+
+        let mut ctx = EvaluationContext::new();
+        ctx.insert("win".to_string(), Variable::from(false));
+        ctx.insert("unix".to_string(), Variable::from(true));
+
+        let scripts = evaluate_steps(&steps, &ctx).unwrap();
+
+        assert_eq!(scripts.len(), 1);
+        assert_eq!(
+            scripts[0].run,
+            Stage1StepRun::Commands(vec!["echo always".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_evaluate_steps_if_tracks_accessed_variables() {
+        let gated_step = Stage0Step::Run(Stage0RunStep {
+            run: ConditionalList::new(vec![Item::Value(Value::new_concrete(
+                "echo enabled".to_string(),
+                None,
+            ))]),
+            condition: Some(step_condition("enable_feature")),
+            ..Default::default()
+        });
+        let mut ctx = EvaluationContext::new();
+        ctx.insert("enable_feature".to_string(), Variable::from(true));
+
+        let scripts = evaluate_steps(&[gated_step], &ctx).unwrap();
+
+        assert_eq!(scripts.len(), 1);
+        assert!(
+            ctx.accessed_variables().contains("enable_feature"),
+            "steps.if variables must participate in used_variant/hash tracking"
+        );
+    }
+
+    #[test]
+    fn test_evaluate_steps_if_undefined_variable_errors() {
+        let undefined_step = Stage0Step::Run(Stage0RunStep {
+            run: ConditionalList::new(vec![Item::Value(Value::new_concrete(
+                "echo undefined".to_string(),
+                None,
+            ))]),
+            condition: Some(step_condition("undefined_feature")),
+            ..Default::default()
+        });
+        let ctx = EvaluationContext::new();
+
+        let err = evaluate_steps(&[undefined_step], &ctx).unwrap_err();
+
+        assert!(
+            err.to_string().contains("undefined variable"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_evaluate_steps_tracks_filtered_out_step_variables() {
+        let step = Stage0Step::Run(Stage0RunStep {
+            run: ConditionalList::new(vec![Item::Value(Value::new_template(
+                JinjaTemplate::new("echo ${{ flavor }}".to_string()).unwrap(),
+                None,
+            ))]),
+            condition: Some(step_condition("win")),
+            ..Default::default()
+        });
+        let mut ctx = EvaluationContext::new();
+        ctx.insert("win".to_string(), Variable::from(false));
+        ctx.insert("flavor".to_string(), Variable::from("vanilla"));
+
+        let scripts = evaluate_steps(&[step], &ctx).unwrap();
+
+        assert!(scripts.is_empty());
+        assert!(ctx.accessed_variables().contains("flavor"));
+    }
+
+    #[test]
+    fn test_evaluate_steps_if_expression_compares_target_platform() {
+        let step = Stage0Step::Run(Stage0RunStep {
+            run: ConditionalList::new(vec![Item::Value(Value::new_concrete(
+                "echo gated".to_string(),
+                None,
+            ))]),
+            condition: Some(step_condition("target_platform == 'win-64'")),
+            ..Default::default()
+        });
+        let mut linux_ctx = EvaluationContext::new();
+        linux_ctx.insert("target_platform".to_string(), Variable::from("linux-64"));
+
+        let scripts = evaluate_steps(std::slice::from_ref(&step), &linux_ctx).unwrap();
+
+        assert!(scripts.is_empty());
+        assert!(linux_ctx.accessed_variables().contains("target_platform"));
+
+        let mut win_ctx = EvaluationContext::new();
+        win_ctx.insert("target_platform".to_string(), Variable::from("win-64"));
+
+        let scripts = evaluate_steps(&[step], &win_ctx).unwrap();
+
+        assert_eq!(scripts.len(), 1);
+        assert!(win_ctx.accessed_variables().contains("target_platform"));
+    }
+
+    /// A run step that sets an explicit interpreter and step-local env.
+    fn run_step_with(cmd: &str, interpreter: &str, env: &[(&str, &str)]) -> Stage0Step {
+        Stage0Step::Run(Stage0RunStep {
+            run: ConditionalList::new(vec![Item::Value(Value::new_concrete(
+                cmd.to_string(),
+                None,
+            ))]),
+            interpreter: Some(Value::new_concrete(interpreter.to_string(), None)),
+            env: env
+                .iter()
+                .map(|(k, v)| (k.to_string(), Value::new_concrete(v.to_string(), None)))
+                .collect(),
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn test_evaluate_steps_carries_interpreter_and_env() {
+        let steps = vec![run_step_with("make install", "bash", &[("FOO", "bar")])];
+        let ctx = EvaluationContext::new();
+
+        let scripts = evaluate_steps(&steps, &ctx).unwrap();
+
+        assert_eq!(scripts.len(), 1);
+        assert_eq!(scripts[0].interpreter.as_deref(), Some("bash"));
+        assert_eq!(scripts[0].env.get("FOO").map(String::as_str), Some("bar"));
+        assert_eq!(
+            scripts[0].run,
+            Stage1StepRun::Commands(vec!["make install".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_evaluate_steps_drops_empty_env_values_like_script_env() {
+        let steps = vec![run_step_with("make install", "bash", &[("EMPTY", "")])];
+        let ctx = EvaluationContext::new();
+
+        let scripts = evaluate_steps(&steps, &ctx).unwrap();
+
+        assert_eq!(scripts.len(), 1);
+        assert!(!scripts[0].env.contains_key("EMPTY"));
+    }
+
+    #[test]
+    fn test_evaluate_steps_rejects_newline_env_values() {
+        let steps = vec![run_step_with(
+            "make install",
+            "bash",
+            &[("INJECT", "safe\necho injected")],
+        )];
+        let ctx = EvaluationContext::new();
+
+        let err = evaluate_steps(&steps, &ctx).unwrap_err();
+
+        assert!(err.to_string().contains("contains a newline"), "{err}");
+    }
+
+    #[test]
+    fn test_evaluate_script_rejects_newline_env_values() {
+        let mut env = IndexMap::new();
+        env.insert(
+            "INJECT".to_string(),
+            Value::new_concrete("safe\necho injected".to_string(), None),
+        );
+        let script = crate::stage0::types::Script {
+            content: Some(ConditionalList::new(vec![Item::Value(
+                Value::new_concrete("echo hi".to_string(), None),
+            )])),
+            env,
+            ..Default::default()
+        };
+        let ctx = EvaluationContext::new();
+
+        let err = evaluate_script(&script, &ctx).unwrap_err();
+
+        assert!(err.to_string().contains("contains a newline"), "{err}");
+    }
+
+    #[test]
+    fn test_evaluate_steps_carries_cwd() {
+        let step = Stage0Step::Run(Stage0RunStep {
+            run: ConditionalList::new(vec![Item::Value(Value::new_concrete(
+                "make install".to_string(),
+                None,
+            ))]),
+            cwd: Some(Value::new_concrete("subdir".to_string(), None)),
+            ..Default::default()
+        });
+        let ctx = EvaluationContext::new();
+
+        let scripts = evaluate_steps(&[step], &ctx).unwrap();
+
+        assert_eq!(scripts.len(), 1);
+        assert_eq!(
+            scripts[0].cwd.as_deref(),
+            Some(std::path::Path::new("subdir"))
+        );
+    }
+
+    #[test]
+    fn test_evaluate_steps_allows_per_step_interpreters() {
+        // Per-step interpreters are independent sections; no conflict.
+        let steps = vec![
+            run_step_with("echo a", "bash", &[]),
+            run_step_with("echo b", "nu", &[]),
+        ];
+        let ctx = EvaluationContext::new();
+
+        let scripts = evaluate_steps(&steps, &ctx).unwrap();
+
+        assert_eq!(scripts.len(), 2);
+        assert_eq!(scripts[0].interpreter.as_deref(), Some("bash"));
+        assert_eq!(scripts[1].interpreter.as_deref(), Some("nu"));
+    }
+
+    /// `build.steps` is experimental and is rejected without `--experimental`.
+    #[test]
+    fn test_build_steps_requires_experimental() {
+        let build = Stage0Build {
+            plan: Stage0BuildPlan::Steps(vec![run_step("echo a")]),
+            ..Default::default()
+        };
+        let ctx = EvaluationContext::new();
+
+        let err = build.evaluate(&ctx).unwrap_err();
+        assert!(err.to_string().contains("experimental"));
+    }
+
+    #[test]
+    fn test_build_evaluate_uses_steps() {
+        let build = Stage0Build {
+            plan: Stage0BuildPlan::Steps(vec![run_step("echo a"), run_step("echo b")]),
+            ..Default::default()
+        };
+        let ctx = EvaluationContext::with_variables_and_config(
+            IndexMap::new(),
+            JinjaConfig {
+                experimental: true,
+                ..Default::default()
+            },
+        );
+
+        let stage1 = build.evaluate(&ctx).unwrap();
+
+        let steps = stage1.plan.steps().expect("steps mode");
+        assert_eq!(steps.len(), 2);
+        assert_eq!(
+            steps[0].run,
+            Stage1StepRun::Commands(vec!["echo a".to_string()])
+        );
+        assert_eq!(
+            steps[1].run,
+            Stage1StepRun::Commands(vec!["echo b".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_build_evaluate_preserves_steps_mode_when_all_steps_filter_out() {
+        let false_step = Stage0Step::Run(Stage0RunStep {
+            run: ConditionalList::new(vec![Item::Value(Value::new_concrete(
+                "echo filtered".to_string(),
+                None,
+            ))]),
+            condition: Some(step_condition("win")),
+            ..Default::default()
+        });
+        let build = Stage0Build {
+            plan: Stage0BuildPlan::Steps(vec![false_step]),
+            ..Default::default()
+        };
+        let mut ctx = EvaluationContext::with_variables_and_config(
+            IndexMap::new(),
+            JinjaConfig {
+                experimental: true,
+                ..Default::default()
+            },
+        );
+        ctx.insert("win".to_string(), Variable::from(false));
+
+        let stage1 = build.evaluate(&ctx).unwrap();
+
+        assert_eq!(stage1.plan.steps().map(<[_]>::len), Some(0));
+    }
+
+    #[test]
+    fn test_merge_stage1_build_filtered_empty_steps_do_not_inherit_script() {
+        let toplevel = stage1::Build {
+            plan: Stage1BuildPlan::Script(rattler_build_script::Script {
+                content: ScriptContent::Command("echo top-level".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let output = stage1::Build {
+            plan: Stage1BuildPlan::Steps(Vec::new()),
+            ..Default::default()
+        };
+
+        let merged = merge_stage1_build(toplevel, output);
+
+        assert_eq!(merged.plan.steps().map(<[_]>::len), Some(0));
     }
 
     #[test]

--- a/crates/rattler_build_recipe/src/stage0/mod.rs
+++ b/crates/rattler_build_recipe/src/stage0/mod.rs
@@ -15,7 +15,7 @@ mod tests;
 mod types;
 
 pub use about::{About, License};
-pub use build::{BinaryRelocation, Build, PythonBuild};
+pub use build::{BinaryRelocation, Build, BuildPlan, PythonBuild, RunStep, Step};
 pub use extra::Extra;
 pub use match_spec::SerializableMatchSpec;
 pub use output::{

--- a/crates/rattler_build_recipe/src/stage0/parser/build.rs
+++ b/crates/rattler_build_recipe/src/stage0/parser/build.rs
@@ -1,19 +1,22 @@
-use marked_yaml::{Node, types::MarkedMappingNode};
+use marked_yaml::{
+    Node,
+    types::{MarkedMappingNode, MarkedScalarNode},
+};
 use rattler_build_yaml_parser::ParseError;
 use rattler_conda_types::NoArchType;
 
 use crate::stage0::{
     Conditional, ConditionalList, Item, JinjaExpression, NestedItemList,
     build::{
-        BinaryRelocation, Build, DynamicLinking, ForceFileType, PostProcess, PrefixDetection,
-        PrefixIgnore, PythonBuild, VariantKeyUsage,
+        BinaryRelocation, Build, BuildPlan, DynamicLinking, ForceFileType, PostProcess,
+        PrefixDetection, PrefixIgnore, PythonBuild, RunStep, Step, VariantKeyUsage,
     },
     parser::helpers::get_span,
-    types::{IncludeExclude, Value},
+    types::{IncludeExclude, JinjaTemplate, Value},
 };
 use rattler_build_yaml_parser::{
     helpers::contains_jinja_template, parse_conditional_list, parse_conditional_list_or_item,
-    parse_value_with_name,
+    parse_jinja_expression, parse_value_with_name,
 };
 
 /// Macro to parse a value with automatic field name inference for better error messages
@@ -255,7 +258,7 @@ pub(crate) fn parse_script(node: &Node) -> Result<crate::stage0::types::Script, 
                     })?;
 
                     for (env_key_node, env_value_node) in env_mapping.iter() {
-                        let env_key = env_key_node.as_str().to_string();
+                        let env_key = parse_env_key("script.env", env_key_node)?;
                         let env_value = parse_field!("script.env", env_value_node);
                         env.insert(env_key, env_value);
                     }
@@ -348,7 +351,173 @@ pub(crate) fn parse_script(node: &Node) -> Result<crate::stage0::types::Script, 
     ))
 }
 
+fn parse_env_key(field_name: &str, key_node: &MarkedScalarNode) -> Result<String, ParseError> {
+    let key = key_node.as_str();
+    let mut chars = key.chars();
+    let valid = chars
+        .next()
+        .is_some_and(|c| c == '_' || c.is_ascii_alphabetic())
+        && chars.all(|c| c == '_' || c.is_ascii_alphanumeric());
+
+    if !valid {
+        return Err(ParseError::invalid_value(
+            field_name,
+            format!(
+                "invalid environment variable name '{}'; expected [A-Za-z_][A-Za-z0-9_]*",
+                key
+            ),
+            *key_node.span(),
+        ));
+    }
+
+    Ok(key.to_string())
+}
+
 /// Parse build files field - can be a list or include/exclude mapping
+/// Parse the `build.steps` list into an ordered list of [`Step`]s.
+fn parse_steps(node: &Node) -> Result<Vec<Step>, ParseError> {
+    let sequence = node.as_sequence().ok_or_else(|| {
+        ParseError::expected_type("sequence", "non-sequence", get_span(node))
+            .with_message("Expected 'steps' to be a list of steps")
+    })?;
+
+    let mut steps = Vec::with_capacity(sequence.len());
+    for item in sequence.iter() {
+        steps.push(parse_step(item)?);
+    }
+    Ok(steps)
+}
+
+/// Parse a single build step mapping into a [`Step`].
+fn parse_step(node: &Node) -> Result<Step, ParseError> {
+    let mapping = node.as_mapping().ok_or_else(|| {
+        ParseError::expected_type("mapping", "non-mapping", get_span(node))
+            .with_message("Expected each step to be a mapping")
+    })?;
+
+    let mut run = None;
+    let mut condition = None;
+    let mut condition_span = None;
+    let mut interpreter = None;
+    let mut cwd = None;
+    let mut env = indexmap::IndexMap::new();
+
+    for (key_node, value_node) in mapping.iter() {
+        let key = key_node.as_str();
+
+        match key {
+            "run" => {
+                run = Some(parse_step_content(value_node)?);
+            }
+            "if" => {
+                let (parsed_condition, parsed_span) = parse_step_condition(value_node)?;
+                condition = Some(parsed_condition);
+                condition_span = Some(parsed_span);
+            }
+            "interpreter" => {
+                interpreter = Some(parse_field!("steps.interpreter", value_node));
+            }
+            "cwd" => {
+                cwd = Some(parse_field!("steps.cwd", value_node));
+            }
+            "env" => {
+                let env_mapping = value_node.as_mapping().ok_or_else(|| {
+                    ParseError::expected_type("mapping", "non-mapping", get_span(value_node))
+                        .with_message("Expected step 'env' to be a mapping")
+                })?;
+
+                for (env_key_node, env_value_node) in env_mapping.iter() {
+                    let env_key = parse_env_key("steps.env", env_key_node)?;
+                    let env_value = parse_field!("steps.env", env_value_node);
+                    env.insert(env_key, env_value);
+                }
+            }
+            _ => {
+                return Err(ParseError::invalid_value(
+                    "steps",
+                    format!("unknown field '{}' in step", key),
+                    *key_node.span(),
+                )
+                .with_suggestion("Valid fields are: run, if, interpreter, cwd, env"));
+            }
+        }
+    }
+
+    let run = run.ok_or_else(|| {
+        ParseError::invalid_value("steps", "a step must contain a 'run' field", get_span(node))
+            .with_suggestion("Add a 'run:' field with the script to execute")
+    })?;
+
+    Ok(Step::Run(RunStep {
+        run,
+        condition,
+        condition_span,
+        interpreter,
+        cwd,
+        env,
+    }))
+}
+
+/// Parse a step `if` condition as a verbatim Jinja expression.
+fn parse_step_condition(node: &Node) -> Result<(JinjaExpression, marked_yaml::Span), ParseError> {
+    let scalar = node.as_scalar().ok_or_else(|| {
+        ParseError::expected_type("scalar", "non-scalar", get_span(node))
+            .with_message("Expected step 'if' to be a Jinja expression")
+    })?;
+
+    let condition = scalar.as_str();
+    let span = *scalar.span();
+
+    if condition.trim().is_empty() {
+        return Err(ParseError::invalid_value(
+            "steps.if",
+            "step condition must be a non-empty Jinja expression",
+            span,
+        ));
+    }
+
+    if contains_jinja_template(condition) {
+        return Err(ParseError::invalid_value(
+            "steps.if",
+            "step condition is a Jinja expression; do not use `${{ }}` template delimiters",
+            span,
+        )
+        .with_suggestion(
+            "Use `if: target_platform == \"win-64\"`, not `if: ${{ target_platform }} == \"win-64\"`.",
+        ));
+    }
+
+    parse_jinja_expression(node, "steps.if")
+}
+
+/// Parse step `run` content: either a (multiline) scalar string or a list of
+/// commands, into a [`ConditionalList`] of strings.
+fn parse_step_content(node: &Node) -> Result<ConditionalList<String>, ParseError> {
+    if let Some(scalar) = node.as_scalar() {
+        let content = scalar.as_str();
+        let span = *scalar.span();
+
+        let value = if contains_jinja_template(content) {
+            let template = JinjaTemplate::new(content.to_string())
+                .map_err(|e| ParseError::jinja_error(e, span))?;
+            Value::new_template(template, Some(span))
+        } else {
+            Value::new_concrete(content.to_string(), Some(span))
+        };
+
+        return Ok(ConditionalList::new(vec![Item::Value(value)]));
+    }
+
+    if node.as_sequence().is_some() {
+        return parse_conditional_list(node);
+    }
+
+    Err(
+        ParseError::expected_type("scalar string or sequence", "other", get_span(node))
+            .with_message("step 'run' must be a string or a list of commands"),
+    )
+}
+
 fn parse_build_files(node: &Node) -> Result<IncludeExclude, ParseError> {
     // Try parsing as a mapping with include/exclude first
     if let Some(mapping) = node.as_mapping() {
@@ -409,6 +578,8 @@ pub fn parse_build(node: &Node) -> Result<Build, ParseError> {
 
 fn parse_build_from_mapping(mapping: &MarkedMappingNode) -> Result<Build, ParseError> {
     let mut build = Build::default();
+    let mut script_seen = false;
+    let mut steps_span = None;
 
     for (key_node, value_node) in mapping.iter() {
         let key = key_node.as_str();
@@ -421,7 +592,12 @@ fn parse_build_from_mapping(mapping: &MarkedMappingNode) -> Result<Build, ParseE
                 build.string = Some(parse_field!("build.string", value_node));
             }
             "script" => {
-                build.script = parse_script(value_node)?;
+                script_seen = true;
+                build.plan = BuildPlan::Script(Box::new(parse_script(value_node)?));
+            }
+            "steps" => {
+                steps_span = Some(*key_node.span());
+                build.plan = BuildPlan::Steps(parse_steps(value_node)?);
             }
             "noarch" => {
                 build.noarch = Some(parse_noarch(value_node)?);
@@ -464,10 +640,21 @@ fn parse_build_from_mapping(mapping: &MarkedMappingNode) -> Result<Build, ParseE
             _ => {
                 return Err(
                     ParseError::invalid_value("build", format!("unknown field '{}'", key), *key_node.span())
-                        .with_suggestion("Valid fields are: number, string, script, noarch, flags, python, skip, always_copy_files, always_include_files, merge_build_and_host_envs, files, dynamic_linking, variant, prefix_detection, post_process")
+                        .with_suggestion("Valid fields are: number, string, script, steps, noarch, flags, python, skip, always_copy_files, always_include_files, merge_build_and_host_envs, files, dynamic_linking, variant, prefix_detection, post_process")
                 );
             }
         }
+    }
+
+    // A build unit uses either `script` or `steps`, never both. Even an empty
+    // `steps: []` list explicitly selects steps mode.
+    if script_seen && let Some(span) = steps_span {
+        return Err(ParseError::invalid_value(
+            "build",
+            "`script` and `steps` are mutually exclusive; use one or the other",
+            span,
+        )
+        .with_suggestion("Remove either `build.script` or `build.steps`"));
     }
 
     Ok(build)
@@ -844,7 +1031,7 @@ mod tests {
         // When number is not specified, it should be None (inherit from top-level)
         assert!(build.number.is_none());
         assert!(build.string.is_none());
-        assert!(build.script.is_default());
+        assert!(build.plan.is_default());
     }
 
     #[test]
@@ -872,8 +1059,160 @@ script:
 "#;
         let node = marked_yaml::parse_yaml(0, yaml).unwrap();
         let build = parse_build(&node).unwrap();
-        assert!(build.script.content.is_some());
-        assert_eq!(build.script.content.as_ref().unwrap().len(), 2);
+        let script = build.plan.script().expect("script mode");
+        assert!(script.content.is_some());
+        assert_eq!(script.content.as_ref().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_parse_build_with_steps() {
+        let yaml = r#"
+steps:
+  - run: echo "configure"
+  - run: make install
+    if: unix
+    interpreter: bash
+    cwd: subdir
+    env:
+      FOO: bar
+"#;
+        let node = marked_yaml::parse_yaml(0, yaml).unwrap();
+        let build = parse_build(&node).unwrap();
+
+        let steps = build.plan.steps().expect("steps mode");
+        assert_eq!(steps.len(), 2);
+
+        match &steps[0] {
+            Step::Run(first) => {
+                assert_eq!(first.run.len(), 1);
+                assert!(first.condition.is_none());
+                assert!(first.interpreter.is_none());
+                assert!(first.env.is_empty());
+            }
+        }
+
+        match &steps[1] {
+            Step::Run(second) => {
+                assert!(second.condition.is_some());
+                assert!(second.interpreter.is_some());
+                assert!(second.cwd.is_some());
+                assert!(second.env.contains_key("FOO"));
+            }
+        }
+    }
+
+    #[test]
+    fn test_parse_script_env_rejects_invalid_name() {
+        let yaml = r#"
+script:
+  env:
+    BAD-NAME: value
+  content: echo hi
+"#;
+        let node = marked_yaml::parse_yaml(0, yaml).unwrap();
+        let result = parse_build(&node);
+
+        assert!(
+            result.is_err(),
+            "expected invalid script env name to be rejected"
+        );
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("invalid environment variable name"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn test_parse_step_env_rejects_invalid_name() {
+        let yaml = r#"
+steps:
+  - run: echo hi
+    env:
+      BAD-NAME: value
+"#;
+        let node = marked_yaml::parse_yaml(0, yaml).unwrap();
+        let result = parse_build(&node);
+
+        assert!(
+            result.is_err(),
+            "expected invalid step env name to be rejected"
+        );
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("invalid environment variable name"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn test_parse_step_if_rejects_template_syntax() {
+        let yaml = r#"
+steps:
+  - run: echo "step"
+    if: ${{ target_platform }} == "win-64"
+"#;
+        let node = marked_yaml::parse_yaml(0, yaml).unwrap();
+        let result = parse_build(&node);
+
+        assert!(
+            result.is_err(),
+            "expected template-style steps.if to be rejected"
+        );
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("do not use `${{ }}`"), "{err}");
+    }
+
+    #[test]
+    fn test_parse_step_if_rejects_malformed_expression_without_panic() {
+        let yaml = r#"
+steps:
+  - run: echo "step"
+    if: target_platform }}
+"#;
+        let node = marked_yaml::parse_yaml(0, yaml).unwrap();
+        let result = parse_build(&node);
+
+        assert!(
+            result.is_err(),
+            "expected malformed steps.if expression to be rejected"
+        );
+    }
+
+    #[test]
+    fn test_build_script_and_steps_are_mutually_exclusive() {
+        let yaml = r#"
+script: echo "hi"
+steps:
+  - run: echo "step"
+"#;
+        let node = marked_yaml::parse_yaml(0, yaml).unwrap();
+        let result = parse_build(&node);
+
+        assert!(result.is_err(), "expected script+steps to be rejected");
+        let err = result.unwrap_err();
+        assert!(matches!(err, ParseError::InvalidValue { .. }));
+        assert!(err.to_string().contains("mutually exclusive"));
+    }
+
+    #[test]
+    fn test_build_script_and_empty_steps_are_mutually_exclusive() {
+        let yaml = r#"
+script: echo "hi"
+steps: []
+"#;
+        let node = marked_yaml::parse_yaml(0, yaml).unwrap();
+        let result = parse_build(&node);
+
+        assert!(
+            result.is_err(),
+            "explicit empty steps still selects steps mode"
+        );
+        let err = result.unwrap_err();
+        assert!(matches!(err, ParseError::InvalidValue { .. }));
+        assert!(err.to_string().contains("mutually exclusive"));
     }
 
     #[test]

--- a/crates/rattler_build_recipe/src/stage1/build.rs
+++ b/crates/rattler_build_recipe/src/stage1/build.rs
@@ -1,6 +1,9 @@
 //! Stage 1 Build - evaluated build configuration with concrete values
+use std::path::PathBuf;
+
+use indexmap::IndexMap;
 use rattler_build_jinja::Variable;
-use rattler_build_script::Script;
+use rattler_build_script::{Script, ScriptContent};
 use rattler_build_yaml_parser::ParseError;
 use rattler_conda_types::{Flag, NoArchType, package::EntryPoint};
 use serde::{Deserialize, Serialize};
@@ -164,6 +167,130 @@ impl AsRef<str> for BuildString {
     }
 }
 
+/// The evaluated `run` payload for a build step.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum StepRun {
+    /// Multiple commands, joined by the selected interpreter.
+    Commands(Vec<String>),
+    /// A single inline script body.
+    Command(String),
+}
+
+impl Default for StepRun {
+    fn default() -> Self {
+        Self::Commands(Vec::new())
+    }
+}
+
+impl From<StepRun> for ScriptContent {
+    fn from(value: StepRun) -> Self {
+        match value {
+            StepRun::Commands(commands) => Self::Commands(commands),
+            StepRun::Command(command) => Self::Command(command),
+        }
+    }
+}
+
+impl From<&ScriptContent> for StepRun {
+    fn from(value: &ScriptContent) -> Self {
+        match value {
+            ScriptContent::Commands(commands) => Self::Commands(commands.clone()),
+            ScriptContent::Command(command) | ScriptContent::CommandOrPath(command) => {
+                Self::Command(command.clone())
+            }
+            ScriptContent::Path(path) => Self::Command(path.to_string_lossy().into_owned()),
+            ScriptContent::Default => Self::Commands(Vec::new()),
+        }
+    }
+}
+
+/// A stage1 build step with evaluated metadata and script content.
+///
+/// This is deliberately separate from [`Script`]: rendered recipes use
+/// `build.steps[].run`, while `build.script` uses the normal script syntax.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Step {
+    /// Script content to execute for this step.
+    pub run: StepRun,
+    /// Optional interpreter override for this step.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub interpreter: Option<String>,
+    /// Environment variables scoped to this step only.
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    pub env: IndexMap<String, String>,
+    /// Optional working directory for this step, relative to the host prefix.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<PathBuf>,
+}
+
+impl Step {
+    /// Create a step from an evaluated script payload.
+    pub fn new(script: Script) -> Self {
+        Self {
+            run: StepRun::from(&script.content),
+            interpreter: script.interpreter,
+            env: script.env,
+            cwd: script.cwd,
+        }
+    }
+
+    /// Convert this step into the script representation used by the executor.
+    pub fn to_script(&self) -> Script {
+        Script {
+            interpreter: self.interpreter.clone(),
+            env: self.env.clone(),
+            secrets: Vec::new(),
+            content: self.run.clone().into(),
+            cwd: self.cwd.clone(),
+            content_explicit: false,
+        }
+    }
+}
+
+/// The executable build plan: either a single legacy script, or explicit
+/// ordered build steps.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BuildPlan {
+    /// Legacy `build.script` mode. `Script::default()` preserves default
+    /// `build.sh` / `build.bat` discovery.
+    Script(Script),
+    /// Explicit `build.steps` mode. An empty vector is meaningful: it disables
+    /// legacy default script discovery.
+    Steps(Vec<Step>),
+}
+
+impl Default for BuildPlan {
+    fn default() -> Self {
+        Self::Script(Script::default())
+    }
+}
+
+impl BuildPlan {
+    /// Returns true if this is the default script-discovery plan.
+    pub fn is_default(&self) -> bool {
+        matches!(self, Self::Script(script) if script.is_default())
+    }
+
+    /// Returns the script in legacy script mode.
+    pub fn script(&self) -> Option<&Script> {
+        match self {
+            Self::Script(script) => Some(script),
+            Self::Steps(_) => None,
+        }
+    }
+
+    /// Returns the steps in explicit steps mode.
+    pub fn steps(&self) -> Option<&[Step]> {
+        match self {
+            Self::Script(_) => None,
+            Self::Steps(steps) => Some(steps.as_slice()),
+        }
+    }
+}
+
 /// Variant key usage configuration (evaluated)
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct VariantKeyUsage {
@@ -277,6 +404,7 @@ impl<'de> serde::Deserialize<'de> for PostProcess {
         D: serde::Deserializer<'de>,
     {
         #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
         struct PostProcessHelper {
             files: GlobVec,
             regex: String,
@@ -296,6 +424,7 @@ impl<'de> serde::Deserialize<'de> for PostProcess {
 
 /// Evaluated build configuration with all templates and conditionals resolved
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(try_from = "BuildDeserialize")]
 pub struct Build {
     /// Build number (increments with each rebuild)
     /// None means inherit from top-level, Some(n) means use n (even if n is 0)
@@ -307,9 +436,9 @@ pub struct Build {
     #[serde(default)]
     pub string: BuildString,
 
-    /// Build script - contains script content, interpreter, environment variables, etc.
-    #[serde(default, skip_serializing_if = "Script::is_default")]
-    pub script: Script,
+    /// Executable build plan: either a single legacy script or explicit steps.
+    #[serde(default, flatten, skip_serializing_if = "BuildPlan::is_default")]
+    pub plan: BuildPlan,
 
     /// Noarch type - "python" or "generic" if set
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -360,6 +489,105 @@ pub struct Build {
     /// Post-processing operations
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub post_process: Vec<PostProcess>,
+}
+
+#[derive(Default)]
+enum PresentField<T> {
+    #[default]
+    Missing,
+    Present(T),
+}
+
+impl<'de, T> Deserialize<'de> for PresentField<T>
+where
+    T: serde::de::DeserializeOwned,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::Error as _;
+
+        let value = serde_yaml::Value::deserialize(deserializer)?;
+        if value.is_null() {
+            return Err(D::Error::custom("null is not a valid value for this field"));
+        }
+        T::deserialize(value)
+            .map(Self::Present)
+            .map_err(D::Error::custom)
+    }
+}
+
+#[derive(Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct BuildDeserialize {
+    #[serde(default)]
+    number: Option<u64>,
+    #[serde(default)]
+    string: BuildString,
+    #[serde(default)]
+    script: PresentField<Script>,
+    #[serde(default)]
+    steps: PresentField<Vec<Step>>,
+    #[serde(default)]
+    noarch: Option<NoArchType>,
+    #[serde(default)]
+    flags: Vec<Flag>,
+    #[serde(default)]
+    python: PythonBuild,
+    #[serde(default)]
+    skip: bool,
+    #[serde(default)]
+    always_copy_files: GlobVec,
+    #[serde(default)]
+    always_include_files: GlobVec,
+    #[serde(default)]
+    merge_build_and_host_envs: bool,
+    #[serde(default)]
+    files: GlobVec,
+    #[serde(default)]
+    dynamic_linking: DynamicLinking,
+    #[serde(default)]
+    variant: VariantKeyUsage,
+    #[serde(default)]
+    prefix_detection: PrefixDetection,
+    #[serde(default)]
+    post_process: Vec<PostProcess>,
+}
+
+impl TryFrom<BuildDeserialize> for Build {
+    type Error = String;
+
+    fn try_from(raw: BuildDeserialize) -> Result<Self, Self::Error> {
+        let plan = match (raw.script, raw.steps) {
+            (PresentField::Present(_), PresentField::Present(_)) => {
+                return Err(
+                    "`script` and `steps` are mutually exclusive; use one or the other".to_string(),
+                );
+            }
+            (PresentField::Missing, PresentField::Present(steps)) => BuildPlan::Steps(steps),
+            (PresentField::Present(script), PresentField::Missing) => BuildPlan::Script(script),
+            (PresentField::Missing, PresentField::Missing) => BuildPlan::Script(Script::default()),
+        };
+
+        Ok(Self {
+            number: raw.number,
+            string: raw.string,
+            plan,
+            noarch: raw.noarch,
+            flags: raw.flags,
+            python: raw.python,
+            skip: raw.skip,
+            always_copy_files: raw.always_copy_files,
+            always_include_files: raw.always_include_files,
+            merge_build_and_host_envs: raw.merge_build_and_host_envs,
+            files: raw.files,
+            dynamic_linking: raw.dynamic_linking,
+            variant: raw.variant,
+            prefix_detection: raw.prefix_detection,
+            post_process: raw.post_process,
+        })
+    }
 }
 
 /// Dynamic linking configuration
@@ -506,7 +734,7 @@ impl Build {
     pub fn is_default(&self) -> bool {
         self.number.is_none()
             && matches!(self.string, BuildString::Default)
-            && self.script.is_default()
+            && self.plan.is_default()
             && self.noarch.is_none()
             && self.flags.is_empty()
             && self.python.entry_points.is_empty()
@@ -559,17 +787,150 @@ mod tests {
         use rattler_build_script::ScriptContent;
 
         let build = Build {
-            script: Script {
+            plan: BuildPlan::Script(Script {
                 content: ScriptContent::Commands(vec![
                     "echo hello".to_string(),
                     "make install".to_string(),
                 ]),
                 ..Default::default()
-            },
+            }),
             ..Default::default()
         };
 
         assert!(!build.is_default());
-        assert!(!build.script.is_default());
+        assert!(!build.plan.is_default());
+    }
+
+    #[test]
+    fn test_build_with_steps_is_not_default_and_serializes_steps() {
+        use rattler_build_script::ScriptContent;
+
+        let build = Build {
+            plan: BuildPlan::Steps(vec![Step::new(Script {
+                interpreter: Some("bash".to_string()),
+                env: [("FOO".to_string(), "bar".to_string())]
+                    .into_iter()
+                    .collect(),
+                content: ScriptContent::Commands(vec!["echo step".to_string()]),
+                cwd: Some("subdir".into()),
+                ..Default::default()
+            })]),
+            ..Default::default()
+        };
+
+        assert!(!build.is_default());
+        let yaml = serde_yaml::to_string(&build).unwrap();
+        assert!(yaml.contains("steps:"), "{yaml}");
+        assert!(yaml.contains("run:"), "{yaml}");
+        assert!(yaml.contains("echo step"), "{yaml}");
+        assert!(yaml.contains("interpreter: bash"), "{yaml}");
+        assert!(yaml.contains("cwd: subdir"), "{yaml}");
+        assert!(!yaml.contains("source_index"), "{yaml}");
+
+        let recipe_yaml = format!(
+            "package:\n  name: test-pkg\n  version: 1.0.0\nbuild:\n{}",
+            yaml.lines()
+                .map(|line| format!("  {line}\n"))
+                .collect::<String>()
+        );
+        let parsed = crate::stage0::parse_recipe_from_source(&recipe_yaml).unwrap();
+        assert_eq!(parsed.build.plan.steps().map(<[_]>::len), Some(1));
+
+        let roundtripped: Build = serde_yaml::from_str(&yaml).unwrap();
+        let steps = roundtripped.plan.steps().expect("steps mode");
+        assert_eq!(steps.len(), 1);
+        assert_eq!(
+            steps[0].run,
+            StepRun::Commands(vec!["echo step".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_build_deserialize_rejects_unknown_step_fields() {
+        let yaml = r#"
+steps:
+  - if: win
+    run: echo windows
+"#;
+
+        let result = serde_yaml::from_str::<Build>(yaml);
+        assert!(
+            result.is_err(),
+            "expected unknown step fields to be rejected"
+        );
+        assert!(result.unwrap_err().to_string().contains("unknown field"));
+    }
+
+    #[test]
+    fn test_build_deserialize_rejects_unknown_build_fields() {
+        let result = serde_yaml::from_str::<Build>("unexpected: true\n");
+        assert!(
+            result.is_err(),
+            "expected unknown build fields to be rejected"
+        );
+        assert!(result.unwrap_err().to_string().contains("unknown field"));
+    }
+
+    #[test]
+    fn test_build_deserialize_rejects_unknown_post_process_fields() {
+        let yaml = r#"
+post_process:
+  - files:
+      - bin/*
+    regex: foo
+    replacement: bar
+    unexpected: true
+"#;
+
+        let result = serde_yaml::from_str::<Build>(yaml);
+        assert!(
+            result.is_err(),
+            "expected unknown post_process fields to be rejected"
+        );
+        assert!(result.unwrap_err().to_string().contains("unknown field"));
+    }
+
+    #[test]
+    fn test_build_deserialize_rejects_script_and_steps() {
+        let yaml = r#"
+script: echo script
+steps:
+  - run: echo step
+"#;
+
+        let result = serde_yaml::from_str::<Build>(yaml);
+        assert!(result.is_err(), "expected script+steps to be rejected");
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("mutually exclusive")
+        );
+    }
+
+    #[test]
+    fn test_build_deserialize_rejects_null_script_or_steps() {
+        for yaml in ["script:\n", "steps:\n", "script:\nsteps: []\n"] {
+            let result = serde_yaml::from_str::<Build>(yaml);
+            assert!(
+                result.is_err(),
+                "expected null script/steps to be rejected: {yaml:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_explicit_empty_steps_serializes_steps_mode() {
+        let build = Build {
+            plan: BuildPlan::Steps(Vec::new()),
+            ..Default::default()
+        };
+
+        assert!(!build.is_default());
+        let yaml = serde_yaml::to_string(&build).unwrap();
+        assert!(yaml.contains("steps: []"), "{yaml}");
+
+        let roundtripped: Build = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(roundtripped.plan.steps().map(<[_]>::len), Some(0));
     }
 }

--- a/crates/rattler_build_recipe/src/stage1/mod.rs
+++ b/crates/rattler_build_recipe/src/stage1/mod.rs
@@ -29,7 +29,7 @@ pub mod tests;
 mod variant_tests;
 
 pub use about::About;
-pub use build::{Build, Rpaths};
+pub use build::{Build, BuildPlan, Rpaths, Step};
 pub use extra::Extra;
 pub use hash::{HashInfo, HashInput, compute_hash};
 use indexmap::IndexMap;

--- a/crates/rattler_build_recipe/src/variant_render.rs
+++ b/crates/rattler_build_recipe/src/variant_render.rs
@@ -218,6 +218,9 @@ pub struct RenderedVariant {
     /// dependencies to their correct variants.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub full_combination: BTreeMap<NormalizedKey, Variable>,
+    /// Whether experimental features were enabled when this variant was rendered.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub experimental: bool,
     /// The rendered stage1 recipe
     pub recipe: Stage1Recipe,
     /// Pin subpackage dependencies that need to be tracked for exact pinning
@@ -974,6 +977,7 @@ fn render_with_empty_combinations(
             RenderedVariant {
                 variant,
                 full_combination: BTreeMap::new(), // No combination when rendering with empty combinations
+                experimental: config.experimental,
                 recipe,
                 pin_subpackages: BTreeMap::new(),
                 hash_info: None,
@@ -1415,6 +1419,7 @@ fn render_with_variants(
             results.push(RenderedVariant {
                 variant,
                 full_combination: combination.clone(), // Track the full combination for pin matching
+                experimental: config.experimental,
                 recipe,
                 pin_subpackages: BTreeMap::new(), // Will be populated after first build string resolution
                 hash_info: None,
@@ -1496,6 +1501,54 @@ python:
 
         assert!(variants.contains(&"3.9.*".to_string()));
         assert!(variants.contains(&"3.10.*".to_string()));
+    }
+
+    #[test]
+    fn test_build_steps_if_participates_in_variant_matrix() {
+        let recipe_yaml = r#"
+package:
+  name: test-pkg
+  version: "1.0.0"
+
+build:
+  steps:
+    - if: feature_enabled
+      run: echo enabled
+"#;
+
+        let variant_yaml = r#"
+feature_enabled:
+  - true
+  - false
+"#;
+
+        let stage0_recipe = stage0::parse_recipe_or_multi_from_source(recipe_yaml).unwrap();
+        let variant_config = VariantConfig::from_yaml_str(variant_yaml).unwrap();
+
+        let rendered = render_recipe_with_variant_config(
+            &stage0_recipe,
+            &variant_config,
+            RenderConfig::new().with_experimental(true),
+        )
+        .unwrap();
+
+        assert_eq!(rendered.len(), 2);
+        let variants = rendered
+            .iter()
+            .map(|r| {
+                r.variant
+                    .get(&"feature_enabled".into())
+                    .unwrap()
+                    .to_string()
+            })
+            .collect::<Vec<_>>();
+        assert!(variants.contains(&"true".to_string()), "{variants:?}");
+        assert!(variants.contains(&"false".to_string()), "{variants:?}");
+        assert!(
+            rendered
+                .iter()
+                .all(|r| r.recipe.build.plan.steps().is_some())
+        );
     }
 
     #[test]

--- a/crates/rattler_build_recipe/tests/source_parsing_test.rs
+++ b/crates/rattler_build_recipe/tests/source_parsing_test.rs
@@ -586,7 +586,9 @@ fn test_parse_nested_conditionals() {
     // The script should have 2 top-level items (unix and win conditionals)
     let script_content = recipe
         .build
-        .script
+        .plan
+        .script()
+        .expect("script mode")
         .content
         .as_ref()
         .expect("Script content should exist");

--- a/crates/rattler_build_script/src/activation.rs
+++ b/crates/rattler_build_script/src/activation.rs
@@ -94,7 +94,7 @@ mod tests {
     use rattler_conda_types::Platform;
     use rattler_shell::shell;
 
-    use crate::execution::{EnvironmentIsolation, ExecutionArgs, ResolvedScriptContents};
+    use crate::execution::{EnvironmentIsolation, ExecutionArgs};
     use crate::{ExecutionContext, runtime::RuntimeEnv};
 
     /// The activation script must set the Windows architecture variables after
@@ -112,8 +112,7 @@ mod tests {
             "ARMv8 (64-bit) Family".to_string(),
         );
         let args = ExecutionArgs {
-            script: ResolvedScriptContents::Missing,
-            interpreter: None,
+            sections: Vec::new(),
             env_vars,
             secrets: IndexMap::new(),
             context: ExecutionContext::shared(
@@ -147,8 +146,7 @@ mod tests {
         fs_err::create_dir_all(&build_prefix).unwrap();
 
         let args = ExecutionArgs {
-            script: ResolvedScriptContents::Inline(String::new()),
-            interpreter: None,
+            sections: Vec::new(),
             env_vars: IndexMap::new(),
             secrets: IndexMap::new(),
             context: ExecutionContext::separate(

--- a/crates/rattler_build_script/src/execution.rs
+++ b/crates/rattler_build_script/src/execution.rs
@@ -74,10 +74,9 @@ impl std::str::FromStr for EnvironmentIsolation {
 /// Arguments for executing a script in a given interpreter.
 #[derive(Debug)]
 pub struct ExecutionArgs {
-    /// Contents of the script to execute
-    pub script: ResolvedScriptContents,
-    /// Explicit interpreter requested for the script, if any.
-    pub interpreter: Option<String>,
+    /// The ordered sections the build wrapper is composed of. Each section runs
+    /// in its own scope with its own interpreter and step-local `env`.
+    pub sections: Vec<BuildScriptSection>,
     /// Environment variables to set before executing the script
     pub env_vars: IndexMap<String, String>,
     /// Secrets to set as env vars and replace in the output
@@ -224,17 +223,19 @@ impl Script {
             })
             .collect::<IndexMap<String, String>>();
 
-        let work_dir = if let Some(cwd) = self.cwd.as_ref() {
-            context.host().path().join(cwd)
-        } else {
-            work_dir.to_owned()
-        };
+        let section_cwd = self.cwd.as_ref().map(|cwd| context.host().path().join(cwd));
+        let work_dir = work_dir.to_owned();
 
         tracing::debug!("Running script in {}", work_dir.display());
 
         let exec_args = ExecutionArgs {
-            script: contents,
-            interpreter: self.interpreter.clone(),
+            sections: vec![BuildScriptSection {
+                interpreter: self.interpreter.clone(),
+                content: contents,
+                env: IndexMap::new(),
+                cwd: section_cwd,
+                label: None,
+            }],
             env_vars,
             secrets,
             context,
@@ -343,7 +344,7 @@ impl Script {
             let render = |script: &str| -> Result<String, std::io::Error> {
                 renderer(script).map_err(|e| {
                     std::io::Error::other(format!(
-                        "Failed to render jinja template in build `script`: {}",
+                        "Failed to render jinja template in build script content: {}",
                         e
                     ))
                 })
@@ -417,12 +418,32 @@ impl Decoder for CrLfNormalizer {
     }
 }
 
+/// An owned build-wrapper section carried on [`ExecutionArgs::sections`].
+///
+/// One per build step (or one for a plain `build.script`), with its resolved
+/// content, explicit interpreter, step-local `env`, optional `cwd`, and label.
+/// It is borrowed into a [`ScriptSection`] during wrapper generation.
+#[derive(Debug)]
+pub struct BuildScriptSection {
+    /// Explicit interpreter for this section, or `None` to fall back to the
+    /// wrapper shell.
+    pub interpreter: Option<String>,
+    /// Resolved content for this section.
+    pub content: ResolvedScriptContents,
+    /// Environment variables scoped to this section only.
+    pub env: IndexMap<String, String>,
+    /// Optional working directory for this section.
+    pub cwd: Option<PathBuf>,
+    /// Optional annotation rendered as a boundary comment above the section.
+    pub label: Option<String>,
+}
+
 /// One unit of a generated build wrapper: content run in a single interpreter,
-/// with optional step-local `env` and a boundary-comment label.
+/// with optional step-local `env`, optional `cwd`, and a boundary-comment label.
 ///
 /// `env` is scoped to the section (see `NativeShellRunner::scope_section`) and is
-/// distinct from [`ExecutionArgs::env_vars`], the whole-build environment. Today
-/// one section is built from [`ExecutionArgs`]; the step expander will build many.
+/// distinct from [`ExecutionArgs::env_vars`], the whole-build environment. The
+/// wrapper is built from one [`ScriptSection`] per [`ExecutionArgs::sections`] entry.
 pub(crate) struct ScriptSection<'a> {
     /// Explicit interpreter, or `None` to infer from a file-backed path and
     /// otherwise fall back to the wrapper shell.
@@ -431,6 +452,8 @@ pub(crate) struct ScriptSection<'a> {
     pub content: &'a ResolvedScriptContents,
     /// Environment variables scoped to this section only.
     pub env: &'a IndexMap<String, String>,
+    /// Optional working directory for this section.
+    pub cwd: Option<&'a Path>,
     /// Optional annotation rendered as a boundary comment above the section.
     pub label: Option<&'a str>,
 }
@@ -456,12 +479,12 @@ fn section_script_filename(extension: &str, index: SectionIndex) -> String {
 
 /// Returns the path to the generated native build wrapper script.
 ///
-/// The wrapper sources the activation script, then runs an ordered list of
-/// sections, each wrapped in an isolated scope (see `scope_section`). Sections
-/// with no interpreter, or with the native wrapper shell itself (`cmd` on
-/// Windows, `bash` on Unix), are appended directly to the wrapper; sections with
-/// a specialized interpreter are written to script files and invoked via the
-/// resolved interpreter.
+/// The wrapper sources the activation script, then runs the ordered
+/// [`ExecutionArgs::sections`], each wrapped in an isolated scope (see
+/// `scope_section`). Sections with no interpreter, or with the native wrapper
+/// shell itself (`cmd` on Windows, `bash` on Unix), are appended directly to the
+/// wrapper; sections with a specialized interpreter are written to script files
+/// and invoked via the resolved interpreter.
 pub(crate) async fn generate_build_script(
     args: &ExecutionArgs,
 ) -> Result<PathBuf, crate::InterpreterError> {
@@ -482,14 +505,17 @@ pub(crate) async fn generate_build_script(
     )
     .await?;
 
-    // One section today; the expander will build many.
-    let no_env = IndexMap::new();
-    let sections = [ScriptSection {
-        interpreter: args.interpreter.as_deref(),
-        content: &args.script,
-        env: &no_env,
-        label: None,
-    }];
+    let sections: Vec<ScriptSection> = args
+        .sections
+        .iter()
+        .map(|section| ScriptSection {
+            interpreter: section.interpreter.as_deref(),
+            content: &section.content,
+            env: &section.env,
+            cwd: section.cwd.as_deref(),
+            label: section.label.as_deref(),
+        })
+        .collect();
 
     let total = sections.len();
     let mut fragments = Vec::with_capacity(total);
@@ -507,7 +533,7 @@ pub(crate) async fn generate_build_script(
         if body.trim().is_empty() {
             continue;
         }
-        fragments.push(runner.scope_section(section.label, section.env, &body)?);
+        fragments.push(runner.scope_section(section.label, section.env, section.cwd, &body)?);
     }
 
     let build_script = format!(
@@ -577,7 +603,35 @@ async fn build_section_body(
 
     if !needs_specialized_interpreter {
         // No interpreter, or one that matches the wrapper shell: the content is
-        // the native wrapper body, run directly by the wrapper shell.
+        // native wrapper code. Most shells can inline it directly, but cmd.exe
+        // needs call indirection so `exit /b` exits only this section instead
+        // of terminating the whole wrapper.
+        if let Some(native_command) = runner.native_section_script_command(
+            &args
+                .work_dir
+                .join(section_script_filename(shell.extension(), index)),
+        ) && !script_text.trim().is_empty()
+        {
+            let script_path = args
+                .work_dir
+                .join(section_script_filename(shell.extension(), index));
+            tokio::fs::write(
+                &script_path,
+                crate::native_runner::write_shell_script(shell.clone(), &script_text)?,
+            )
+            .await?;
+            let quoted = native_command
+                .iter()
+                .map(|arg| crate::native_runner::quote_arg(shell, arg))
+                .collect::<Vec<_>>();
+            let command_refs = quoted.iter().map(String::as_str).collect::<Vec<_>>();
+            let mut body = String::new();
+            shell
+                .run_command(&mut body, command_refs)
+                .map_err(std::io::Error::other)?;
+            return Ok(body);
+        }
+
         return Ok(script_text);
     }
 
@@ -613,7 +667,11 @@ async fn build_section_body(
 }
 
 /// Runs a script with the given execution arguments.
-pub(crate) async fn run_script(exec_args: ExecutionArgs) -> Result<(), crate::InterpreterError> {
+///
+/// Most callers use [`Script::run_script`], which builds the [`ExecutionArgs`]
+/// from a single script. This lower-level entry point runs a pre-built
+/// `ExecutionArgs` directly and is used when composing multiple sections.
+pub async fn run_script(exec_args: ExecutionArgs) -> Result<(), crate::InterpreterError> {
     let runner =
         crate::native_runner::native_runner(exec_args.context.runtime().process_platform());
     let build_script_path = generate_build_script(&exec_args).await?;
@@ -623,7 +681,7 @@ pub(crate) async fn run_script(exec_args: ExecutionArgs) -> Result<(), crate::In
         exec_args.env_isolation,
         &exec_args.env_vars,
         &exec_args.secrets,
-        &exec_args.runtime,
+        exec_args.context.runtime(),
     );
 
     let output = crate::execution::run_process_with_replacements(
@@ -757,7 +815,7 @@ pub(crate) fn resolve_process_env(
 
             for var in PASSTHROUGH_ENV_VARS
                 .iter()
-                .chain(platform_passthrough_vars(runtime.platform()))
+                .chain(platform_passthrough_vars(runtime.process_platform()))
             {
                 if let Some(value) = runtime.var(var) {
                     process_env.insert((*var).to_owned(), value.to_owned());
@@ -930,8 +988,7 @@ mod tests {
         fs_err::create_dir_all(&prefix).unwrap();
 
         let args = ExecutionArgs {
-            script: ResolvedScriptContents::Inline(String::new()),
-            interpreter: None,
+            sections: Vec::new(),
             env_vars: IndexMap::new(),
             secrets: IndexMap::new(),
             context: ExecutionContext::shared(
@@ -1035,11 +1092,16 @@ mod tests {
         fs::create_dir_all(&prefix).unwrap();
 
         let args = ExecutionArgs {
-            script: ResolvedScriptContents::Commands(vec![
-                "echo Hello".to_string(),
-                "echo World".to_string(),
-            ]),
-            interpreter: None,
+            sections: vec![BuildScriptSection {
+                interpreter: None,
+                content: ResolvedScriptContents::Commands(vec![
+                    "echo Hello".to_string(),
+                    "echo World".to_string(),
+                ]),
+                env: IndexMap::new(),
+                cwd: None,
+                label: None,
+            }],
             env_vars: IndexMap::new(),
             secrets: IndexMap::new(),
             context: ExecutionContext::shared(
@@ -1057,10 +1119,10 @@ mod tests {
             .await
             .unwrap();
 
-        let wrapper = fs::read_to_string(tmp.path().join("conda_build.bat")).unwrap();
+        let script = fs::read_to_string(tmp.path().join("conda_build_script.bat")).unwrap();
         assert!(
-            wrapper.contains("if %errorlevel% neq 0 exit /b %errorlevel%"),
-            "cmd wrapper must propagate errors between commands, got:\n{wrapper}"
+            script.contains("if %errorlevel% neq 0 exit /b %errorlevel%"),
+            "cmd section script must propagate errors between commands, got:\n{script}"
         );
     }
 
@@ -1274,8 +1336,13 @@ mod tests {
         interpreter: Option<&str>,
     ) -> ExecutionArgs {
         ExecutionArgs {
-            script,
-            interpreter: interpreter.map(str::to_string),
+            sections: vec![BuildScriptSection {
+                interpreter: interpreter.map(str::to_string),
+                content: script,
+                env: IndexMap::new(),
+                cwd: None,
+                label: None,
+            }],
             env_vars: IndexMap::new(),
             secrets: IndexMap::new(),
             context: ExecutionContext::shared(
@@ -1386,7 +1453,7 @@ mod tests {
             EnvironmentIsolation::Strict,
             &env_vars,
             &secrets,
-            &runtime.with_platform(Platform::Linux64),
+            &runtime.with_process_platform(Platform::Linux64),
         );
         assert!(!linux_env.contains_key("SYSTEMROOT"));
     }
@@ -1530,8 +1597,39 @@ mod tests {
         );
     }
 
-    fn has_line(s: &str, want: &str) -> bool {
-        s.lines().any(|l| l.trim_end() == want)
+    fn bash_wrapper_body(wrapper: &str) -> String {
+        let normalized = wrapper.replace("\r\n", "\n");
+        let body = normalized
+            .split_once("## End of preamble")
+            .map(|(_, body)| body.trim_start())
+            .unwrap_or_else(|| panic!("missing bash preamble marker:\n{wrapper}"));
+
+        // The command-tracing prologue is part of the native wrapper preamble,
+        // even though it is intentionally emitted after activation.
+        body.strip_prefix(
+            "# Trace each command as it runs so a failing line is visible (see #2264).\n\
+             # Placed after activation so the sourced environment setup is not traced.\n\
+             set -x\n",
+        )
+        .unwrap_or(body)
+        .trim()
+        .to_string()
+    }
+
+    fn cmd_wrapper_body(wrapper: &str, work_dir: &Path) -> String {
+        let normalized = wrapper.replace("\r\n", "\n").replace('\\', "/");
+        let normalized = if let Ok(command_processor) = std::env::var("COMSPEC") {
+            normalized.replace(&command_processor.replace('\\', "/"), "cmd.exe")
+        } else {
+            normalized
+        };
+        let work_dir = work_dir.to_string_lossy().replace('\\', "/");
+        let normalized = normalized.replace(&work_dir, "$WORK_DIR");
+        let start = normalized
+            .find("@rem ===")
+            .or_else(|| normalized.find("setlocal"))
+            .unwrap_or_else(|| panic!("missing cmd section body:\n{wrapper}"));
+        normalized[start..].trim().to_string()
     }
 
     /// The single section is subshell-wrapped on bash (uniform isolation).
@@ -1554,12 +1652,11 @@ mod tests {
         };
         generate_build_script(&args).await.unwrap();
         let wrapper = fs::read_to_string(tmp.path().join("conda_build.sh")).unwrap();
-        assert!(
-            has_line(&wrapper, "("),
-            "section must be subshell-wrapped:\n{wrapper}"
-        );
-        assert!(has_line(&wrapper, ")"), "{wrapper}");
-        assert!(wrapper.contains("echo hi"), "{wrapper}");
+        insta::assert_snapshot!(bash_wrapper_body(&wrapper), @r###"
+(
+echo hi
+)
+"###);
     }
 
     /// A recipe with no build script stays preamble-only: no empty subshell.
@@ -1582,15 +1679,11 @@ mod tests {
         };
         generate_build_script(&args).await.unwrap();
         let wrapper = fs::read_to_string(tmp.path().join("conda_build.sh")).unwrap();
-        assert!(
-            !has_line(&wrapper, "("),
-            "no script => no subshell:\n{wrapper}"
-        );
-        assert!(wrapper.contains("End of preamble"), "{wrapper}");
+        insta::assert_snapshot!(bash_wrapper_body(&wrapper), @"");
     }
 
-    /// The single section is `setlocal`/`endlocal`-scoped on cmd, with the
-    /// trailing errorlevel guard.
+    /// The single section is `setlocal`/`endlocal`-scoped on cmd, `pushd` /
+    /// `popd`-scoped for cwd, with a trailing errorlevel guard.
     #[tokio::test]
     async fn test_cmd_single_section_setlocal_and_guard() {
         let tmp = tempfile::tempdir().unwrap();
@@ -1610,12 +1703,219 @@ mod tests {
         };
         generate_build_script(&args).await.unwrap();
         let wrapper = fs::read_to_string(tmp.path().join("conda_build.bat")).unwrap();
-        assert!(has_line(&wrapper, "setlocal"), "{wrapper}");
-        assert!(has_line(&wrapper, "endlocal"), "{wrapper}");
-        assert!(
-            has_line(&wrapper, "if %errorlevel% neq 0 exit /b %errorlevel%"),
-            "{wrapper}"
+        insta::assert_snapshot!(cmd_wrapper_body(&wrapper, tmp.path()), @r###"
+setlocal
+pushd "." || exit /b 1
+@cmd.exe /d /c call $WORK_DIR/conda_build_script.bat
+set "RB_SECTION_ERRORLEVEL=%errorlevel%"
+popd
+if %RB_SECTION_ERRORLEVEL% equ 0 if %errorlevel% neq 0 set "RB_SECTION_ERRORLEVEL=%errorlevel%"
+endlocal & if %RB_SECTION_ERRORLEVEL% neq 0 exit /b %RB_SECTION_ERRORLEVEL%
+"###);
+    }
+
+    /// Native cmd sections are invoked through a nested `cmd /c call` so `exit /b`
+    /// and bare `exit` inside a section script return to the wrapper instead of
+    /// skipping later steps.
+    #[tokio::test]
+    async fn test_cmd_sections_use_call_indirection() {
+        let tmp = tempfile::tempdir().unwrap();
+        let prefix = tmp.path().join("prefix");
+        fs::create_dir_all(&prefix).unwrap();
+        let base = execution_args(
+            tmp.path().to_path_buf(),
+            prefix,
+            ResolvedScriptContents::Missing,
+            None,
         );
+
+        let args = ExecutionArgs {
+            context: ExecutionContext::shared(
+                RuntimeEnv::for_test(Platform::Win64),
+                base.context.host().path(),
+                Platform::Win64,
+                Platform::Win64,
+            ),
+            sections: vec![
+                BuildScriptSection {
+                    interpreter: None,
+                    content: ResolvedScriptContents::Inline("echo one\nexit /b 0".to_string()),
+                    env: IndexMap::new(),
+                    cwd: None,
+                    label: Some("step 0".to_string()),
+                },
+                BuildScriptSection {
+                    interpreter: None,
+                    content: ResolvedScriptContents::Inline("echo two".to_string()),
+                    env: IndexMap::new(),
+                    cwd: None,
+                    label: Some("step 1".to_string()),
+                },
+            ],
+            ..base
+        };
+
+        generate_build_script(&args).await.unwrap();
+        let wrapper = fs::read_to_string(tmp.path().join("conda_build.bat")).unwrap();
+        insta::assert_snapshot!(cmd_wrapper_body(&wrapper, tmp.path()), @r###"
+@rem === step 0 ===
+setlocal
+pushd "." || exit /b 1
+@cmd.exe /d /c call $WORK_DIR/conda_build_step0.bat
+set "RB_SECTION_ERRORLEVEL=%errorlevel%"
+popd
+if %RB_SECTION_ERRORLEVEL% equ 0 if %errorlevel% neq 0 set "RB_SECTION_ERRORLEVEL=%errorlevel%"
+endlocal & if %RB_SECTION_ERRORLEVEL% neq 0 exit /b %RB_SECTION_ERRORLEVEL%
+@rem === step 1 ===
+setlocal
+pushd "." || exit /b 1
+@cmd.exe /d /c call $WORK_DIR/conda_build_step1.bat
+set "RB_SECTION_ERRORLEVEL=%errorlevel%"
+popd
+if %RB_SECTION_ERRORLEVEL% equ 0 if %errorlevel% neq 0 set "RB_SECTION_ERRORLEVEL=%errorlevel%"
+endlocal & if %RB_SECTION_ERRORLEVEL% neq 0 exit /b %RB_SECTION_ERRORLEVEL%
+"###);
+    }
+
+    #[tokio::test]
+    async fn test_cmd_call_indirection_escapes_percent_paths() {
+        let tmp = tempfile::tempdir().unwrap();
+        let work_dir = tmp.path().join("%NO_SUCH_VAR%");
+        let prefix = work_dir.join("prefix");
+        fs::create_dir_all(&prefix).unwrap();
+        let args = execution_args(
+            work_dir.clone(),
+            prefix,
+            ResolvedScriptContents::Inline("echo hi".to_string()),
+            None,
+        );
+        let args = ExecutionArgs {
+            context: ExecutionContext::shared(
+                RuntimeEnv::for_test(Platform::Win64),
+                args.context.host().path(),
+                Platform::Win64,
+                Platform::Win64,
+            ),
+            ..args
+        };
+
+        generate_build_script(&args).await.unwrap();
+        let wrapper = fs::read_to_string(work_dir.join("conda_build.bat")).unwrap();
+
+        assert!(
+            wrapper.contains("cmd.exe /d /c call"),
+            "native cmd sections should use nested cmd call indirection:\n{wrapper}"
+        );
+        assert!(
+            wrapper.contains("%%NO_SUCH_VAR%%"),
+            "percent signs in call paths must be escaped for the outer batch context:\n{wrapper}"
+        );
+    }
+
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn test_cmd_bare_exit_does_not_skip_later_sections() {
+        let tmp = tempfile::tempdir().unwrap();
+        let prefix = tmp.path().join("prefix");
+        fs::create_dir_all(&prefix).unwrap();
+        let base = execution_args(
+            tmp.path().to_path_buf(),
+            prefix,
+            ResolvedScriptContents::Missing,
+            None,
+        );
+
+        let args = ExecutionArgs {
+            context: ExecutionContext::shared(
+                RuntimeEnv::for_test(Platform::Win64),
+                base.context.host().path(),
+                Platform::Win64,
+                Platform::Win64,
+            ),
+            sections: vec![
+                BuildScriptSection {
+                    interpreter: None,
+                    content: ResolvedScriptContents::Inline("echo one\nexit 0".to_string()),
+                    env: IndexMap::new(),
+                    cwd: None,
+                    label: Some("step 0".to_string()),
+                },
+                BuildScriptSection {
+                    interpreter: None,
+                    content: ResolvedScriptContents::Inline("echo two> marker.txt".to_string()),
+                    env: IndexMap::new(),
+                    cwd: None,
+                    label: Some("step 1".to_string()),
+                },
+            ],
+            ..base
+        };
+
+        run_script(args).await.unwrap();
+
+        assert!(
+            tmp.path().join("marker.txt").exists(),
+            "bare `exit 0` in the first cmd section must not skip the second section"
+        );
+    }
+
+    /// Multiple sections compose in order, each scoped, with labels and env.
+    #[tokio::test]
+    async fn test_multiple_sections_composed_in_order() {
+        let tmp = tempfile::tempdir().unwrap();
+        let prefix = tmp.path().join("prefix");
+        fs::create_dir_all(&prefix).unwrap();
+        let base = execution_args(
+            tmp.path().to_path_buf(),
+            prefix,
+            ResolvedScriptContents::Missing,
+            None,
+        );
+
+        let mut env0 = IndexMap::new();
+        env0.insert("FOO".to_string(), "bar".to_string());
+
+        let args = ExecutionArgs {
+            context: ExecutionContext::shared(
+                RuntimeEnv::for_test(Platform::Linux64),
+                base.context.host().path(),
+                Platform::Linux64,
+                Platform::Linux64,
+            ),
+            sections: vec![
+                BuildScriptSection {
+                    interpreter: None,
+                    content: ResolvedScriptContents::Inline("echo one".to_string()),
+                    env: env0,
+                    cwd: Some(PathBuf::from("/tmp/step0")),
+                    label: Some("step 0".to_string()),
+                },
+                BuildScriptSection {
+                    interpreter: None,
+                    content: ResolvedScriptContents::Inline("echo two".to_string()),
+                    env: IndexMap::new(),
+                    cwd: None,
+                    label: Some("step 1".to_string()),
+                },
+            ],
+            ..base
+        };
+
+        generate_build_script(&args).await.unwrap();
+        let wrapper = fs::read_to_string(tmp.path().join("conda_build.sh")).unwrap();
+
+        insta::assert_snapshot!(bash_wrapper_body(&wrapper), @r###"
+# === step 0 ===
+(
+export FOO=bar
+cd /tmp/step0
+echo one
+)
+# === step 1 ===
+(
+echo two
+)
+"###);
     }
 
     /// A sole section keeps the historic file name; multiple are numbered.

--- a/crates/rattler_build_script/src/interpreter/mod.rs
+++ b/crates/rattler_build_script/src/interpreter/mod.rs
@@ -316,7 +316,7 @@ mod tests {
     use super::*;
     use crate::{
         ExecutionContext, RuntimeEnv,
-        execution::{ExecutionArgs, ResolvedScriptContents},
+        execution::{BuildScriptSection, ExecutionArgs, ResolvedScriptContents},
     };
     use fs_err as fs;
     use indexmap::IndexMap;
@@ -331,8 +331,13 @@ mod tests {
         interpreter: Option<&str>,
     ) -> ExecutionArgs {
         ExecutionArgs {
-            script,
-            interpreter: interpreter.map(str::to_string),
+            sections: vec![BuildScriptSection {
+                interpreter: interpreter.map(str::to_string),
+                content: script,
+                env: IndexMap::new(),
+                cwd: None,
+                label: None,
+            }],
             env_vars: IndexMap::new(),
             secrets: IndexMap::new(),
             context: ExecutionContext::shared(
@@ -395,7 +400,19 @@ mod tests {
             .unwrap();
 
         let build_script = fs::read_to_string(native_build_script_path(tmp.path())).unwrap();
-        assert!(build_script.contains("echo native"));
+        if cfg!(windows) {
+            assert!(build_script.contains("conda_build_script.bat"));
+            assert_eq!(
+                fs::read_to_string(tmp.path().join("conda_build_script.bat"))
+                    .unwrap()
+                    .replace("\r\n", "\n")
+                    .trim(),
+                "echo native"
+            );
+        } else {
+            assert!(build_script.contains("echo native"));
+            assert!(!tmp.path().join("conda_build_script.sh").exists());
+        }
         assert!(!tmp.path().join("conda_build_script.py").exists());
     }
 
@@ -454,12 +471,14 @@ mod tests {
     }
 
     /// An interpreter that matches the wrapper shell (`cmd` on Windows, `bash`
-    /// on Unix) is inlined into the wrapper rather than resolved from the build
-    /// environment and re-invoked. This must succeed even with an empty prefix:
-    /// `cmd` in particular is a system shell, not a conda-provided executable,
-    /// so resolving it from the build environment used to fail with
-    /// "interpreter 'cmd' was not found in the build environment".
-    /// Regression test for the `file: build` -> `build.bat` path on Windows.
+    /// on Unix) is treated as native wrapper code rather than resolved from the
+    /// build environment and re-invoked. On Windows the native body is invoked
+    /// through `call` indirection so `exit /b` cannot terminate the wrapper.
+    /// This must succeed even with an empty prefix: `cmd` in particular is a
+    /// system shell, not a conda-provided executable, so resolving it from the
+    /// build environment used to fail with "interpreter 'cmd' was not found in
+    /// the build environment". Regression test for the `file: build` ->
+    /// `build.bat` path on Windows.
     #[tokio::test]
     async fn interpreter_matching_wrapper_shell_is_native_body() {
         let tmp = tempfile::tempdir().unwrap();
@@ -483,13 +502,22 @@ mod tests {
             .expect("native wrapper shell must not be resolved from the build environment");
 
         let build_script = fs::read_to_string(native_build_script_path(tmp.path())).unwrap();
-        assert!(
-            build_script.contains(marker),
-            "wrapper should inline the script body, got:\n{build_script}"
-        );
-        // No separate interpreter script file is written for the native shell.
-        assert!(!tmp.path().join("conda_build_script.bat").exists());
-        assert!(!tmp.path().join("conda_build_script.sh").exists());
+        if cfg!(windows) {
+            assert!(build_script.contains("conda_build_script.bat"));
+            assert_eq!(
+                fs::read_to_string(tmp.path().join("conda_build_script.bat"))
+                    .unwrap()
+                    .replace("\r\n", "\n")
+                    .trim(),
+                marker
+            );
+        } else {
+            assert!(
+                build_script.contains(marker),
+                "wrapper should inline the script body, got:\n{build_script}"
+            );
+            assert!(!tmp.path().join("conda_build_script.sh").exists());
+        }
     }
 
     #[tokio::test]
@@ -513,7 +541,18 @@ mod tests {
             .unwrap();
 
         let build_script = fs::read_to_string(native_build_script_path(tmp.path())).unwrap();
-        assert!(build_script.contains("echo custom"));
+        if cfg!(windows) {
+            assert!(build_script.contains("conda_build_script.bat"));
+            assert_eq!(
+                fs::read_to_string(tmp.path().join("conda_build_script.bat"))
+                    .unwrap()
+                    .replace("\r\n", "\n")
+                    .trim(),
+                "echo custom"
+            );
+        } else {
+            assert!(build_script.contains("echo custom"));
+        }
     }
 
     /// A build-prefix-only interpreter (`brush`) errors when absent instead of

--- a/crates/rattler_build_script/src/lib.rs
+++ b/crates/rattler_build_script/src/lib.rs
@@ -32,7 +32,8 @@ mod runtime;
 
 #[cfg(feature = "execution")]
 pub use execution::{
-    EnvironmentIsolation, ExecutionArgs, ResolvedScriptContents, create_build_script,
+    BuildScriptSection, EnvironmentIsolation, ExecutionArgs, ResolvedScriptContents,
+    create_build_script, run_script,
 };
 #[cfg(feature = "execution")]
 pub use execution_context::{ExecutionContext, PrefixLayout, PrefixWithPlatform};

--- a/crates/rattler_build_script/src/native_runner/bash.rs
+++ b/crates/rattler_build_script/src/native_runner/bash.rs
@@ -54,6 +54,7 @@ set -x
         &self,
         label: Option<&str>,
         env: &IndexMap<String, String>,
+        cwd: Option<&Path>,
         body: &str,
     ) -> Result<String, std::io::Error> {
         let shell = shell::Bash::default();
@@ -63,9 +64,14 @@ set -x
         }
         out.push_str("(\n");
         for (key, value) in env {
+            super::validate_env_assignment(key, value)?;
             shell
                 .set_env_var(&mut out, key, value)
                 .map_err(std::io::Error::other)?;
+        }
+        if let Some(cwd) = cwd {
+            let cwd = super::quote_arg(&self.shell(), &cwd.to_string_lossy());
+            let _ = writeln!(out, "cd {cwd}");
         }
         out.push_str(body);
         if !body.ends_with('\n') {

--- a/crates/rattler_build_script/src/native_runner/cmd_exe.rs
+++ b/crates/rattler_build_script/src/native_runner/cmd_exe.rs
@@ -103,14 +103,28 @@ IF "%CONDA_BUILD%" == "" (
         false
     }
 
-    /// `setlocal`/`endlocal` scope plus an errorlevel guard. The guard is
-    /// required even on the last section: falling off the end after `endlocal`
-    /// exits 0 regardless of failure, but `endlocal` preserves the
-    /// `%errorlevel%` value so the guard still catches it.
+    fn native_section_script_command(&self, script_path: &Path) -> Option<Vec<String>> {
+        // Activated build environments can replace PATH entirely. Resolve the
+        // command processor before entering the wrapper so nested native
+        // sections do not depend on `cmd.exe` remaining discoverable.
+        let command_processor = std::env::var("COMSPEC").unwrap_or_else(|_| "cmd.exe".to_string());
+        Some(vec![
+            command_processor,
+            "/d".to_string(),
+            "/c".to_string(),
+            "call".to_string(),
+            script_path.to_string_lossy().into_owned(),
+        ])
+    }
+
+    /// `setlocal`/`endlocal` scope environment changes, while `pushd`/`popd`
+    /// restore the working directory after successful sections. The saved
+    /// errorlevel keeps `popd`/`endlocal` from masking a failing body.
     fn scope_section(
         &self,
         label: Option<&str>,
         env: &IndexMap<String, String>,
+        cwd: Option<&Path>,
         body: &str,
     ) -> Result<String, std::io::Error> {
         let shell = shell::CmdExe;
@@ -120,15 +134,34 @@ IF "%CONDA_BUILD%" == "" (
         }
         out.push_str("setlocal\n");
         for (key, value) in env {
+            super::validate_env_assignment(key, value)?;
             shell
                 .set_env_var(&mut out, key, value)
                 .map_err(std::io::Error::other)?;
         }
+        let cwd = cwd
+            .map(|cwd| super::quote_arg(&self.shell(), &cwd.to_string_lossy()))
+            .unwrap_or_else(|| ".".to_string());
+        // `pushd` can misparse an unquoted path containing forward slashes as
+        // command switches, even when the path has no spaces.
+        let cwd = if cwd.starts_with('"') {
+            cwd
+        } else {
+            format!("\"{cwd}\"")
+        };
+        // Use command chaining instead of inspecting `%errorlevel%`: a successful
+        // `pushd` does not reliably clear an error left by environment activation.
+        let _ = writeln!(out, "pushd {cwd} || exit /b 1");
         out.push_str(body);
         if !body.ends_with('\n') {
             out.push('\n');
         }
-        out.push_str("endlocal\nif %errorlevel% neq 0 exit /b %errorlevel%");
+        out.push_str("set \"RB_SECTION_ERRORLEVEL=%errorlevel%\"\n");
+        out.push_str("popd\n");
+        out.push_str(
+            "if %RB_SECTION_ERRORLEVEL% equ 0 if %errorlevel% neq 0 set \"RB_SECTION_ERRORLEVEL=%errorlevel%\"\n",
+        );
+        out.push_str("endlocal & if %RB_SECTION_ERRORLEVEL% neq 0 exit /b %RB_SECTION_ERRORLEVEL%");
         Ok(out)
     }
 

--- a/crates/rattler_build_script/src/native_runner/mod.rs
+++ b/crates/rattler_build_script/src/native_runner/mod.rs
@@ -159,6 +159,13 @@ pub(crate) trait NativeShellRunner: Send + Sync {
         true
     }
 
+    /// Returns a native-shell command that invokes a section script file, if
+    /// native sections must be run indirectly. `cmd.exe` uses this so
+    /// `exit /b` exits only the called section script, not the whole wrapper.
+    fn native_section_script_command(&self, _script_path: &Path) -> Option<Vec<String>> {
+        None
+    }
+
     /// Wraps a non-empty section body in an isolated shell scope so its
     /// step-local `env` and shell state don't leak into later sections and a
     /// failure aborts the wrapper. `env` is emitted via [`Shell::set_env_var`]
@@ -167,6 +174,7 @@ pub(crate) trait NativeShellRunner: Send + Sync {
         &self,
         label: Option<&str>,
         env: &IndexMap<String, String>,
+        cwd: Option<&Path>,
         body: &str,
     ) -> Result<String, std::io::Error>;
 
@@ -194,20 +202,64 @@ pub(crate) fn write_shell_script(
     Ok(bytes)
 }
 
-/// Quotes a single command argument for the given shell when it contains
-/// whitespace (or is empty). `rattler_shell::Shell::run_command` joins arguments
-/// with spaces without quoting, so a resolved interpreter or script path
-/// containing spaces (e.g. `C:\Program Files\nodejs\node.exe`) would otherwise
-/// be split by the shell.
-pub(crate) fn quote_arg(shell: &ShellEnum, arg: &str) -> String {
-    if !arg.is_empty() && !arg.chars().any(char::is_whitespace) {
-        return arg.to_string();
+/// Validate an env assignment before emitting it into a shell wrapper.
+pub(crate) fn validate_env_assignment(key: &str, value: &str) -> Result<(), std::io::Error> {
+    let mut chars = key.chars();
+    let valid_key = chars
+        .next()
+        .is_some_and(|c| c == '_' || c.is_ascii_alphabetic())
+        && chars.all(|c| c == '_' || c.is_ascii_alphanumeric());
+    if !valid_key {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("invalid environment variable name '{key}'; expected [A-Za-z_][A-Za-z0-9_]*"),
+        ));
     }
+    if value.contains(['\n', '\r']) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "environment variable '{key}' contains a newline, which cannot be represented safely in build scripts"
+            ),
+        ));
+    }
+    Ok(())
+}
+
+/// Quotes a single command argument for the given shell when it contains shell
+/// metacharacters, whitespace, or is empty. `rattler_shell::Shell::run_command`
+/// joins arguments with spaces without quoting, so a resolved interpreter,
+/// script path, or `cwd` containing characters like spaces or `&` would
+/// otherwise be split or interpreted by the shell. For cmd batch files, literal
+/// `%` characters are also escaped to avoid environment-variable expansion.
+pub(crate) fn quote_arg(shell: &ShellEnum, arg: &str) -> String {
+    fn posix_needs_quotes(arg: &str) -> bool {
+        arg.is_empty()
+            || arg.chars().any(|c| {
+                !(c.is_ascii_alphanumeric()
+                    || matches!(c, '/' | '.' | '-' | '_' | ':' | '+' | '=' | '@' | '%'))
+            })
+    }
+
+    fn cmd_needs_quotes(arg: &str) -> bool {
+        arg.is_empty()
+            || arg.chars().any(|c| {
+                c.is_whitespace()
+                    || matches!(c, '&' | '|' | '<' | '>' | '(' | ')' | '^' | ';' | ',' | '=')
+            })
+    }
+
     match shell {
-        ShellEnum::CmdExe(_) => format!("\"{arg}\""),
-        // POSIX single-quoting neutralizes spaces and metacharacters; an
-        // embedded single quote is closed, escaped, and reopened.
-        _ => format!("'{}'", arg.replace('\'', r"'\''")),
+        ShellEnum::CmdExe(_) => {
+            let escaped = arg.replace('%', "%%");
+            if cmd_needs_quotes(&escaped) {
+                format!("\"{escaped}\"")
+            } else {
+                escaped
+            }
+        }
+        _ if posix_needs_quotes(arg) => format!("'{}'", arg.replace('\'', r"'\''")),
+        _ => arg.to_string(),
     }
 }
 
@@ -219,11 +271,6 @@ mod tests {
     use rattler_conda_types::Platform;
     use rattler_shell::shell::{self, Shell};
 
-    /// True if any line equals `want` after trimming trailing whitespace.
-    fn has_line(s: &str, want: &str) -> bool {
-        s.lines().any(|l| l.trim_end() == want)
-    }
-
     /// bash scopes a section in a bare subshell, emits the label comment, and
     /// quotes env via `set_env_var` (shlex). No errorlevel guard — `set -e`
     /// from the preamble handles failure.
@@ -233,17 +280,15 @@ mod tests {
         let mut env = IndexMap::new();
         env.insert("FOO".to_string(), "a b".to_string());
         let out = runner
-            .scope_section(Some("uses: configure"), &env, "echo hi")
+            .scope_section(Some("uses: configure"), &env, None, "echo hi")
             .unwrap();
-        assert!(out.contains("# === uses: configure ==="), "{out}");
-        assert!(has_line(&out, "("), "missing subshell open:\n{out}");
-        assert!(has_line(&out, ")"), "missing subshell close:\n{out}");
-        assert!(
-            out.contains("export FOO='a b'"),
-            "env must be quoted:\n{out}"
-        );
-        assert!(out.contains("echo hi"), "{out}");
-        assert!(!out.contains("errorlevel"), "bash needs no guard:\n{out}");
+        insta::assert_snapshot!(out, @r###"
+# === uses: configure ===
+(
+export FOO='a b'
+echo hi
+)
+"###);
     }
 
     /// No label and empty env => just `( body )`.
@@ -251,31 +296,89 @@ mod tests {
     fn bash_scope_section_minimal() {
         let runner = native_runner(Platform::Linux64);
         let out = runner
-            .scope_section(None, &IndexMap::new(), "echo hi")
+            .scope_section(None, &IndexMap::new(), None, "echo hi")
             .unwrap();
-        assert!(!out.contains("# ==="), "no label => no comment:\n{out}");
-        assert!(has_line(&out, "("), "{out}");
-        assert!(has_line(&out, ")"), "{out}");
+        insta::assert_snapshot!(out, @r###"
+(
+echo hi
+)
+"###);
     }
 
-    /// cmd scopes via `setlocal`/`endlocal`, sets env via `@SET`, and always
-    /// appends the errorlevel guard (required even for the last section).
+    /// cmd scopes env via `setlocal`/`endlocal`, cwd via `pushd`/`popd`, and
+    /// appends an errorlevel guard (required even for the last section).
     #[test]
     fn cmd_scope_section_setlocal_env_and_guard() {
         let runner = native_runner(Platform::Win64);
         let mut env = IndexMap::new();
         env.insert("FOO".to_string(), "bar".to_string());
         let out = runner
-            .scope_section(Some("step 1"), &env, "echo hi")
+            .scope_section(Some("step 1"), &env, None, "echo hi")
             .unwrap();
-        assert!(out.contains("@rem === step 1 ==="), "{out}");
-        assert!(has_line(&out, "setlocal"), "{out}");
-        assert!(has_line(&out, "endlocal"), "{out}");
+        insta::assert_snapshot!(out, @r###"
+@rem === step 1 ===
+setlocal
+@SET "FOO=bar"
+pushd "." || exit /b 1
+echo hi
+set "RB_SECTION_ERRORLEVEL=%errorlevel%"
+popd
+if %RB_SECTION_ERRORLEVEL% equ 0 if %errorlevel% neq 0 set "RB_SECTION_ERRORLEVEL=%errorlevel%"
+endlocal & if %RB_SECTION_ERRORLEVEL% neq 0 exit /b %RB_SECTION_ERRORLEVEL%
+"###);
+    }
+
+    #[test]
+    fn cmd_scope_section_pushd_uses_cwd() {
+        let runner = native_runner(Platform::Win64);
+        let out = runner
+            .scope_section(
+                Some("step 1"),
+                &IndexMap::new(),
+                Some(std::path::Path::new(r"C:\some&dir")),
+                "echo hi",
+            )
+            .unwrap();
+
+        insta::assert_snapshot!(out, @r###"
+@rem === step 1 ===
+setlocal
+pushd "C:\some&dir" || exit /b 1
+echo hi
+set "RB_SECTION_ERRORLEVEL=%errorlevel%"
+popd
+if %RB_SECTION_ERRORLEVEL% equ 0 if %errorlevel% neq 0 set "RB_SECTION_ERRORLEVEL=%errorlevel%"
+endlocal & if %RB_SECTION_ERRORLEVEL% neq 0 exit /b %RB_SECTION_ERRORLEVEL%
+"###);
+    }
+
+    #[test]
+    fn scope_section_rejects_invalid_env_names() {
+        let runner = native_runner(Platform::Linux64);
+        let mut env = IndexMap::new();
+        env.insert("BAD-NAME".to_string(), "value".to_string());
+
+        let err = runner
+            .scope_section(None, &env, None, "echo hi")
+            .expect_err("invalid env name should fail");
+
         assert!(
-            has_line(&out, "if %errorlevel% neq 0 exit /b %errorlevel%"),
-            "guard required even when last:\n{out}"
+            err.to_string()
+                .contains("invalid environment variable name")
         );
-        assert!(out.contains(r#"@SET "FOO=bar""#), "{out}");
+    }
+
+    #[test]
+    fn cmd_scope_section_rejects_newline_env_values() {
+        let runner = native_runner(Platform::Win64);
+        let mut env = IndexMap::new();
+        env.insert("FOO".to_string(), "safe\necho injected".to_string());
+
+        let err = runner
+            .scope_section(None, &env, None, "echo hi")
+            .expect_err("newline env value should fail");
+
+        assert!(err.to_string().contains("contains a newline"));
     }
 
     #[test]
@@ -404,11 +507,12 @@ mod tests {
         // No whitespace: left untouched (flags must not be quoted).
         assert_eq!(quote_arg(&bash, "-NoLogo"), "-NoLogo");
         assert_eq!(quote_arg(&bash, "/usr/bin/python"), "/usr/bin/python");
-        // Whitespace: single-quoted for posix shells.
+        // Whitespace and metacharacters are single-quoted for posix shells.
         assert_eq!(
             quote_arg(&bash, "/opt/my tools/node"),
             "'/opt/my tools/node'"
         );
+        assert_eq!(quote_arg(&bash, "/tmp/a&b"), "'/tmp/a&b'");
         // Embedded single quote is escaped.
         assert_eq!(quote_arg(&bash, "a'b c"), "'a'\\''b c'");
     }
@@ -420,6 +524,18 @@ mod tests {
         assert_eq!(
             quote_arg(&cmd, r"C:\Program Files\nodejs\node.exe"),
             "\"C:\\Program Files\\nodejs\\node.exe\""
+        );
+        assert_eq!(quote_arg(&cmd, r"C:\tmp\a&b"), "\"C:\\tmp\\a&b\"");
+        assert_eq!(quote_arg(&cmd, r"C:\tmp\a;b"), "\"C:\\tmp\\a;b\"");
+        assert_eq!(quote_arg(&cmd, r"C:\tmp\a,b"), "\"C:\\tmp\\a,b\"");
+        assert_eq!(quote_arg(&cmd, r"C:\tmp\a=b"), "\"C:\\tmp\\a=b\"");
+        assert_eq!(
+            quote_arg(&cmd, r"C:\tmp\%NO_SUCH_VAR%\script.bat"),
+            r"C:\tmp\%%NO_SUCH_VAR%%\script.bat"
+        );
+        assert_eq!(
+            quote_arg(&cmd, r"C:\tmp\%NO_SUCH_VAR% dir\script.bat"),
+            r#""C:\tmp\%%NO_SUCH_VAR%% dir\script.bat""#
         );
     }
 }

--- a/crates/rattler_build_script/src/script.rs
+++ b/crates/rattler_build_script/src/script.rs
@@ -197,6 +197,7 @@ impl Script {
             && self.interpreter.is_none()
             && self.env.is_empty()
             && self.secrets.is_empty()
+            && self.cwd.is_none()
     }
 }
 

--- a/crates/rattler_build_script/tests/serialization_tests.rs
+++ b/crates/rattler_build_script/tests/serialization_tests.rs
@@ -208,6 +208,16 @@ fn test_script_deserialization_with_all_fields() {
 }
 
 #[test]
+fn test_script_with_cwd_is_not_default() {
+    let script = Script {
+        cwd: Some(PathBuf::from("subdir")),
+        ..Default::default()
+    };
+
+    assert!(!script.is_default());
+}
+
+#[test]
 fn test_script_roundtrip() {
     let mut env = IndexMap::new();
     env.insert("KEY".to_string(), "VALUE".to_string());

--- a/crates/rattler_build_yaml_parser/src/conditional.rs
+++ b/crates/rattler_build_yaml_parser/src/conditional.rs
@@ -95,6 +95,26 @@ where
     Ok(ConditionalListOrItem::new(vec![item]))
 }
 
+/// Parse a Jinja expression from a scalar YAML node.
+///
+/// This is used by stage0 `if` condition syntax. Expressions are verbatim
+/// Jinja expressions and do not include `${{ }}` template delimiters.
+pub fn parse_jinja_expression(
+    yaml: &MarkedNode,
+    field_name: &str,
+) -> ParseResult<(JinjaExpression, marked_yaml::Span)> {
+    let condition_scalar = yaml
+        .as_scalar()
+        .ok_or_else(|| ParseError::expected_type("scalar", "non-scalar", get_span(yaml)))?;
+
+    let condition_span = *condition_scalar.span();
+    let condition = JinjaExpression::new(condition_scalar.as_str().to_string()).map_err(|e| {
+        ParseError::jinja_error(format!("Failed to parse {field_name}: {e}"), condition_span)
+    })?;
+
+    Ok((condition, condition_span))
+}
+
 /// Parse an Item<T> from YAML using a custom converter
 ///
 /// This handles both simple values and conditional (if/then/else) items.
@@ -132,13 +152,7 @@ where
         .get("if")
         .ok_or_else(|| ParseError::missing_field("if", get_span(yaml)))?;
 
-    let condition_scalar = condition_node.as_scalar().ok_or_else(|| {
-        ParseError::expected_type("scalar", "non-scalar", get_span(condition_node))
-    })?;
-
-    let condition_span = *condition_scalar.span();
-    let condition = JinjaExpression::new(condition_scalar.as_str().to_string())
-        .map_err(|e| ParseError::jinja_error(e, condition_span))?;
+    let (condition, condition_span) = parse_jinja_expression(condition_node, "if")?;
 
     // Get the "then" field - parse as NestedItemList to support nested conditionals
     let then_yaml = mapping

--- a/crates/rattler_build_yaml_parser/src/lib.rs
+++ b/crates/rattler_build_yaml_parser/src/lib.rs
@@ -47,7 +47,7 @@ pub mod yaml;
 pub use conditional::{
     parse_conditional_list, parse_conditional_list_or_item,
     parse_conditional_list_or_item_with_converter, parse_conditional_list_with_converter,
-    parse_item_with_converter,
+    parse_item_with_converter, parse_jinja_expression,
 };
 pub use converter::{BoolConverter, FromStrConverter, NodeConverter};
 pub use error::{FileParseError, ParseError, ParseErrorWithSource, ParseResult, WithSourceCode};

--- a/docs/build_script.md
+++ b/docs/build_script.md
@@ -42,6 +42,47 @@ build:
         - copy %RECIPE_DIR%\my_script_with_recipe.bat %LIBRARY_BIN%\super-cool-script.bat
 ```
 
+## Experimental build steps
+
+`build.steps` is an experimental alternative to `build.script`. Enable it with
+`--experimental`. `script` and `steps` are mutually exclusive; even
+`steps: []` explicitly selects steps mode and prevents default `build.sh` /
+`build.bat` discovery.
+
+Each step is a scoped section of the generated build wrapper, so step-local
+`env` values and `cwd` changes do not leak into later steps. A step supports:
+
+- **`run`** - Required inline command, multiline string, or list of commands.
+- **`if`** - Optional Jinja selector expression, such as `unix` or
+  `target_platform == "linux-64"`. Do not wrap expressions in `${{ }}`.
+- **`interpreter`** - Optional interpreter override for this step.
+- **`cwd`** - Optional working directory for this step. Relative paths are
+  resolved against the host prefix (`$PREFIX` / `%PREFIX%`), and the wrapper
+  changes to it only for that step.
+- **`env`** - Optional environment variables scoped to this step.
+
+```yaml title="recipe.yaml"
+build:
+  steps:
+    - if: unix
+      run: |
+        mkdir -p "$PREFIX/bin"
+        cp "$RECIPE_DIR/my_script_with_recipe.sh" "$PREFIX/bin/super-cool-script.sh"
+
+    - if: win
+      run: copy %RECIPE_DIR%\my_script_with_recipe.bat %LIBRARY_BIN%\super-cool-script.bat
+
+    - run: python -m pip install . --no-deps
+      env:
+        SETUPTOOLS_SCM_PRETEND_VERSION: ${{ version }}
+```
+
+!!! warning "Windows multiline steps"
+    On Windows, a multiline `run: |` block is emitted as one command-list item.
+    Rattler-Build inserts fail-fast guards between list items, not between the
+    physical lines inside one multiline scalar, so check `%errorlevel%` yourself
+    when a multiline `cmd.exe` block needs per-line failure handling.
+
 ## Environment variables
 
 There are many environment variables that are automatically set during the build
@@ -79,7 +120,7 @@ for your script.
 So far, the following interpreters are supported:
 
 - `bash` (default on Unix)
-- `cmd.exe` (default on Windows)
+- `cmd` (Windows `cmd.exe`)
 - `powershell`
 - `nushell`
 - `brush`
@@ -91,7 +132,8 @@ So far, the following interpreters are supported:
 
 Rattler-Build automatically detects the interpreter based on the file extension
 (`.sh`/`.bash`, `.bat`/`.cmd`, `.ps1`, `.nu`, `.py`, `.pl`, `.r`, `.rb`, `.js`) or you
-can specify it in the `interpreter` key in the `script` section of your recipe.
+can specify it in the `interpreter` key in the `script` section of your recipe
+(use `interpreter: cmd` for Windows `cmd.exe`).
 
 ```yaml title="recipe.yaml"
 build:

--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -591,14 +591,14 @@ with the following fields (all optional):
   the rendered recipe. The variables must already be set in the environment
   running `rattler-build`.
 - **`interpreter`** - Explicit interpreter to run `content` with. Supported
-  values are `bash` (default on Unix), `cmd.exe` (default on Windows),
+  values are `bash` (default on Unix), `cmd` (Windows `cmd.exe`),
   `powershell`, `nu` (nushell), `brush`, `python`, `perl`, `rscript`, `ruby`
   and `node`/`nodejs`. When unset, the interpreter is auto-detected from the
   script's file extension (`.sh`/`.bash`, `.bat`/`.cmd`, `.ps1`, `.nu`, `.py`,
   `.pl`, `.r`, `.rb`, `.js`).
-- **`cwd`** - Working directory for the script, relative to the
-  `[build folder]/work` directory. Defaults to the `[build folder]/work`
-  directory itself.
+- **`cwd`** - Working directory for the script. Relative paths are resolved
+  against the host prefix (`$PREFIX` / `%PREFIX%`). Defaults to the build work
+  directory.
 
 !!! note "Where interpreters come from"
 
@@ -617,7 +617,7 @@ with the following fields (all optional):
     (`build.merge_build_and_host_envs`), that single environment is used.
 
     Two interpreters are resolved differently:
-     - `bash`/`cmd.exe` (and `powershell` on Windows) may be taken from the
+     - `bash`/`cmd` (and `powershell` on Windows) may be taken from the
        system `PATH` on their native platform.
      - `brush` is resolved **only** from the build environment (not the host
        prefix or the system `PATH`), so it must be in `requirements.build`.
@@ -667,6 +667,40 @@ requirements:
   build:
     - nushell
 ```
+
+#### Build steps (experimental)
+
+`build.steps` is an experimental alternative to `build.script` and requires
+`--experimental`. `script` and `steps` are mutually exclusive, including
+`steps: []`.
+
+Each step is a scoped build-wrapper section. Step-local `env` values and `cwd`
+changes apply only to that step. A step supports:
+
+- **`run`** - Required inline command, multiline string, or list of commands.
+- **`if`** - Optional Jinja selector expression evaluated before the step runs. Do not wrap expressions in `${{ }}`.
+- **`interpreter`** - Optional interpreter override for this step.
+- **`cwd`** - Optional working directory for this step. Relative paths are
+  resolved against the host prefix (`$PREFIX` / `%PREFIX%`).
+- **`env`** - Optional environment variables scoped to this step.
+
+```yaml title="recipe.yaml"
+build:
+  steps:
+    - if: unix
+      run:
+        - mkdir -p "$PREFIX/bin"
+        - cp "$RECIPE_DIR/tool" "$PREFIX/bin/tool"
+
+    - run: python -m pip install . --no-deps
+      env:
+        SETUPTOOLS_SCM_PRETEND_VERSION: ${{ version }}
+```
+
+!!! warning "Windows multiline steps"
+    On Windows, a multiline `run: |` block is emitted as one command-list item.
+    Fail-fast guards are inserted between list items, not between the physical
+    lines inside one multiline scalar.
 
 See [Build script](../build_script.md) for more examples and the full
 behaviour of environment variables, secrets, and interpreters.

--- a/py-rattler-build/rust/src/build.rs
+++ b/py-rattler-build/rust/src/build.rs
@@ -223,6 +223,7 @@ pub(crate) fn output_from_rendered_variant(
             ),
             store_recipe: !effective_no_include_recipe,
             force_colors: false,
+            experimental: rendered_variant.inner.experimental,
             env_isolation,
             sandbox_config: None,
             exclude_newer,

--- a/py-rattler-build/rust/src/stage0.rs
+++ b/py-rattler-build/rust/src/stage0.rs
@@ -463,14 +463,32 @@ impl PyStage0Build {
         }
     }
 
-    /// Get the build script configuration
+    /// Get the build script configuration, if this build uses script mode.
     #[getter]
-    fn script(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
-        let json_value =
-            serde_json::to_value(&self.inner.script).map_err(RattlerBuildError::from)?;
-        pythonize::pythonize(py, &json_value)
-            .map(|obj| obj.into())
-            .map_err(|e| RattlerBuildError::RecipeParse(format!("{}", e)).into())
+    fn script(&self, py: Python<'_>) -> PyResult<Option<Py<PyAny>>> {
+        match self.inner.plan.script() {
+            Some(script) => {
+                let json_value = serde_json::to_value(script).map_err(RattlerBuildError::from)?;
+                let py_value = pythonize::pythonize(py, &json_value)
+                    .map_err(|e| RattlerBuildError::RecipeParse(format!("{}", e)))?;
+                Ok(Some(py_value.into()))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Get the build steps, if this build uses steps mode.
+    #[getter]
+    fn steps(&self, py: Python<'_>) -> PyResult<Option<Py<PyAny>>> {
+        match self.inner.plan.steps() {
+            Some(steps) => {
+                let json_value = serde_json::to_value(steps).map_err(RattlerBuildError::from)?;
+                let py_value = pythonize::pythonize(py, &json_value)
+                    .map_err(|e| RattlerBuildError::RecipeParse(format!("{}", e)))?;
+                Ok(Some(py_value.into()))
+            }
+            None => Ok(None),
+        }
     }
 
     /// Get the noarch type (may be a template or None)

--- a/py-rattler-build/rust/src/stage1.rs
+++ b/py-rattler-build/rust/src/stage1.rs
@@ -174,12 +174,29 @@ impl PyStage1Build {
     }
 
     #[getter]
-    fn script(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
-        let json_value =
-            serde_json::to_value(&self.inner.script).map_err(RattlerBuildError::from)?;
-        pythonize::pythonize(py, &json_value)
-            .map(|obj| obj.into())
-            .map_err(|e| RattlerBuildError::RecipeParse(format!("{}", e)).into())
+    fn script(&self, py: Python<'_>) -> PyResult<Option<Py<PyAny>>> {
+        match self.inner.plan.script() {
+            Some(script) => {
+                let json_value = serde_json::to_value(script).map_err(RattlerBuildError::from)?;
+                let py_value = pythonize::pythonize(py, &json_value)
+                    .map_err(|e| RattlerBuildError::RecipeParse(format!("{}", e)))?;
+                Ok(Some(py_value.into()))
+            }
+            None => Ok(None),
+        }
+    }
+
+    #[getter]
+    fn steps(&self, py: Python<'_>) -> PyResult<Option<Py<PyAny>>> {
+        match self.inner.plan.steps() {
+            Some(steps) => {
+                let json_value = serde_json::to_value(steps).map_err(RattlerBuildError::from)?;
+                let py_value = pythonize::pythonize(py, &json_value)
+                    .map_err(|e| RattlerBuildError::RecipeParse(format!("{}", e)))?;
+                Ok(Some(py_value.into()))
+            }
+            None => Ok(None),
+        }
     }
 
     #[getter]

--- a/py-rattler-build/src/rattler_build/stage0.py
+++ b/py-rattler-build/src/rattler_build/stage0.py
@@ -301,6 +301,7 @@ class Stage0Recipe(ABC):
         no_include_recipe: bool = False,
         exclude_newer: datetime | None = None,
         env_isolation: EnvironmentIsolation = EnvironmentIsolation.STRICT,
+        render_config: RenderConfig | None = None,
     ) -> list[BuildResult]:
         """Build this recipe.
 
@@ -320,6 +321,7 @@ class Stage0Recipe(ABC):
             no_include_recipe: Don't include recipe in the output package.
             exclude_newer: Exclude packages newer than this timestamp.
             env_isolation: Environment isolation mode. Defaults to ``EnvironmentIsolation.STRICT``.
+            render_config: Optional RenderConfig to use when rendering before building.
 
         Returns:
             list[BuildResult]: List of build results, one per variant built.
@@ -341,7 +343,7 @@ class Stage0Recipe(ABC):
         """
 
         # Render the recipe to get Stage1 variants
-        rendered_variants = self.render(variant_config)
+        rendered_variants = self.render(variant_config, render_config)
 
         # Build each rendered variant using its run_build method
         results: list[BuildResult] = []
@@ -538,9 +540,14 @@ class Build:
         return self._inner.string
 
     @property
-    def script(self) -> Any:
-        """Get the build script configuration."""
+    def script(self) -> Any | None:
+        """Get the build script configuration, if this build uses script mode."""
         return self._inner.script
+
+    @property
+    def steps(self) -> Any | None:
+        """Get the build steps, if this build uses steps mode."""
+        return self._inner.steps
 
     @property
     def noarch(self) -> Any | None:

--- a/py-rattler-build/src/rattler_build/stage1.py
+++ b/py-rattler-build/src/rattler_build/stage1.py
@@ -129,9 +129,14 @@ class Build:
         return self._inner.string
 
     @property
-    def script(self) -> Any:
-        """Get the build script."""
+    def script(self) -> Any | None:
+        """Get the build script, if this build uses script mode."""
         return self._inner.script
+
+    @property
+    def steps(self) -> Any | None:
+        """Get the build steps, if this build uses steps mode."""
+        return self._inner.steps
 
     @property
     def noarch(self) -> Any | None:

--- a/py-rattler-build/tests/unit/test_recipe_api.py
+++ b/py-rattler-build/tests/unit/test_recipe_api.py
@@ -71,6 +71,41 @@ def test_recipe_all_sections() -> None:
     assert "https://github.com/example/test-package" == about.repository
 
 
+def test_run_build_passes_render_config(monkeypatch, tmp_path: Path) -> None:
+    """Stage0Recipe.run_build forwards render configuration."""
+    recipe = Stage0Recipe.from_yaml(
+        """
+package:
+  name: test-package
+  version: 1.0.0
+""",
+        recipe_dir=tmp_path,
+    )
+    platform = PlatformConfig(target_platform="linux-64", experimental=True)
+    render_config = RenderConfig(platform=platform)
+    captured: dict[str, object] = {}
+
+    class FakeVariant:
+        def run_build(self, **kwargs: object) -> str:
+            captured["run_build_kwargs"] = kwargs
+            return "built"
+
+    def fake_render(
+        variant_config: VariantConfig | None = None,
+        render_config: RenderConfig | None = None,
+    ) -> list[FakeVariant]:
+        captured["variant_config"] = variant_config
+        captured["render_config"] = render_config
+        return [FakeVariant()]
+
+    monkeypatch.setattr(recipe, "render", fake_render)
+
+    result = recipe.run_build(render_config=render_config)
+
+    assert result == ["built"]
+    assert captured["render_config"] is render_config
+
+
 def test_recipe_representations() -> None:
     """Test string representations of Stage0 and Stage1 objects."""
     stage0 = Stage0Recipe.from_file(str(TEST_RECIPE_FILE))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -577,6 +577,7 @@ pub async fn get_build_output(
                 ),
                 store_recipe: !build_data.no_include_recipe,
                 force_colors: build_data.color_build_log && console::colors_enabled(),
+                experimental: build_data.common.experimental,
                 env_isolation: build_data.env_isolation,
                 sandbox_config: build_data.sandbox_configuration.clone(),
                 exclude_newer: build_data.exclude_newer,
@@ -1105,6 +1106,10 @@ pub async fn rebuild_package_core(
     };
     output.system_tools.warn_if_changed(&current_build_tool);
     output.system_tools = SystemTools::new("rattler-build", env!("CARGO_PKG_VERSION"));
+
+    // Set invocation-only build configuration that is not serialized into the
+    // package's rendered recipe.
+    output.build_configuration.experimental = rebuild_data.common.experimental;
 
     // set recipe dir to the temp folder
     output.build_configuration.directories.recipe_dir = temp_dir;

--- a/test-data/recipes/build_steps/recipe.yaml
+++ b/test-data/recipes/build_steps/recipe.yaml
@@ -1,0 +1,41 @@
+package:
+  name: build_steps_test
+  version: "1.0.0"
+
+build:
+  number: 0
+  # Exercises `build.steps`: ordered run steps, per-step `if`, and step-local
+  # `env`. Each step becomes one scoped section of the generated build wrapper.
+  steps:
+    - if: unix
+      run: |
+        mkdir -p "$PREFIX/share/build_steps/cwd"
+        echo "one" > "$PREFIX/share/build_steps/step1.txt"
+    - if: unix
+      run: echo "${{ GREETING }}" > "$PREFIX/share/build_steps/step2.txt"
+      env:
+        GREETING: hello-from-step
+    - if: unix
+      run: printf '%s\n' "${GREETING:-unset}" > "$PREFIX/share/build_steps/step3.txt"
+    - if: unix
+      cwd: share/build_steps/cwd
+      run: pwd > pwd.txt
+
+    - if: win
+      run: |
+        if not exist "%PREFIX%\share\build_steps\cwd" mkdir "%PREFIX%\share\build_steps\cwd"
+        echo one> "%PREFIX%\share\build_steps\step1.txt"
+    - if: win
+      run: echo ${{ GREETING }}> "%PREFIX%\share\build_steps\step2.txt"
+      env:
+        GREETING: hello-from-step
+    - if: win
+      run: |
+        if defined GREETING (
+          echo %GREETING%> "%PREFIX%\share\build_steps\step3.txt"
+        ) else (
+          echo unset> "%PREFIX%\share\build_steps\step3.txt"
+        )
+    - if: win
+      cwd: share\build_steps\cwd
+      run: cd > pwd.txt

--- a/test-data/recipes/default_build_script/build.bat
+++ b/test-data/recipes/default_build_script/build.bat
@@ -1,0 +1,2 @@
+if not exist "%PREFIX%\share\default_build_script" mkdir "%PREFIX%\share\default_build_script"
+echo default-build-script> "%PREFIX%\share\default_build_script\marker.txt"

--- a/test-data/recipes/default_build_script/build.sh
+++ b/test-data/recipes/default_build_script/build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p "$PREFIX/share/default_build_script"
+echo default-build-script > "$PREFIX/share/default_build_script/marker.txt"

--- a/test-data/recipes/default_build_script/recipe.yaml
+++ b/test-data/recipes/default_build_script/recipe.yaml
@@ -1,0 +1,6 @@
+package:
+  name: default_build_script_test
+  version: "1.0.0"
+
+build:
+  number: 0

--- a/test/end-to-end/test_build_steps.py
+++ b/test/end-to-end/test_build_steps.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+from helpers import RattlerBuild, get_extracted_package
+
+
+def test_build_steps(rattler_build: RattlerBuild, recipes: Path, tmp_path: Path):
+    """`build.steps` compiles into the generated wrapper and runs in order.
+
+    Run steps execute as scoped sections: one writes via the build-time
+    `$PREFIX`, one uses step-local `env`, one proves env does not leak, and one
+    runs from a step-local `cwd`.
+    """
+    rattler_build.build(
+        recipes / "build_steps", tmp_path, extra_args=["--experimental"]
+    )
+    pkg = get_extracted_package(tmp_path, "build_steps_test")
+
+    step1 = pkg / "share" / "build_steps" / "step1.txt"
+    step2 = pkg / "share" / "build_steps" / "step2.txt"
+    step3 = pkg / "share" / "build_steps" / "step3.txt"
+    cwd_pwd = pkg / "share" / "build_steps" / "cwd" / "pwd.txt"
+
+    assert step1.exists(), "first step did not run"
+    assert step2.exists(), "second step did not run"
+    assert step3.exists(), "third step did not run"
+    assert cwd_pwd.exists(), "cwd step did not run in its target directory"
+    assert "hello-from-step" in step2.read_text(), (
+        "step-local env did not reach the section"
+    )
+    assert "unset" in step3.read_text(), "step-local env leaked to a later section"
+
+
+def test_default_build_script_still_runs(
+    rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
+):
+    """A legacy build.sh/build.bat is still discovered when no script is declared."""
+    rattler_build.build(recipes / "default_build_script", tmp_path)
+    pkg = get_extracted_package(tmp_path, "default_build_script_test")
+
+    marker = pkg / "share" / "default_build_script" / "marker.txt"
+    assert marker.exists(), "default build script did not run"
+    assert "default-build-script" in marker.read_text()

--- a/test/end-to-end/test_debug.py
+++ b/test/end-to-end/test_debug.py
@@ -63,7 +63,7 @@ def test_debug_multiple_outputs(
     # checking for build scripts to see if they were created
     if platform.system() == "Windows":
         assert (work_dir / "conda_build.bat").exists()
-        with open(work_dir / "conda_build.bat") as f:
+        with open(work_dir / "conda_build_script.bat") as f:
             content = f.read()
             assert "Building output1" in content
     else:
@@ -94,7 +94,7 @@ def test_debug_multiple_outputs(
 
     if platform.system() == "Windows":
         assert (work_dir / "conda_build.bat").exists()
-        with open(work_dir / "conda_build.bat") as f:
+        with open(work_dir / "conda_build_script.bat") as f:
             content = f.read()
             assert "Building output2" in content
     else:


### PR DESCRIPTION
## What

Adds experimental `build.steps` as an alternative to `build.script` for package outputs.

Each step runs as an isolated section of the generated build wrapper and can define its own `if` condition, `interpreter`, `cwd`, and `env`. Environment and shell state from one step do not leak into later steps, and a failing step stops the build.

```yaml
build:
  steps:
    - if: unix
      run: make
    - run: make install
      env:
        DESTDIR: $PREFIX
```

`script` and `steps` are mutually exclusive. Existing recipes using `build.script` or the default `build.sh` / `build.bat` keep their current behavior.

The new syntax currently only supports `run` steps and requires `--experimental`. The stage 0 and stage 1 Rust and Python recipe APIs expose the build plan as either a script or steps.

## Testing

- `pixi run build-release`
- `pixi run pytest test/end-to-end/test_build_steps.py -v`
