### PR TITLE
chore: release 0.71.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.71.0] - 2026-07-27
+### ✨ Highlights
+
+This release adds iOS and Android platform support and improves cross-architecture Windows command execution. It also fixes cache-output build setting inheritance and defers tests until transitive outputs are available.
+
+
+
+### Added
+
+- Make CMD subprocesses match `build_platform` architecture when running emulated by @baszalmstra in [#2664](https://github.com/prefix-dev/rattler-build/pull/2664)
+- Add iOS and Android platform support by @wolfv in [#2682](https://github.com/prefix-dev/rattler-build/pull/2682)
+
+
+### Fixed
+
+- Package content tests for ios by @wolfv in [#2684](https://github.com/prefix-dev/rattler-build/pull/2684)
+- Defer tests until transitive outputs are built by @wolfv in [#2686](https://github.com/prefix-dev/rattler-build/pull/2686)
+- Stop wrapping solver errors by @wolfv in [#2687](https://github.com/prefix-dev/rattler-build/pull/2687)
+- Inherit all top-level build settings for cache outputs by @Hofer-Julian in [#2641](https://github.com/prefix-dev/rattler-build/pull/2641)
+
+
+### Removed
+
+- Remove the rattler-build-conda-compat integration API by @Hofer-Julian in [#2675](https://github.com/prefix-dev/rattler-build/pull/2675)
+
+
+
 ## [0.70.1] - 2026-07-23
 ### ✨ Highlights
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4803,7 +4803,7 @@ dependencies = [
 
 [[package]]
 name = "rattler-build"
-version = "0.70.1"
+version = "0.71.0"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler-build"
-version = "0.70.1"
+version = "0.71.0"
 authors = ["rattler-build contributors <hi@prefix.dev>"]
 repository = "https://github.com/prefix-dev/rattler-build"
 edition = "2024"

--- a/py-rattler-build/pyproject.toml
+++ b/py-rattler-build/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "py-rattler-build"
-version = "0.70.1"
+version = "0.71.0"
 requires-python = ">=3.10"
 description = "The fastest way to build conda packages programatically"
 readme = "README.md"

--- a/py-rattler-build/rust/Cargo.lock
+++ b/py-rattler-build/rust/Cargo.lock
@@ -4271,7 +4271,7 @@ dependencies = [
 
 [[package]]
 name = "py-rattler-build"
-version = "0.70.1"
+version = "0.71.0"
 dependencies = [
  "clap",
  "fs-err",
@@ -4635,7 +4635,7 @@ dependencies = [
 
 [[package]]
 name = "rattler-build"
-version = "0.70.1"
+version = "0.71.0"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",

--- a/py-rattler-build/rust/Cargo.toml
+++ b/py-rattler-build/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-rattler-build"
-version = "0.70.1"
+version = "0.71.0"
 edition = "2024"
 license = "BSD-3-Clause"
 publish = false

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/prefix-dev/rattler-build"
 
 [version]
-current = "0.70.1"
+current = "0.71.0"
 
 # Example of a semver regexp.
 # Make sure this matches current_version before


### PR DESCRIPTION
## [0.71.0] - 2026-07-27
### ✨ Highlights

This release adds iOS and Android platform support and improves cross-architecture Windows command execution. It also fixes cache-output build setting inheritance and defers tests until transitive outputs are available.



### Added

- Make CMD subprocesses match `build_platform` architecture when running emulated by @baszalmstra in [#2664](https://github.com/prefix-dev/rattler-build/pull/2664)
- Add iOS and Android platform support by @wolfv in [#2682](https://github.com/prefix-dev/rattler-build/pull/2682)


### Fixed

- Package content tests for ios by @wolfv in [#2684](https://github.com/prefix-dev/rattler-build/pull/2684)
- Defer tests until transitive outputs are built by @wolfv in [#2686](https://github.com/prefix-dev/rattler-build/pull/2686)
- Stop wrapping solver errors by @wolfv in [#2687](https://github.com/prefix-dev/rattler-build/pull/2687)
- Inherit all top-level build settings for cache outputs by @Hofer-Julian in [#2641](https://github.com/prefix-dev/rattler-build/pull/2641)


### Removed

- Remove the rattler-build-conda-compat integration API by @Hofer-Julian in [#2675](https://github.com/prefix-dev/rattler-build/pull/2675)