### PR TITLE
chore: run brush scripts with -euxo pipefail by default

### DIFF
--- a/crates/rattler_build_script/src/interpreter/brush.rs
+++ b/crates/rattler_build_script/src/interpreter/brush.rs
@@ -22,10 +22,7 @@ impl InterpreterInvocation for BrushInvocation {
         // invocation makes them the default for inline and file-backed scripts
         // alike, while a script can still opt out with `set +e` etc.
         vec![
-            "-e".to_string(),
-            "-u".to_string(),
-            "-x".to_string(),
-            "-o".to_string(),
+            "-euxo".to_string(),
             "pipefail".to_string(),
             script_path.to_string_lossy().into_owned(),
         ]

--- a/crates/rattler_build_script/src/interpreter/brush.rs
+++ b/crates/rattler_build_script/src/interpreter/brush.rs
@@ -16,6 +16,18 @@ impl InterpreterInvocation for BrushInvocation {
     }
 
     fn args(&self, script_path: &std::path::Path) -> Vec<String> {
-        vec![script_path.to_string_lossy().into_owned()]
+        // Match the strictness the bash wrapper gets from its preamble: fail on
+        // errors (`-e`), unset variables (`-u`) and pipeline failures
+        // (`-o pipefail`), and trace commands (`-x`). Passing these at
+        // invocation makes them the default for inline and file-backed scripts
+        // alike, while a script can still opt out with `set +e` etc.
+        vec![
+            "-e".to_string(),
+            "-u".to_string(),
+            "-x".to_string(),
+            "-o".to_string(),
+            "pipefail".to_string(),
+            script_path.to_string_lossy().into_owned(),
+        ]
     }
 }

--- a/crates/rattler_build_script/src/interpreter/mod.rs
+++ b/crates/rattler_build_script/src/interpreter/mod.rs
@@ -899,6 +899,24 @@ mod tests {
         assert_eq!(closest_interpreter("PowerShell"), Some("powershell"));
     }
 
+    /// `brush` runs scripts under `set -euxo pipefail` semantics by default,
+    /// passed as invocation flags ahead of the script path so both inline and
+    /// file-backed scripts get them. `bash` keeps its plain invocation (its
+    /// strict modes come from the wrapper preamble instead).
+    #[test]
+    fn brush_invocation_defaults_to_strict_mode_flags() {
+        let script = Path::new("conda_build_script.sh");
+
+        assert_eq!(
+            super::brush::BrushInvocation.args(script),
+            ["-e", "-u", "-x", "-o", "pipefail", "conda_build_script.sh"]
+        );
+        assert_eq!(
+            super::bash::BashInvocation.args(script),
+            ["conda_build_script.sh"]
+        );
+    }
+
     /// `cmd` propagates a non-zero exit between commands; others join plainly.
     #[test]
     fn join_commands_is_interpreter_specific() {

--- a/crates/rattler_build_script/src/interpreter/mod.rs
+++ b/crates/rattler_build_script/src/interpreter/mod.rs
@@ -909,7 +909,7 @@ mod tests {
 
         assert_eq!(
             super::brush::BrushInvocation.args(script),
-            ["-e", "-u", "-x", "-o", "pipefail", "conda_build_script.sh"]
+            ["-euxo", "pipefail", "conda_build_script.sh"]
         );
         assert_eq!(
             super::bash::BashInvocation.args(script),

--- a/docs/build_script.md
+++ b/docs/build_script.md
@@ -140,7 +140,7 @@ requirements:
 
 `brush` is always taken from the build environment, so it must be listed in `requirements/build`. A `brush` found on the system `PATH` is intentionally not used, which keeps builds reproducible.
 
-Scripts run with `set -euxo pipefail` semantics by default: `brush` is invoked with `-e -u -x -o pipefail`, so the script aborts on errors, unset variables and pipeline failures, and traces every command. A script can relax this where needed with e.g. `set +e` or `set +u`.
+Scripts run with `set -euxo pipefail` semantics by default: `brush` is invoked with `-euxo pipefail`, so the script aborts on errors, unset variables and pipeline failures, and traces every command. A script can relax this where needed with e.g. `set +e` or `set +u`.
 
 ```yaml title="recipe.yaml"
 build:

--- a/docs/build_script.md
+++ b/docs/build_script.md
@@ -140,6 +140,8 @@ requirements:
 
 `brush` is always taken from the build environment, so it must be listed in `requirements/build`. A `brush` found on the system `PATH` is intentionally not used, which keeps builds reproducible.
 
+Scripts run with `set -euxo pipefail` semantics by default: `brush` is invoked with `-e -u -x -o pipefail`, so the script aborts on errors, unset variables and pipeline failures, and traces every command. A script can relax this where needed with e.g. `set +e` or `set +u`.
+
 ```yaml title="recipe.yaml"
 build:
   script:

--- a/test-data/recipes/brush-test/recipe.yaml
+++ b/test-data/recipes/brush-test/recipe.yaml
@@ -9,7 +9,7 @@ build:
     # wrapper that performs activation before invoking brush.
     interpreter: brush
     content: |
-      # brush is invoked with `-e -u -x -o pipefail`, so strict mode is on
+      # brush is invoked with `-euxo pipefail`, so strict mode is on
       # without a `set -euxo pipefail` prologue in the script.
       [[ $- == *e* && $- == *u* && $- == *x* ]]
       set -o | grep -q "pipefail.*on"

--- a/test-data/recipes/brush-test/recipe.yaml
+++ b/test-data/recipes/brush-test/recipe.yaml
@@ -9,6 +9,10 @@ build:
     # wrapper that performs activation before invoking brush.
     interpreter: brush
     content: |
+      # brush is invoked with `-e -u -x -o pipefail`, so strict mode is on
+      # without a `set -euxo pipefail` prologue in the script.
+      [[ $- == *e* && $- == *u* && $- == *x* ]]
+      set -o | grep -q "pipefail.*on"
       echo "Hello from brush!" > "$PREFIX/hello.txt"
 
 requirements:


### PR DESCRIPTION
When using brush as the interpreter you currently have to start every script with set -euxo pipefail to get sane failure behavior. This changes the brush invocation to pass -euxo pipefail so that is the default: scripts abort on errors, unset variables and pipeline failures, and commands are traced, matching the strictness the bash wrapper already gets from its preamble. A script can still opt out locally with set +e etc.

Because the flags are passed at invocation they apply both to inline scripts and file-backed scripts. The brush end-to-end recipe now asserts the options are active without any set prologue, and the docs mention the new default.