### PR TITLE
chore: release 0.69.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.69.1] - 2026-07-16
+### ✨ Highlights
+
+This release fixes a bug where you get this message on every shell startup if you have Rattler-Build completions installed:
+
+```
+rattler-build 0.69.0
+No configuration file loaded
+```
+
+### Fixed
+
+- Only load config and print banner for config-consuming subcommands by @Hofer-Julian in [#2658](https://github.com/prefix-dev/rattler-build/pull/2658)
+- Resolve changelog preview range end to a commit SHA by @Hofer-Julian in [#2659](https://github.com/prefix-dev/rattler-build/pull/2659)
+
+
+
 ## [0.69.0] - 2026-07-15
 ### ✨ Highlights
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4795,7 +4795,7 @@ dependencies = [
 
 [[package]]
 name = "rattler-build"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler-build"
-version = "0.69.0"
+version = "0.69.1"
 authors = ["rattler-build contributors <hi@prefix.dev>"]
 repository = "https://github.com/prefix-dev/rattler-build"
 edition = "2024"

--- a/py-rattler-build/pyproject.toml
+++ b/py-rattler-build/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "py-rattler-build"
-version = "0.69.0"
+version = "0.69.1"
 requires-python = ">=3.10"
 description = "The fastest way to build conda packages programatically"
 readme = "README.md"

--- a/py-rattler-build/rust/Cargo.lock
+++ b/py-rattler-build/rust/Cargo.lock
@@ -4311,7 +4311,7 @@ dependencies = [
 
 [[package]]
 name = "py-rattler-build"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "clap",
  "fs-err",
@@ -4674,7 +4674,7 @@ dependencies = [
 
 [[package]]
 name = "rattler-build"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",

--- a/py-rattler-build/rust/Cargo.toml
+++ b/py-rattler-build/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-rattler-build"
-version = "0.69.0"
+version = "0.69.1"
 edition = "2024"
 license = "BSD-3-Clause"
 publish = false

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/prefix-dev/rattler-build"
 
 [version]
-current = "0.69.0"
+current = "0.69.1"
 
 # Example of a semver regexp.
 # Make sure this matches current_version before


### PR DESCRIPTION
## [0.69.1] - 2026-07-16
### ✨ Highlights

This release fixes a bug where you get this message on every shell startup if you have Rattler-Build completions installed:

```
rattler-build 0.69.0
No configuration file loaded
```

### Fixed

- Only load config and print banner for config-consuming subcommands by @Hofer-Julian in [#2658](https://github.com/prefix-dev/rattler-build/pull/2658)
- Resolve changelog preview range end to a commit SHA by @Hofer-Julian in [#2659](https://github.com/prefix-dev/rattler-build/pull/2659)