### PR TITLE
feat(build-steps): support steps in staging outputs

### DIFF
--- a/crates/rattler_build_core/src/script.rs
+++ b/crates/rattler_build_core/src/script.rs
@@ -3,9 +3,14 @@
 //! This module provides integration between Rattler-Build and the rattler_build_script crate,
 //! specifically handling the execution of build scripts within the Output context.
 
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
+
 use indexmap::IndexMap;
 use minijinja::Value;
-use rattler_build_jinja::Jinja;
+use rattler_build_jinja::{Jinja, JinjaConfig, Variable};
 
 // Re-export from rattler_build_script
 pub use rattler_build_script::{
@@ -14,11 +19,119 @@ pub use rattler_build_script::{
     platform_script_extensions,
 };
 
-use crate::{
-    env_vars::{self},
-    metadata::Output,
-};
+use crate::{env_vars, metadata::Output};
 use rattler_build_recipe::stage1::build::BuildPlan;
+
+/// Prepare execution arguments for a stage1 build plan.
+///
+/// Package outputs and staging outputs intentionally share this implementation
+/// so `build.script` and `build.steps` resolve content, env, cwd, secrets, and
+/// labels the same way in both places.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn prepare_build_plan_execution_args(
+    plan: &BuildPlan,
+    recipe_context: &IndexMap<String, Variable>,
+    selector_config: JinjaConfig,
+    mut env_vars: HashMap<String, Option<String>>,
+    work_dir: PathBuf,
+    recipe_dir: &Path,
+    context: ExecutionContext,
+    sandbox_config: Option<SandboxConfiguration>,
+    env_isolation: rattler_build_script::EnvironmentIsolation,
+    experimental: bool,
+) -> Result<ExecutionArgs, std::io::Error> {
+    if matches!(plan, BuildPlan::Steps(_)) && !experimental {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "`build.steps` is an experimental feature: provide the `--experimental` flag to enable it",
+        ));
+    }
+
+    if let Some(architecture) = context.windows_processor_architecture() {
+        env_vars.insert(
+            "PROCESSOR_ARCHITECTURE".to_string(),
+            Some(architecture.to_string()),
+        );
+    }
+    if let Some(wow64_architecture) = context.windows_processor_architecture_w6432() {
+        env_vars.insert(
+            "PROCESSOR_ARCHITEW6432".to_string(),
+            Some(wow64_architecture.unwrap_or_default().to_string()),
+        );
+    }
+
+    let mut env_vars: IndexMap<String, String> = env_vars
+        .into_iter()
+        .filter_map(|(key, value)| value.map(|value| (key, value)))
+        .collect();
+    if let BuildPlan::Script(script) = plan {
+        env_vars.extend(script.env().clone());
+    }
+
+    let scripts: Vec<(Script, Option<usize>)> = match plan {
+        BuildPlan::Steps(steps) => steps
+            .iter()
+            .enumerate()
+            .map(|(index, step)| (step.to_script(), Some(index)))
+            .collect(),
+        BuildPlan::Script(script) => vec![(script.clone(), None)],
+    };
+
+    let mut secrets = IndexMap::new();
+    let mut sections = Vec::with_capacity(scripts.len());
+    for (script, step_index) in scripts {
+        let mut section_jinja = Jinja::new(selector_config.clone()).with_context(recipe_context);
+        for (key, value) in env_vars.iter().chain(script.env()) {
+            section_jinja
+                .context_mut()
+                .insert(key.clone(), Value::from_safe_string(value.clone()));
+        }
+        let section_jinja_renderer = |template: &str| {
+            section_jinja
+                .render_str(template)
+                .map_err(|error| error.to_string())
+        };
+        let content = script.resolve_content(
+            recipe_dir,
+            Some(&section_jinja_renderer),
+            platform_script_extensions(),
+        )?;
+
+        for name in script.secrets() {
+            if let Some(value) = context.runtime().var(name) {
+                secrets.insert(name.to_string(), value.to_string());
+            } else {
+                tracing::warn!("Secret {} not found in environment", name);
+            }
+        }
+
+        let cwd = script
+            .cwd
+            .as_ref()
+            .map(|cwd| context.host().path().join(cwd));
+        sections.push(BuildScriptSection {
+            interpreter: script.interpreter.clone(),
+            content,
+            env: if step_index.is_some() {
+                script.env().clone()
+            } else {
+                Default::default()
+            },
+            cwd,
+            label: step_index.map(|index| format!("step {index}")),
+        });
+    }
+
+    Ok(ExecutionArgs {
+        sections,
+        env_vars,
+        secrets,
+        context,
+        work_dir,
+        sandbox_config,
+        env_isolation,
+    })
+}
 
 impl Output {
     /// Helper function to get a jinja renderer for the output's recipe context.
@@ -39,12 +152,6 @@ impl Output {
         let host_platform = self.host_platform().platform;
         let env_isolation = self.build_configuration.env_isolation;
         let build = self.recipe.build();
-        if matches!(&build.plan, BuildPlan::Steps(_)) && !self.build_configuration.experimental {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                "`build.steps` is an experimental feature: provide the `--experimental` flag to enable it",
-            ));
-        }
         let runtime = RuntimeEnv::current();
         let context = if build.merge_build_and_host_envs {
             ExecutionContext::shared(
@@ -74,94 +181,18 @@ impl Output {
             context.runtime(),
         ));
         env_vars.extend(env_vars::env_vars_from_variant(self.variant()));
-        if let Some(architecture) = context.windows_processor_architecture() {
-            env_vars.insert(
-                "PROCESSOR_ARCHITECTURE".to_string(),
-                Some(architecture.to_string()),
-            );
-        }
-        if let Some(wow64_architecture) = context.windows_processor_architecture_w6432() {
-            env_vars.insert(
-                "PROCESSOR_ARCHITEW6432".to_string(),
-                Some(wow64_architecture.unwrap_or_default().to_string()),
-            );
-        }
-
-        let mut env_vars: IndexMap<String, String> = env_vars
-            .into_iter()
-            .filter_map(|(k, v)| v.map(|v| (k, v)))
-            .collect();
-        if let BuildPlan::Script(script) = &build.plan {
-            env_vars.extend(script.env().clone());
-        }
-
-        let recipe_dir = &self.build_configuration.directories.recipe_dir;
-        let scripts: Vec<(Script, Option<usize>)> = match &build.plan {
-            BuildPlan::Steps(steps) => steps
-                .iter()
-                .enumerate()
-                .map(|(index, step)| (step.to_script(), Some(index)))
-                .collect(),
-            BuildPlan::Script(script) => vec![(script.clone(), None)],
-        };
-
-        let mut secrets = IndexMap::new();
-        let work_dir = self.build_configuration.directories.work_dir.clone();
-        let mut sections = Vec::with_capacity(scripts.len());
-
-        for (script, step_index) in scripts {
-            let mut section_jinja = Jinja::new(self.build_configuration.selector_config())
-                .with_context(&self.recipe.context);
-            for (key, value) in env_vars.iter().chain(script.env()) {
-                section_jinja
-                    .context_mut()
-                    .insert(key.clone(), Value::from_safe_string(value.clone()));
-            }
-            let section_jinja_renderer = |template: &str| {
-                section_jinja
-                    .render_str(template)
-                    .map_err(|err| err.to_string())
-            };
-            let content = script.resolve_content(
-                recipe_dir,
-                Some(&section_jinja_renderer),
-                platform_script_extensions(),
-            )?;
-
-            for name in script.secrets() {
-                if let Some(value) = context.runtime().var(name) {
-                    secrets.insert(name.to_string(), value.to_string());
-                } else {
-                    tracing::warn!("Secret {} not found in environment", name);
-                }
-            }
-
-            let cwd = script
-                .cwd
-                .as_ref()
-                .map(|cwd| context.host().path().join(cwd));
-            sections.push(BuildScriptSection {
-                interpreter: script.interpreter.clone(),
-                content,
-                env: if step_index.is_some() {
-                    script.env().clone()
-                } else {
-                    Default::default()
-                },
-                cwd,
-                label: step_index.map(|index| format!("step {index}")),
-            });
-        }
-
-        Ok(ExecutionArgs {
-            sections,
+        prepare_build_plan_execution_args(
+            &build.plan,
+            &self.recipe.context,
+            self.build_configuration.selector_config(),
             env_vars,
-            secrets,
+            self.build_configuration.directories.work_dir.clone(),
+            &self.build_configuration.directories.recipe_dir,
             context,
-            work_dir,
-            sandbox_config: self.build_configuration.sandbox_config().cloned(),
+            self.build_configuration.sandbox_config().cloned(),
             env_isolation,
-        })
+            self.build_configuration.experimental,
+        )
     }
 
     /// Run the build script for the output as defined in the recipe's build section.

--- a/crates/rattler_build_core/src/staging.rs
+++ b/crates/rattler_build_core/src/staging.rs
@@ -11,9 +11,8 @@ use std::{
 
 use fs_err as fs;
 use miette::{Context, IntoDiagnostic};
-use minijinja::Value;
-use rattler_build_jinja::{Jinja, Variable};
-use rattler_build_recipe::stage1::{BuildPlan, InheritsFrom, StagingCache};
+use rattler_build_jinja::Variable;
+use rattler_build_recipe::stage1::{InheritsFrom, StagingCache};
 use rattler_build_script::{ExecutionContext, RuntimeEnv};
 use rattler_build_types::NormalizedKey;
 use serde::{Deserialize, Serialize};
@@ -27,6 +26,7 @@ use crate::{
     render::resolved_dependencies::{
         FinalizedDependencies, RunExportsDownload, install_environments, resolve_dependencies,
     },
+    script::prepare_build_plan_execution_args,
     source::{copy_dir::CopyDir, fetch_sources},
     utils::remove_dir_all_force,
 };
@@ -81,18 +81,6 @@ pub struct StagingCacheMetadata {
     /// physically installed in the host prefix.
     #[serde(default)]
     pub library_name_map: LibraryNameMap,
-}
-
-fn staging_build_script(
-    staging: &StagingCache,
-) -> Result<&rattler_build_script::Script, miette::Error> {
-    match &staging.build.plan {
-        BuildPlan::Script(script) => Ok(script),
-        BuildPlan::Steps(_) => Err(miette::miette!(
-            "staging cache `{}` uses `build.steps`, but staging builds only support `build.script`",
-            staging.name
-        )),
-    }
 }
 
 impl Output {
@@ -318,28 +306,6 @@ impl Output {
             env_vars.remove(key);
         }
 
-        // Create Jinja context
-        let selector_config = self.build_configuration.selector_config();
-        let mut jinja = Jinja::new(selector_config.clone());
-
-        // Add context from the recipe
-        for (k, v) in self.recipe.context().iter() {
-            jinja.context_mut().insert(k.clone(), v.clone().into());
-        }
-
-        // Add env vars to jinja context
-        for (k, v) in &env_vars {
-            if let Some(value) = v {
-                jinja
-                    .context_mut()
-                    .insert(k.clone(), Value::from_safe_string(value.clone()));
-            }
-        }
-
-        let jinja_renderer = |template: &str| -> Result<String, String> {
-            jinja.render_str(template).map_err(|e| e.to_string())
-        };
-
         let context = if staging.build.merge_build_and_host_envs {
             ExecutionContext::shared(
                 runtime.clone(),
@@ -357,16 +323,20 @@ impl Output {
             )
         };
 
-        staging_build_script(staging)?
-            .run_script(
-                env_vars,
-                &self.build_configuration.directories.work_dir,
-                &self.build_configuration.directories.recipe_dir,
-                context,
-                Some(jinja_renderer),
-                self.build_configuration.sandbox_config(),
-                self.build_configuration.env_isolation,
-            )
+        let exec_args = prepare_build_plan_execution_args(
+            &staging.build.plan,
+            self.recipe.context(),
+            self.build_configuration.selector_config(),
+            env_vars,
+            self.build_configuration.directories.work_dir.clone(),
+            &self.build_configuration.directories.recipe_dir,
+            context,
+            self.build_configuration.sandbox_config().cloned(),
+            self.build_configuration.env_isolation,
+            self.build_configuration.experimental,
+        )
+        .into_diagnostic()?;
+        rattler_build_script::run_script(exec_args)
             .await
             .into_diagnostic()?;
 
@@ -598,14 +568,25 @@ pub fn should_inherit_run_exports(inherits: &InheritsFrom) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rattler_build_recipe::stage1::{Build, Requirements};
+    use rattler_build_jinja::JinjaConfig;
+    use rattler_build_recipe::stage1::{
+        Build, Requirements,
+        build::{BuildPlan, Step, StepRun},
+    };
+    use rattler_build_script::EnvironmentIsolation;
 
     #[test]
-    fn staging_build_steps_returns_error_instead_of_panicking() {
+    fn staging_build_steps_prepare_as_sections() {
         let staging = StagingCache::new(
             "compile".to_string(),
             Build {
-                plan: BuildPlan::Steps(Vec::new()),
+                plan: BuildPlan::Steps(vec![Step {
+                    run: StepRun::Commands(vec!["echo hi".to_string()]),
+                    env: [("FOO".to_string(), "bar".to_string())]
+                        .into_iter()
+                        .collect(),
+                    ..Default::default()
+                }]),
                 ..Default::default()
             },
             Requirements::default(),
@@ -613,11 +594,26 @@ mod tests {
             BTreeMap::new(),
         );
 
-        let err = staging_build_script(&staging).unwrap_err();
+        let args = prepare_build_plan_execution_args(
+            &staging.build.plan,
+            &indexmap::IndexMap::new(),
+            JinjaConfig::default(),
+            std::collections::HashMap::new(),
+            PathBuf::from("."),
+            Path::new("."),
+            PathBuf::from("."),
+            None,
+            None,
+            EnvironmentIsolation::default(),
+            true,
+        )
+        .unwrap();
 
-        assert!(
-            err.to_string().contains("staging builds only support"),
-            "unexpected error: {err}"
+        assert_eq!(args.sections.len(), 1);
+        assert_eq!(args.sections[0].label.as_deref(), Some("step 0"));
+        assert_eq!(
+            args.sections[0].env.get("FOO").map(String::as_str),
+            Some("bar")
         );
     }
 }

--- a/crates/rattler_build_core/src/staging.rs
+++ b/crates/rattler_build_core/src/staging.rs
@@ -574,6 +574,7 @@ mod tests {
         build::{BuildPlan, Step, StepRun},
     };
     use rattler_build_script::EnvironmentIsolation;
+    use rattler_conda_types::Platform;
 
     #[test]
     fn staging_build_steps_prepare_as_sections() {
@@ -601,8 +602,12 @@ mod tests {
             std::collections::HashMap::new(),
             PathBuf::from("."),
             Path::new("."),
-            PathBuf::from("."),
-            None,
+            ExecutionContext::shared(
+                RuntimeEnv::for_test(Platform::current()),
+                Path::new("."),
+                Platform::current(),
+                Platform::current(),
+            ),
             None,
             EnvironmentIsolation::default(),
             true,

--- a/crates/rattler_build_recipe/src/stage0/build.rs
+++ b/crates/rattler_build_recipe/src/stage0/build.rs
@@ -154,15 +154,10 @@ impl BuildPlan {
 
     /// Collect all variables used in the build plan.
     pub fn used_variables(&self) -> Vec<String> {
-        let mut vars = Vec::new();
-        match self {
-            Self::Script(script) => vars.extend(script.used_variables()),
-            Self::Steps(steps) => {
-                for step in steps {
-                    vars.extend(step.used_variables());
-                }
-            }
-        }
+        let mut vars: Vec<_> = match self {
+            Self::Script(script) => script.used_variables(),
+            Self::Steps(steps) => steps.iter().flat_map(Step::used_variables).collect(),
+        };
         vars.sort();
         vars.dedup();
         vars

--- a/crates/rattler_build_recipe/src/stage0/evaluate.rs
+++ b/crates/rattler_build_recipe/src/stage0/evaluate.rs
@@ -521,12 +521,12 @@ pub fn evaluate_optional_string_value(
     }
 }
 
-/// Extract the template source from a Value<String> without evaluating it
-/// This is used for deferred evaluation (e.g., build.string with hash variable)
-fn extract_template_source(value: &Value<String>) -> Option<String> {
+/// Extract the original string from a `Value<String>` without evaluating templates.
+/// This is used for deferred/lazy evaluation (e.g., build.string or build scripts).
+fn string_value_source(value: &Value<String>) -> String {
     match value.inner() {
-        ValueInner::Concrete(v) => Some(v.clone()),
-        ValueInner::Template(template) => Some(template.source().to_string()),
+        ValueInner::Concrete(v) => v.clone(),
+        ValueInner::Template(template) => template.source().to_string(),
     }
 }
 
@@ -573,15 +573,8 @@ fn evaluate_or_preserve_template(
     // Try to evaluate
     match evaluate_string_value(value, context) {
         Ok(result) => Ok(result),
-        Err(e) => {
-            if is_undefined_variable_error(&e) {
-                // This is an undefined variable error - preserve the template
-                Ok(extract_template_source(value).unwrap_or_default())
-            } else {
-                // This is a different error (syntax error, etc.) - propagate it
-                Err(e)
-            }
-        }
+        Err(e) if is_undefined_variable_error(&e) => Ok(string_value_source(value)),
+        Err(e) => Err(e),
     }
 }
 
@@ -924,7 +917,7 @@ pub fn preserve_string_list(
         track_template_variables(value, ctx);
 
         // Extract the original string value without evaluating templates
-        let s = extract_template_source(value).unwrap_or_default();
+        let s = string_value_source(value);
         // Filter out empty strings
         Ok(if s.is_empty() { None } else { Some(s) })
     })
@@ -1273,11 +1266,11 @@ pub fn evaluate_script(
     }
 
     // Evaluate interpreter normally (it's typically simple and doesn't use env vars)
-    let interpreter = if let Some(interp) = &script.interpreter {
-        Some(evaluate_string_value(interp, context)?)
-    } else {
-        None
-    };
+    let interpreter = script
+        .interpreter
+        .as_ref()
+        .map(|interp| evaluate_string_value(interp, context))
+        .transpose()?;
 
     let env = evaluate_env_map("script.env", &script.env, context)?;
 
@@ -1285,11 +1278,11 @@ pub fn evaluate_script(
     let secrets = script.secrets.clone();
 
     // Evaluate cwd normally (it's a path, not a script command)
-    let cwd = if let Some(cwd_val) = &script.cwd {
-        Some(PathBuf::from(evaluate_string_value(cwd_val, context)?))
-    } else {
-        None
-    };
+    let cwd = script
+        .cwd
+        .as_ref()
+        .map(|cwd| evaluate_string_value(cwd, context).map(PathBuf::from))
+        .transpose()?;
 
     // For content: evaluate conditionals but preserve templates with undefined vars
     let (content, inferred_interpreter) = if let Some(file_val) = &script.file {
@@ -1376,14 +1369,16 @@ pub fn evaluate_steps(
                     continue;
                 }
 
-                let interpreter = match &run.interpreter {
-                    Some(interpreter) => Some(evaluate_string_value(interpreter, context)?),
-                    None => None,
-                };
-                let cwd = match &run.cwd {
-                    Some(cwd) => Some(PathBuf::from(evaluate_string_value(cwd, context)?)),
-                    None => None,
-                };
+                let interpreter = run
+                    .interpreter
+                    .as_ref()
+                    .map(|interpreter| evaluate_string_value(interpreter, context))
+                    .transpose()?;
+                let cwd = run
+                    .cwd
+                    .as_ref()
+                    .map(|cwd| evaluate_string_value(cwd, context).map(PathBuf::from))
+                    .transpose()?;
 
                 scripts.push(Stage1Step::new(rattler_build_script::Script {
                     interpreter,
@@ -1397,6 +1392,27 @@ pub fn evaluate_steps(
     }
 
     Ok(scripts)
+}
+
+fn evaluate_build_plan(
+    plan: &Stage0BuildPlan,
+    context: &EvaluationContext,
+) -> Result<Stage1BuildPlan, ParseError> {
+    match plan {
+        Stage0BuildPlan::Steps(steps) => {
+            if !context.jinja_config().experimental {
+                return Err(ParseError::invalid_value(
+                    "build.steps",
+                    "`build.steps` is an experimental feature: provide the `--experimental` flag to enable it",
+                    Span::new_blank(),
+                ));
+            }
+            Ok(Stage1BuildPlan::Steps(evaluate_steps(steps, context)?))
+        }
+        Stage0BuildPlan::Script(script) => {
+            Ok(Stage1BuildPlan::Script(evaluate_script(script, context)?))
+        }
+    }
 }
 
 fn evaluate_env_map(
@@ -2148,7 +2164,7 @@ impl Evaluate for Stage0Build {
                 // Track variables without failing on undefined
                 track_template_variables(s, context);
 
-                let template = extract_template_source(s).unwrap();
+                let template = string_value_source(s);
                 crate::stage1::build::BuildString::unresolved(template, s.span().cloned())
             });
 
@@ -2161,21 +2177,7 @@ impl Evaluate for Stage0Build {
         // (enforced during parsing). Steps mode is preserved even if the list is
         // empty or all steps filter out, so outputs don't accidentally inherit a
         // top-level script.
-        let plan = match &self.plan {
-            Stage0BuildPlan::Steps(steps) => {
-                if !context.jinja_config().experimental {
-                    return Err(ParseError::invalid_value(
-                        "build.steps",
-                        "`build.steps` is an experimental feature: provide the `--experimental` flag to enable it",
-                        Span::new_blank(),
-                    ));
-                }
-                Stage1BuildPlan::Steps(evaluate_steps(steps, context)?)
-            }
-            Stage0BuildPlan::Script(script) => {
-                Stage1BuildPlan::Script(evaluate_script(script, context)?)
-            }
-        };
+        let plan = evaluate_build_plan(&self.plan, context)?;
 
         // Evaluate noarch
         //
@@ -2293,6 +2295,17 @@ impl Evaluate for Stage0Build {
             variant,
             prefix_detection,
             post_process,
+        })
+    }
+}
+
+impl Evaluate for stage0::StagingBuild {
+    type Output = Stage1Build;
+
+    fn evaluate(&self, context: &EvaluationContext) -> Result<Self::Output, ParseError> {
+        Ok(Stage1Build {
+            plan: evaluate_build_plan(&self.plan, context)?,
+            ..Stage1Build::default()
         })
     }
 }
@@ -3494,12 +3507,7 @@ impl Evaluate for crate::stage0::MultiOutputRecipe {
                     evaluate_string_value(&staging_output.staging.name, &context_with_vars)?;
 
                 // Evaluate staging output components
-                let script = evaluate_script(&staging_output.build.script, &context_with_vars)?;
-                let build = crate::stage1::Build {
-                    plan: Stage1BuildPlan::Script(script),
-                    ..crate::stage1::Build::default()
-                };
-
+                let build = staging_output.build.evaluate(&context_with_vars)?;
                 let requirements = staging_output.requirements.evaluate(&context_with_vars)?;
 
                 // Staging outputs inherit top-level sources (prepend), then add their own
@@ -4343,6 +4351,127 @@ outputs:
                 assert!(!staging_cache.requirements.build.is_empty()); // Should have gcc, cmake
                 assert!(!staging_cache.requirements.host.is_empty()); // Should have zlib
                 assert!(staging_cache.requirements.run.is_empty()); // Staging has no run requirements
+            }
+            _ => panic!("Expected MultiOutputRecipe"),
+        }
+    }
+
+    #[test]
+    fn test_staging_build_script_and_steps_are_mutually_exclusive() {
+        let recipe_yaml = r#"
+schema_version: 1
+
+recipe:
+  name: myproject
+  version: 1.0.0
+
+outputs:
+  - staging:
+      name: build-cache
+    build:
+      script: echo script
+      steps: []
+"#;
+
+        let err = parse_recipe_or_multi_from_source(recipe_yaml).unwrap_err();
+        assert!(err.to_string().contains("mutually exclusive"), "{err}");
+    }
+
+    #[test]
+    fn test_staging_build_steps_requires_experimental() {
+        let recipe_yaml = r#"
+schema_version: 1
+
+recipe:
+  name: myproject
+  version: 1.0.0
+
+outputs:
+  - staging:
+      name: build-cache
+    build:
+      steps:
+        - run: echo staging
+
+  - package:
+      name: mylib
+      version: 1.0.0
+    inherit: build-cache
+"#;
+
+        let parsed = parse_recipe_or_multi_from_source(recipe_yaml).unwrap();
+
+        match parsed {
+            stage0::Recipe::MultiOutput(multi) => {
+                let ctx = EvaluationContext::for_platform(rattler_conda_types::Platform::Linux64);
+                let err = multi.evaluate(&ctx).unwrap_err();
+                assert!(err.to_string().contains("experimental"), "{err}");
+            }
+            _ => panic!("Expected MultiOutputRecipe"),
+        }
+    }
+
+    #[test]
+    fn test_staging_build_steps_evaluate_into_cache() {
+        let recipe_yaml = r#"
+schema_version: 1
+
+recipe:
+  name: myproject
+  version: 1.0.0
+
+outputs:
+  - staging:
+      name: build-cache
+    build:
+      steps:
+        - run: echo one
+        - if: target_platform == 'linux-64'
+          run: echo ${{ flavor }}
+          env:
+            FLAVOR: ${{ flavor }}
+
+  - package:
+      name: mylib
+      version: 1.0.0
+    inherit: build-cache
+"#;
+
+        let parsed = parse_recipe_or_multi_from_source(recipe_yaml).unwrap();
+
+        match parsed {
+            stage0::Recipe::MultiOutput(multi) => {
+                let mut variables = IndexMap::new();
+                variables.insert("flavor".to_string(), Variable::from("vanilla"));
+                let ctx = EvaluationContext::with_variables_and_config(
+                    variables,
+                    JinjaConfig {
+                        target_platform: rattler_conda_types::Platform::Linux64,
+                        host_platform: rattler_conda_types::Platform::Linux64,
+                        build_platform: rattler_conda_types::Platform::Linux64,
+                        experimental: true,
+                        ..Default::default()
+                    },
+                );
+
+                let recipes = multi.evaluate(&ctx).unwrap();
+                assert_eq!(recipes.len(), 1);
+
+                let staging_cache = &recipes[0].staging_caches[0];
+                let steps = staging_cache.build.plan.steps().expect("steps mode");
+                assert_eq!(steps.len(), 2);
+                assert_eq!(
+                    steps[0].run,
+                    Stage1StepRun::Commands(vec!["echo one".to_string()])
+                );
+                assert_eq!(
+                    steps[1].run,
+                    Stage1StepRun::Commands(vec!["echo ${{ flavor }}".to_string()])
+                );
+                assert_eq!(
+                    steps[1].env.get("FLAVOR").map(String::as_str),
+                    Some("vanilla")
+                );
             }
             _ => panic!("Expected MultiOutputRecipe"),
         }

--- a/crates/rattler_build_recipe/src/stage0/output.rs
+++ b/crates/rattler_build_recipe/src/stage0/output.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 
 use crate::stage0::{
     about::About,
-    build::Build,
+    build::{Build, BuildPlan},
     package::{Package, PackageMetadata},
     requirements::Requirements,
     source::Source,
@@ -126,7 +126,7 @@ pub struct StagingOutput {
     #[serde(default)]
     pub requirements: Requirements,
 
-    /// Build configuration (only script is allowed)
+    /// Build configuration.
     #[serde(default)]
     pub build: StagingBuild,
 }
@@ -138,17 +138,12 @@ pub struct StagingMetadata {
     pub name: Value<String>,
 }
 
-/// Build configuration for staging outputs
-///
-/// Only the script field is allowed for staging outputs.
+/// Build configuration for staging outputs.
 #[derive(Debug, Clone, PartialEq, Serialize, Default)]
 pub struct StagingBuild {
-    /// Build script - contains script content, interpreter, environment variables, etc.
-    #[serde(
-        default,
-        skip_serializing_if = "crate::stage0::types::Script::is_default"
-    )]
-    pub script: crate::stage0::types::Script,
+    /// Executable build plan: either a single legacy script or explicit steps.
+    #[serde(default, flatten)]
+    pub plan: BuildPlan,
 }
 
 /// Package output configuration
@@ -523,11 +518,7 @@ impl Inherit {
 impl StagingBuild {
     /// Get all used variables in staging build
     pub fn used_variables(&self) -> Vec<String> {
-        let mut vars = Vec::new();
-        vars.extend(self.script.used_variables());
-        vars.sort();
-        vars.dedup();
-        vars
+        self.plan.used_variables()
     }
 }
 

--- a/crates/rattler_build_recipe/src/stage0/parser/build.rs
+++ b/crates/rattler_build_recipe/src/stage0/parser/build.rs
@@ -375,7 +375,7 @@ fn parse_env_key(field_name: &str, key_node: &MarkedScalarNode) -> Result<String
 
 /// Parse build files field - can be a list or include/exclude mapping
 /// Parse the `build.steps` list into an ordered list of [`Step`]s.
-fn parse_steps(node: &Node) -> Result<Vec<Step>, ParseError> {
+pub(crate) fn parse_steps(node: &Node) -> Result<Vec<Step>, ParseError> {
     let sequence = node.as_sequence().ok_or_else(|| {
         ParseError::expected_type("sequence", "non-sequence", get_span(node))
             .with_message("Expected 'steps' to be a list of steps")
@@ -518,6 +518,47 @@ fn parse_step_content(node: &Node) -> Result<ConditionalList<String>, ParseError
     )
 }
 
+pub(crate) fn parse_build_plan_key(
+    plan: &mut BuildPlan,
+    key: &str,
+    value_node: &Node,
+    key_span: marked_yaml::Span,
+    script_seen: &mut bool,
+    steps_span: &mut Option<marked_yaml::Span>,
+) -> Result<bool, ParseError> {
+    match key {
+        "script" => {
+            *script_seen = true;
+            *plan = BuildPlan::Script(Box::new(parse_script(value_node)?));
+            Ok(true)
+        }
+        "steps" => {
+            *steps_span = Some(key_span);
+            *plan = BuildPlan::Steps(parse_steps(value_node)?);
+            Ok(true)
+        }
+        _ => Ok(false),
+    }
+}
+
+pub(crate) fn reject_script_and_steps(
+    script_seen: bool,
+    steps_span: Option<marked_yaml::Span>,
+) -> Result<(), ParseError> {
+    // A build unit uses either `script` or `steps`, never both. Even an empty
+    // `steps: []` list explicitly selects steps mode.
+    if script_seen && let Some(span) = steps_span {
+        return Err(ParseError::invalid_value(
+            "build",
+            "`script` and `steps` are mutually exclusive; use one or the other",
+            span,
+        )
+        .with_suggestion("Remove either `build.script` or `build.steps`"));
+    }
+
+    Ok(())
+}
+
 fn parse_build_files(node: &Node) -> Result<IncludeExclude, ParseError> {
     // Try parsing as a mapping with include/exclude first
     if let Some(mapping) = node.as_mapping() {
@@ -591,13 +632,15 @@ fn parse_build_from_mapping(mapping: &MarkedMappingNode) -> Result<Build, ParseE
             "string" => {
                 build.string = Some(parse_field!("build.string", value_node));
             }
-            "script" => {
-                script_seen = true;
-                build.plan = BuildPlan::Script(Box::new(parse_script(value_node)?));
-            }
-            "steps" => {
-                steps_span = Some(*key_node.span());
-                build.plan = BuildPlan::Steps(parse_steps(value_node)?);
+            "script" | "steps" => {
+                parse_build_plan_key(
+                    &mut build.plan,
+                    key,
+                    value_node,
+                    *key_node.span(),
+                    &mut script_seen,
+                    &mut steps_span,
+                )?;
             }
             "noarch" => {
                 build.noarch = Some(parse_noarch(value_node)?);
@@ -646,16 +689,7 @@ fn parse_build_from_mapping(mapping: &MarkedMappingNode) -> Result<Build, ParseE
         }
     }
 
-    // A build unit uses either `script` or `steps`, never both. Even an empty
-    // `steps: []` list explicitly selects steps mode.
-    if script_seen && let Some(span) = steps_span {
-        return Err(ParseError::invalid_value(
-            "build",
-            "`script` and `steps` are mutually exclusive; use one or the other",
-            span,
-        )
-        .with_suggestion("Remove either `build.script` or `build.steps`"));
-    }
+    reject_script_and_steps(script_seen, steps_span)?;
 
     Ok(build)
 }

--- a/crates/rattler_build_recipe/src/stage0/parser/output_parser.rs
+++ b/crates/rattler_build_recipe/src/stage0/parser/output_parser.rs
@@ -261,7 +261,7 @@ fn parse_staging_output(
         Requirements::default()
     };
 
-    // Parse optional build (only script allowed)
+    // Parse optional build plan.
     let build = if let Some(build_node) = mapping.get("build") {
         parse_staging_build(build_node)?
     } else {
@@ -351,7 +351,8 @@ fn parse_staging_requirements(yaml: &MarkedNode, config: ParseConfig) -> ParseRe
     super::requirements::parse_requirements_with_config(yaml, config)
 }
 
-/// Parse staging build (only script allowed)
+/// Parse staging build. Staging supports the same executable build plan as
+/// package outputs, but none of the package-only build settings.
 fn parse_staging_build(yaml: &MarkedNode) -> ParseResult<StagingBuild> {
     let mapping = yaml.as_mapping().ok_or_else(|| {
         ParseError::expected_type("mapping", "non-mapping", get_span(yaml))
@@ -359,29 +360,37 @@ fn parse_staging_build(yaml: &MarkedNode) -> ParseResult<StagingBuild> {
     })?;
 
     let mut build = StagingBuild::default();
+    let mut script_seen = false;
+    let mut steps_span = None;
 
     for (key_node, value_node) in mapping.iter() {
         let key = key_node.as_str();
 
-        match key {
-            "script" => {
-                build.script = crate::stage0::parser::build::parse_script(value_node)?;
-            }
-            _ => {
-                return Err(ParseError::invalid_value(
-                    "staging build",
-                    format!(
-                        "unknown field '{}' - only 'script' is allowed in staging builds",
-                        key
-                    ),
-                    *key_node.span(),
-                )
-                .with_suggestion(
-                    "staging outputs can only have a 'script' field in the build section",
-                ));
-            }
+        if crate::stage0::parser::build::parse_build_plan_key(
+            &mut build.plan,
+            key,
+            value_node,
+            *key_node.span(),
+            &mut script_seen,
+            &mut steps_span,
+        )? {
+            continue;
         }
+
+        return Err(ParseError::invalid_value(
+            "staging build",
+            format!(
+                "unknown field '{}' - only 'script' and 'steps' are allowed in staging builds",
+                key
+            ),
+            *key_node.span(),
+        )
+        .with_suggestion(
+            "staging outputs can only have 'script' or 'steps' in the build section",
+        ));
     }
+
+    crate::stage0::parser::build::reject_script_and_steps(script_seen, steps_span)?;
 
     Ok(build)
 }

--- a/crates/rattler_build_recipe/src/stage1/build.rs
+++ b/crates/rattler_build_recipe/src/stage1/build.rs
@@ -78,10 +78,7 @@ impl BuildString {
 
     /// Get the resolved string value, if available
     pub fn as_resolved(&self) -> Option<&str> {
-        match self {
-            BuildString::Resolved(s) => Some(s),
-            BuildString::Unresolved(_, _) | BuildString::Default => None,
-        }
+        self.as_str()
     }
 
     /// Get the string value, only if resolved
@@ -192,16 +189,20 @@ impl From<StepRun> for ScriptContent {
     }
 }
 
+fn step_run_from_content(value: ScriptContent) -> StepRun {
+    match value {
+        ScriptContent::Commands(commands) => StepRun::Commands(commands),
+        ScriptContent::Command(command) | ScriptContent::CommandOrPath(command) => {
+            StepRun::Command(command)
+        }
+        ScriptContent::Path(path) => StepRun::Command(path.to_string_lossy().into_owned()),
+        ScriptContent::Default => StepRun::Commands(Vec::new()),
+    }
+}
+
 impl From<&ScriptContent> for StepRun {
     fn from(value: &ScriptContent) -> Self {
-        match value {
-            ScriptContent::Commands(commands) => Self::Commands(commands.clone()),
-            ScriptContent::Command(command) | ScriptContent::CommandOrPath(command) => {
-                Self::Command(command.clone())
-            }
-            ScriptContent::Path(path) => Self::Command(path.to_string_lossy().into_owned()),
-            ScriptContent::Default => Self::Commands(Vec::new()),
-        }
+        step_run_from_content(value.clone())
     }
 }
 
@@ -229,7 +230,7 @@ impl Step {
     /// Create a step from an evaluated script payload.
     pub fn new(script: Script) -> Self {
         Self {
-            run: StepRun::from(&script.content),
+            run: step_run_from_content(script.content),
             interpreter: script.interpreter,
             env: script.env,
             cwd: script.cwd,
@@ -737,29 +738,15 @@ impl Build {
             && self.plan.is_default()
             && self.noarch.is_none()
             && self.flags.is_empty()
-            && self.python.entry_points.is_empty()
-            && self.python.skip_pyc_compilation.is_empty()
-            && !self.python.use_python_app_entrypoint
-            && !self.python.version_independent
-            && self.python.site_packages_path.is_none()
+            && self.python.is_default()
             && !self.skip
             && self.always_copy_files.is_empty()
             && self.always_include_files.is_empty()
             && !self.merge_build_and_host_envs
             && self.files.is_empty()
-            && self.dynamic_linking.rpaths.is_empty()
-            && self.dynamic_linking.binary_relocation.is_all()
-            && self.dynamic_linking.missing_dso_allowlist.is_empty()
-            && self.dynamic_linking.rpath_allowlist.is_empty()
-            && self.dynamic_linking.overdepending_behavior == LinkingCheckBehavior::Ignore
-            && self.dynamic_linking.overlinking_behavior == LinkingCheckBehavior::Ignore
-            && self.variant.use_keys.is_empty()
-            && self.variant.ignore_keys.is_empty()
-            && self.variant.down_prioritize_variant.is_none()
-            && self.prefix_detection.force_file_type.text.is_empty()
-            && self.prefix_detection.force_file_type.binary.is_empty()
-            && self.prefix_detection.ignore.is_none()
-            && !self.prefix_detection.ignore_binary_files
+            && self.dynamic_linking.is_default()
+            && self.variant.is_default()
+            && self.prefix_detection.is_default()
             && self.post_process.is_empty()
     }
 }

--- a/crates/rattler_build_recipe/src/stage1/recipe.rs
+++ b/crates/rattler_build_recipe/src/stage1/recipe.rs
@@ -15,14 +15,14 @@ use super::{About, Build, Extra, Package, Requirements, Source, TestType};
 /// A staging cache is similar to a Recipe but:
 /// - Does not produce a package artifact
 /// - Only has build/host requirements (no run requirements)
-/// - Only has a build script (no tests, no about section)
+/// - Only has a build plan (no tests, no about section)
 /// - Results are cached and can be inherited by package outputs
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StagingCache {
     /// Name of the staging cache (unique identifier)
     pub name: String,
 
-    /// Build configuration (only script field is used)
+    /// Build configuration.
     #[serde(default, skip_serializing_if = "Build::is_default")]
     pub build: Build,
 

--- a/docs/multiple_output_cache.md
+++ b/docs/multiple_output_cache.md
@@ -8,7 +8,7 @@ Sometimes you build a package and want to split the contents into multiple sub-p
 For example, when building a C/C++ package, you might want to create multiple packages for the
 runtime requirements (library), and the development time requirements such as header files.
 
-Staging outputs make this easy. A staging output runs its build script once, then copies its files directly into each inheriting package's prefix. Since these are "new" files in the prefix, they will be included in the output package.
+Staging outputs make this easy. A staging output runs its build plan once, then copies its files directly into each inheriting package's prefix. Since these are "new" files in the prefix, they will be included in the output package.
 
 Let's take a look at an example:
 
@@ -53,6 +53,8 @@ outputs:
 ```
 
 In this example, we have a staging output called `mypackage-build` that creates files during its build. The two package outputs `mypackage-library` and `mypackage-headers` inherit from it using the `inherit:` key.
+
+Staging `build:` sections support the same executable build plan as package outputs: either `script:` or experimental `steps:` (with `--experimental`).
 
 When building, the staging output runs first and creates files in `$PREFIX`. These files are then copied into the `$PREFIX` of each inheriting output package.
 The easiest way to select a subset of the files in the prefix is by using the `files` field in the output definition.
@@ -255,11 +257,11 @@ cache directory contains:
 ```txt
 output/build_cache/staging_<sha256>/
 ├─ metadata.json    # Cache metadata (deps, sources, file lists, variant)
-├─ prefix/          # Cached prefix files (only files added by the build script)
+├─ prefix/          # Cached prefix files (only files added by the build plan)
 └─ work_dir/        # Cached work directory
 ```
 
-On a **cache hit**, the staging build script is skipped entirely — the cached
+On a **cache hit**, the staging build plan is skipped entirely — the cached
 prefix and work directory files are restored directly. On a **cache miss**, the
 full build runs and the results are cached for future use.
 
@@ -276,9 +278,9 @@ applicable.
 
 ### File capture
 
-Only files **added** by the build script are cached — files that were already
+Only files **added** by the build plan are cached — files that were already
 present in the host environment from dependencies are excluded. This means the
-staging cache contains exactly the files that the build script installed into
+staging cache contains exactly the files that the build plan installed into
 `$PREFIX`, not the entire environment.
 
 

--- a/test-data/recipes/staging/build-steps.yaml
+++ b/test-data/recipes/staging/build-steps.yaml
@@ -1,0 +1,39 @@
+schema_version: 1
+
+recipe:
+  name: staging-build-steps
+  version: 1.0.0
+
+outputs:
+  - staging:
+      name: staging-build-steps-cache
+    build:
+      steps:
+        - if: unix
+          run: echo "one" > "$PREFIX/staging-steps.txt"
+        - if: unix
+          run: echo "${{ MARKER }}" >> "$PREFIX/staging-steps.txt"
+          env:
+            MARKER: two
+        - if: win
+          run: echo one> "%PREFIX%\staging-steps.txt"
+        - if: win
+          run: echo ${{ MARKER }}>> "%PREFIX%\staging-steps.txt"
+          env:
+            MARKER: two
+
+  - package:
+      name: staging-build-steps-a
+      version: 1.0.0
+    inherit: staging-build-steps-cache
+    build:
+      files:
+        - "**/*"
+
+  - package:
+      name: staging-build-steps-b
+      version: 1.0.0
+    inherit: staging-build-steps-cache
+    build:
+      files:
+        - "**/*"

--- a/test/end-to-end/test_staging.py
+++ b/test/end-to-end/test_staging.py
@@ -34,6 +34,25 @@ def test_basic_staging(rattler_build: RattlerBuild, recipes: Path, tmp_path: Pat
     assert content1 == content2
 
 
+def test_staging_build_steps(
+    rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
+):
+    """Test that staging outputs execute `build.steps` once and share the result."""
+    rattler_build.build(
+        recipes / "staging/build-steps.yaml",
+        tmp_path,
+        extra_args=["--experimental"],
+    )
+
+    pkg1 = get_extracted_package(tmp_path, "staging-build-steps-a")
+    pkg2 = get_extracted_package(tmp_path, "staging-build-steps-b")
+
+    content1 = (pkg1 / "staging-steps.txt").read_text().splitlines()
+    content2 = (pkg2 / "staging-steps.txt").read_text().splitlines()
+    assert content1 == ["one", "two"]
+    assert content2 == content1
+
+
 @pytest.mark.skipif(os.name == "nt", reason="symlinks not fully supported on Windows")
 def test_staging_symlinks(rattler_build: RattlerBuild, recipes: Path, tmp_path: Path):
     """Test that symlinks are properly cached and restored in staging outputs."""


### PR DESCRIPTION
## What

Extends experimental `build.steps` from #2646 to staging outputs.

Staging outputs can now use the same executable build plan as package outputs: either `script` or `steps`. The steps run when populating the staging cache, and inheriting package outputs receive the resulting files as before.

This also shares build plan preparation between package and staging output execution instead of maintaining separate script-only paths.

## Testing

- `cargo test --workspace --all-targets`
- `pixi run build-release`
- `pixi run pytest test/end-to-end/test_staging.py::test_staging_build_steps -v`

The new end-to-end test executes multiple staging steps and verifies that both inheriting packages receive the shared result.
