### PR TITLE
feat: keep `target_platform` concrete for noarch packages and add `build.subdir`

### DIFF
--- a/crates/rattler_build_core/src/build.rs
+++ b/crates/rattler_build_core/src/build.rs
@@ -234,9 +234,8 @@ pub async fn run_build(
     // Check for symlinks on Windows if not allowed
     // Skip the check for noarch packages that have __unix in run dependencies,
     // since they will never be installed on Windows.
-    if (output.build_configuration.target_platform.is_windows()
-        || (output.build_configuration.target_platform == Platform::NoArch
-            && !has_unix_virtual_package(&output)))
+    if (output.subdir().is_windows()
+        || (output.subdir() == Platform::NoArch && !has_unix_virtual_package(&output)))
         && !tool_configuration.allow_symlinks_on_windows
     {
         tracing::info!("Checking for symlinks ...");

--- a/crates/rattler_build_core/src/env_vars.rs
+++ b/crates/rattler_build_core/src/env_vars.rs
@@ -394,7 +394,7 @@ pub fn vars(output: &Output, build_state: &str) -> HashMap<String, Option<String
     } else {
         insert!(vars, "CONDA_BUILD_CROSS_COMPILATION", "0");
     }
-    insert!(vars, "SUBDIR", output.target_platform().to_string());
+    insert!(vars, "SUBDIR", output.subdir().to_string());
     insert!(
         vars,
         "build_platform",

--- a/crates/rattler_build_core/src/package_test/content_test.rs
+++ b/crates/rattler_build_core/src/package_test/content_test.rs
@@ -395,7 +395,7 @@ impl PackageContentsTestExt for PackageContentsTest {
     fn run_test(&self, paths: &PathsJson, output: &Output) -> Result<(), TestError> {
         let span = tracing::info_span!("Package content test");
         let _enter = span.enter();
-        let target_platform = output.target_platform();
+        let target_platform = &output.subdir();
         let paths: Vec<&PathBuf> = paths.paths.iter().map(|p| &p.relative_path).collect();
 
         let mut collected_issues = Vec::new();

--- a/crates/rattler_build_core/src/package_test/content_test.rs
+++ b/crates/rattler_build_core/src/package_test/content_test.rs
@@ -395,7 +395,7 @@ impl PackageContentsTestExt for PackageContentsTest {
     fn run_test(&self, paths: &PathsJson, output: &Output) -> Result<(), TestError> {
         let span = tracing::info_span!("Package content test");
         let _enter = span.enter();
-        let target_platform = &output.subdir();
+        let subdir = &output.subdir();
         let paths: Vec<&PathBuf> = paths.paths.iter().map(|p| &p.relative_path).collect();
 
         let mut collected_issues = Vec::new();
@@ -416,7 +416,7 @@ impl PackageContentsTestExt for PackageContentsTest {
             let globs = self.get_globs_for_section(
                 section.clone(),
                 true,
-                target_platform,
+                subdir,
                 version_independent_override,
             )?;
             Self::check_globs(
@@ -432,7 +432,7 @@ impl PackageContentsTestExt for PackageContentsTest {
             let globs = self.get_globs_for_section(
                 section,
                 false,
-                target_platform,
+                subdir,
                 version_independent_override,
             )?;
             Self::check_globs(

--- a/crates/rattler_build_core/src/packaging.rs
+++ b/crates/rattler_build_core/src/packaging.rs
@@ -919,13 +919,12 @@ pub fn package_conda(
 
     print_enhanced_file_listing(&files, &tmp, output)?;
 
-    let output_folder =
-        local_channel_dir.join(output.build_configuration.target_platform.to_string());
+    let output_folder = local_channel_dir.join(output.subdir().to_string());
     tracing::info!("Creating target folder '{}'", output_folder.display());
 
     fs::create_dir_all(&output_folder)?;
 
-    if let Platform::NoArch = output.build_configuration.target_platform {
+    if let Platform::NoArch = output.subdir() {
         create_empty_build_folder(
             local_channel_dir,
             &output.build_configuration.build_platform.platform,

--- a/crates/rattler_build_core/src/packaging/file_mapper.rs
+++ b/crates/rattler_build_core/src/packaging/file_mapper.rs
@@ -98,7 +98,7 @@ impl Output {
         prefix: &Path,
         dest_folder: &Path,
     ) -> Result<Option<PathBuf>, PackagingError> {
-        let target_platform = &self.build_configuration.target_platform;
+        let target_platform = &self.subdir();
         let entry_points = &self.recipe.build().python.entry_points;
 
         let path_rel = path.strip_prefix(prefix)?;

--- a/crates/rattler_build_core/src/packaging/file_mapper.rs
+++ b/crates/rattler_build_core/src/packaging/file_mapper.rs
@@ -98,7 +98,7 @@ impl Output {
         prefix: &Path,
         dest_folder: &Path,
     ) -> Result<Option<PathBuf>, PackagingError> {
-        let target_platform = &self.subdir();
+        let subdir = &self.subdir();
         let entry_points = &self.recipe.build().python.entry_points;
 
         let path_rel = path.strip_prefix(prefix)?;
@@ -187,7 +187,7 @@ impl Output {
                 // on Windows, if the file ends with -script.py, remove the -script.py suffix
                 if let Some(Component::Normal(name)) = new_parts.last_mut()
                     && let Some(name_str) = name.to_str()
-                    && target_platform.is_windows()
+                    && subdir.is_windows()
                     && let Some(stripped_suffix) = name_str.strip_suffix("-script.py")
                 {
                     *name = stripped_suffix.as_ref();
@@ -217,7 +217,7 @@ impl Output {
 
         // Handle symlinks: make absolute symlinks relative and copy the link
         if metadata.file_type().is_symlink() {
-            if target_platform.is_windows() {
+            if subdir.is_windows() {
                 tracing::warn!("Symlink creation on Windows requires administrator privileges");
             }
             // Read the link target

--- a/crates/rattler_build_core/src/packaging/metadata.rs
+++ b/crates/rattler_build_core/src/packaging/metadata.rs
@@ -249,7 +249,10 @@ impl Output {
 
     /// Returns the contents of the `hash_input.json` file.
     pub fn hash_input(&self) -> HashInput {
-        HashInput::from_variant(&self.build_configuration.variant)
+        HashInput::from_variant(
+            &self.build_configuration.variant,
+            &self.recipe.build().noarch.unwrap_or(NoArchType::none()),
+        )
     }
 
     /// Create the about.json file for the given output.
@@ -311,10 +314,10 @@ impl Output {
     /// Create the contents of the index.json file for the given output.
     pub fn index_json(&self) -> Result<IndexJson, PackagingError> {
         let recipe = &self.recipe;
-        let target_platform = self.target_platform();
+        let subdir = self.subdir();
 
-        let arch = target_platform.arch().map(|a| a.to_string());
-        let platform = target_platform.only_platform().map(|p| p.to_string());
+        let arch = subdir.arch().map(|a| a.to_string());
+        let platform = subdir.only_platform().map(|p| p.to_string());
 
         let finalized_dependencies = self
             .finalized_dependencies
@@ -372,7 +375,7 @@ impl Output {
             build_number: recipe.build().number.unwrap_or(0),
             arch,
             platform,
-            subdir: Some(self.build_configuration.target_platform.to_string()),
+            subdir: Some(subdir.to_string()),
             license: recipe.about().license.as_ref().map(|l| l.to_string()),
             license_family: recipe.about().license_family.clone(),
             timestamp: Some(self.build_configuration.timestamp.into()),
@@ -506,7 +509,7 @@ impl Output {
                 } else if meta.is_file() {
                     let content_type = content_type.ok_or_else(|| PackagingError::ContentTypeNotFound(p.clone()))?;
                     let prefix_placeholder = create_prefix_placeholder(
-                        &self.build_configuration.target_platform,
+                        &self.subdir(),
                         p,
                         temp_files.temp_dir.path(),
                         &temp_files.encoded_prefix,

--- a/crates/rattler_build_core/src/post_process/checks.rs
+++ b/crates/rattler_build_core/src/post_process/checks.rs
@@ -546,7 +546,7 @@ pub fn perform_linking_checks(
         .collect();
 
     // check all DSOs and what they are linking
-    let target_platform = output.subdir();
+    let subdir = output.subdir();
     let host_prefix = output.prefix();
 
     // Parallel processing of DSO files
@@ -566,7 +566,7 @@ pub fn perform_linking_checks(
                     );
                     for (lib, resolved) in &resolved_libraries {
                         // filter out @self on macOS
-                        if target_platform.is_osx() && lib.to_str() == Some("self") {
+                        if subdir.is_osx() && lib.to_str() == Some("self") {
                             continue;
                         }
 
@@ -621,7 +621,7 @@ pub fn perform_linking_checks(
             let lib = lib.strip_prefix(host_prefix).unwrap_or(lib);
 
             // skip @self on macOS
-            if target_platform.is_osx() && lib.to_str() == Some("self") {
+            if subdir.is_osx() && lib.to_str() == Some("self") {
                 continue;
             }
 

--- a/crates/rattler_build_core/src/post_process/checks.rs
+++ b/crates/rattler_build_core/src/post_process/checks.rs
@@ -419,9 +419,9 @@ fn add_windows_system_libs(
     // Load dsolists from both build and host prefixes.
     let build_result = load_dsolists(
         &output.build_configuration.directories.build_prefix,
-        &output.build_configuration.target_platform,
+        &output.subdir(),
     )?;
-    let host_result = load_dsolists(output.prefix(), &output.build_configuration.target_platform)?;
+    let host_result = load_dsolists(output.prefix(), &output.subdir())?;
 
     let (build_allow, build_deny) = build_result.unwrap_or_default();
     let (host_allow, host_deny) = host_result.unwrap_or_default();
@@ -503,7 +503,7 @@ struct SystemLibs {
 fn find_system_libs(output: &Output) -> Result<SystemLibs, LinkingCheckError> {
     let mut allow_builder = GlobSetBuilder::new();
     let mut deny_builder = GlobSetBuilder::new();
-    let platform = &output.build_configuration.target_platform;
+    let platform = &output.subdir();
 
     if platform.is_osx() {
         add_osx_system_libs(output, &mut allow_builder)?;
@@ -546,7 +546,7 @@ pub fn perform_linking_checks(
         .collect();
 
     // check all DSOs and what they are linking
-    let target_platform = output.target_platform();
+    let target_platform = output.subdir();
     let host_prefix = output.prefix();
 
     // Parallel processing of DSO files
@@ -554,7 +554,7 @@ pub fn perform_linking_checks(
         .par_iter()
         .filter_map(|file| {
             // Parse the DSO to get the list of libraries it links to
-            match relink::get_relinker(output.build_configuration.target_platform, file) {
+            match relink::get_relinker(output.subdir(), file) {
                 Ok(relinker) => {
                     let mut file_dsos = Vec::new();
 

--- a/crates/rattler_build_core/src/post_process/relink.rs
+++ b/crates/rattler_build_core/src/post_process/relink.rs
@@ -146,7 +146,7 @@ pub fn get_relinker(platform: Platform, path: &Path) -> Result<Box<dyn Relinker>
 /// `@loader_path` variable. The change for Mach-O files is applied with the `install_name_tool`.
 pub fn relink(temp_files: &TempFiles, output: &Output) -> Result<(), RelinkError> {
     let dynamic_linking = &output.recipe.build().dynamic_linking;
-    let target_platform = output.build_configuration.target_platform;
+    let target_platform = output.subdir();
     let relocation_config = &dynamic_linking.binary_relocation;
 
     if target_platform == Platform::NoArch

--- a/crates/rattler_build_core/src/post_process/relink.rs
+++ b/crates/rattler_build_core/src/post_process/relink.rs
@@ -146,12 +146,12 @@ pub fn get_relinker(platform: Platform, path: &Path) -> Result<Box<dyn Relinker>
 /// `@loader_path` variable. The change for Mach-O files is applied with the `install_name_tool`.
 pub fn relink(temp_files: &TempFiles, output: &Output) -> Result<(), RelinkError> {
     let dynamic_linking = &output.recipe.build().dynamic_linking;
-    let target_platform = output.subdir();
+    let subdir = output.subdir();
     let relocation_config = &dynamic_linking.binary_relocation;
 
-    if target_platform == Platform::NoArch
+    if subdir == Platform::NoArch
         // skip linking checks for wasm
-        || target_platform.arch() == Some(Arch::Wasm32)
+        || subdir.arch() == Some(Arch::Wasm32)
         || relocation_config.is_none()
     {
         return Ok(());
@@ -187,9 +187,9 @@ pub fn relink(temp_files: &TempFiles, output: &Output) -> Result<(), RelinkError
                 return Ok(None);
             }
 
-            match get_relinker(target_platform, p) {
+            match get_relinker(subdir, p) {
                 Ok(relinker) => {
-                    if !target_platform.is_windows() {
+                    if !subdir.is_windows() {
                         relinker.relink(
                             tmp_prefix,
                             encoded_prefix,

--- a/crates/rattler_build_core/src/render/resolved_dependencies.rs
+++ b/crates/rattler_build_core/src/render/resolved_dependencies.rs
@@ -1084,7 +1084,7 @@ pub(crate) async fn resolve_dependencies(
     let host_run_exports = filter_run_exports(&ignore_run_exports, &host_run_exports, "host")?;
 
     // add the host run exports to the run dependencies
-    if output.target_platform() == &Platform::NoArch {
+    if output.subdir() == Platform::NoArch {
         // ignore build noarch depends
         depends.extend(host_run_exports.noarch.iter().cloned());
     } else {

--- a/crates/rattler_build_core/src/types/build_configuration.rs
+++ b/crates/rattler_build_core/src/types/build_configuration.rs
@@ -21,10 +21,10 @@ fn default_true() -> bool {
 /// The configuration for a build of a package
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BuildConfiguration {
-    /// The target platform for the build
+    /// The target platform for the build. This is never `noarch`, the subdir
+    /// of a noarch package is derived from the recipe instead.
     pub target_platform: Platform,
-    /// The host platform (usually target platform, but for `noarch` it's the
-    /// build platform)
+    /// The host platform (usually the same as the target platform)
     pub host_platform: PlatformWithVirtualPackages,
     /// The build platform (the platform that the build is running on)
     pub build_platform: PlatformWithVirtualPackages,

--- a/crates/rattler_build_core/src/types/build_output.rs
+++ b/crates/rattler_build_core/src/types/build_output.rs
@@ -142,6 +142,19 @@ impl BuildOutput {
         &self.build_configuration.target_platform
     }
 
+    /// The subdir of the package created by this output. This is the explicit
+    /// `build.subdir` from the recipe if set, `noarch` for noarch packages,
+    /// and the target platform otherwise.
+    pub fn subdir(&self) -> Platform {
+        if let Some(subdir) = self.recipe.build().subdir {
+            subdir
+        } else if self.recipe.build().noarch.is_none() {
+            self.build_configuration.target_platform
+        } else {
+            Platform::NoArch
+        }
+    }
+
     /// Shorthand to retrieve the target platform for this output
     pub fn host_platform(&self) -> &PlatformWithVirtualPackages {
         &self.build_configuration.host_platform

--- a/crates/rattler_build_recipe/src/stage0/build.rs
+++ b/crates/rattler_build_recipe/src/stage0/build.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use itertools::Itertools as _;
-use rattler_conda_types::{Flag, NoArchType, package::EntryPoint};
+use rattler_conda_types::{Flag, NoArchType, Platform, package::EntryPoint};
 use serde::{Deserialize, Serialize};
 
 use crate::stage0::types::{ConditionalList, IncludeExclude, Item, Script, Value};
@@ -43,6 +43,12 @@ pub struct Build {
     /// Noarch type - python or generic
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub noarch: Option<Value<NoArchType>>,
+
+    /// Override the subdir the package is created for. Defaults to the target
+    /// platform (or `noarch` for noarch packages). Cannot be combined with
+    /// `noarch`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subdir: Option<Value<Platform>>,
 
     /// V3 package variant flags.
     #[serde(default, skip_serializing_if = "ConditionalList::is_empty")]
@@ -96,6 +102,7 @@ impl Default for Build {
             string: None,
             script: Script::default(),
             noarch: None,
+            subdir: None,
             flags: ConditionalList::default(),
             python: PythonBuild::default(),
             skip: ConditionalList::default(),
@@ -277,6 +284,7 @@ impl Build {
             string,
             script,
             noarch,
+            subdir,
             flags,
             python,
             skip,
@@ -304,6 +312,10 @@ impl Build {
 
         if let Some(noarch) = noarch {
             vars.extend(noarch.used_variables());
+        }
+
+        if let Some(subdir) = subdir {
+            vars.extend(subdir.used_variables());
         }
 
         vars.extend(flags.used_variables());

--- a/crates/rattler_build_recipe/src/stage0/evaluate.rs
+++ b/crates/rattler_build_recipe/src/stage0/evaluate.rs
@@ -29,8 +29,8 @@ use indexmap::IndexMap;
 use rattler_build_script::ScriptContent;
 use rattler_build_types::NormalizedKey;
 use rattler_conda_types::{
-    MatchSpec, NoArchType, PackageName, PackageNameMatcher, ParseStrictness, RepodataRevision,
-    VersionWithSource,
+    MatchSpec, NoArchType, PackageName, PackageNameMatcher, ParseStrictness, Platform,
+    RepodataRevision, VersionWithSource,
 };
 use rattler_digest::{Md5Hash, Sha256Hash};
 
@@ -820,9 +820,7 @@ fn evaluate_flag_list(
 /// Skip values are Jinja expressions like `is_abi3`, `not unix`, etc.
 /// They are rendered through Jinja to track accessed variables
 /// (important for variant hash computation), and then evaluated eagerly
-/// to produce a boolean result. This matches the behavior of main where
-/// skip conditions are resolved during parsing, before the variant gets
-/// noarch overrides that would change `target_platform`.
+/// to produce a boolean result.
 ///
 /// Returns true if ANY skip condition evaluates to true (OR logic).
 pub fn evaluate_skip_list(
@@ -2113,6 +2111,42 @@ impl Evaluate for Stage0Build {
             }
         };
 
+        // Evaluate the subdir override
+        let subdir = match &self.subdir {
+            None => None,
+            Some(v) => {
+                let span = v.span().copied().unwrap_or_else(Span::new_blank);
+                let rendered = if let Some(value) = v.as_concrete() {
+                    Some(*value)
+                } else if let Some(template) = v.as_template() {
+                    let s = render_template(template.source(), context, v.span())?;
+                    if s.is_empty() {
+                        None
+                    } else {
+                        Some(s.parse::<Platform>().map_err(|e| {
+                            ParseError::invalid_value(
+                                "subdir",
+                                format!("invalid subdir '{}': {}", s, e),
+                                span,
+                            )
+                        })?)
+                    }
+                } else {
+                    unreachable!("Value must be either concrete or template")
+                };
+
+                if rendered.is_some() && noarch.is_some() {
+                    return Err(ParseError::invalid_value(
+                        "subdir",
+                        "`build.subdir` cannot be combined with `build.noarch`",
+                        span,
+                    ));
+                }
+
+                rendered
+            }
+        };
+
         // Evaluate skip conditions as Jinja boolean expressions
         // This tracks accessed variables for proper variant hash computation
         let skip = evaluate_skip_list(&self.skip, context)?;
@@ -2190,6 +2224,7 @@ impl Evaluate for Stage0Build {
             string,
             script,
             noarch,
+            subdir,
             flags,
             python,
             skip,
@@ -2894,11 +2929,6 @@ impl Evaluate for Stage0Recipe {
             })
             .collect();
 
-        // Ensure that `target_platform` is set to "noarch" for noarch packages
-        if !noarch.is_none() {
-            actual_variant.insert("target_platform".into(), Variable::from_string("noarch"));
-        }
-
         // Add virtual packages from run requirements to the variant
         // Virtual packages (starting with '__') should be included in the hash
         for dep in &requirements.run {
@@ -2955,6 +2985,9 @@ fn merge_stage1_build(
 
     // Noarch: inherit from top-level if not set in output
     let noarch = output.noarch.or(toplevel.noarch);
+
+    // Subdir override: inherit from top-level if not set in output
+    let subdir = output.subdir.or(toplevel.subdir);
 
     // V3 package flags: use output if not empty, otherwise inherit from top-level
     let flags = if output.flags.is_empty() {
@@ -3031,6 +3064,7 @@ fn merge_stage1_build(
         number,
         string,
         noarch,
+        subdir,
         flags,
         python,
         skip,
@@ -3177,6 +3211,9 @@ fn evaluate_package_output_to_recipe(
         }
         if output_build.noarch.is_none() {
             output_build.noarch = toplevel_build.noarch;
+        }
+        if output_build.subdir.is_none() {
+            output_build.subdir = toplevel_build.subdir;
         }
         if output_build.python.is_default() {
             output_build.python = toplevel_build.python;
@@ -3336,11 +3373,6 @@ fn evaluate_package_output_to_recipe(
         })
         .map(|(k, v)| (NormalizedKey::from(k.as_str()), v.clone()))
         .collect();
-
-    // Ensure that `target_platform` is set to "noarch" for noarch packages
-    if !noarch.is_none() {
-        actual_variant.insert("target_platform".into(), Variable::from_string("noarch"));
-    }
 
     // Add virtual packages from run requirements to the variant
     // Virtual packages (starting with '__') should be included in the hash
@@ -4077,6 +4109,40 @@ requirements:
         assert_undefined_with_default_hint(&eval(cond, &[]).unwrap_err());
         // Invalid noarch types are still rejected.
         assert!(eval(r#"${{ "banana" }}"#, &[]).is_err());
+    }
+
+    #[test]
+    fn test_build_subdir() {
+        let eval = |subdir: &str, vars: &[(&str, Variable)]| {
+            let recipe = format!(
+                "schema_version: 1\n\npackage:\n  name: p\n  version: \"1.0\"\n\nbuild:\n  subdir: {subdir}\n"
+            );
+            evaluate_recipe_with_vars(&recipe, vars).map(|r| r.build.subdir)
+        };
+
+        // Concrete platform
+        assert_eq!(
+            eval("linux-aarch64", &[]).unwrap(),
+            Some(Platform::LinuxAarch64)
+        );
+        // Template
+        assert_eq!(
+            eval(
+                "${{ my_subdir }}",
+                &[("my_subdir", Variable::from("osx-arm64"))]
+            )
+            .unwrap(),
+            Some(Platform::OsxArm64)
+        );
+        // A template rendering to an invalid platform is rejected
+        assert!(eval(r#"${{ "not-a-platform" }}"#, &[]).is_err());
+    }
+
+    #[test]
+    fn test_build_subdir_conflicts_with_noarch() {
+        let recipe = "schema_version: 1\n\npackage:\n  name: p\n  version: \"1.0\"\n\nbuild:\n  noarch: generic\n  subdir: linux-64\n";
+        let err = evaluate_recipe_with_vars(recipe, &[]).unwrap_err();
+        assert!(err.to_string().contains("cannot be combined"));
     }
 
     /// #2544: `down_prioritize_variant` referencing a variant key that is only

--- a/crates/rattler_build_recipe/src/stage0/parser/build.rs
+++ b/crates/rattler_build_recipe/src/stage0/parser/build.rs
@@ -426,6 +426,9 @@ fn parse_build_from_mapping(mapping: &MarkedMappingNode) -> Result<Build, ParseE
             "noarch" => {
                 build.noarch = Some(parse_noarch(value_node)?);
             }
+            "subdir" => {
+                build.subdir = Some(parse_field!("build.subdir", value_node));
+            }
             "flags" => {
                 build.flags = parse_conditional_list(value_node)?;
             }
@@ -464,7 +467,7 @@ fn parse_build_from_mapping(mapping: &MarkedMappingNode) -> Result<Build, ParseE
             _ => {
                 return Err(
                     ParseError::invalid_value("build", format!("unknown field '{}'", key), *key_node.span())
-                        .with_suggestion("Valid fields are: number, string, script, noarch, flags, python, skip, always_copy_files, always_include_files, merge_build_and_host_envs, files, dynamic_linking, variant, prefix_detection, post_process")
+                        .with_suggestion("Valid fields are: number, string, script, noarch, subdir, flags, python, skip, always_copy_files, always_include_files, merge_build_and_host_envs, files, dynamic_linking, variant, prefix_detection, post_process")
                 );
             }
         }

--- a/crates/rattler_build_recipe/src/stage1/build.rs
+++ b/crates/rattler_build_recipe/src/stage1/build.rs
@@ -2,7 +2,7 @@
 use rattler_build_jinja::Variable;
 use rattler_build_script::Script;
 use rattler_build_yaml_parser::ParseError;
-use rattler_conda_types::{Flag, NoArchType, package::EntryPoint};
+use rattler_conda_types::{Flag, NoArchType, Platform, package::EntryPoint};
 use serde::{Deserialize, Serialize};
 
 use crate::stage1::HashInfo;
@@ -315,6 +315,10 @@ pub struct Build {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub noarch: Option<NoArchType>,
 
+    /// Override the subdir the package is created for
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subdir: Option<Platform>,
+
     /// V3 package variant flags.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub flags: Vec<Flag>,
@@ -323,9 +327,7 @@ pub struct Build {
     #[serde(default, skip_serializing_if = "PythonBuild::is_default")]
     pub python: PythonBuild,
 
-    /// Whether the build should be skipped (pre-evaluated from skip conditions).
-    /// Skip conditions are evaluated eagerly during recipe evaluation, before
-    /// the variant gets noarch overrides
+    /// Whether the build should be skipped (pre-evaluated from skip conditions)
     #[serde(default, skip)]
     pub skip: bool,
 
@@ -508,6 +510,7 @@ impl Build {
             && matches!(self.string, BuildString::Default)
             && self.script.is_default()
             && self.noarch.is_none()
+            && self.subdir.is_none()
             && self.flags.is_empty()
             && self.python.entry_points.is_empty()
             && self.python.skip_pyc_compilation.is_empty()

--- a/crates/rattler_build_recipe/src/stage1/hash.rs
+++ b/crates/rattler_build_recipe/src/stage1/hash.rs
@@ -86,10 +86,23 @@ pub struct HashInfo {
 pub struct HashInput(String);
 
 impl HashInput {
-    /// Create a new hash input from a variant
-    pub fn from_variant(variant: &BTreeMap<NormalizedKey, Variable>) -> Self {
+    /// Create a new hash input from a variant.
+    ///
+    /// For noarch packages, `target_platform` is set to `noarch` in the hash
+    /// input so the hash is independent of the platform the package is built
+    /// for (matching conda-build).
+    pub fn from_variant(variant: &BTreeMap<NormalizedKey, Variable>, noarch: &NoArchType) -> Self {
         let mut buf = Vec::new();
         let mut ser = serde_json::Serializer::with_formatter(&mut buf, PythonFormatter {});
+
+        let mut noarch_variant;
+        let variant = if noarch.is_none() {
+            variant
+        } else {
+            noarch_variant = variant.clone();
+            noarch_variant.insert("target_platform".into(), "noarch".into());
+            &noarch_variant
+        };
 
         // BTree has sorted keys, which is important for hashing
         variant
@@ -169,7 +182,7 @@ impl HashInfo {
     /// Compute the build string for a given variant
     pub fn from_variant(variant: &BTreeMap<NormalizedKey, Variable>, noarch: &NoArchType) -> Self {
         Self {
-            hash: Self::hash_from_input(&HashInput::from_variant(variant)),
+            hash: Self::hash_from_input(&HashInput::from_variant(variant, noarch)),
             prefix: Self::hash_prefix(variant, noarch),
         }
     }
@@ -376,7 +389,7 @@ mod tests {
             Variable::from("linux-64"),
         );
 
-        let hash_input = HashInput::from_variant(&variant);
+        let hash_input = HashInput::from_variant(&variant, &NoArchType::none());
         let json_str = hash_input.as_str();
 
         // Should be valid JSON

--- a/crates/rattler_build_recipe/src/stage1/snapshots/rattler_build_recipe__stage1__variant_tests__tests__build_string_py_noarch.snap
+++ b/crates/rattler_build_recipe/src/stage1/snapshots/rattler_build_recipe__stage1__variant_tests__tests__build_string_py_noarch.snap
@@ -2,4 +2,4 @@
 source: crates/rattler_build_recipe/src/stage1/variant_tests.rs
 expression: "format!(\"{:?}\", used_variant)"
 ---
-{NormalizedKey("__unix"): "__unix", NormalizedKey("target_platform"): "noarch"}
+{NormalizedKey("__unix"): "__unix", NormalizedKey("target_platform"): "linux-64"}

--- a/crates/rattler_build_recipe/src/stage1/variant_tests.rs
+++ b/crates/rattler_build_recipe/src/stage1/variant_tests.rs
@@ -536,6 +536,27 @@ build:
     }
 
     #[test]
+    fn test_hash_noarch_platform_independent() {
+        // The hash input replaces target_platform with noarch, so noarch
+        // packages hash identically regardless of the platform they target
+        let mut variant1 = BTreeMap::new();
+        variant1.insert(
+            NormalizedKey::from("target_platform"),
+            Variable::from("linux-64"),
+        );
+        let mut variant2 = BTreeMap::new();
+        variant2.insert(
+            NormalizedKey::from("target_platform"),
+            Variable::from("win-64"),
+        );
+
+        let hash1 = HashInfo::from_variant(&variant1, &NoArchType::generic());
+        let hash2 = HashInfo::from_variant(&variant2, &NoArchType::generic());
+
+        assert_eq!(hash1, hash2);
+    }
+
+    #[test]
     fn test_hash_deterministic() {
         let mut variant = BTreeMap::new();
         variant.insert(
@@ -654,12 +675,15 @@ requirements:
         assert!(!used_variant.contains_key(&NormalizedKey::from("python")));
         // The virtual __unix dependency should be included in the variant
         assert!(used_variant.contains_key(&NormalizedKey::from("__unix")));
+        // target_platform stays the actual platform in the variant
         assert_eq!(
             used_variant.get(&NormalizedKey::from("target_platform")),
-            Some(&Variable::from("noarch"))
+            Some(&Variable::from("linux-64"))
         );
 
         insta::assert_snapshot!(format!("{:?}", used_variant));
+        // The hash input replaces target_platform with noarch, so the build
+        // string is unchanged from before the subdir decoupling
         let build_string = recipe
             .build()
             .string

--- a/crates/rattler_build_recipe/src/variant_render.rs
+++ b/crates/rattler_build_recipe/src/variant_render.rs
@@ -966,11 +966,6 @@ fn render_with_empty_combinations(
                 .collect();
             variant.retain(|key, _| !ignore_keys.contains(key));
 
-            // For noarch packages, override target_platform
-            if recipe.build.noarch.is_some() {
-                variant.insert("target_platform".into(), "noarch".into());
-            }
-
             RenderedVariant {
                 variant,
                 full_combination: BTreeMap::new(), // No combination when rendering with empty combinations
@@ -3019,9 +3014,8 @@ build:
     fn test_noarch_should_not_override_target_platform_for_skip() {
         // When building a noarch package on a native platform (e.g., linux-64),
         // the skip condition `target_platform == "noarch"` should evaluate to false
-        // because the target_platform should remain the build platform, not "noarch".
-        // Skip conditions are evaluated eagerly during recipe evaluation, before
-        // the variant gets the noarch target_platform override.
+        // because target_platform remains the actual platform for noarch packages;
+        // only the package subdir becomes "noarch".
         use crate::stage0::parse_recipe_from_source;
 
         let recipe_yaml = r#"

--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -734,6 +734,26 @@ variable is still an error: if the variable is only defined on some platforms,
 provide an explicit fallback with the `default` filter, e.g.
 `${{ "python" if use_noarch | default(false) }}`.
 
+Note that for noarch packages the `target_platform` variable keeps its
+concrete value (e.g. `linux-64`) during rendering and in the build script;
+only the subdir of the resulting package becomes `noarch`.
+
+### Overriding the subdir of a package
+
+The `subdir` key overrides the subdir the package is created for. This is
+useful for packages such as cross-compilers where the subdir of the package
+does not match the platform the build runs on. It cannot be combined with
+`noarch`.
+
+```yaml
+build:
+  subdir: linux-aarch64
+```
+
+This only affects how the package is stamped and where it is placed; it does
+not change `target_platform` or how dependencies are resolved. It is the
+equivalent of the output-level `target` key of conda-build.
+
 ### Include only certain files in the package
 
 Sometimes you may want to include only a subset of the files installed by the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,12 +140,6 @@ fn find_variants(
         let recipe = rendered.recipe;
         let variant = rendered.variant;
 
-        let effective_target_platform = if recipe.build().noarch.is_none() {
-            target_platform
-        } else {
-            Platform::NoArch
-        };
-
         // The recipe has already been evaluated and has its build string resolved
         // (including proper variant filtering for noarch python)
         // Extract the build string and hash from the already-evaluated recipe
@@ -160,7 +154,7 @@ fn find_variants(
             version: recipe.package().version().to_string(),
             build_string: build_string.to_string(),
             noarch_type: recipe.build().noarch.unwrap_or(NoArchType::none()),
-            target_platform: effective_target_platform,
+            target_platform,
             used_vars: variant,
             recipe,
             hash: rendered.hash_info.expect("Should be set after evaluation"),
@@ -716,8 +710,8 @@ pub async fn run_build_from_args(
         let (skip_test, skip_test_reason) = match tool_configuration.test_strategy {
             TestStrategy::Skip => (true, "the argument --test=skip was set".to_string()),
             TestStrategy::Native => {
-                // Skip if `host_platform != build_platform` and `target_platform != noarch`
-                if output.build_configuration.target_platform != Platform::NoArch
+                // Skip if `host_platform != build_platform` and the package is not `noarch`
+                if output.subdir() != Platform::NoArch
                     && output.build_configuration.host_platform.platform
                         != output.build_configuration.build_platform.platform
                 {
@@ -766,7 +760,7 @@ pub async fn run_build_from_args(
                             .directories
                             .output_dir
                             .join("test"),
-                        target_platform: Some(output.build_configuration.target_platform),
+                        target_platform: Some(output.subdir()),
                         host_platform: Some(output.build_configuration.host_platform.clone()),
                         current_platform: output.build_configuration.build_platform.clone(),
                         keep_test_prefix: tool_configuration.no_clean,
@@ -858,10 +852,10 @@ pub async fn skip_noarch(
     if let Some(noarch_build_platform) = tool_configuration.noarch_build_platform {
         outputs.retain(|output| {
             // Skip the build if:
-            // - target_platform is "noarch"
+            // - the package is `noarch`
             // and
             // - build_platform != noarch_build_platform
-            let should_skip = output.build_configuration.target_platform == Platform::NoArch
+            let should_skip = output.subdir() == Platform::NoArch
                 && output.build_configuration.build_platform.platform != noarch_build_platform;
 
             if should_skip {

--- a/test-data/recipes/build_subdir/recipe.yaml
+++ b/test-data/recipes/build_subdir/recipe.yaml
@@ -1,0 +1,7 @@
+package:
+  name: build-subdir-override
+  version: "1.0.0"
+
+build:
+  subdir: linux-aarch64
+  number: 0

--- a/test-data/recipes/noarch_concrete_target_platform/recipe.yaml
+++ b/test-data/recipes/noarch_concrete_target_platform/recipe.yaml
@@ -1,0 +1,16 @@
+package:
+  name: noarch-concrete-target-platform
+  version: "1.0.0"
+
+build:
+  noarch: generic
+  script:
+    - if: unix
+      then: |
+        echo "$target_platform" > $PREFIX/target_platform_env.txt
+        echo "${{ target_platform }}" > $PREFIX/target_platform_jinja.txt
+        echo "$SUBDIR" > $PREFIX/subdir_env.txt
+      else: |
+        echo %target_platform%> %PREFIX%\target_platform_env.txt
+        echo ${{ target_platform }}> %PREFIX%\target_platform_jinja.txt
+        echo %SUBDIR%> %PREFIX%\subdir_env.txt

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -1109,7 +1109,7 @@ def test_noarch_variants(rattler_build: RattlerBuild, recipes: Path, tmp_path: P
 
     assert rendered[0]["build_configuration"]["variant"] == {
         "__unix": "__unix",
-        "target_platform": "noarch",
+        "target_platform": "linux-64",
     }
 
     pin = {
@@ -1123,7 +1123,7 @@ def test_noarch_variants(rattler_build: RattlerBuild, recipes: Path, tmp_path: P
     assert rendered[1]["recipe"]["requirements"]["run"] == [pin]
     assert rendered[1]["build_configuration"]["variant"] == {
         "rattler_build_demo": "1 unix_5600cae_0",
-        "target_platform": "noarch",
+        "target_platform": "linux-64",
     }
 
     output = rattler_build(
@@ -1137,7 +1137,7 @@ def test_noarch_variants(rattler_build: RattlerBuild, recipes: Path, tmp_path: P
 
     assert rendered[0]["build_configuration"]["variant"] == {
         "__win": "__win >=11.0.123 foobar",
-        "target_platform": "noarch",
+        "target_platform": "win-64",
     }
 
     pin = {
@@ -1151,8 +1151,47 @@ def test_noarch_variants(rattler_build: RattlerBuild, recipes: Path, tmp_path: P
     assert rendered[1]["recipe"]["requirements"]["run"] == [pin]
     assert rendered[1]["build_configuration"]["variant"] == {
         "rattler_build_demo": "1 win_19aa286_0",
-        "target_platform": "noarch",
+        "target_platform": "win-64",
     }
+
+
+def test_noarch_target_platform_is_concrete(
+    rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
+):
+    """The build script of a noarch package sees the concrete target platform,
+    while the package itself is stamped and placed as noarch."""
+    rattler_build.build(recipes / "noarch_concrete_target_platform", tmp_path)
+
+    package_path = get_package(tmp_path, "noarch-concrete-target-platform")
+    assert package_path.parent.name == "noarch"
+
+    pkg = get_extracted_package(tmp_path, "noarch-concrete-target-platform")
+    index = json.loads((pkg / "info/index.json").read_text())
+    assert index["subdir"] == "noarch"
+    assert index.get("platform") is None
+    assert index.get("arch") is None
+
+    current = host_subdir()
+    assert (pkg / "target_platform_env.txt").read_text().strip() == current
+    assert (pkg / "target_platform_jinja.txt").read_text().strip() == current
+    # SUBDIR refers to the package subdir
+    assert (pkg / "subdir_env.txt").read_text().strip() == "noarch"
+
+
+def test_build_subdir_override(
+    rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
+):
+    """`build.subdir` overrides the subdir the package is stamped with."""
+    rattler_build.build(recipes / "build_subdir", tmp_path, extra_args=["--test=skip"])
+
+    package_path = get_package(tmp_path, "build-subdir-override")
+    assert package_path.parent.name == "linux-aarch64"
+
+    pkg = get_extracted_package(tmp_path, "build-subdir-override")
+    index = json.loads((pkg / "info/index.json").read_text())
+    assert index["subdir"] == "linux-aarch64"
+    assert index["platform"] == "linux"
+    assert index["arch"] == "aarch64"
 
 
 def test_platform_selectors_use_host_platform(
@@ -1563,7 +1602,7 @@ def test_used_vars(rattler_build: RattlerBuild, recipes: Path, tmp_path: Path):
     rendered = json.loads(output)
     assert len(rendered) == 1
     assert rendered[0]["build_configuration"]["variant"] == {
-        "target_platform": "noarch"
+        "target_platform": "linux-64"
     }
 
 


### PR DESCRIPTION
For noarch outputs, `target_platform` used to be replaced with `noarch` everywhere: in the variant, the jinja context, and the `target_platform` environment variable in the build script. This does not match conda-build, where `target_platform` keeps the requested platform and only the subdir of the resulting package becomes `noarch` (see the Discord discussion with @isuruf).

With this PR:

```yaml
build:
  noarch: generic
  script:
    - echo $target_platform  # linux-64 (was: noarch)
    - echo $SUBDIR           # noarch (unchanged)
```

The package is still stamped as `noarch` and placed in the `noarch` folder.

Build strings do not change. The hash input still replaces `target_platform` with `noarch` for noarch packages (now inside `HashInput::from_variant`), so hashes remain platform independent and byte-identical to what rattler-build produces today. `test_build_string_py_noarch` and `test_noarch_variants` assert the exact same build strings as before, and a new test asserts that noarch hashes are identical across target platforms.

## Implementation

- `BuildConfiguration::target_platform` is now always a concrete platform. The subdir of a package is derived instead: `Output::subdir()` returns `build.subdir` if set, `noarch` for noarch packages, and the target platform otherwise.
- Everything that used `target_platform == NoArch` as an "is this noarch?" check (relinking, linking checks, the Windows symlink check, run-export selection, `--noarch-build-platform`, native test skipping) now uses `Output::subdir()`, so behavior there is unchanged.
- index.json `subdir`/`arch`/`platform`, the output folder, prefix placeholder detection, file mapping, and package content tests also go through `Output::subdir()` and behave as before.

Visible behavior changes for noarch builds besides `target_platform` itself:

- `CONDA_BUILD_CROSS_COMPILATION` is now `0` when host and build platform match. It was always `1` for noarch because `noarch != build_platform`.
- The platform default environment variables (e.g. `MACOSX_DEPLOYMENT_TARGET`) are now set in the build script because `os_vars` receives a concrete platform. This is what made the compiler activation workaround in `tzdata-feedstock` necessary before.
- `ARCH` is unchanged (it was already derived from the host platform).

## `build.subdir`

Conda-build has an output-level `target` key that only controls the subdir the package is stamped with. This PR ports it as `build.subdir` (renamed per @isuruf's suggestion):

```yaml
build:
  subdir: linux-aarch64
```

It only affects index.json and the output folder. It does not change `target_platform` or dependency resolution, and it cannot be combined with `noarch`. The key supports jinja templates and inherits from the top-level build section in multi-output recipes, like `noarch`.

## Open questions

- `SUBDIR` in the build script still refers to the package subdir (`noarch`), while conda-build populates it from `host_subdir` (a concrete platform). Should we follow conda-build here as well?
- Test scripts still see `target_platform` as the package subdir, because at test time the value is derived from the package (index.json / `hash_input.json`) rather than from the build.

## Compatibility with existing conda-forge recipes

<details><summary>Assessment of the impact on conda-forge recipes</summary>

### Summary

Changing rattler-build so that `target_platform` remains the requested platform for noarch outputs appears to have a small compatibility risk for conda-forge recipes.

The search did not find a current `recipe.yaml` that clearly and intentionally relies on `target_platform=noarch`. The strongest ecosystem evidence points in the opposite direction: `tzdata-feedstock` explicitly works around rattler-build setting `target_platform` to `noarch`.

One recipe, `m2w64-sysroot-feedstock`, has a build script whose behavior can change depending on the value. It should be included in regression testing, although its normal conda-forge noarch build is unlikely to change.

### Behavior in conda-build

Given a noarch recipe built with `target_platform=win-64`, conda-build keeps the requested target platform visible to the build script:

```yaml
package:
  name: foo
  version: "1.0.0"

build:
  number: 0
  noarch: generic
  script:
    - echo %target_platform%
```

Running:

```console
conda-build recipe --variants "{target_platform: win-64}"
```

prints:

```text
win-64
```

The resulting package is nevertheless placed in the `noarch` subdirectory.

Conda-build therefore distinguishes between:

- the requested target or host platform, exposed as `target_platform`;
- whether the package is noarch, stored as recipe metadata;
- the final package subdirectory.

`SUBDIR` is populated from `config.host_subdir`, not from the final package subdirectory ([source](https://github.com/conda/conda-build/blob/88e566afe3b903ec5ad9ef21cc7a2b383caf3911/conda_build/environ.py#L390-L415)). When package metadata is created, conda-build explicitly sets the package subdirectory to `noarch` when `metadata.noarch` is set ([source](https://github.com/conda/conda-build/blob/88e566afe3b903ec5ad9ef21cc7a2b383caf3911/conda_build/metadata.py#L1899-L1907)).

Conda-build also supports an output-level `target` key:

```yaml
outputs:
  - name: foo
    target: noarch
```

This is assigned to `output_metadata.config.target_subdir` ([source](https://github.com/conda/conda-build/blob/88e566afe3b903ec5ad9ef21cc7a2b383caf3911/conda_build/metadata.py#L2513-L2514)) and controls the final package subdirectory ([source](https://github.com/conda/conda-build/blob/88e566afe3b903ec5ad9ef21cc7a2b383caf3911/conda_build/build.py#L1981-L1993)). It remains separate from `target_platform`.

### Conda-forge search

The search focused on current `recipe.yaml` files because those are the recipes using the v1 recipe format and rattler-build. It covered:

- literal comparisons between `target_platform` and `noarch`;
- `${{ target_platform }}` interpolation in noarch outputs;
- `build_platform != target_platform` selectors in noarch outputs;
- inline build scripts referencing `target_platform`;
- external shell and batch scripts referencing the runtime `target_platform` environment variable;
- mixed multi-output recipes where only some outputs are noarch.

No current `recipe.yaml` was found containing a literal comparison such as:

```yaml
target_platform == "noarch"
target_platform != "noarch"
```

GitHub code search indexes default branches and can lag behind recent changes, so this is not a guarantee that no such recipe exists. It does, however, cover the most direct ways a recipe could intentionally depend on the behavior.

### Confirmed workaround: `tzdata-feedstock`

[`tzdata-feedstock`](https://github.com/conda-forge/tzdata-feedstock/blob/7861f3afa58b5b0bb7e7fc171358ca3a725ee570/recipe/recipe.yaml#L16-L23) explicitly overrides `target_platform`:

```yaml
build:
  number: 1
  noarch: generic
  script:
    file: build.sh
    # Workaround as rattler-build sets target_platform to noarch, such that the compiler-activation script would not be run
    # https://github.com/conda-forge/tzdata-feedstock/pull/34#issuecomment-3593550598
    env: { target_platform: "${{ host_platform }}" }
```

This is not a dependency on the current behavior. It documents a concrete problem caused by it: compiler activation does not run when `target_platform=noarch`.

Keeping `target_platform` concrete would make this workaround unnecessary and align rattler-build with conda-build.

### Potentially behavior-sensitive recipe: `m2w64-sysroot-feedstock`

[`m2w64-sysroot-feedstock`](https://github.com/conda-forge/m2w64-sysroot-feedstock/blob/c5ae60d3f8d6efa47a86be4db1aa5493ad2d8918/recipe/recipe.yaml#L192-L198) defines a noarch output using `copy.sh`:

```yaml
- package:
    name: m2w64-sysroot_win-64
  build:
    noarch: generic
    merge_build_and_host_envs: false
    script: copy.sh
```

The corresponding [`copy.sh`](https://github.com/conda-forge/m2w64-sysroot-feedstock/blob/c5ae60d3f8d6efa47a86be4db1aa5493ad2d8918/recipe/copy.sh#L10-L13) contains:

```bash
if [[ "$target_platform" != "win-64" ]]; then
  mkdir -p ${PREFIX}/${HOST}/sysroot
  ln -sf ${PREFIX}/${HOST}/sysroot/usr ${PREFIX}/${HOST}/sysroot/ucrt64
fi
```

With the current rattler-build behavior, the condition is true because `target_platform=noarch`. With a concrete `target_platform`, it would be false when the requested platform is `win-64`.

This deserves regression coverage. However, the noarch package is normally produced in a Linux conda-forge job. In that job the concrete target is `linux-64`, so the condition remains true and the resulting artifact should be unchanged.

### References that do not rely on `target_platform=noarch`

Several noarch outputs use expressions such as:

```yaml
- if: build_platform != target_platform
  then:
    - python
    - cross-python_${{ target_platform }}
```

Examples include:

- [`mnelab-feedstock`](https://github.com/conda-forge/mnelab-feedstock/blob/d5a8af9cb6f6d1f064f816e5b1a95aac543d8a7b/recipe/recipe.yaml#L16-L32)
- [`lightgbm-feedstock`](https://github.com/conda-forge/lightgbm-feedstock/blob/80d7982ebf3297c33671e172007016d46b18cd33/recipe/recipe.yaml#L87-L101)
- [`conda-global-feedstock`](https://github.com/conda-forge/conda-global-feedstock/blob/054a2af2c512c81e5cad238c66662c67e60456de/recipe/recipe.yaml#L61-L78)
- [`pybind11-feedstock`](https://github.com/conda-forge/pybind11-feedstock/blob/7d2ea6398560d09fad899862455721d27d89dc1f/recipe/recipe.yaml#L89-L105)
- [`pyb2d3-feedstock`](https://github.com/conda-forge/pyb2d3-feedstock/blob/6eae35ca06bf03d136d4adc74c26105acf3dca88/recipe/recipe.yaml#L63-L84)
- [`gz-msgs-feedstock`](https://github.com/conda-forge/gz-msgs-feedstock/blob/3181b50ec6970b009e92f705ed92fe50b1329bbf/recipe/recipe.yaml#L89-L115)

These are not evidence of reliance on `target_platform=noarch`. Recipe expressions are evaluated using the requested platform before rattler-build assigns the effective noarch output platform. If these expressions saw `noarch`, some would attempt to depend on a package such as `cross-python_noarch`, which is clearly not their intent.

Other recipes explicitly require selectors to see the requested platform:

- [`stim-split-feedstock`](https://github.com/conda-forge/stim-split-feedstock/blob/c6bb026b59abe85f06f3be6715f4cd1fcd6d04e9/recipe/recipe.yaml#L82-L87) skips its noarch output unless `target_platform` is `linux-64`.
- [`backports.zstd-feedstock`](https://github.com/conda-forge/backports.zstd-feedstock/blob/85e12f8c168b1c049db1996fc788ba638151b2bf/recipe/recipe.yaml#L55-L59) uses `target_platform == "linux-64"` when selecting its single noarch build.

These recipes support preserving the requested target platform rather than replacing it with `noarch`.

### Risk assessment

The direct recipe compatibility risk appears low:

- no recipe was found that intentionally checks for `target_platform=noarch`;
- one recipe explicitly works around the current behavior;
- one external script is potentially behavior-sensitive but should be unchanged in its normal noarch build job;
- many noarch recipes already expect recipe expressions to see the requested platform.

The less visible risk is indirect behavior in activation scripts supplied by build dependencies. Those scripts can inspect `target_platform` without the recipe mentioning it. The `tzdata` workaround demonstrates that this already causes incompatibilities when the value is `noarch`.

The intended invariant:

> `target_platform` describes the platform for which the build was requested. Whether the resulting package is noarch is separate output metadata and must not replace the requested target platform.

</details>
