### PR TITLE
refactor: inject RuntimeEnv into script environment generation

### DIFF
--- a/crates/rattler_build_core/src/android/env.rs
+++ b/crates/rattler_build_core/src/android/env.rs
@@ -1,4 +1,5 @@
 //! Android specific environment variables
+use rattler_build_script::RuntimeEnv;
 use rattler_conda_types::Platform;
 use std::{collections::HashMap, path::Path};
 
@@ -36,8 +37,9 @@ fn target_triple(target_platform: &Platform) -> Option<&'static str> {
 pub fn default_env_vars_target(
     prefix: &Path,
     target_platform: &Platform,
+    runtime: &RuntimeEnv,
 ) -> HashMap<String, Option<String>> {
-    let mut vars = unix::env::default_env_vars_target(prefix);
+    let mut vars = unix::env::default_env_vars_target(prefix, runtime);
 
     if let Some(abi) = android_abi(target_platform) {
         vars.insert("ANDROID_ABI".to_string(), Some(abi.to_string()));
@@ -84,7 +86,11 @@ mod tests {
 
     #[test]
     fn target_vars_include_unix_and_android_specific_vars() {
-        let vars = default_env_vars_target(Path::new("/some/prefix"), &Platform::AndroidAarch64);
+        let vars = default_env_vars_target(
+            Path::new("/some/prefix"),
+            &Platform::AndroidAarch64,
+            &RuntimeEnv::for_test(Platform::Linux64),
+        );
         // inherited from the generic unix vars
         assert!(vars.contains_key("PKG_CONFIG_PATH"));
         assert!(vars.contains_key("CMAKE_GENERATOR"));

--- a/crates/rattler_build_core/src/env_vars.rs
+++ b/crates/rattler_build_core/src/env_vars.rs
@@ -1,10 +1,10 @@
 //! Functions to collect environment variables that are used during the build process.
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
-use std::{collections::HashMap, env};
 
 use rattler_build_jinja::Variable;
-use rattler_build_script::EnvironmentIsolation;
+use rattler_build_script::{EnvironmentIsolation, RuntimeEnv};
 use rattler_build_types::NormalizedKey;
 use rattler_conda_types::{Platform, RepoDataRecord};
 use std::collections::BTreeMap;
@@ -208,6 +208,7 @@ pub fn os_vars(
     build_platform: &Platform,
     env_isolation: EnvironmentIsolation,
     work_dir: &Path,
+    runtime: &RuntimeEnv,
 ) -> HashMap<String, Option<String>> {
     let mut vars = HashMap::new();
 
@@ -228,7 +229,10 @@ pub fn os_vars(
     insert!(
         vars,
         "CPU_COUNT",
-        env::var("CPU_COUNT").unwrap_or_else(|_| num_cpus::get().to_string())
+        runtime
+            .var("CPU_COUNT")
+            .map(str::to_owned)
+            .unwrap_or_else(|| num_cpus::get().to_string())
     );
 
     match env_isolation {
@@ -239,9 +243,15 @@ pub fn os_vars(
         }
         EnvironmentIsolation::CondaBuild | EnvironmentIsolation::None => {
             // Forward locale from host (conda-build behavior)
-            vars.insert("LANG".to_string(), env::var("LANG").ok());
-            vars.insert("LC_ALL".to_string(), env::var("LC_ALL").ok());
-            vars.insert("MAKEFLAGS".to_string(), env::var("MAKEFLAGS").ok());
+            vars.insert("LANG".to_string(), runtime.var("LANG").map(str::to_owned));
+            vars.insert(
+                "LC_ALL".to_string(),
+                runtime.var("LC_ALL").map(str::to_owned),
+            );
+            vars.insert(
+                "MAKEFLAGS".to_string(),
+                runtime.var("MAKEFLAGS").map(str::to_owned),
+            );
         }
     }
 
@@ -250,25 +260,44 @@ pub fn os_vars(
         "SHLIB_EXT",
         rattler_build_types::shlib_ext(os_platform)
     );
-    vars.insert(path_var.to_string(), env::var(path_var).ok());
+    vars.insert(
+        path_var.to_string(),
+        runtime.var(path_var).map(str::to_owned),
+    );
 
     if os_platform.is_windows() {
-        vars.extend(windows::env::default_env_vars_target(prefix));
+        vars.extend(windows::env::default_env_vars_target(prefix, runtime));
     } else if os_platform.is_osx() {
-        vars.extend(macos::env::default_env_vars_target(prefix, os_platform));
+        vars.extend(macos::env::default_env_vars_target(
+            prefix,
+            os_platform,
+            runtime,
+        ));
     } else if os_platform.is_ios() {
-        vars.extend(ios::env::default_env_vars_target(prefix, os_platform));
+        vars.extend(ios::env::default_env_vars_target(
+            prefix,
+            os_platform,
+            runtime,
+        ));
     } else if os_platform.is_android() {
-        vars.extend(android::env::default_env_vars_target(prefix, os_platform));
+        vars.extend(android::env::default_env_vars_target(
+            prefix,
+            os_platform,
+            runtime,
+        ));
     } else if os_platform.is_linux() {
         vars.extend(linux::env::default_env_vars_target(
             prefix,
             os_platform,
             env_isolation,
+            runtime,
         ));
     }
     if build_platform.is_windows() {
-        vars.extend(windows::env::default_env_vars_build(build_platform));
+        vars.extend(windows::env::default_env_vars_build(
+            build_platform,
+            runtime,
+        ));
     } else if build_platform.is_osx() {
         vars.extend(macos::env::default_env_vars_build(build_platform));
     } else if build_platform.is_linux() {
@@ -281,7 +310,10 @@ pub fn os_vars(
                 insert!(vars, "USERPROFILE", work_dir.to_string_lossy());
             }
             EnvironmentIsolation::CondaBuild => {
-                vars.insert("USERPROFILE".to_string(), env::var("USERPROFILE").ok());
+                vars.insert(
+                    "USERPROFILE".to_string(),
+                    runtime.var("USERPROFILE").map(str::to_owned),
+                );
             }
             EnvironmentIsolation::None => {}
         }
@@ -297,7 +329,7 @@ pub fn os_vars(
             EnvironmentIsolation::CondaBuild => {
                 vars.insert(
                     "HOME".to_string(),
-                    Some(env::var("HOME").unwrap_or_else(|_| "UNKNOWN".to_string())),
+                    Some(runtime.var("HOME").unwrap_or("UNKNOWN").to_owned()),
                 );
             }
             EnvironmentIsolation::None => {}
@@ -498,6 +530,27 @@ pub fn env_vars_from_variant(
 mod test {
     use super::*;
 
+    #[test]
+    fn os_vars_uses_the_injected_runtime_environment() {
+        let runtime = RuntimeEnv::for_test(Platform::Linux64).with_var("PATH", "/injected/bin");
+
+        let vars = os_vars(
+            Path::new("/some/prefix"),
+            &Platform::Linux64,
+            &Platform::Linux64,
+            &Platform::Linux64,
+            EnvironmentIsolation::CondaBuild,
+            Path::new("/some/work"),
+            &runtime,
+        );
+
+        assert_eq!(
+            vars.get("PATH").and_then(|value| value.as_deref()),
+            Some("/injected/bin")
+        );
+        assert_eq!(vars.get("LANG"), Some(&None));
+    }
+
     /// noarch on a Windows host still emits Windows target vars (issue #2475).
     #[test]
     fn test_noarch_uses_host_platform_for_os_vars() {
@@ -511,6 +564,7 @@ mod test {
             &Platform::Win64,
             EnvironmentIsolation::Strict,
             work_dir,
+            &RuntimeEnv::for_test(Platform::Win64),
         );
 
         assert!(vars.contains_key("LIBRARY_PREFIX"));
@@ -532,13 +586,12 @@ mod test {
             &Platform::WinArm64,
             EnvironmentIsolation::Strict,
             Path::new("/some/work"),
+            &RuntimeEnv::for_test(Platform::WinArm64),
         );
 
-        let expected =
-            std::env::var("BUILD").unwrap_or_else(|_| "arm64-pc-windows-19.0.0".to_string());
         assert_eq!(
             vars.get("BUILD").and_then(|value| value.as_deref()),
-            Some(expected.as_str())
+            Some("arm64-pc-windows-19.0.0")
         );
     }
 
@@ -555,6 +608,7 @@ mod test {
             &Platform::Linux64,
             EnvironmentIsolation::Strict,
             work_dir,
+            &RuntimeEnv::for_test(Platform::Linux64),
         );
 
         assert!(!vars.contains_key("LIBRARY_PREFIX"));

--- a/crates/rattler_build_core/src/ios/env.rs
+++ b/crates/rattler_build_core/src/ios/env.rs
@@ -1,4 +1,5 @@
 //! iOS specific environment variables
+use rattler_build_script::RuntimeEnv;
 use rattler_conda_types::Platform;
 use std::{collections::HashMap, path::Path};
 
@@ -25,8 +26,9 @@ fn target_triple(target_platform: &Platform) -> Option<String> {
 pub fn default_env_vars_target(
     prefix: &Path,
     target_platform: &Platform,
+    runtime: &RuntimeEnv,
 ) -> HashMap<String, Option<String>> {
-    let mut vars = unix::env::default_env_vars_target(prefix);
+    let mut vars = unix::env::default_env_vars_target(prefix, runtime);
 
     if let Some(arch) = target_platform.arch() {
         vars.insert("IOS_ARCH".to_string(), Some(arch.as_str().to_string()));
@@ -69,7 +71,11 @@ mod tests {
 
     #[test]
     fn target_vars_include_unix_and_ios_specific_vars() {
-        let vars = default_env_vars_target(Path::new("/some/prefix"), &Platform::IosArm64);
+        let vars = default_env_vars_target(
+            Path::new("/some/prefix"),
+            &Platform::IosArm64,
+            &RuntimeEnv::for_test(Platform::Linux64),
+        );
         // inherited from the generic unix vars
         assert!(vars.contains_key("PKG_CONFIG_PATH"));
         assert!(vars.contains_key("CMAKE_GENERATOR"));

--- a/crates/rattler_build_core/src/linux/env.rs
+++ b/crates/rattler_build_core/src/linux/env.rs
@@ -2,7 +2,7 @@
 use std::env::consts::ARCH;
 use std::{collections::HashMap, path::Path};
 
-use rattler_build_script::EnvironmentIsolation;
+use rattler_build_script::{EnvironmentIsolation, RuntimeEnv};
 use rattler_conda_types::Platform;
 
 use crate::unix;
@@ -12,8 +12,9 @@ pub fn default_env_vars_target(
     prefix: &Path,
     target_platform: &Platform,
     env_isolation: EnvironmentIsolation,
+    runtime: &RuntimeEnv,
 ) -> HashMap<String, Option<String>> {
-    let mut vars = unix::env::default_env_vars_target(prefix);
+    let mut vars = unix::env::default_env_vars_target(prefix, runtime);
 
     let build_distro = match target_platform {
         Platform::Linux32 | Platform::Linux64 => "cos6",
@@ -30,21 +31,40 @@ pub fn default_env_vars_target(
         env_isolation,
         EnvironmentIsolation::CondaBuild | EnvironmentIsolation::None
     ) {
-        vars.insert("CFLAGS".to_string(), std::env::var("CFLAGS").ok());
-        vars.insert("CXXFLAGS".to_string(), std::env::var("CXXFLAGS").ok());
-        vars.insert("LDFLAGS".to_string(), std::env::var("LDFLAGS").ok());
+        vars.insert(
+            "CFLAGS".to_string(),
+            runtime.var("CFLAGS").map(str::to_owned),
+        );
+        vars.insert(
+            "CXXFLAGS".to_string(),
+            runtime.var("CXXFLAGS").map(str::to_owned),
+        );
+        vars.insert(
+            "LDFLAGS".to_string(),
+            runtime.var("LDFLAGS").map(str::to_owned),
+        );
     }
     vars.insert(
         "QEMU_LD_PREFIX".to_string(),
-        std::env::var("QEMU_LD_PREFIX").ok(),
+        runtime.var("QEMU_LD_PREFIX").map(str::to_owned),
     );
-    vars.insert("QEMU_UNAME".to_string(), std::env::var("QEMU_UNAME").ok());
-    vars.insert("DEJAGNU".to_string(), std::env::var("DEJAGNU").ok());
-    vars.insert("DISPLAY".to_string(), std::env::var("DISPLAY").ok());
+    vars.insert(
+        "QEMU_UNAME".to_string(),
+        runtime.var("QEMU_UNAME").map(str::to_owned),
+    );
+    vars.insert(
+        "DEJAGNU".to_string(),
+        runtime.var("DEJAGNU").map(str::to_owned),
+    );
+    vars.insert(
+        "DISPLAY".to_string(),
+        runtime.var("DISPLAY").map(str::to_owned),
+    );
     vars.insert(
         "LD_RUN_PATH".to_string(),
-        std::env::var("LD_RUN_PATH")
-            .ok()
+        runtime
+            .var("LD_RUN_PATH")
+            .map(str::to_owned)
             .or_else(|| Some(prefix.join("lib").to_string_lossy().to_string())),
     );
     vars.insert(
@@ -83,18 +103,16 @@ pub fn default_env_vars_build(build_platform: &Platform) -> HashMap<String, Opti
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serial_test::serial;
-
     #[test]
-    #[serial]
     fn build_and_ld_run_path_defaults() {
         let tmp_prefix = tempfile::tempdir().unwrap();
-        unsafe { std::env::remove_var("LD_RUN_PATH") };
+        let runtime = RuntimeEnv::for_test(Platform::Linux64);
 
         let vars = default_env_vars_target(
             tmp_prefix.path(),
             &Platform::Linux64,
             EnvironmentIsolation::Strict,
+            &runtime,
         );
         let build_val = vars
             .get("BUILD")
@@ -112,22 +130,21 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn ld_run_path_env_preserved() {
         let tmp_prefix = tempfile::tempdir().unwrap();
-        unsafe { std::env::set_var("LD_RUN_PATH", "/custom/lib") };
+        let runtime =
+            RuntimeEnv::for_test(Platform::Linux64).with_var("LD_RUN_PATH", "/custom/lib");
 
         let vars = default_env_vars_target(
             tmp_prefix.path(),
             &Platform::Linux64,
             EnvironmentIsolation::Strict,
+            &runtime,
         );
         assert_eq!(
             vars.get("LD_RUN_PATH"),
             Some(&Some("/custom/lib".to_string()))
         );
-
-        unsafe { std::env::remove_var("LD_RUN_PATH") };
     }
 
     #[test]
@@ -137,6 +154,7 @@ mod tests {
             tmp_prefix.path(),
             &Platform::Linux64,
             EnvironmentIsolation::Strict,
+            &RuntimeEnv::for_test(Platform::Linux64),
         );
         assert_eq!(vars.get("CFLAGS"), None);
         assert_eq!(vars.get("CXXFLAGS"), None);

--- a/crates/rattler_build_core/src/macos/env.rs
+++ b/crates/rattler_build_core/src/macos/env.rs
@@ -1,4 +1,5 @@
 //! macOS specific environment variables
+use rattler_build_script::RuntimeEnv;
 use rattler_conda_types::Platform;
 use std::{collections::HashMap, path::Path};
 
@@ -8,8 +9,9 @@ use crate::unix;
 pub fn default_env_vars_target(
     prefix: &Path,
     target_platform: &Platform,
+    runtime: &RuntimeEnv,
 ) -> HashMap<String, Option<String>> {
-    let mut vars = unix::env::default_env_vars_target(prefix);
+    let mut vars = unix::env::default_env_vars_target(prefix, runtime);
     let arch = target_platform
         .arch()
         .expect("arch missing on target_platform")

--- a/crates/rattler_build_core/src/package_test/run_test.rs
+++ b/crates/rattler_build_core/src/package_test/run_test.rs
@@ -235,6 +235,7 @@ impl Tests {
             &build_platform,
             config.env_isolation,
             tmp_dir.path(),
+            &RuntimeEnv::current(),
         );
         if config.env_isolation == EnvironmentIsolation::None {
             env_vars.retain(|key, _| key != ShellEnum::default().path_var(&build_platform));
@@ -849,6 +850,7 @@ async fn run_python_test_inner(
         &build_platform,
         config.env_isolation,
         &test_dir,
+        &RuntimeEnv::current(),
     );
 
     let context = shared_test_context(&test_prefix, host_platform);
@@ -961,6 +963,7 @@ async fn run_perl_test(
         &build_platform,
         config.env_isolation,
         &test_folder,
+        &RuntimeEnv::current(),
     );
     let context = shared_test_context(&test_prefix, host_platform);
 
@@ -1076,6 +1079,7 @@ async fn run_commands_test(
         &build_platform,
         config.env_isolation,
         &test_dir,
+        &RuntimeEnv::current(),
     );
     if config.env_isolation == EnvironmentIsolation::None {
         env_vars.retain(|key, _| key != ShellEnum::default().path_var(&build_platform));
@@ -1289,6 +1293,7 @@ async fn run_r_test(
         &build_platform,
         config.env_isolation,
         &test_folder,
+        &RuntimeEnv::current(),
     );
     let context = shared_test_context(&test_prefix, host_platform);
 
@@ -1372,6 +1377,7 @@ async fn run_ruby_test(
         &build_platform,
         config.env_isolation,
         &test_folder,
+        &RuntimeEnv::current(),
     );
     let context = shared_test_context(&test_prefix, host_platform);
 

--- a/crates/rattler_build_core/src/script.rs
+++ b/crates/rattler_build_core/src/script.rs
@@ -45,16 +45,17 @@ impl Output {
                 "`build.steps` is an experimental feature: provide the `--experimental` flag to enable it",
             ));
         }
+        let runtime = RuntimeEnv::current();
         let context = if build.merge_build_and_host_envs {
             ExecutionContext::shared(
-                RuntimeEnv::current(),
+                runtime.clone(),
                 &host_prefix,
                 self.build_configuration.build_platform.platform,
                 host_platform,
             )
         } else {
             ExecutionContext::separate(
-                RuntimeEnv::current(),
+                runtime.clone(),
                 &self.build_configuration.directories.build_prefix,
                 self.build_configuration.build_platform.platform,
                 &host_prefix,
@@ -70,6 +71,7 @@ impl Output {
             &self.build_configuration.build_platform.platform,
             env_isolation,
             &self.build_configuration.directories.work_dir,
+            context.runtime(),
         ));
         env_vars.extend(env_vars::env_vars_from_variant(self.variant()));
         if let Some(architecture) = context.windows_processor_architecture() {

--- a/crates/rattler_build_core/src/staging.rs
+++ b/crates/rattler_build_core/src/staging.rs
@@ -288,6 +288,7 @@ impl Output {
         // Run the build script
         let target_platform = self.build_configuration.target_platform;
         let host_platform = self.host_platform().platform;
+        let runtime = RuntimeEnv::current();
         let mut env_vars = env_vars::vars(self, "BUILD");
         env_vars.extend(env_vars::os_vars(
             self.prefix(),
@@ -296,6 +297,7 @@ impl Output {
             &self.build_configuration.build_platform.platform,
             self.build_configuration.env_isolation,
             &self.build_configuration.directories.work_dir,
+            &runtime,
         ));
         // Use the staging cache's own used_variant rather than the inheriting
         // output's: the staging cache is shared across all inheritors, and the
@@ -340,14 +342,14 @@ impl Output {
 
         let context = if staging.build.merge_build_and_host_envs {
             ExecutionContext::shared(
-                RuntimeEnv::current(),
+                runtime.clone(),
                 &self.build_configuration.directories.host_prefix,
                 self.build_configuration.build_platform.platform,
                 host_platform,
             )
         } else {
             ExecutionContext::separate(
-                RuntimeEnv::current(),
+                runtime.clone(),
                 &self.build_configuration.directories.build_prefix,
                 self.build_configuration.build_platform.platform,
                 &self.build_configuration.directories.host_prefix,

--- a/crates/rattler_build_core/src/unix/env.rs
+++ b/crates/rattler_build_core/src/unix/env.rs
@@ -1,6 +1,11 @@
 use std::{collections::HashMap, path::Path};
 
-pub fn default_env_vars_target(prefix: &Path) -> HashMap<String, Option<String>> {
+use rattler_build_script::RuntimeEnv;
+
+pub fn default_env_vars_target(
+    prefix: &Path,
+    runtime: &RuntimeEnv,
+) -> HashMap<String, Option<String>> {
     let mut vars = HashMap::new();
     vars.insert(
         "PKG_CONFIG_PATH".to_string(),
@@ -12,7 +17,7 @@ pub fn default_env_vars_target(prefix: &Path) -> HashMap<String, Option<String>>
     );
     vars.insert(
         "SSL_CERT_FILE".to_string(),
-        std::env::var("SSL_CERT_FILE").ok(),
+        runtime.var("SSL_CERT_FILE").map(str::to_owned),
     );
     vars
 }
@@ -24,7 +29,10 @@ mod tests {
     #[test]
     fn pkconfig_path_uses_prefix() {
         let tmp = tempfile::tempdir().expect("create temp dir");
-        let env_vars = default_env_vars_target(tmp.path());
+        let env_vars = default_env_vars_target(
+            tmp.path(),
+            &RuntimeEnv::for_test(rattler_conda_types::Platform::Linux64),
+        );
         let expected = tmp
             .path()
             .join("lib/pkgconfig")
@@ -35,7 +43,10 @@ mod tests {
 
     #[test]
     fn home_not_set_by_default_env_vars() {
-        let env_vars = default_env_vars_target(Path::new("/some/prefix"));
+        let env_vars = default_env_vars_target(
+            Path::new("/some/prefix"),
+            &RuntimeEnv::for_test(rattler_conda_types::Platform::Linux64),
+        );
         assert_eq!(env_vars.get("HOME"), None);
     }
 }

--- a/crates/rattler_build_core/src/windows/env.rs
+++ b/crates/rattler_build_core/src/windows/env.rs
@@ -3,6 +3,7 @@ use std::{
     path::{Component::*, Path, Prefix::Disk},
 };
 
+use rattler_build_script::RuntimeEnv;
 use rattler_conda_types::Platform;
 use regex::Regex;
 
@@ -39,7 +40,10 @@ fn to_cygdrive(path: &Path) -> String {
     }
 }
 
-pub fn default_env_vars_target(prefix: &Path) -> HashMap<String, Option<String>> {
+pub fn default_env_vars_target(
+    prefix: &Path,
+    runtime: &RuntimeEnv,
+) -> HashMap<String, Option<String>> {
     let library_prefix = prefix.join("Library");
     let mut vars = HashMap::<String, Option<String>>::new();
     vars.insert(
@@ -68,8 +72,8 @@ pub fn default_env_vars_target(prefix: &Path) -> HashMap<String, Option<String>>
     // This adds the LIB and INCLUDE vars. It would not be entirely correct if someone
     // overwrites the LIBRARY_LIB or LIBRARY_INCLUDE variables from the variants.yaml
     // but I think for now this is fine.
-    let lib_var = std::env::var("LIB").ok().unwrap_or_default();
-    let include_var = std::env::var("INCLUDE").ok().unwrap_or_default();
+    let lib_var = runtime.var("LIB").unwrap_or_default();
+    let include_var = runtime.var("INCLUDE").unwrap_or_default();
     vars.insert(
         "LIB".to_string(),
         Some(format!("{};{}", library_lib.display(), lib_var)),
@@ -83,7 +87,10 @@ pub fn default_env_vars_target(prefix: &Path) -> HashMap<String, Option<String>>
     vars
 }
 
-pub fn default_env_vars_build(build_platform: &Platform) -> HashMap<String, Option<String>> {
+pub fn default_env_vars_build(
+    build_platform: &Platform,
+    runtime: &RuntimeEnv,
+) -> HashMap<String, Option<String>> {
     let mut vars = HashMap::<String, Option<String>>::new();
     let default_vars = vec![
         "ALLUSERSPROFILE",
@@ -121,7 +128,7 @@ pub fn default_env_vars_build(build_platform: &Platform) -> HashMap<String, Opti
     ];
 
     for var in default_vars {
-        vars.insert(var.to_string(), std::env::var(var).ok());
+        vars.insert(var.to_string(), runtime.var(var).map(str::to_owned));
     }
 
     // Do we need to get these from the variant configuration?
@@ -138,17 +145,20 @@ pub fn default_env_vars_build(build_platform: &Platform) -> HashMap<String, Opti
     vars.insert(
         "BUILD".to_string(),
         Some(
-            std::env::var("BUILD")
-                .unwrap_or_else(|_| format!("{}-pc-windows-{}", win_arch, win_msvc)),
+            runtime
+                .var("BUILD")
+                .map(str::to_owned)
+                .unwrap_or_else(|| format!("{}-pc-windows-{}", win_arch, win_msvc)),
         ),
     );
 
     let re_vs_comntools = Regex::new(r"^VS[0-9]{2,3}COMNTOOLS$").unwrap();
     let re_vs_installdir = Regex::new(r"^VS[0-9]{4}INSTALLDIR$").unwrap();
 
-    for (key, val) in std::env::vars() {
-        if re_vs_comntools.is_match(&key) || re_vs_installdir.is_match(&key) {
-            vars.insert(key, Some(val));
+    for (key, val) in runtime.vars() {
+        let normalized_key = key.to_ascii_uppercase();
+        if re_vs_comntools.is_match(&normalized_key) || re_vs_installdir.is_match(&normalized_key) {
+            vars.insert(key.to_owned(), Some(val.to_owned()));
         }
     }
 
@@ -157,6 +167,26 @@ pub fn default_env_vars_build(build_platform: &Platform) -> HashMap<String, Opti
 
 #[cfg(test)]
 mod test {
+    use super::*;
+
+    #[test]
+    fn build_vars_use_the_injected_runtime_environment() {
+        let runtime = RuntimeEnv::for_test(Platform::Win64)
+            .with_var("vs140comntools", "C:\\VS140")
+            .with_var("BUILD", "injected-build");
+        let vars = default_env_vars_build(&Platform::Win64, &runtime);
+
+        assert_eq!(
+            vars.get("vs140comntools")
+                .and_then(|value| value.as_deref()),
+            Some("C:\\VS140")
+        );
+        assert_eq!(
+            vars.get("BUILD").and_then(|value| value.as_deref()),
+            Some("injected-build")
+        );
+    }
+
     #[cfg(target_os = "windows")]
     #[test]
     fn test_cygdrive() {

--- a/crates/rattler_build_script/src/runtime.rs
+++ b/crates/rattler_build_script/src/runtime.rs
@@ -24,6 +24,14 @@ impl EnvironmentVariables {
         }
     }
 
+    fn from_iter(values: impl IntoIterator<Item = (String, String)>, platform: Platform) -> Self {
+        let mut environment = Self::new(platform.is_windows());
+        for (name, value) in values {
+            environment.insert(name, value);
+        }
+        environment
+    }
+
     fn get(&self, name: &str) -> Option<&str> {
         let name = self
             .case_insensitive_keys
@@ -61,15 +69,11 @@ pub struct RuntimeEnv {
 impl RuntimeEnv {
     /// Captures the real process environment variables and the current platform.
     pub fn current() -> Self {
-        let current_platform = Platform::current();
-        let mut runtime_env = Self {
-            env: EnvironmentVariables::new(current_platform.is_windows()),
-            process_platform: current_platform,
-        };
-        for (name, value) in std::env::vars() {
-            runtime_env.env.insert(name, value)
+        let process_platform = Platform::current();
+        Self {
+            env: EnvironmentVariables::from_iter(std::env::vars(), process_platform),
+            process_platform,
         }
-        runtime_env
     }
 
     /// Creates a runtime environment with an empty variable set and the given
@@ -137,6 +141,16 @@ mod tests {
         assert_eq!(RuntimeEnv::for_test(Platform::Win64).exe_suffix(), ".exe");
         assert_eq!(RuntimeEnv::for_test(Platform::Linux64).exe_suffix(), "");
         assert_eq!(RuntimeEnv::for_test(Platform::OsxArm64).exe_suffix(), "");
+    }
+
+    #[test]
+    fn environment_variables_from_iter_uses_platform_casing() {
+        let environment = EnvironmentVariables::from_iter(
+            [("Path".to_string(), "C:\\bin".to_string())],
+            Platform::Win64,
+        );
+
+        assert_eq!(environment.get("PATH"), Some("C:\\bin"));
     }
 
     #[test]

--- a/py-rattler-build/rust/src/render.rs
+++ b/py-rattler-build/rust/src/render.rs
@@ -82,6 +82,7 @@ impl PyRenderConfig {
             &build_platform,
             EnvironmentIsolation::default(),
             &std::path::PathBuf::new(),
+            &rattler_build::script::RuntimeEnv::current(),
         )
         .keys()
         .cloned()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -397,6 +397,7 @@ pub async fn get_build_output(
         &build_data.build_platform,
         build_data.env_isolation,
         &std::path::PathBuf::new(),
+        &crate::script::RuntimeEnv::current(),
     )
     .keys()
     .cloned()


### PR DESCRIPTION
Pass `RuntimeEnv` into build-script environment generation instead of reading the process environment directly.

`os_vars` and the OS-specific helpers now take the runtime explicitly. Build and staging script preparation reuse one captured runtime for both generated environment variables and `ExecutionContext`. Package-test and render-only callers pass their runtime explicitly as well.

This builds on the merged `EnvironmentVariables` implementation from #2676. It adds a direct iterator-plus-platform constructor, which `RuntimeEnv::current` uses to capture the process environment while preserving Windows case-insensitive lookup behavior.

## Testing

- `pixi run cargo test -p rattler_build_script --lib runtime::tests`
- `pixi run cargo check -p rattler_build_core --tests`
- `pixi run cargo test -p rattler_build_core --lib` (201 passed before the final Windows casing regression cases)
- `pixi run cargo check --workspace --all-targets` completed before the out-of-workspace Python check.
- `cargo check` in `py-rattler-build/rust` could not complete because the temporary workspace ran out of disk space while Pixi built the Python environment.