### PR TITLE
fix: expand Jinja statement blocks in `render_context`

### DIFF
--- a/py-rattler-build/rust/src/render.rs
+++ b/py-rattler-build/rust/src/render.rs
@@ -511,9 +511,9 @@ pub fn render_context(
     {
         for (key, value) in map {
             let context_value = match value.as_str() {
-                Some(source) if source.contains("${{") => {
+                Some(source) if is_templated(source) => {
                     let rendered = substitute_expressions(&jinja, source);
-                    if rendered.contains("${{") {
+                    if is_templated(&rendered) {
                         continue;
                     }
                     minijinja::Value::from(rendered)
@@ -597,24 +597,45 @@ fn python_jinja_function(
 
 /// Render a single JSON scalar with the current Jinja context.
 ///
-/// Non-strings and strings without a `${{` marker pass through unchanged.
-/// Each `${{ ... }}` expression is rendered on its own so that a scalar mixing
-/// resolvable and unresolvable expressions (e.g.
+/// Non-strings and strings without a `${{` or `{%` marker pass through
+/// unchanged. Each `${{ ... }}` expression is rendered on its own so that a
+/// scalar mixing resolvable and unresolvable expressions (e.g.
 /// `${{ name }}-${{ unknown }}`) keeps only the unresolved part verbatim.
 fn render_json_scalar(jinja: &Jinja, value: &serde_json::Value) -> serde_json::Value {
     let Some(source) = value.as_str() else {
         return value.clone();
     };
-    if !source.contains("${{") {
+    if !is_templated(source) {
         return value.clone();
     }
     serde_json::Value::String(substitute_expressions(jinja, source))
 }
 
+/// Whether a scalar carries Jinja syntax: a `${{ ... }}` expression or a
+/// `{% ... %}` statement block.
+fn is_templated(source: &str) -> bool {
+    source.contains("${{") || source.contains("{%")
+}
+
 /// Replace every `${{ ... }}` expression in `source` by rendering it on its
 /// own. An expression that fails to render (undefined variable or a preserved
 /// helper function) is kept verbatim.
+///
+/// A scalar containing a statement block (`{% if %}`, `{% for %}`, `{% raw %}`)
+/// cannot be split this way, because the block spans the surrounding text and
+/// its body may depend on the loop or branch it sits in. Such a scalar is
+/// rendered as a whole instead, and kept verbatim if that fails.
 fn substitute_expressions(jinja: &Jinja, source: &str) -> String {
+    if source.contains("{%") {
+        return jinja
+            .render_str(source)
+            .unwrap_or_else(|_| source.to_string());
+    }
+    substitute_inline_expressions(jinja, source)
+}
+
+/// Replace every `${{ ... }}` expression in a source without statement blocks.
+fn substitute_inline_expressions(jinja: &Jinja, source: &str) -> String {
     let mut out = String::new();
     let mut rest = source;
     while let Some(start) = rest.find("${{") {

--- a/py-rattler-build/tests/unit/test_render_context.py
+++ b/py-rattler-build/tests/unit/test_render_context.py
@@ -130,3 +130,29 @@ def test_render_context_keeps_substituted_scalars_as_strings() -> None:
     assert rendered["tests"][0]["python"]["python_version"] == "3.10"
     # An untemplated scalar keeps whatever type it had.
     assert rendered["context"]["build_num"] == 5
+
+
+def test_render_context_expands_statement_blocks() -> None:
+    # taken from trzsz-feedstock, which conda-forge builds with rattler-build
+    recipe = {
+        "context": {"license_ignore": "github.com/ipfs/kubo bazil.org/fuse"},
+        "requirements": {"build": ["{% if unix %}go-nocgo{% else %}go{% endif %}"]},
+        "build": {"script": ["licenses {% for i in license_ignore | split %}--ignore ${{ i }} {% endfor %}"]},
+    }
+
+    rendered = render_context(recipe)
+
+    assert rendered["requirements"]["build"] == ["go-nocgo"]
+    assert rendered["build"]["script"] == ["licenses --ignore github.com/ipfs/kubo --ignore bazil.org/fuse "]
+
+
+def test_render_context_keeps_unresolvable_statement_blocks_verbatim() -> None:
+    source = "{% if unknown_var %}a{% else %}b{% endif %}"
+    rendered = render_context({"build": {"string": source}})
+    assert rendered["build"]["string"] == source
+
+
+def test_render_context_expands_raw_blocks() -> None:
+    recipe = {"build": {"script": ["echo {% raw %}${{ not_a_template }}{% endraw %}"]}}
+    rendered = render_context(recipe)
+    assert rendered["build"]["script"] == ["echo ${{ not_a_template }}"]


### PR DESCRIPTION
Follow-up to #2662 / #2670.

`render_context` substitutes each `${{ ... }}` expression individually, so that a scalar mixing resolvable and unresolvable parts keeps only the unresolved part verbatim. The scan only looked for `${{`, though, so a scalar containing a Jinja *statement* block came back untouched.

Recipes do use them. `trzsz-feedstock` has:

```yaml
requirements:
  build:
    - "{% if target_platform == 'win-arm64' %} go {% else %} ${{ compiler('go-nocgo') }} {% endif %}"
```

Rendering that recipe through `render_recipes` gives `['go-nocgo_linux-64', 'go-licenses']`, so `render_context` leaving the literal string in place made the lint-oriented render disagree with the real one. Consumers then see a dependency whose name is `{%`.

A statement block spans the surrounding text and its body can depend on the branch or loop it sits in, so it cannot be split the way inline expressions are. A scalar containing `{%` is therefore rendered as a whole, and kept verbatim if that fails - matching the leniency the per-expression path already has. Scalars without `{%` are unaffected and still render expression by expression.

## Testing

Three cases added to `test_render_context.py`: statement blocks expand (`{% if %}` and `{% for %}`, taken from real feedstocks), an unresolvable block stays verbatim, and `{% raw %}` is honoured.

```
175 passed, 5 skipped
```

clippy `-D warnings`, `cargo fmt --check` and ruff all clean.

Found while diffing `rattler-build-conda-compat` against the released version over a 1001-feedstock corpus - 4 recipes there use this syntax (kubo, qiskit-aer, trzsz, tsshd). None of them changed conda-smithy's lint output, so this is a correctness fix rather than a user-visible bug today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)