### PR TITLE
refactor: drop scalar re-typing from `render_context`

### DIFF
--- a/py-rattler-build/rust/src/render.rs
+++ b/py-rattler-build/rust/src/render.rs
@@ -454,19 +454,17 @@ pub fn render_recipes(
 /// evaluated with the callable's return value instead of being preserved. A
 /// callable that raises falls back to preserving the expression verbatim.
 ///
-/// A fully resolved scalar is re-parsed as a YAML scalar so that its type
-/// (int, bool, ...) is recovered, matching how the recipe would be read back.
-/// Pass ``retype=False`` to keep every substituted scalar a string instead,
-/// e.g. when the caller wants to recover scalar types itself using the
-/// original document's quoting information.
+/// Every substituted scalar stays a string. Recovering the YAML type of a
+/// rendered scalar needs the original document's quoting to tell
+/// `"${{ python_min }}"` from `${{ build_number }}`, and that information is
+/// gone by the time the recipe reaches this function, so the caller does it.
 #[pyfunction]
-#[pyo3(signature = (recipe, jinja_config=None, functions=None, retype=true))]
+#[pyo3(signature = (recipe, jinja_config=None, functions=None))]
 pub fn render_context(
     py: Python<'_>,
     recipe: &Bound<'_, PyAny>,
     jinja_config: Option<PyJinjaConfig>,
     functions: Option<Bound<'_, PyDict>>,
-    retype: bool,
 ) -> PyResult<Py<PyAny>> {
     // Accept either a parsed Stage0 recipe or a raw recipe dictionary. The
     // dictionary path preserves the recipe's exact structure, which is what a
@@ -503,12 +501,11 @@ pub fn render_context(
     }
 
     // Evaluate the `context` section in order and feed it forward. Rendered
-    // entries are fed forward as *strings* — the same value a Jinja engine
-    // produces — so that comparisons in later entries (e.g.
-    // `${{ x if major == '0' else y }}`) keep working. The typed YAML re-parse
-    // only lands in the output tree. Entries that do not fully resolve are not
-    // fed forward at all, so a reference to them stays verbatim instead of
-    // having the unresolved template expanded into it.
+    // entries are fed forward as *strings* - the same value a Jinja engine
+    // produces - so that comparisons in later entries (e.g.
+    // `${{ x if major == '0' else y }}`) keep working. Entries that do not
+    // fully resolve are not fed forward at all, so a reference to them stays
+    // verbatim instead of having the unresolved template expanded into it.
     if let Some(context) = tree.get("context").cloned()
         && let Some(map) = context.as_object()
     {
@@ -527,7 +524,7 @@ pub fn render_context(
         }
     }
 
-    render_tree(&mut tree, &jinja, retype);
+    render_tree(&mut tree, &jinja);
 
     pythonize::pythonize(py, &tree)
         .map(|obj| obj.into())
@@ -604,71 +601,14 @@ fn python_jinja_function(
 /// Each `${{ ... }}` expression is rendered on its own so that a scalar mixing
 /// resolvable and unresolvable expressions (e.g.
 /// `${{ name }}-${{ unknown }}`) keeps only the unresolved part verbatim.
-fn render_json_scalar(jinja: &Jinja, value: &serde_json::Value, retype: bool) -> serde_json::Value {
+fn render_json_scalar(jinja: &Jinja, value: &serde_json::Value) -> serde_json::Value {
     let Some(source) = value.as_str() else {
         return value.clone();
     };
     if !source.contains("${{") {
         return value.clone();
     }
-    let rendered = substitute_expressions(jinja, source);
-    if !retype || rendered.contains("${{") {
-        // Something was left unresolved (or the caller wants to recover the
-        // scalar types itself), keep it as a string.
-        serde_json::Value::String(rendered)
-    } else {
-        // Fully resolved: recover the scalar type (int/bool/...) the way YAML
-        // would read it back.
-        reparse_yaml_scalar(&rendered)
-    }
-}
-
-/// Re-parse a fully rendered scalar as YAML to recover its type, the way the
-/// value would be read back from a rendered recipe file.
-///
-/// Escape sequences are escaped before parsing so a rendered value containing
-/// newlines survives as a single-line plain scalar instead of being folded or
-/// rejected by the YAML parser; a string result is unescaped again.
-fn reparse_yaml_scalar(rendered: &str) -> serde_json::Value {
-    let escaped = rendered
-        .replace('\\', "\\\\")
-        .replace('\n', "\\n")
-        .replace('\t', "\\t")
-        .replace('\r', "\\r");
-
-    match serde_yaml::from_str::<serde_json::Value>(&escaped) {
-        Ok(serde_json::Value::String(s)) => serde_json::Value::String(unescape_scalar(&s)),
-        // A scalar must stay a scalar: a rendered value that happens to parse
-        // as a mapping or list (e.g. "foo: bar") is kept as a string.
-        Ok(serde_json::Value::Object(_)) | Ok(serde_json::Value::Array(_)) | Err(_) => {
-            serde_json::Value::String(rendered.to_string())
-        }
-        Ok(other) => other,
-    }
-}
-
-/// Reverse the escaping applied in [`reparse_yaml_scalar`].
-fn unescape_scalar(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    let mut chars = s.chars();
-    while let Some(c) = chars.next() {
-        if c != '\\' {
-            out.push(c);
-            continue;
-        }
-        match chars.next() {
-            Some('n') => out.push('\n'),
-            Some('t') => out.push('\t'),
-            Some('r') => out.push('\r'),
-            Some('\\') => out.push('\\'),
-            Some(other) => {
-                out.push('\\');
-                out.push(other);
-            }
-            None => out.push('\\'),
-        }
-    }
-    out
+    serde_json::Value::String(substitute_expressions(jinja, source))
 }
 
 /// Replace every `${{ ... }}` expression in `source` by rendering it on its
@@ -700,17 +640,17 @@ fn substitute_expressions(jinja: &Jinja, source: &str) -> String {
 }
 
 /// Recursively render every templated string in the tree in place.
-fn render_tree(value: &mut serde_json::Value, jinja: &Jinja, retype: bool) {
+fn render_tree(value: &mut serde_json::Value, jinja: &Jinja) {
     match value {
-        serde_json::Value::String(_) => *value = render_json_scalar(jinja, value, retype),
+        serde_json::Value::String(_) => *value = render_json_scalar(jinja, value),
         serde_json::Value::Array(items) => {
             for item in items {
-                render_tree(item, jinja, retype);
+                render_tree(item, jinja);
             }
         }
         serde_json::Value::Object(map) => {
             for (_key, v) in map.iter_mut() {
-                render_tree(v, jinja, retype);
+                render_tree(v, jinja);
             }
         }
         _ => {}

--- a/py-rattler-build/src/rattler_build/render.py
+++ b/py-rattler-build/src/rattler_build/render.py
@@ -34,8 +34,6 @@ def render_context(
     recipe: Any,
     jinja_config: JinjaConfig | None = None,
     functions: dict[str, Callable[..., Any]] | None = None,
-    *,
-    retype: bool = True,
 ) -> dict[str, Any]:
     """Render a recipe's ``context`` section and substitute it into the recipe.
 
@@ -56,20 +54,18 @@ def render_context(
             ``pin_subpackage``) to Python callables. A mapped helper is evaluated
             with the callable's return value instead of being preserved verbatim.
             A callable that raises falls back to preserving the expression.
-        retype: Re-parse fully resolved scalars as YAML so their types
-            (int, bool, ...) are recovered, matching how a rendered recipe file
-            would be read back. Pass ``False`` to keep every substituted scalar
-            a string, e.g. when the caller recovers scalar types itself using
-            the original document's quoting information.
 
     Returns:
-        The recipe as a plain dictionary with the context substituted.
+        The recipe as a plain dictionary with the context substituted. Every
+        substituted scalar is a string: telling ``"${{ python_min }}"`` from
+        ``${{ build_number }}`` needs the original document's quoting, which is
+        lost on the way in, so recovering YAML scalar types is up to the caller.
     """
     # Unwrap the Python Stage0Recipe wrapper to its inner Rust object; a plain
     # dict is passed through untouched.
     inner = getattr(recipe, "_wrapper", recipe)
     config_inner = jinja_config._config if jinja_config is not None else None
-    return _render.render_context(inner, config_inner, functions, retype)
+    return _render.render_context(inner, config_inner, functions)
 
 
 def render_recipes(

--- a/py-rattler-build/src/rattler_build/stage0.py
+++ b/py-rattler-build/src/rattler_build/stage0.py
@@ -295,8 +295,6 @@ class Stage0Recipe(ABC):
         self,
         jinja_config: JinjaConfig | None = None,
         functions: dict[str, Callable[..., Any]] | None = None,
-        *,
-        retype: bool = True,
     ) -> dict[str, Any]:
         """Render the ``context`` section and substitute it into the recipe.
 
@@ -317,15 +315,14 @@ class Stage0Recipe(ABC):
                 that an unresolvable expression can be kept verbatim.
             functions: Optional mapping of helper names to Python callables that
                 are evaluated instead of preserving the helper call verbatim.
-            retype: Re-parse fully resolved scalars as YAML so their types
-                (int, bool, ...) are recovered. Pass ``False`` to keep every
-                substituted scalar a string.
 
         Returns:
-            The recipe as a plain dictionary with the context substituted.
+            The recipe as a plain dictionary with the context substituted. Every
+            substituted scalar is a string; recovering YAML scalar types needs
+            the original document's quoting and is up to the caller.
         """
         config_inner = jinja_config._config if jinja_config is not None else None
-        return _render.render_context(self._wrapper, config_inner, functions, retype)
+        return _render.render_context(self._wrapper, config_inner, functions)
 
     def run_build(
         self,

--- a/py-rattler-build/tests/unit/test_render_context.py
+++ b/py-rattler-build/tests/unit/test_render_context.py
@@ -24,8 +24,8 @@ requirements:
 def test_render_context_resolves_context_and_preserves_the_rest() -> None:
     rendered = render_context(Stage0Recipe.from_yaml(RECIPE))
 
-    # `context` entries are evaluated (and typed like YAML would read them back).
-    assert rendered["context"]["major"] == 1
+    # `context` entries are evaluated; substituted scalars stay strings.
+    assert rendered["context"]["major"] == "1"
     # Plain variables are substituted.
     assert rendered["package"]["name"] == "mypkg"
     assert rendered["package"]["version"] == "1.2.3"
@@ -56,7 +56,7 @@ def test_render_context_uses_jinja_config_platform() -> None:
     assert rendered["context"]["sel"] == "yes"
 
 
-def test_render_context_feeds_strings_forward_and_types_the_output() -> None:
+def test_render_context_feeds_rendered_strings_forward() -> None:
     recipe = {
         "context": {
             "version": "0.2025.39",
@@ -69,9 +69,8 @@ def test_render_context_feeds_strings_forward_and_types_the_output() -> None:
 
     rendered = render_context(recipe)
 
-    # The output recovers YAML types for fully resolved entries...
-    assert rendered["context"]["major"] == 0
-    # ...but later entries see the rendered *string*, like a Jinja engine would.
+    # Later entries see the rendered *string*, like a Jinja engine would.
+    assert rendered["context"]["major"] == "0"
     assert rendered["context"]["tag"] == "weekly"
     # Unresolved entries stay verbatim and references to them are not expanded.
     assert rendered["context"]["combo"] == "${{ unknown_thing }}"
@@ -117,17 +116,17 @@ def test_render_context_with_raising_function_preserves_expression() -> None:
     assert rendered["requirements"]["build"] == ["${{ compiler('c') }}"]
 
 
-def test_render_context_retype_false_keeps_substituted_scalars_as_strings() -> None:
+def test_render_context_keeps_substituted_scalars_as_strings() -> None:
     recipe = {
         "context": {"build_num": 5, "python_min": "3.10"},
         "build": {"number": "${{ build_num }}"},
         "tests": [{"python": {"python_version": "${{ python_min }}"}}],
     }
 
-    rendered = render_context(recipe, retype=False)
-    assert rendered["build"]["number"] == "5"
-    # with re-typing, "3.10" would read back as the float 3.1
-    assert rendered["tests"][0]["python"]["python_version"] == "3.10"
-
     rendered = render_context(recipe)
-    assert rendered["build"]["number"] == 5
+    # Recovering scalar types is the caller's job: reading these back as YAML
+    # needs the source quoting to know "3.10" is a version and not the float 3.1.
+    assert rendered["build"]["number"] == "5"
+    assert rendered["tests"][0]["python"]["python_version"] == "3.10"
+    # An untemplated scalar keeps whatever type it had.
+    assert rendered["context"]["build_num"] == 5


### PR DESCRIPTION
Follow-up to #2662.

`render_context` re-parses every fully resolved scalar as YAML to recover its type, which needs escaping and unescaping newlines around the parse. That only works with the source quoting at hand - `"${{ python_min }}"` must stay `"3.10"` while `${{ build_number }}` should become an int - and the quoting is gone by the time a recipe reaches the bindings (`depythonize` sees ruamel's `DoubleQuotedScalarString` as a plain `str`).

So the only consumer, `rattler-build-conda-compat`, can't use it and passes `retype=False`: it recovers scalar types itself against the original ruamel tree. That leaves `retype=True` as a public knob with no correct caller, exercised only by its own test.

This drops the flag and the re-parse, so substituted scalars always come back as strings:

- `render_context`, `render_json_scalar` and `render_tree` lose the `retype` parameter
- `reparse_yaml_scalar` and `unescape_scalar` are gone

## Testing

- `py-rattler-build`: 172 passed, clippy `-D warnings` clean, ruff and `ty` clean
- `rattler-build-conda-compat`: 78 passed, mypy clean
- conda-smithy `test_lint_recipe.py` against the local compat: 4163 passed
- Differential run over a 1001-feedstock corpus (released compat vs this branch), comparing conda-smithy's lints and hints, `render_recipe_with_context` output and `get_all_url_sources`: **0 regressions**

🤖 Generated with [Claude Code](https://claude.com/claude-code)