### PR TITLE
feat: add iOS and Android platform support

### DIFF
--- a/crates/rattler_build_core/src/android/env.rs
+++ b/crates/rattler_build_core/src/android/env.rs
@@ -1,0 +1,105 @@
+//! Android specific environment variables
+use rattler_conda_types::Platform;
+use std::{collections::HashMap, path::Path};
+
+use crate::unix;
+
+/// Minimum Android API level targeted by conda packages. This matches the
+/// minimum supported by CPython's Android support (PEP 738).
+const DEFAULT_API_LEVEL: &str = "24";
+
+/// Returns the NDK ABI name for an Android platform, e.g. `arm64-v8a`. These are
+/// the names used by the NDK's CMake toolchain (`ANDROID_ABI`).
+fn android_abi(target_platform: &Platform) -> Option<&'static str> {
+    match target_platform {
+        Platform::AndroidAarch64 => Some("arm64-v8a"),
+        Platform::AndroidArmV7a => Some("armeabi-v7a"),
+        Platform::Android64 => Some("x86_64"),
+        Platform::Android32 => Some("x86"),
+        _ => None,
+    }
+}
+
+/// Returns the clang target triple for an Android platform. Note that the 32-bit
+/// arm target uses the `androideabi` suffix.
+fn target_triple(target_platform: &Platform) -> Option<&'static str> {
+    match target_platform {
+        Platform::AndroidAarch64 => Some("aarch64-linux-android"),
+        Platform::AndroidArmV7a => Some("armv7a-linux-androideabi"),
+        Platform::Android64 => Some("x86_64-linux-android"),
+        Platform::Android32 => Some("i686-linux-android"),
+        _ => None,
+    }
+}
+
+/// Get default env vars for Android
+pub fn default_env_vars_target(
+    prefix: &Path,
+    target_platform: &Platform,
+) -> HashMap<String, Option<String>> {
+    let mut vars = unix::env::default_env_vars_target(prefix);
+
+    if let Some(abi) = android_abi(target_platform) {
+        vars.insert("ANDROID_ABI".to_string(), Some(abi.to_string()));
+    }
+
+    // The NDK's minimum supported API level. Recipes and variant configs can
+    // override it just like `MACOSX_DEPLOYMENT_TARGET` on macOS.
+    vars.insert(
+        "ANDROID_API_LEVEL".to_string(),
+        Some(DEFAULT_API_LEVEL.to_string()),
+    );
+
+    if let Some(triple) = target_triple(target_platform) {
+        vars.insert("HOST".to_string(), Some(triple.to_string()));
+    }
+
+    vars
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn abis_match_ndk_names() {
+        assert_eq!(android_abi(&Platform::AndroidAarch64), Some("arm64-v8a"));
+        assert_eq!(android_abi(&Platform::AndroidArmV7a), Some("armeabi-v7a"));
+        assert_eq!(android_abi(&Platform::Android64), Some("x86_64"));
+        assert_eq!(android_abi(&Platform::Android32), Some("x86"));
+        assert_eq!(android_abi(&Platform::Linux64), None);
+    }
+
+    #[test]
+    fn armv7a_triple_uses_androideabi_suffix() {
+        assert_eq!(
+            target_triple(&Platform::AndroidArmV7a),
+            Some("armv7a-linux-androideabi")
+        );
+        assert_eq!(
+            target_triple(&Platform::AndroidAarch64),
+            Some("aarch64-linux-android")
+        );
+    }
+
+    #[test]
+    fn target_vars_include_unix_and_android_specific_vars() {
+        let vars = default_env_vars_target(Path::new("/some/prefix"), &Platform::AndroidAarch64);
+        // inherited from the generic unix vars
+        assert!(vars.contains_key("PKG_CONFIG_PATH"));
+        assert!(vars.contains_key("CMAKE_GENERATOR"));
+        // Android specific
+        assert_eq!(
+            vars.get("ANDROID_ABI"),
+            Some(&Some("arm64-v8a".to_string()))
+        );
+        assert_eq!(
+            vars.get("ANDROID_API_LEVEL"),
+            Some(&Some(DEFAULT_API_LEVEL.to_string()))
+        );
+        assert_eq!(
+            vars.get("HOST"),
+            Some(&Some("aarch64-linux-android".to_string()))
+        );
+    }
+}

--- a/crates/rattler_build_core/src/android/mod.rs
+++ b/crates/rattler_build_core/src/android/mod.rs
@@ -1,0 +1,1 @@
+pub mod env;

--- a/crates/rattler_build_core/src/build.rs
+++ b/crates/rattler_build_core/src/build.rs
@@ -289,13 +289,21 @@ fn check_for_binary_prefix(output: &Output, paths_json: &PathsJson) -> Result<()
 }
 
 /// Check if the output has a Unix-specific virtual package (`__unix`, `__osx`,
-/// `__linux`, or `__glibc`) in its finalized run dependencies, indicating this
-/// package is only intended for Unix systems.
+/// `__linux`, `__glibc`, `__ios`, or `__android`) in its finalized run
+/// dependencies, indicating this package is only intended for Unix systems.
 fn has_unix_virtual_package(output: &Output) -> bool {
     output.finalized_dependencies.as_ref().is_some_and(|deps| {
         deps.run.depends.iter().any(|dep| {
             dep.spec().name.as_exact().is_some_and(|name| {
-                ["__unix", "__osx", "__linux", "__glibc"].contains(&name.as_normalized())
+                [
+                    "__unix",
+                    "__osx",
+                    "__linux",
+                    "__glibc",
+                    "__ios",
+                    "__android",
+                ]
+                .contains(&name.as_normalized())
             })
         })
     })

--- a/crates/rattler_build_core/src/env_vars.rs
+++ b/crates/rattler_build_core/src/env_vars.rs
@@ -9,7 +9,9 @@ use rattler_build_types::NormalizedKey;
 use rattler_conda_types::{Platform, RepoDataRecord};
 use std::collections::BTreeMap;
 
+use crate::android;
 use crate::consts;
+use crate::ios;
 use crate::linux;
 use crate::macos;
 use crate::metadata::Output;
@@ -253,6 +255,10 @@ pub fn os_vars(
         vars.extend(windows::env::default_env_vars_target(prefix));
     } else if os_platform.is_osx() {
         vars.extend(macos::env::default_env_vars_target(prefix, os_platform));
+    } else if os_platform.is_ios() {
+        vars.extend(ios::env::default_env_vars_target(prefix, os_platform));
+    } else if os_platform.is_android() {
+        vars.extend(android::env::default_env_vars_target(prefix, os_platform));
     } else if os_platform.is_linux() {
         vars.extend(linux::env::default_env_vars_target(
             prefix,

--- a/crates/rattler_build_core/src/ios/env.rs
+++ b/crates/rattler_build_core/src/ios/env.rs
@@ -1,0 +1,84 @@
+//! iOS specific environment variables
+use rattler_conda_types::Platform;
+use std::{collections::HashMap, path::Path};
+
+use crate::unix;
+
+/// Minimum iOS version targeted by conda packages. This matches the minimum
+/// supported by CPython's iOS support (PEP 730).
+const DEFAULT_DEPLOYMENT_TARGET: &str = "13.0";
+
+/// Returns the clang target triple for an iOS platform, e.g. `arm64-apple-ios`
+/// for a device or `arm64-apple-ios-simulator` for the simulator.
+fn target_triple(target_platform: &Platform) -> Option<String> {
+    let arch = target_platform.arch()?.as_str().to_string();
+    match target_platform {
+        Platform::IosArm64 => Some(format!("{arch}-apple-ios")),
+        Platform::IosSimulatorArm64 | Platform::IosSimulator64 => {
+            Some(format!("{arch}-apple-ios-simulator"))
+        }
+        _ => None,
+    }
+}
+
+/// Get default env vars for iOS
+pub fn default_env_vars_target(
+    prefix: &Path,
+    target_platform: &Platform,
+) -> HashMap<String, Option<String>> {
+    let mut vars = unix::env::default_env_vars_target(prefix);
+
+    if let Some(arch) = target_platform.arch() {
+        vars.insert("IOS_ARCH".to_string(), Some(arch.as_str().to_string()));
+    }
+
+    // Xcode's standard knob for the minimum supported OS version. Recipes and
+    // variant configs can override it just like `MACOSX_DEPLOYMENT_TARGET`.
+    vars.insert(
+        "IPHONEOS_DEPLOYMENT_TARGET".to_string(),
+        Some(DEFAULT_DEPLOYMENT_TARGET.to_string()),
+    );
+
+    if let Some(triple) = target_triple(target_platform) {
+        vars.insert("HOST".to_string(), Some(triple));
+    }
+
+    vars
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn triples_distinguish_device_and_simulator() {
+        assert_eq!(
+            target_triple(&Platform::IosArm64).as_deref(),
+            Some("arm64-apple-ios")
+        );
+        assert_eq!(
+            target_triple(&Platform::IosSimulatorArm64).as_deref(),
+            Some("arm64-apple-ios-simulator")
+        );
+        assert_eq!(
+            target_triple(&Platform::IosSimulator64).as_deref(),
+            Some("x86_64-apple-ios-simulator")
+        );
+        assert_eq!(target_triple(&Platform::OsxArm64), None);
+    }
+
+    #[test]
+    fn target_vars_include_unix_and_ios_specific_vars() {
+        let vars = default_env_vars_target(Path::new("/some/prefix"), &Platform::IosArm64);
+        // inherited from the generic unix vars
+        assert!(vars.contains_key("PKG_CONFIG_PATH"));
+        assert!(vars.contains_key("CMAKE_GENERATOR"));
+        // iOS specific
+        assert_eq!(vars.get("IOS_ARCH"), Some(&Some("arm64".to_string())));
+        assert_eq!(
+            vars.get("IPHONEOS_DEPLOYMENT_TARGET"),
+            Some(&Some(DEFAULT_DEPLOYMENT_TARGET.to_string()))
+        );
+        assert_eq!(vars.get("HOST"), Some(&Some("arm64-apple-ios".to_string())));
+    }
+}

--- a/crates/rattler_build_core/src/ios/mod.rs
+++ b/crates/rattler_build_core/src/ios/mod.rs
@@ -1,0 +1,1 @@
+pub mod env;

--- a/crates/rattler_build_core/src/lib.rs
+++ b/crates/rattler_build_core/src/lib.rs
@@ -21,9 +21,11 @@ pub mod tool_configuration;
 pub mod types;
 pub mod utils;
 
+mod android;
 /// Constants used throughout the build process.
 pub mod consts;
 pub mod env_vars;
+mod ios;
 mod linux;
 mod macos;
 pub mod package_info;

--- a/crates/rattler_build_core/src/post_process/checks.rs
+++ b/crates/rattler_build_core/src/post_process/checks.rs
@@ -505,11 +505,15 @@ fn find_system_libs(output: &Output) -> Result<SystemLibs, LinkingCheckError> {
     let mut deny_builder = GlobSetBuilder::new();
     let platform = &output.build_configuration.target_platform;
 
-    if platform.is_osx() {
+    if platform.is_osx() || platform.is_ios() {
+        // iOS links against Mach-O system libraries and frameworks, so it uses the
+        // same `.tbd` stub / framework discovery as macOS.
         add_osx_system_libs(output, &mut allow_builder)?;
     } else if platform.is_windows() {
         add_windows_system_libs(output, &mut allow_builder, &mut deny_builder)?;
     } else {
+        // Android falls through here: its `sysroot_android-*` package and `*.so*`
+        // libraries are discovered the same way as Linux.
         add_linux_system_libs(output, &mut allow_builder)?;
     }
 
@@ -565,8 +569,10 @@ pub fn perform_linking_checks(
                         resolved_libraries
                     );
                     for (lib, resolved) in &resolved_libraries {
-                        // filter out @self on macOS
-                        if target_platform.is_osx() && lib.to_str() == Some("self") {
+                        // filter out @self on Mach-O platforms (macOS, iOS)
+                        if (target_platform.is_osx() || target_platform.is_ios())
+                            && lib.to_str() == Some("self")
+                        {
                             continue;
                         }
 
@@ -620,8 +626,10 @@ pub fn perform_linking_checks(
         for lib in &package.shared_libraries {
             let lib = lib.strip_prefix(host_prefix).unwrap_or(lib);
 
-            // skip @self on macOS
-            if target_platform.is_osx() && lib.to_str() == Some("self") {
+            // skip @self on Mach-O platforms (macOS, iOS)
+            if (target_platform.is_osx() || target_platform.is_ios())
+                && lib.to_str() == Some("self")
+            {
                 continue;
             }
 

--- a/crates/rattler_build_core/src/post_process/relink.rs
+++ b/crates/rattler_build_core/src/post_process/relink.rs
@@ -106,12 +106,14 @@ pub trait Relinker {
 
 /// Returns the relink helper for the current platform.
 pub fn get_relinker(platform: Platform, path: &Path) -> Result<Box<dyn Relinker>, RelinkError> {
-    if platform.is_linux() {
+    if platform.is_linux() || platform.is_android() {
+        // Android produces ELF objects, just like Linux.
         if !SharedObject::test_file(path)? {
             return Err(RelinkError::UnknownFileFormat);
         }
         Ok(Box::new(SharedObject::new(path)?))
-    } else if platform.is_osx() {
+    } else if platform.is_osx() || platform.is_ios() {
+        // iOS produces Mach-O objects, just like macOS.
         if !Dylib::test_file(path)? {
             return Err(RelinkError::UnknownFileFormat);
         }

--- a/crates/rattler_build_jinja/src/jinja.rs
+++ b/crates/rattler_build_jinja/src/jinja.rs
@@ -222,6 +222,16 @@ impl Jinja {
             }
         }
 
+        // `only_platform()` reports "iossimulator" for the simulator targets, so the
+        // derived `ios` family selector above would only match real devices. A recipe
+        // saying `if: ios` almost always means "building for iOS at all", so widen it
+        // to cover the simulator too (`iossimulator` stays available for the narrow
+        // case). This mirrors how `osx` covers every macOS architecture.
+        context.insert(
+            "ios".to_string(),
+            Value::from(config.host_platform.is_ios()),
+        );
+
         // Add variant variables to context
         for (key, value) in &config.variant {
             context.insert(key.normalize(), value.clone().into());
@@ -441,7 +451,9 @@ fn default_compiler(platform: Platform, language: &str) -> Option<Variable> {
                         "cxx" => "vs2022",
                         _ => unreachable!(),
                     }
-                } else if platform.is_osx() {
+                } else if platform.is_osx() || platform.is_ios() || platform.is_android() {
+                    // Apple platforms use Apple clang; the Android NDK also ships
+                    // clang as its only supported toolchain.
                     match language {
                         "c" => "clang",
                         "cxx" => "clangxx",
@@ -928,6 +940,12 @@ fn set_jinja(
     });
     env.add_function("is_unix", |platform: &str| {
         Ok(parse_platform(platform)?.is_unix())
+    });
+    env.add_function("is_ios", |platform: &str| {
+        Ok(parse_platform(platform)?.is_ios())
+    });
+    env.add_function("is_android", |platform: &str| {
+        Ok(parse_platform(platform)?.is_android())
     });
 
     register_io_functions(&mut env, experimental, recipe_path);
@@ -1546,6 +1564,11 @@ mod tests {
             (Platform::OsxArm64, ".dylib"),
             (Platform::Osx64, ".dylib"),
             (Platform::Win64, ".dll"),
+            // iOS is Mach-O, Android is ELF
+            (Platform::IosArm64, ".dylib"),
+            (Platform::IosSimulatorArm64, ".dylib"),
+            (Platform::AndroidAarch64, ".so"),
+            (Platform::AndroidArmV7a, ".so"),
         ];
         for (target_platform, expected) in cases {
             let jinja = Jinja::new(JinjaConfig {
@@ -2274,5 +2297,102 @@ mod tests {
             "flang",
             default_compiler(platform, "fortran").unwrap().to_string()
         );
+    }
+
+    #[test]
+    fn test_default_compiler_apple_and_android_use_clang() {
+        // Apple platforms and the Android NDK all use clang.
+        for platform in [
+            Platform::OsxArm64,
+            Platform::IosArm64,
+            Platform::IosSimulatorArm64,
+            Platform::IosSimulator64,
+            Platform::AndroidAarch64,
+            Platform::AndroidArmV7a,
+            Platform::Android64,
+            Platform::Android32,
+        ] {
+            assert_eq!(
+                "clang",
+                default_compiler(platform, "c").unwrap().to_string(),
+                "unexpected c compiler for {platform}"
+            );
+            assert_eq!(
+                "clangxx",
+                default_compiler(platform, "cxx").unwrap().to_string(),
+                "unexpected cxx compiler for {platform}"
+            );
+        }
+    }
+
+    #[test]
+    fn eval_ios_and_android_selectors() {
+        // The `ios` selector covers devices *and* simulators, while
+        // `iossimulator` stays narrow.
+        let jinja = Jinja::new(JinjaConfig {
+            target_platform: Platform::IosSimulatorArm64,
+            host_platform: Platform::IosSimulatorArm64,
+            build_platform: Platform::OsxArm64,
+            ..Default::default()
+        });
+        assert!(jinja.eval("ios").expect("host is ios").is_true());
+        assert!(
+            jinja
+                .eval("iossimulator")
+                .expect("host is iossimulator")
+                .is_true()
+        );
+        assert!(jinja.eval("unix").expect("ios is unix").is_true());
+        assert!(!jinja.eval("osx").expect("ios is not osx").is_true());
+
+        let jinja = Jinja::new(JinjaConfig {
+            target_platform: Platform::IosArm64,
+            host_platform: Platform::IosArm64,
+            build_platform: Platform::OsxArm64,
+            ..Default::default()
+        });
+        assert!(jinja.eval("ios").expect("host is ios").is_true());
+        assert!(
+            !jinja
+                .eval("iossimulator")
+                .expect("device is not a simulator")
+                .is_true()
+        );
+
+        let jinja = Jinja::new(JinjaConfig {
+            target_platform: Platform::AndroidAarch64,
+            host_platform: Platform::AndroidAarch64,
+            build_platform: Platform::Linux64,
+            ..Default::default()
+        });
+        assert!(jinja.eval("android").expect("host is android").is_true());
+        assert!(jinja.eval("unix").expect("android is unix").is_true());
+        assert!(!jinja.eval("linux").expect("android is not linux").is_true());
+        assert!(jinja.eval("aarch64").expect("host is aarch64").is_true());
+    }
+
+    #[test]
+    fn eval_is_ios_and_is_android_functions() {
+        let jinja = Jinja::new(JinjaConfig::default());
+        assert!(jinja.eval("is_ios('ios-arm64')").unwrap().is_true());
+        assert!(
+            jinja
+                .eval("is_ios('iossimulator-arm64')")
+                .unwrap()
+                .is_true()
+        );
+        assert!(!jinja.eval("is_ios('osx-arm64')").unwrap().is_true());
+        assert!(
+            jinja
+                .eval("is_android('android-aarch64')")
+                .unwrap()
+                .is_true()
+        );
+        assert!(!jinja.eval("is_android('linux-64')").unwrap().is_true());
+        // iOS/Android are unix but not osx/linux
+        assert!(jinja.eval("is_unix('ios-arm64')").unwrap().is_true());
+        assert!(jinja.eval("is_unix('android-64')").unwrap().is_true());
+        assert!(!jinja.eval("is_linux('android-64')").unwrap().is_true());
+        assert!(!jinja.eval("is_osx('ios-arm64')").unwrap().is_true());
     }
 }

--- a/crates/rattler_build_types/src/lib.rs
+++ b/crates/rattler_build_types/src/lib.rs
@@ -21,9 +21,11 @@ use rattler_conda_types::Platform;
 pub fn shlib_ext(platform: &Platform) -> &'static str {
     if platform.is_windows() {
         ".dll"
-    } else if platform.is_osx() {
+    } else if platform.is_osx() || platform.is_ios() {
+        // iOS is Mach-O like macOS.
         ".dylib"
-    } else if platform.is_linux() {
+    } else if platform.is_linux() || platform.is_android() {
+        // Android is ELF like Linux (Bionic instead of glibc, same object format).
         ".so"
     } else {
         ".not_implemented"
@@ -42,4 +44,29 @@ pub fn short_version(input: &str, length: u32) -> String {
         }
     }
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shlib_ext_follows_object_format() {
+        // Mach-O
+        assert_eq!(shlib_ext(&Platform::Osx64), ".dylib");
+        assert_eq!(shlib_ext(&Platform::OsxArm64), ".dylib");
+        assert_eq!(shlib_ext(&Platform::IosArm64), ".dylib");
+        assert_eq!(shlib_ext(&Platform::IosSimulatorArm64), ".dylib");
+        assert_eq!(shlib_ext(&Platform::IosSimulator64), ".dylib");
+        // ELF
+        assert_eq!(shlib_ext(&Platform::Linux64), ".so");
+        assert_eq!(shlib_ext(&Platform::AndroidAarch64), ".so");
+        assert_eq!(shlib_ext(&Platform::AndroidArmV7a), ".so");
+        assert_eq!(shlib_ext(&Platform::Android64), ".so");
+        assert_eq!(shlib_ext(&Platform::Android32), ".so");
+        // PE
+        assert_eq!(shlib_ext(&Platform::Win64), ".dll");
+        // no known extension
+        assert_eq!(shlib_ext(&Platform::NoArch), ".not_implemented");
+    }
 }

--- a/docs/compilers.md
+++ b/docs/compilers.md
@@ -31,6 +31,22 @@ When the template function is evaluated, it will look something like:
 you can use `${{ compiler('rust') }}` and `rust_compiler_{version}` in your
 variant config.
 
+### Default compilers
+
+If no `{lang}_compiler` is set in the variant config, `compiler('c')` and
+`compiler('cxx')` fall back to a per-platform default:
+
+| Target platform             | `compiler('c')` | `compiler('cxx')` |
+|-----------------------------|-----------------|-------------------|
+| Windows                     | `vs2022`        | `vs2022`          |
+| macOS, iOS, Android         | `clang`         | `clangxx`         |
+| `emscripten-wasm32`         | `emscripten`    | `emscripten`      |
+| Linux (and everything else) | `gcc`           | `gxx`             |
+
+For `compiler('fortran')` the default is `flang` on Windows and `gfortran`
+elsewhere. Any other language passes through unchanged, so `compiler('rust')`
+resolves to `rust_{target_platform}`.
+
 ## Cross-compilation
 
 Cross-compilation is supported by Rattler-Build and the compiler template

--- a/docs/selectors.md
+++ b/docs/selectors.md
@@ -71,15 +71,25 @@ The following variables are available during rendering of the recipe:
 | `linux`              | "true" if `host_platform` is Linux                                     |
 | `osx`                | "true" if `host_platform` is OSX / macOS                               |
 | `win`                | "true" if `host_platform` is Windows                                   |
-| `unix`               | "true" if `host_platform` is a Unix (macOS or Linux)                   |
+| `ios`                | "true" if `host_platform` is iOS (device or simulator)                 |
+| `iossimulator`       | "true" if `host_platform` is an iOS simulator                          |
+| `android`            | "true" if `host_platform` is Android                                   |
+| `unix`               | "true" if `host_platform` is a Unix (macOS, Linux, iOS or Android)     |
 | `x86`, `x86_64`      | x86 32/64-bit Architecture (based on `host_platform`)                  |
-| `aarch64`            | 64-bit Arm (if `host_platform` is `linux-aarch64`)                     |
-| `arm64`              | 64-bit Arm (if `host_platform` is `osx-arm64` or `win-arm64`)          |
+| `aarch64`            | 64-bit Arm (if `host_platform` is `linux-aarch64` or `android-aarch64`)|
+| `arm64`              | 64-bit Arm (if `host_platform` is `osx-arm64`, `win-arm64` or `ios-*`) |
 | `armV6l`, `armV7l`   | 32-bit Arm                                                             |
+| `armv7a`             | 32-bit Arm using Android's `armeabi-v7a` ABI                           |
 | `ppc64`, `s390x`,    | Big endian                                                             |
 | `ppc64le`            | Little endian                                                          |
 | `riscv32`, `riscv64` | The [RISC-V](https://wikipedia.org/wiki/RISC-V) Architecture           |
 | `wasm32`             | The [WebAssembly](https://wikipedia.org/wiki/WebAssembly) Architecture |
+
+!!! note "iOS and Android are not `osx` / `linux`"
+    Although iOS is Mach-O based like macOS, and Android is ELF based like Linux, they
+    are *distinct* platform families: `osx` is false on iOS and `linux` is false on
+    Android. Both are `unix`. Use `ios` / `android` to select them, and note that
+    `ios` also covers the simulator targets (use `iossimulator` for the narrower case).
 
 ### Variant selectors
 


### PR DESCRIPTION
rattler 0.49 added `ios-arm64`, `iossimulator-{arm64,64}` and `android-{aarch64,armv7a,64,32}`. This wires those platforms through the places where rattler-build branches on the platform.

The key subtlety: these are **distinct platform families**. iOS is *not* `is_osx()` and Android is *not* `is_linux()` — both only report `is_unix()`. So every existing `is_osx()`/`is_linux()` branch silently fell through to the wrong default.

## Changes

| Area | Before | After |
|---|---|---|
| `shlib_ext` | `.not_implemented` | iOS → `.dylib` (Mach-O), Android → `.so` (ELF) |
| `default_compiler` | `gcc`/`gxx` | `clang`/`clangxx` for both |
| `get_relinker` | `UnknownPlatform` | iOS → `Dylib`, Android → `SharedObject` |

`get_relinker` was the hardest blocker: `UnknownPlatform` propagates rather than being swallowed like `UnknownFileFormat`, so **any** iOS/Android package containing a compiled binary failed the build outright.

**Linking checks** — iOS now uses the macOS `.tbd`/framework discovery instead of the Linux sysroot path, and both `@self` filters cover it. Android keeps the Linux path, which is already generic over `sysroot_{target_platform}` + `*.so*`.

**Build env vars** — new `ios`/`android` modules. These platforms previously got *zero* target vars, not even `PKG_CONFIG_PATH`/`CMAKE_GENERATOR`, which would break cmake/pkg-config builds. iOS gets `IOS_ARCH` + `IPHONEOS_DEPLOYMENT_TARGET`; Android gets `ANDROID_ABI` (NDK names: `arm64-v8a`, `armeabi-v7a`, …) + `ANDROID_API_LEVEL`; both get a `HOST` triple. These flow into `os_env_var_keys` automatically, so they're variant-overridable like `MACOSX_DEPLOYMENT_TARGET`.

**Jinja** — added `is_ios()`/`is_android()`. The `ios` selector is widened to cover simulators: `only_platform()` reports `"iossimulator"` separately, so the auto-derived `ios` family matched devices only, and `if: ios` almost always means "building for iOS at all". `iossimulator` remains for the narrow case. The `android` selector, the platform aliases, and the new `armv7a` arch all come free from the existing `Platform::iter()`/`Arch::iter()` derivation.

**`has_unix_virtual_package`** — added `__ios`/`__android` so noarch packages depending on them skip the Windows symlink check.

Docs: `selectors.md` gains the new selectors plus a note that iOS/Android are *not* `osx`/`linux`; `compilers.md` gains a default-compiler table (which didn't exist before).

## Testing

`cargo clippy --workspace --all-targets` clean, `cargo fmt` applied, full workspace suite green. 9 new tests covering `shlib_ext` per object format, clang defaults across all 8 new platforms, the `ios`/`iossimulator`/`android` selectors, the `is_*` functions, and the NDK ABI/triple mappings.

## Points worth reviewer input

- **`HOST`** — no other platform module sets it (they set `BUILD`), so this is a new convention here. It's the autoconf/conda-build standard and iOS/Android are always cross-builds, but it doesn't follow existing precedent in this repo.
- **Deployment target defaults** — `IPHONEOS_DEPLOYMENT_TARGET=13.0`, `ANDROID_API_LEVEL=24`, taken from the CPython minimums (PEP 730/738).
- **`compiler('fortran')`** still yields `gfortran` on iOS/Android via the generic unix default. There's no real gfortran for these targets; I left it rather than invent something.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
