### PR TITLE
fix: set `LIBRARY_PREFIX` and friends for noarch builds on Windows

### DIFF
--- a/crates/rattler_build_core/src/env_vars.rs
+++ b/crates/rattler_build_core/src/env_vars.rs
@@ -202,12 +202,25 @@ pub fn language_vars(output: &Output) -> HashMap<String, Option<String>> {
 pub fn os_vars(
     prefix: &Path,
     target_platform: &Platform,
+    host_platform: &Platform,
     env_isolation: EnvironmentIsolation,
     work_dir: &Path,
 ) -> HashMap<String, Option<String>> {
     let mut vars = HashMap::new();
 
-    let path_var = if target_platform.is_windows() {
+    // For `noarch` outputs there is no concrete target platform, but the build
+    // script still runs against a real host platform. Use the host platform to
+    // decide which OS-specific variables to emit (e.g. `LIBRARY_PREFIX` and
+    // friends on Windows), so that `noarch: generic` packages can still compile
+    // native artifacts during the build.
+    // See https://github.com/prefix-dev/rattler-build/issues/2475
+    let os_platform = if *target_platform == Platform::NoArch {
+        host_platform
+    } else {
+        target_platform
+    };
+
+    let path_var = if os_platform.is_windows() {
         "Path"
     } else {
         "PATH"
@@ -236,18 +249,18 @@ pub fn os_vars(
     insert!(
         vars,
         "SHLIB_EXT",
-        rattler_build_types::shlib_ext(target_platform)
+        rattler_build_types::shlib_ext(os_platform)
     );
     vars.insert(path_var.to_string(), env::var(path_var).ok());
 
-    if target_platform.is_windows() {
+    if os_platform.is_windows() {
         vars.extend(windows::env::default_env_vars_target(prefix));
-    } else if target_platform.is_osx() {
-        vars.extend(macos::env::default_env_vars_target(prefix, target_platform));
-    } else if target_platform.is_linux() {
+    } else if os_platform.is_osx() {
+        vars.extend(macos::env::default_env_vars_target(prefix, os_platform));
+    } else if os_platform.is_linux() {
         vars.extend(linux::env::default_env_vars_target(
             prefix,
-            target_platform,
+            os_platform,
             env_isolation,
         ));
     }
@@ -477,4 +490,56 @@ pub fn env_vars_from_variant(
             }
         })
         .collect()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// For a `noarch` target built on a Windows host, the Windows-specific target
+    /// variables (e.g. `LIBRARY_PREFIX`) must still be emitted so that
+    /// `noarch: generic` packages can compile native artifacts. See
+    /// https://github.com/prefix-dev/rattler-build/issues/2475
+    #[test]
+    fn test_noarch_uses_host_platform_for_os_vars() {
+        let prefix = Path::new("/some/prefix");
+        let work_dir = Path::new("/some/work");
+
+        let vars = os_vars(
+            prefix,
+            &Platform::NoArch,
+            &Platform::Win64,
+            EnvironmentIsolation::Strict,
+            work_dir,
+        );
+
+        // Windows target vars should be present because the host is Windows.
+        assert!(vars.contains_key("LIBRARY_PREFIX"));
+        assert!(vars.contains_key("LIBRARY_BIN"));
+        assert!(vars.contains_key("SCRIPTS"));
+        // The Windows path variable is `Path`, not `PATH`.
+        assert!(vars.contains_key("Path"));
+        assert_eq!(
+            vars.get("SHLIB_EXT").and_then(|v| v.as_deref()),
+            Some(".dll")
+        );
+    }
+
+    /// A `noarch` target on a non-Windows host must not emit Windows target vars.
+    #[test]
+    fn test_noarch_non_windows_host_has_no_windows_vars() {
+        let prefix = Path::new("/some/prefix");
+        let work_dir = Path::new("/some/work");
+
+        let vars = os_vars(
+            prefix,
+            &Platform::NoArch,
+            &Platform::Linux64,
+            EnvironmentIsolation::Strict,
+            work_dir,
+        );
+
+        assert!(!vars.contains_key("LIBRARY_PREFIX"));
+        assert!(vars.contains_key("PATH"));
+    }
 }

--- a/crates/rattler_build_core/src/env_vars.rs
+++ b/crates/rattler_build_core/src/env_vars.rs
@@ -208,12 +208,8 @@ pub fn os_vars(
 ) -> HashMap<String, Option<String>> {
     let mut vars = HashMap::new();
 
-    // For `noarch` outputs there is no concrete target platform, but the build
-    // script still runs against a real host platform. Use the host platform to
-    // decide which OS-specific variables to emit (e.g. `LIBRARY_PREFIX` and
-    // friends on Windows), so that `noarch: generic` packages can still compile
-    // native artifacts during the build.
-    // See https://github.com/prefix-dev/rattler-build/issues/2475
+    // For `noarch` outputs, fall back to the host platform so Windows target
+    // vars (e.g. `LIBRARY_PREFIX`) are still emitted. See issue #2475.
     let os_platform = if *target_platform == Platform::NoArch {
         host_platform
     } else {
@@ -496,10 +492,7 @@ pub fn env_vars_from_variant(
 mod test {
     use super::*;
 
-    /// For a `noarch` target built on a Windows host, the Windows-specific target
-    /// variables (e.g. `LIBRARY_PREFIX`) must still be emitted so that
-    /// `noarch: generic` packages can compile native artifacts. See
-    /// https://github.com/prefix-dev/rattler-build/issues/2475
+    /// noarch on a Windows host still emits Windows target vars (issue #2475).
     #[test]
     fn test_noarch_uses_host_platform_for_os_vars() {
         let prefix = Path::new("/some/prefix");
@@ -513,11 +506,9 @@ mod test {
             work_dir,
         );
 
-        // Windows target vars should be present because the host is Windows.
         assert!(vars.contains_key("LIBRARY_PREFIX"));
         assert!(vars.contains_key("LIBRARY_BIN"));
         assert!(vars.contains_key("SCRIPTS"));
-        // The Windows path variable is `Path`, not `PATH`.
         assert!(vars.contains_key("Path"));
         assert_eq!(
             vars.get("SHLIB_EXT").and_then(|v| v.as_deref()),
@@ -525,7 +516,7 @@ mod test {
         );
     }
 
-    /// A `noarch` target on a non-Windows host must not emit Windows target vars.
+    /// noarch on a non-Windows host does not emit Windows target vars.
     #[test]
     fn test_noarch_non_windows_host_has_no_windows_vars() {
         let prefix = Path::new("/some/prefix");

--- a/crates/rattler_build_core/src/package_test/run_test.rs
+++ b/crates/rattler_build_core/src/package_test/run_test.rs
@@ -205,8 +205,13 @@ impl Tests {
         })?;
 
         let platform = Platform::current();
-        let mut env_vars =
-            env_vars::os_vars(environment, &platform, config.env_isolation, tmp_dir.path());
+        let mut env_vars = env_vars::os_vars(
+            environment,
+            &platform,
+            &platform,
+            config.env_isolation,
+            tmp_dir.path(),
+        );
         if config.env_isolation == EnvironmentIsolation::None {
             env_vars.retain(|key, _| key != ShellEnum::default().path_var(&platform));
         }
@@ -794,7 +799,13 @@ async fn run_python_test_inner(
     let platform = Platform::current();
     let test_dir = prefix.join("test");
     fs::create_dir_all(&test_dir)?;
-    let test_env_vars = env_vars::os_vars(&test_prefix, &platform, config.env_isolation, &test_dir);
+    let test_env_vars = env_vars::os_vars(
+        &test_prefix,
+        &platform,
+        &platform,
+        config.env_isolation,
+        &test_dir,
+    );
 
     script
         .run_script(
@@ -898,8 +909,13 @@ async fn run_perl_test(
     fs::create_dir_all(&test_folder)?;
 
     let platform = Platform::current();
-    let test_env_vars =
-        env_vars::os_vars(&test_prefix, &platform, config.env_isolation, &test_folder);
+    let test_env_vars = env_vars::os_vars(
+        &test_prefix,
+        &platform,
+        &platform,
+        config.env_isolation,
+        &test_folder,
+    );
 
     script
         .run_script(
@@ -1006,7 +1022,13 @@ async fn run_commands_test(
     })?;
 
     let platform = Platform::current();
-    let mut env_vars = env_vars::os_vars(&run_prefix, &platform, config.env_isolation, &test_dir);
+    let mut env_vars = env_vars::os_vars(
+        &run_prefix,
+        &platform,
+        &platform,
+        config.env_isolation,
+        &test_dir,
+    );
     if config.env_isolation == EnvironmentIsolation::None {
         env_vars.retain(|key, _| key != ShellEnum::default().path_var(&platform));
     }
@@ -1200,8 +1222,13 @@ async fn run_r_test(
     fs::create_dir_all(&test_folder)?;
 
     let platform = Platform::current();
-    let test_env_vars =
-        env_vars::os_vars(&test_prefix, &platform, config.env_isolation, &test_folder);
+    let test_env_vars = env_vars::os_vars(
+        &test_prefix,
+        &platform,
+        &platform,
+        config.env_isolation,
+        &test_folder,
+    );
 
     script
         .run_script(
@@ -1276,8 +1303,13 @@ async fn run_ruby_test(
     fs::create_dir_all(&test_folder)?;
 
     let platform = Platform::current();
-    let test_env_vars =
-        env_vars::os_vars(&test_prefix, &platform, config.env_isolation, &test_folder);
+    let test_env_vars = env_vars::os_vars(
+        &test_prefix,
+        &platform,
+        &platform,
+        config.env_isolation,
+        &test_folder,
+    );
 
     script
         .run_script(

--- a/crates/rattler_build_core/src/script.rs
+++ b/crates/rattler_build_core/src/script.rs
@@ -30,11 +30,13 @@ impl Output {
     async fn prepare_build_script(&self) -> Result<ExecutionArgs, std::io::Error> {
         let host_prefix = self.build_configuration.directories.host_prefix.clone();
         let target_platform = self.build_configuration.target_platform;
+        let host_platform = self.host_platform().platform;
         let env_isolation = self.build_configuration.env_isolation;
         let mut env_vars = env_vars::vars(self, "BUILD");
         env_vars.extend(env_vars::os_vars(
             &host_prefix,
             &target_platform,
+            &host_platform,
             env_isolation,
             &self.build_configuration.directories.work_dir,
         ));

--- a/crates/rattler_build_core/src/staging.rs
+++ b/crates/rattler_build_core/src/staging.rs
@@ -274,10 +274,12 @@ impl Output {
 
         // Run the build script
         let target_platform = self.build_configuration.target_platform;
+        let host_platform = self.host_platform().platform;
         let mut env_vars = env_vars::vars(self, "BUILD");
         env_vars.extend(env_vars::os_vars(
             self.prefix(),
             &target_platform,
+            &host_platform,
             self.build_configuration.env_isolation,
             &self.build_configuration.directories.work_dir,
         ));

--- a/py-rattler-build/rust/src/render.rs
+++ b/py-rattler-build/rust/src/render.rs
@@ -78,6 +78,7 @@ impl PyRenderConfig {
         let os_env_var_keys = rattler_build::env_vars::os_vars(
             &std::path::PathBuf::new(),
             &host_platform,
+            &host_platform,
             EnvironmentIsolation::default(),
             &std::path::PathBuf::new(),
         )

--- a/py-rattler-build/rust/src/render.rs
+++ b/py-rattler-build/rust/src/render.rs
@@ -77,7 +77,7 @@ impl PyRenderConfig {
         // We use an empty prefix path since we just need the keys, not the values
         let os_env_var_keys = rattler_build::env_vars::os_vars(
             &std::path::PathBuf::new(),
-            &host_platform,
+            &target_platform,
             &host_platform,
             EnvironmentIsolation::default(),
             &std::path::PathBuf::new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -393,6 +393,7 @@ pub async fn get_build_output(
     let os_env_var_keys = env_vars::os_vars(
         &std::path::PathBuf::new(),
         &build_data.host_platform,
+        &build_data.host_platform,
         build_data.env_isolation,
         &std::path::PathBuf::new(),
     )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -392,7 +392,7 @@ pub async fn get_build_output(
     // Get OS environment variable keys that can be overridden by variant config
     let os_env_var_keys = env_vars::os_vars(
         &std::path::PathBuf::new(),
-        &build_data.host_platform,
+        &build_data.target_platform,
         &build_data.host_platform,
         build_data.env_isolation,
         &std::path::PathBuf::new(),


### PR DESCRIPTION
## What

For `noarch` outputs there is no concrete target platform, so `os_vars` gated the Windows-specific target variables on `target_platform.is_windows()`, which is `false` for `noarch`. As a result `LIBRARY_PREFIX`, `LIBRARY_BIN`, `SCRIPTS`, `LIB`, `INCLUDE`, ... were never set, and `noarch: generic` recipes that still compile native artifacts during the build failed on Windows.

`os_vars` now also receives the host platform and, when the target is `noarch`, uses it to decide which OS-specific variables to emit (path variable casing, `SHLIB_EXT`, and the target OS default env vars). Non-`noarch` builds and cross-compilation are unchanged.

Fixes #2475