### PR TITLE
fix: Ignore case when querying variables from `RuntimeEnv` on Windows

### DIFF
--- a/crates/rattler_build_script/src/runtime.rs
+++ b/crates/rattler_build_script/src/runtime.rs
@@ -44,7 +44,14 @@ impl RuntimeEnv {
 
     /// Looks up an environment variable by name.
     pub fn var(&self, name: &str) -> Option<&str> {
-        self.env.get(name).map(String::as_str)
+        if self.platform.is_windows() {
+            self.env
+                .iter()
+                .find(|(key, _)| key.to_uppercase() == name.to_uppercase())
+                .map(|(_, val)| val.as_str())
+        } else {
+            self.env.get(name).map(String::as_str)
+        }
     }
 
     /// The value of `PATH`, or an empty string when it is unset.

--- a/crates/rattler_build_script/src/runtime.rs
+++ b/crates/rattler_build_script/src/runtime.rs
@@ -48,16 +48,6 @@ impl EnvironmentVariables {
     fn iter(&self) -> impl Iterator<Item = (&str, &str)> {
         self.values.iter().map(|(k, v)| (k.as_str(), v.as_str()))
     }
-
-    fn set_case_insensitive(&mut self, case_insensitive: bool) {
-        if self.case_insensitive_keys.is_some() != case_insensitive {
-            let values = std::mem::take(&mut self.values);
-            *self = Self::new(case_insensitive);
-            for (name, value) in values {
-                self.insert(name, value);
-            }
-        }
-    }
 }
 
 /// The environment rattler-build is running in: the process environment
@@ -80,10 +70,6 @@ impl RuntimeEnv {
             runtime_env.env.insert(name, value)
         }
         runtime_env
-    }
-
-    pub fn set_case_insensitive(&mut self, case_insensitive: bool) {
-        self.env.set_case_insensitive(case_insensitive);
     }
 
     /// Creates a runtime environment with an empty variable set and the given

--- a/crates/rattler_build_script/src/runtime.rs
+++ b/crates/rattler_build_script/src/runtime.rs
@@ -63,7 +63,7 @@ impl RuntimeEnv {
     pub fn current() -> Self {
         let current_platform = Platform::current();
         let mut runtime_env = Self {
-            env: EnvironmentVariables::new(current_platform.is_windows()), // std::env::vars().collect(),
+            env: EnvironmentVariables::new(current_platform.is_windows()),
             process_platform: current_platform,
         };
         for (name, value) in std::env::vars() {

--- a/crates/rattler_build_script/src/runtime.rs
+++ b/crates/rattler_build_script/src/runtime.rs
@@ -10,21 +10,80 @@ use std::collections::HashMap;
 
 use rattler_conda_types::Platform;
 
+#[derive(Debug, Clone)]
+struct EnvironmentVariables {
+    values: HashMap<String, String>,
+    case_insensitive_keys: Option<HashMap<String, String>>,
+}
+
+impl EnvironmentVariables {
+    fn new(case_insensitive: bool) -> Self {
+        Self {
+            values: HashMap::new(),
+            case_insensitive_keys: case_insensitive.then(HashMap::new),
+        }
+    }
+
+    fn get(&self, name: &str) -> Option<&str> {
+        let name = self
+            .case_insensitive_keys
+            .as_ref()
+            .and_then(|keys| keys.get(&name.to_ascii_lowercase()))
+            .map_or(name, String::as_str);
+        self.values.get(name).map(String::as_str)
+    }
+
+    fn insert(&mut self, name: String, value: String) {
+        if let Some(keys) = &mut self.case_insensitive_keys {
+            let normalized = name.to_ascii_lowercase();
+            if let Some(original) = keys.get(&normalized) {
+                self.values.insert(original.clone(), value);
+                return;
+            }
+            keys.insert(normalized, name.clone());
+        }
+        self.values.insert(name, value);
+    }
+
+    fn iter(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.values.iter().map(|(k, v)| (k.as_str(), v.as_str()))
+    }
+
+    fn set_case_insensitive(&mut self, case_insensitive: bool) {
+        if self.case_insensitive_keys.is_some() != case_insensitive {
+            let values = std::mem::take(&mut self.values);
+            *self = Self::new(case_insensitive);
+            for (name, value) in values {
+                self.insert(name, value);
+            }
+        }
+    }
+}
+
 /// The environment rattler-build is running in: the process environment
 /// variables (including `PATH`) and the platform.
 #[derive(Debug, Clone)]
 pub struct RuntimeEnv {
-    env: HashMap<String, String>,
+    env: EnvironmentVariables,
     process_platform: Platform,
 }
 
 impl RuntimeEnv {
     /// Captures the real process environment variables and the current platform.
     pub fn current() -> Self {
-        Self {
-            env: std::env::vars().collect(),
-            process_platform: Platform::current(),
+        let current_platform = Platform::current();
+        let mut runtime_env = Self {
+            env: EnvironmentVariables::new(current_platform.is_windows()), // std::env::vars().collect(),
+            process_platform: current_platform,
+        };
+        for (name, value) in std::env::vars() {
+            runtime_env.env.insert(name, value)
         }
+        runtime_env
+    }
+
+    pub fn set_case_insensitive(&mut self, case_insensitive: bool) {
+        self.env.set_case_insensitive(case_insensitive);
     }
 
     /// Creates a runtime environment with an empty variable set and the given
@@ -32,7 +91,7 @@ impl RuntimeEnv {
     /// inject the variables a test needs.
     pub fn for_test(platform: Platform) -> Self {
         Self {
-            env: HashMap::new(),
+            env: EnvironmentVariables::new(platform.is_windows()),
             process_platform: platform,
         }
     }
@@ -44,14 +103,7 @@ impl RuntimeEnv {
 
     /// Looks up an environment variable by name.
     pub fn var(&self, name: &str) -> Option<&str> {
-        if self.platform.is_windows() {
-            self.env
-                .iter()
-                .find(|(key, _)| key.to_uppercase() == name.to_uppercase())
-                .map(|(_, val)| val.as_str())
-        } else {
-            self.env.get(name).map(String::as_str)
-        }
+        self.env.get(name)
     }
 
     /// The value of `PATH`, or an empty string when it is unset.
@@ -72,7 +124,7 @@ impl RuntimeEnv {
 
     /// Iterates over all environment variables as `(name, value)` pairs.
     pub fn vars(&self) -> impl Iterator<Item = (&str, &str)> {
-        self.env.iter().map(|(k, v)| (k.as_str(), v.as_str()))
+        self.env.iter()
     }
 
     /// Returns a copy with `name` set to `value` (builder style, for tests).
@@ -99,5 +151,17 @@ mod tests {
         assert_eq!(RuntimeEnv::for_test(Platform::Win64).exe_suffix(), ".exe");
         assert_eq!(RuntimeEnv::for_test(Platform::Linux64).exe_suffix(), "");
         assert_eq!(RuntimeEnv::for_test(Platform::OsxArm64).exe_suffix(), "");
+    }
+
+    #[test]
+    fn env_var_case_insensitive_on_windows() {
+        let runtime_env = RuntimeEnv::for_test(Platform::Win64);
+        assert_eq!(
+            runtime_env
+                .with_var("TEST_CASE", "1")
+                .var("test_case")
+                .unwrap(),
+            "1"
+        );
     }
 }


### PR DESCRIPTION
The canonical name of `PATH` is `Path` on Windows, and `env: HashMap` is not case insensitive.
Fixes #2674.