### PR TITLE
fix: stop wrapping solver errors

### DIFF
--- a/crates/rattler_build_core/src/package_test/run_test.rs
+++ b/crates/rattler_build_core/src/package_test/run_test.rs
@@ -7,6 +7,7 @@
 //! * `imports` - import a list of modules and check if they can be imported
 //! * `files` - check if a list of files exist
 use fs_err as fs;
+use miette::WrapErr;
 use rattler_build_jinja::Variable;
 use rattler_build_recipe::stage1::{
     TestType,
@@ -97,8 +98,8 @@ pub enum TestError {
     #[error("failed to parse MatchSpec: {0}")]
     MatchSpecParse(String),
 
-    #[error("failed to setup test environment: {0}")]
-    TestEnvironmentSetup(String),
+    #[error("{0}")]
+    TestEnvironmentSetup(miette::Report),
 
     #[error("failed to setup test environment: {0}")]
     TestEnvironmentActivation(#[from] ActivationError),
@@ -125,6 +126,27 @@ pub enum TestError {
         "no tests found in package. Expected `info/test/` (conda-build format) or `info/tests/tests.yaml` (rattler-build format)"
     )]
     NoTestsFound,
+}
+
+impl TestError {
+    /// Converts this error into a report without rendering nested reports.
+    pub fn into_report(self) -> miette::Report {
+        match self {
+            Self::TestEnvironmentSetup(report) => report,
+            error => miette::Report::from_err(error),
+        }
+    }
+}
+
+#[test]
+fn test_environment_setup_preserves_diagnostic() {
+    let diagnostic = miette::MietteDiagnostic::new("solver failed");
+    let report = Err::<(), _>(miette::Report::new(diagnostic))
+        .wrap_err("failed to setup test environment")
+        .unwrap_err();
+    let report = TestError::TestEnvironmentSetup(report).into_report();
+
+    assert!(report.downcast_ref::<miette::MietteDiagnostic>().is_some());
 }
 
 /// Create a `.conda` archive from an extracted package directory.
@@ -608,7 +630,8 @@ pub async fn run_test(
             config.exclude_newer,
         )
         .await
-        .map_err(|e| TestError::TestEnvironmentSetup(format!("{e:?}")))?;
+        .wrap_err("failed to setup test environment")
+        .map_err(TestError::TestEnvironmentSetup)?;
 
         // These are the legacy tests
         let (test_folder, tests) = legacy_tests_from_folder(&package_folder).await?;
@@ -802,7 +825,8 @@ async fn run_python_test_inner(
         config.exclude_newer,
     )
     .await
-    .map_err(|e| TestError::TestEnvironmentSetup(format!("{e:?}")))?;
+    .wrap_err("failed to setup test environment")
+    .map_err(TestError::TestEnvironmentSetup)?;
 
     let mut imports = String::new();
     for import in &python_test.imports {
@@ -908,7 +932,8 @@ async fn run_perl_test(
         config.exclude_newer,
     )
     .await
-    .map_err(|e| TestError::TestEnvironmentSetup(format!("{e:?}")))?;
+    .wrap_err("failed to setup test environment")
+    .map_err(TestError::TestEnvironmentSetup)?;
 
     let mut imports = String::new();
     tracing::info!("Testing perl imports:\n");
@@ -992,7 +1017,8 @@ async fn run_commands_test(
             config.exclude_newer,
         )
         .await
-        .map_err(|e| TestError::TestEnvironmentSetup(format!("{e:?}")))?;
+        .wrap_err("failed to setup test environment")
+        .map_err(TestError::TestEnvironmentSetup)?;
         Some(build_prefix)
     } else {
         None
@@ -1022,7 +1048,8 @@ async fn run_commands_test(
         config.exclude_newer,
     )
     .await
-    .map_err(|e| TestError::TestEnvironmentSetup(format!("{e:?}")))?;
+    .wrap_err("failed to setup test environment")
+    .map_err(TestError::TestEnvironmentSetup)?;
 
     let target_platform = config.target_platform.unwrap_or(Platform::current());
     let build_platform = config.current_platform.platform;
@@ -1233,7 +1260,8 @@ async fn run_r_test(
         config.exclude_newer,
     )
     .await
-    .map_err(|e| TestError::TestEnvironmentSetup(format!("{e:?}")))?;
+    .wrap_err("failed to setup test environment")
+    .map_err(TestError::TestEnvironmentSetup)?;
 
     let mut libraries = String::new();
     tracing::info!("Testing R libraries:\n");
@@ -1315,7 +1343,8 @@ async fn run_ruby_test(
         config.exclude_newer,
     )
     .await
-    .map_err(|e| TestError::TestEnvironmentSetup(format!("{e:?}")))?;
+    .wrap_err("failed to setup test environment")
+    .map_err(TestError::TestEnvironmentSetup)?;
 
     let mut requires = String::new();
     tracing::info!("Testing Ruby requires:\n");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -819,11 +819,16 @@ pub async fn run_build_from_args(
                             );
                         }
 
+                        let report = e.into_report();
                         if tool_configuration.continue_on_failure == ContinueOnFailure::Yes {
-                            tracing::error!("Test failed for {}: {}", output.identifier(), e);
-                            output.record_warning(&format!("Test failed: {}", e));
+                            tracing::error!(
+                                "Test failed for {}: {:?}",
+                                output.identifier(),
+                                report
+                            );
+                            output.record_warning(&format!("Test failed: {report:?}"));
                         } else {
-                            return Err(miette::miette!("Test failed: {}", e));
+                            return Err(report).context("Test failed");
                         }
                     }
                 }
@@ -961,7 +966,7 @@ pub async fn run_test(
     let _enter = span.enter();
     package_test::run_test(&package_file, &test_options, None)
         .await
-        .into_diagnostic()?;
+        .map_err(|e| e.into_report())?;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,6 +111,10 @@ fn run_migrate_recipe(opts: MigrateRecipeOpts) -> miette::Result<()> {
 }
 
 fn main() -> miette::Result<()> {
+    miette::set_hook(Box::new(|_| {
+        Box::new(miette::MietteHandlerOpts::new().wrap_lines(false).build())
+    }))?;
+
     // Stack size varies significantly across platforms:
     // - Windows: only 1MB by default
     // - macOS/Linux: ~8MB by default

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,8 +111,17 @@ fn run_migrate_recipe(opts: MigrateRecipeOpts) -> miette::Result<()> {
 }
 
 fn main() -> miette::Result<()> {
-    miette::set_hook(Box::new(|_| {
-        Box::new(miette::MietteHandlerOpts::new().wrap_lines(false).build())
+    let in_ci = matches!(std::env::var("CI").as_deref(), Ok("1" | "true"));
+    let no_wrap = matches!(
+        std::env::var("RATTLER_BUILD_NO_WRAP").as_deref(),
+        Ok("1" | "true")
+    );
+    miette::set_hook(Box::new(move |_| {
+        Box::new(
+            miette::MietteHandlerOpts::new()
+                .wrap_lines(!in_ci && !no_wrap)
+                .build(),
+        )
     }))?;
 
     // Stack size varies significantly across platforms:


### PR DESCRIPTION
Fixes #2668.

- preserve raw `miette::Report` values when test environment setup fails
- add error context without rendering nested graphical reports
- disable line wrapping in the final miette handler

Tests:
- `cargo test -p rattler_build_core test_environment_setup_preserves_diagnostic`
- `cargo check --bin rattler-build`