### PR TITLE
refactor: rename NativeShellRunner to ShellDialect

### DIFF
--- a/crates/rattler_build_script/src/execution.rs
+++ b/crates/rattler_build_script/src/execution.rs
@@ -527,7 +527,7 @@ pub struct BuildScriptSection {
 /// One unit of a generated build wrapper: content run in a single interpreter,
 /// with optional step-local `env`, optional `cwd`, and a boundary-comment label.
 ///
-/// `env` is scoped to the section (see `NativeShellRunner::scope_section`) and is
+/// `env` is scoped to the section (see `ShellDialect::scope_section`) and is
 /// distinct from [`ExecutionArgs::env_vars`], the whole-build environment. The
 /// wrapper is built from one [`ScriptSection`] per [`ExecutionArgs::sections`] entry.
 pub(crate) struct ScriptSection<'a> {
@@ -574,8 +574,8 @@ fn section_script_filename(extension: &str, index: SectionIndex) -> String {
 pub(crate) async fn generate_build_script(
     args: &ExecutionArgs,
 ) -> Result<PathBuf, crate::InterpreterError> {
-    let runner = crate::native_runner::native_runner(args.context.runtime().process_platform());
-    let shell = runner.shell();
+    let dialect = crate::shell_dialect::shell_dialect(args.context.runtime().process_platform());
+    let shell = dialect.shell();
 
     let script_extension = shell.extension();
     let activation_script_path = args.work_dir.join(format!("build_env.{script_extension}"));
@@ -587,7 +587,7 @@ pub(crate) async fn generate_build_script(
         .map_err(|err| std::io::Error::other(err.to_string()))?;
     tokio::fs::write(
         &activation_script_path,
-        crate::native_runner::write_shell_script(shell.clone(), &activation_script)?,
+        crate::shell_dialect::write_shell_script(shell.clone(), &activation_script)?,
     )
     .await?;
 
@@ -608,7 +608,7 @@ pub(crate) async fn generate_build_script(
     for (position, section) in sections.iter().enumerate() {
         let body = build_section_body(
             args,
-            runner.as_ref(),
+            dialect.as_ref(),
             &shell,
             section,
             SectionIndex { position, total },
@@ -619,17 +619,17 @@ pub(crate) async fn generate_build_script(
         if body.trim().is_empty() {
             continue;
         }
-        fragments.push(runner.scope_section(section.label, section.env, section.cwd, &body)?);
+        fragments.push(dialect.scope_section(section.label, section.env, section.cwd, &body)?);
     }
 
     let build_script = format!(
         "{}\n{}",
-        runner.preamble(&activation_script_path),
+        dialect.preamble(&activation_script_path),
         fragments.join("\n"),
     );
     tokio::fs::write(
         &build_script_path,
-        crate::native_runner::write_shell_script(shell, &build_script)?,
+        crate::shell_dialect::write_shell_script(shell, &build_script)?,
     )
     .await?;
 
@@ -649,7 +649,7 @@ pub(crate) async fn generate_build_script(
 /// interpreter applies, otherwise an invocation of the resolved interpreter.
 async fn build_section_body(
     args: &ExecutionArgs,
-    runner: &dyn crate::native_runner::NativeShellRunner,
+    dialect: &dyn crate::shell_dialect::ShellDialect,
     shell: &rattler_shell::shell::ShellEnum,
     section: &ScriptSection<'_>,
     index: SectionIndex,
@@ -664,7 +664,7 @@ async fn build_section_body(
     // No interpreter specified: default to the wrapper shell.
     let interpreter_name = explicit_or_inferred
         .clone()
-        .unwrap_or_else(|| runner.default_interpreter().to_string());
+        .unwrap_or_else(|| dialect.default_interpreter().to_string());
     let interpreter = crate::interpreter::SelectedInterpreter::from_recipe_name(&interpreter_name)
         .ok_or_else(|| crate::InterpreterError::UnsupportedInterpreter(interpreter_name.clone()))?;
 
@@ -677,7 +677,7 @@ async fn build_section_body(
     // conda-provided executable and would otherwise fail to resolve.
     let needs_specialized_interpreter = explicit_or_inferred
         .as_deref()
-        .is_some_and(|name| name != runner.default_interpreter());
+        .is_some_and(|name| name != dialect.default_interpreter());
 
     // Assemble the rendered content; the interpreter joins a command list.
     let script_text = match section.content {
@@ -692,7 +692,7 @@ async fn build_section_body(
         // native wrapper code. Most shells can inline it directly, but cmd.exe
         // needs call indirection so `exit /b` exits only this section instead
         // of terminating the whole wrapper.
-        if let Some(native_command) = runner.native_section_script_command(
+        if let Some(native_command) = dialect.native_section_script_command(
             &args
                 .work_dir
                 .join(section_script_filename(shell.extension(), index)),
@@ -703,12 +703,12 @@ async fn build_section_body(
                 .join(section_script_filename(shell.extension(), index));
             tokio::fs::write(
                 &script_path,
-                crate::native_runner::write_shell_script(shell.clone(), &script_text)?,
+                crate::shell_dialect::write_shell_script(shell.clone(), &script_text)?,
             )
             .await?;
             let quoted = native_command
                 .iter()
-                .map(|arg| crate::native_runner::quote_arg(shell, arg))
+                .map(|arg| crate::shell_dialect::quote_arg(shell, arg))
                 .collect::<Vec<_>>();
             let command_refs = quoted.iter().map(String::as_str).collect::<Vec<_>>();
             let mut body = String::new();
@@ -742,7 +742,7 @@ async fn build_section_body(
     command.extend(interpreter.args(&script_path));
     let quoted = command
         .iter()
-        .map(|arg| crate::native_runner::quote_arg(shell, arg))
+        .map(|arg| crate::shell_dialect::quote_arg(shell, arg))
         .collect::<Vec<_>>();
     let command_refs = quoted.iter().map(String::as_str).collect::<Vec<_>>();
     let mut body = String::new();
@@ -758,10 +758,10 @@ async fn build_section_body(
 /// from a single script. This lower-level entry point runs a pre-built
 /// `ExecutionArgs` directly and is used when composing multiple sections.
 pub async fn run_script(exec_args: ExecutionArgs) -> Result<(), crate::InterpreterError> {
-    let runner =
-        crate::native_runner::native_runner(exec_args.context.runtime().process_platform());
+    let dialect =
+        crate::shell_dialect::shell_dialect(exec_args.context.runtime().process_platform());
     let build_script_path = generate_build_script(&exec_args).await?;
-    let command_spec = runner.command_to_run_script(&build_script_path, &exec_args.context);
+    let command_spec = dialect.command_to_run_script(&build_script_path, &exec_args.context);
 
     let process_env = resolve_process_env(
         exec_args.env_isolation,
@@ -773,9 +773,9 @@ pub async fn run_script(exec_args: ExecutionArgs) -> Result<(), crate::Interpret
     let output = crate::execution::run_process_with_replacements(
         &command_spec,
         &exec_args.work_dir,
-        &exec_args.replacements(runner.replacements_template()),
+        &exec_args.replacements(dialect.replacements_template()),
         &process_env,
-        if runner.supports_sandbox() {
+        if dialect.supports_sandbox() {
             exec_args.sandbox_config.as_ref()
         } else {
             None
@@ -786,7 +786,7 @@ pub async fn run_script(exec_args: ExecutionArgs) -> Result<(), crate::Interpret
 
     if !output.status.success() {
         let status_code = output.status.code().unwrap_or(1);
-        let debug_info = runner.debug_info(&exec_args.work_dir, &exec_args.context);
+        let debug_info = dialect.debug_info(&exec_args.work_dir, &exec_args.context);
         tracing::error!("Script failed with status {}", status_code);
         tracing::error!("{}", debug_info);
         return Err(crate::InterpreterError::ExecutionFailed(
@@ -927,7 +927,7 @@ pub(crate) fn resolve_process_env(
 /// This is used to replace the host prefix with $PREFIX and the build prefix with $BUILD_PREFIX
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn run_process_with_replacements(
-    command_spec: &crate::native_runner::CommandSpec,
+    command_spec: &crate::shell_dialect::CommandSpec,
     cwd: &Path,
     replacements: &HashMap<String, String>,
     process_env: &IndexMap<String, String>,
@@ -1626,7 +1626,7 @@ mod tests {
             "-c".to_string(),
             "printf 'RAW_PREFIX raw-secret\\n'; printf 'RAW_PREFIX raw-secret\\n' >&2".to_string(),
         ];
-        let command_spec = crate::native_runner::CommandSpec {
+        let command_spec = crate::shell_dialect::CommandSpec {
             program: command[0].clone(),
             args: command[1..].to_vec(),
         };

--- a/crates/rattler_build_script/src/execution_context.rs
+++ b/crates/rattler_build_script/src/execution_context.rs
@@ -117,11 +117,11 @@ impl ExecutionContext {
     /// between x64 and ARM64 with `start /machine`; otherwise the child
     /// inherits its normal process environment.
     pub fn windows_processor_architecture(&self) -> Option<&'static str> {
-        crate::native_runner::windows_machine_transition(
+        crate::windows_machine::windows_machine_transition(
             self.runtime.process_platform(),
             self.build.platform(),
         )
-        .map(crate::native_runner::WindowsMachine::processor_architecture)
+        .map(crate::windows_machine::WindowsMachine::processor_architecture)
     }
 
     /// The value to set for `PROCESSOR_ARCHITEW6432` in a switched child.
@@ -131,18 +131,18 @@ impl ExecutionContext {
     /// the inherited value when no transition is needed or native detection is
     /// unavailable.
     pub fn windows_processor_architecture_w6432(&self) -> Option<Option<&'static str>> {
-        let machine = crate::native_runner::windows_machine_transition(
+        let machine = crate::windows_machine::windows_machine_transition(
             self.runtime.process_platform(),
             self.build.platform(),
         )?;
 
         match machine {
-            crate::native_runner::WindowsMachine::X86 => {
-                crate::native_runner::native_windows_machine()
-                    .map(crate::native_runner::WindowsMachine::wow64_processor_architecture)
+            crate::windows_machine::WindowsMachine::X86 => {
+                crate::windows_machine::native_windows_machine()
+                    .map(crate::windows_machine::WindowsMachine::wow64_processor_architecture)
             }
-            crate::native_runner::WindowsMachine::Amd64
-            | crate::native_runner::WindowsMachine::Arm64 => Some(None),
+            crate::windows_machine::WindowsMachine::Amd64
+            | crate::windows_machine::WindowsMachine::Arm64 => Some(None),
         }
     }
 }

--- a/crates/rattler_build_script/src/interpreter/mod.rs
+++ b/crates/rattler_build_script/src/interpreter/mod.rs
@@ -3,7 +3,7 @@
 //! This module maps recipe `interpreter` values and inferred file extensions to
 //! [`InterpreterInvocation`] implementations. It resolves interpreter executables
 //! with [`find_interpreter`] and reports failures through [`InterpreterError`].
-//! Native wrapper execution lives in `crate::native_runner`.
+//! Native wrapper execution lives in `crate::shell_dialect`.
 
 mod bash;
 mod brush;

--- a/crates/rattler_build_script/src/lib.rs
+++ b/crates/rattler_build_script/src/lib.rs
@@ -26,9 +26,11 @@ mod execution_context;
 #[cfg(feature = "execution")]
 mod interpreter;
 #[cfg(feature = "execution")]
-mod native_runner;
-#[cfg(feature = "execution")]
 mod runtime;
+#[cfg(feature = "execution")]
+mod shell_dialect;
+#[cfg(feature = "execution")]
+mod windows_machine;
 
 #[cfg(feature = "execution")]
 pub use execution::{

--- a/crates/rattler_build_script/src/shell_dialect/bash.rs
+++ b/crates/rattler_build_script/src/shell_dialect/bash.rs
@@ -4,12 +4,12 @@ use std::path::Path;
 use indexmap::IndexMap;
 use rattler_shell::shell::{self, Shell};
 
-use super::{CommandSpec, NativeShellRunner};
+use super::{CommandSpec, ShellDialect};
 use crate::{ExecutionContext, PrefixLayout};
 
-pub(crate) struct BashNativeRunner;
+pub(crate) struct BashDialect;
 
-impl NativeShellRunner for BashNativeRunner {
+impl ShellDialect for BashDialect {
     fn shell(&self) -> shell::ShellEnum {
         shell::Bash::default().into()
     }

--- a/crates/rattler_build_script/src/shell_dialect/cmd_exe.rs
+++ b/crates/rattler_build_script/src/shell_dialect/cmd_exe.rs
@@ -4,12 +4,15 @@ use std::path::Path;
 use indexmap::IndexMap;
 use rattler_shell::shell::{self, Shell};
 
-use super::{CommandSpec, NativeShellRunner, windows_machine_transition};
-use crate::{ExecutionContext, PrefixLayout};
+use super::{CommandSpec, ShellDialect};
+use crate::{
+    ExecutionContext, PrefixLayout,
+    windows_machine::{WindowsMachine, windows_machine_transition},
+};
 
-pub(crate) struct CmdExeNativeRunner;
+pub(crate) struct CmdExeDialect;
 
-impl NativeShellRunner for CmdExeNativeRunner {
+impl ShellDialect for CmdExeDialect {
     fn shell(&self) -> shell::ShellEnum {
         shell::CmdExe.into()
     }
@@ -56,7 +59,7 @@ IF "%CONDA_BUILD%" == "" (
                 .file_name()
                 .expect("generated build script has a filename")
                 .to_string_lossy();
-            let script_name = crate::native_runner::quote_arg(&self.shell(), &script_name);
+            let script_name = super::quote_arg(&self.shell(), &script_name);
             // `/machine x86` does not redirect an explicit `cmd.exe` lookup
             // from System32. Launch the x86 command interpreter from SysWOW64
             // directly. SystemRoot is conventionally an unspaced system path,
@@ -64,9 +67,8 @@ IF "%CONDA_BUILD%" == "" (
             // other architectures use `cmd.exe`, whose image selection is
             // handled by `/machine`.
             let child_cmd = match machine {
-                crate::native_runner::WindowsMachine::X86 => r"%SystemRoot%\SysWOW64\cmd.exe",
-                crate::native_runner::WindowsMachine::Amd64
-                | crate::native_runner::WindowsMachine::Arm64 => "cmd.exe",
+                WindowsMachine::X86 => r"%SystemRoot%\SysWOW64\cmd.exe",
+                WindowsMachine::Amd64 | WindowsMachine::Arm64 => "cmd.exe",
             };
             let command = format!(
                 "start /b /wait /machine {} {} /d /c {} & exit /b !ERRORLEVEL!",

--- a/crates/rattler_build_script/src/shell_dialect/mod.rs
+++ b/crates/rattler_build_script/src/shell_dialect/mod.rs
@@ -1,18 +1,16 @@
-//! Platform-native wrapper execution support.
+//! Platform-native shell dialect support.
 //!
-//! This module selects the [`NativeShellRunner`] for a platform and provides
-//! helpers for writing shell-specific scripts. Specialized interpreters are
-//! described by `crate::interpreter` and are emitted as commands inside the
-//! native wrapper.
+//! This module selects the [`ShellDialect`] for a platform and provides helpers
+//! for writing shell-specific scripts. Specialized interpreters are described by
+//! `crate::interpreter` and are emitted as commands inside the native wrapper.
 
 mod bash;
 mod cmd_exe;
 
 use std::path::Path;
 
-use rattler_conda_types::Platform;
-
 use indexmap::IndexMap;
+use rattler_conda_types::Platform;
 use rattler_shell::shell::{Shell, ShellEnum};
 
 use crate::ExecutionContext;
@@ -36,104 +34,8 @@ impl CommandSpec {
     }
 }
 
-/// Requested Windows child process architecture for a supported transition.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum WindowsMachine {
-    X86,
-    Amd64,
-    Arm64,
-}
-
-impl WindowsMachine {
-    pub(crate) fn start_argument(self) -> &'static str {
-        match self {
-            Self::X86 => "x86",
-            Self::Amd64 => "amd64",
-            Self::Arm64 => "arm64",
-        }
-    }
-
-    pub(crate) fn processor_architecture(self) -> &'static str {
-        match self {
-            Self::X86 => "x86",
-            Self::Amd64 => "AMD64",
-            Self::Arm64 => "ARM64",
-        }
-    }
-
-    /// The `PROCESSOR_ARCHITEW6432` marker Windows exposes to an x86 child.
-    pub(crate) fn wow64_processor_architecture(self) -> Option<&'static str> {
-        (self != Self::X86).then(|| self.processor_architecture())
-    }
-
-    #[cfg(windows)]
-    fn from_image_file_machine(machine: u16) -> Option<Self> {
-        use windows_sys::Win32::System::SystemInformation::{
-            IMAGE_FILE_MACHINE_AMD64, IMAGE_FILE_MACHINE_ARM64, IMAGE_FILE_MACHINE_I386,
-        };
-
-        match machine {
-            IMAGE_FILE_MACHINE_I386 => Some(Self::X86),
-            IMAGE_FILE_MACHINE_AMD64 => Some(Self::Amd64),
-            IMAGE_FILE_MACHINE_ARM64 => Some(Self::Arm64),
-            _ => None,
-        }
-    }
-}
-
-/// Returns the requested child architecture when a supported Windows build
-/// process transition is needed. Rattler-build ships x64 and ARM64 binaries,
-/// and both can launch x86 build tools; x86 rattler-build processes are not
-/// supported as cross-architecture launchers.
-pub(crate) fn windows_machine_transition(
-    process_platform: Platform,
-    build_platform: Platform,
-) -> Option<WindowsMachine> {
-    match (process_platform, build_platform) {
-        (Platform::Win64, Platform::Win32) | (Platform::WinArm64, Platform::Win32) => {
-            Some(WindowsMachine::X86)
-        }
-        (Platform::Win64, Platform::WinArm64) => Some(WindowsMachine::Arm64),
-        (Platform::WinArm64, Platform::Win64) => Some(WindowsMachine::Amd64),
-        _ => None,
-    }
-}
-
-/// Detects the native Windows machine architecture without affecting launch
-/// selection. This is only used to reproduce the `PROCESSOR_ARCHITEW6432`
-/// value that Windows exposes to x86 WOW64 processes.
-#[cfg(windows)]
-pub(crate) fn native_windows_machine() -> Option<WindowsMachine> {
-    use windows_sys::Win32::System::{
-        SystemInformation::IMAGE_FILE_MACHINE_UNKNOWN,
-        Threading::{GetCurrentProcess, IsWow64Process2},
-    };
-
-    let mut process_machine = IMAGE_FILE_MACHINE_UNKNOWN;
-    let mut native_machine = IMAGE_FILE_MACHINE_UNKNOWN;
-    // `IsWow64Process2` is available on every Windows version that supports
-    // `start /machine`. A failure leaves the inherited WOW64 marker untouched.
-    if unsafe {
-        IsWow64Process2(
-            GetCurrentProcess(),
-            &mut process_machine,
-            &mut native_machine,
-        )
-    } == 0
-    {
-        return None;
-    }
-
-    WindowsMachine::from_image_file_machine(native_machine)
-}
-
-#[cfg(not(windows))]
-pub(crate) fn native_windows_machine() -> Option<WindowsMachine> {
-    None
-}
-
-/// Defines platform-native wrapper execution.
-pub(crate) trait NativeShellRunner: Send + Sync {
+/// Defines the platform-native shell syntax used for wrapper execution.
+pub(crate) trait ShellDialect: Send + Sync {
     /// Returns the shell syntax used for the generated native wrapper script.
     fn shell(&self) -> ShellEnum;
 
@@ -154,7 +56,7 @@ pub(crate) trait NativeShellRunner: Send + Sync {
     /// Returns the replacement template used when streaming process output.
     fn replacements_template(&self) -> &'static str;
 
-    /// Returns whether this native shell runner supports rattler-sandbox execution.
+    /// Returns whether this shell dialect supports rattler-sandbox execution.
     fn supports_sandbox(&self) -> bool {
         true
     }
@@ -185,11 +87,11 @@ pub(crate) trait NativeShellRunner: Send + Sync {
 /// Selects the native wrapper shell for the given platform: `cmd.exe` on
 /// Windows, `bash` elsewhere. The script runs on the host, so callers pass the
 /// runtime platform (which equals the host).
-pub(crate) fn native_runner(platform: Platform) -> Box<dyn NativeShellRunner> {
+pub(crate) fn shell_dialect(platform: Platform) -> Box<dyn ShellDialect> {
     if platform.is_windows() {
-        Box::new(cmd_exe::CmdExeNativeRunner)
+        Box::new(cmd_exe::CmdExeDialect)
     } else {
-        Box::new(bash::BashNativeRunner)
+        Box::new(bash::BashDialect)
     }
 }
 
@@ -265,8 +167,11 @@ pub(crate) fn quote_arg(shell: &ShellEnum, arg: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{WindowsMachine, native_runner, quote_arg, windows_machine_transition};
-    use crate::{ExecutionContext, RuntimeEnv};
+    use super::{quote_arg, shell_dialect};
+    use crate::{
+        ExecutionContext, RuntimeEnv,
+        windows_machine::{WindowsMachine, windows_machine_transition},
+    };
     use indexmap::IndexMap;
     use rattler_conda_types::Platform;
     use rattler_shell::shell::{self, Shell};
@@ -276,10 +181,10 @@ mod tests {
     /// from the preamble handles failure.
     #[test]
     fn bash_scope_section_subshell_env_and_label() {
-        let runner = native_runner(Platform::Linux64);
+        let dialect = shell_dialect(Platform::Linux64);
         let mut env = IndexMap::new();
         env.insert("FOO".to_string(), "a b".to_string());
-        let out = runner
+        let out = dialect
             .scope_section(Some("uses: configure"), &env, None, "echo hi")
             .unwrap();
         insta::assert_snapshot!(out, @r###"
@@ -294,8 +199,8 @@ echo hi
     /// No label and empty env => just `( body )`.
     #[test]
     fn bash_scope_section_minimal() {
-        let runner = native_runner(Platform::Linux64);
-        let out = runner
+        let dialect = shell_dialect(Platform::Linux64);
+        let out = dialect
             .scope_section(None, &IndexMap::new(), None, "echo hi")
             .unwrap();
         insta::assert_snapshot!(out, @r###"
@@ -309,10 +214,10 @@ echo hi
     /// appends an errorlevel guard (required even for the last section).
     #[test]
     fn cmd_scope_section_setlocal_env_and_guard() {
-        let runner = native_runner(Platform::Win64);
+        let dialect = shell_dialect(Platform::Win64);
         let mut env = IndexMap::new();
         env.insert("FOO".to_string(), "bar".to_string());
-        let out = runner
+        let out = dialect
             .scope_section(Some("step 1"), &env, None, "echo hi")
             .unwrap();
         insta::assert_snapshot!(out, @r###"
@@ -330,8 +235,8 @@ endlocal & if %RB_SECTION_ERRORLEVEL% neq 0 exit /b %RB_SECTION_ERRORLEVEL%
 
     #[test]
     fn cmd_scope_section_pushd_uses_cwd() {
-        let runner = native_runner(Platform::Win64);
-        let out = runner
+        let dialect = shell_dialect(Platform::Win64);
+        let out = dialect
             .scope_section(
                 Some("step 1"),
                 &IndexMap::new(),
@@ -354,11 +259,11 @@ endlocal & if %RB_SECTION_ERRORLEVEL% neq 0 exit /b %RB_SECTION_ERRORLEVEL%
 
     #[test]
     fn scope_section_rejects_invalid_env_names() {
-        let runner = native_runner(Platform::Linux64);
+        let dialect = shell_dialect(Platform::Linux64);
         let mut env = IndexMap::new();
         env.insert("BAD-NAME".to_string(), "value".to_string());
 
-        let err = runner
+        let err = dialect
             .scope_section(None, &env, None, "echo hi")
             .expect_err("invalid env name should fail");
 
@@ -370,11 +275,11 @@ endlocal & if %RB_SECTION_ERRORLEVEL% neq 0 exit /b %RB_SECTION_ERRORLEVEL%
 
     #[test]
     fn cmd_scope_section_rejects_newline_env_values() {
-        let runner = native_runner(Platform::Win64);
+        let dialect = shell_dialect(Platform::Win64);
         let mut env = IndexMap::new();
         env.insert("FOO".to_string(), "safe\necho injected".to_string());
 
-        let err = runner
+        let err = dialect
             .scope_section(None, &env, None, "echo hi")
             .expect_err("newline env value should fail");
 
@@ -382,15 +287,15 @@ endlocal & if %RB_SECTION_ERRORLEVEL% neq 0 exit /b %RB_SECTION_ERRORLEVEL%
     }
 
     #[test]
-    fn native_runner_follows_the_platform() {
+    fn shell_dialect_follows_the_platform() {
         // Independent of the host this test runs on.
-        assert_eq!(native_runner(Platform::Win64).shell().extension(), "bat");
-        assert_eq!(native_runner(Platform::Linux64).shell().extension(), "sh");
-        assert_eq!(native_runner(Platform::OsxArm64).shell().extension(), "sh");
+        assert_eq!(shell_dialect(Platform::Win64).shell().extension(), "bat");
+        assert_eq!(shell_dialect(Platform::Linux64).shell().extension(), "sh");
+        assert_eq!(shell_dialect(Platform::OsxArm64).shell().extension(), "sh");
 
-        assert_eq!(native_runner(Platform::Win64).default_interpreter(), "cmd");
+        assert_eq!(shell_dialect(Platform::Win64).default_interpreter(), "cmd");
         assert_eq!(
-            native_runner(Platform::Linux64).default_interpreter(),
+            shell_dialect(Platform::Linux64).default_interpreter(),
             "bash"
         );
     }
@@ -398,7 +303,7 @@ endlocal & if %RB_SECTION_ERRORLEVEL% neq 0 exit /b %RB_SECTION_ERRORLEVEL%
     #[test]
     fn cmd_switches_between_supported_windows_architectures() {
         let script = std::path::Path::new("work/conda_build.bat");
-        let runner = native_runner(Platform::Win64);
+        let dialect = shell_dialect(Platform::Win64);
 
         let x64_to_arm = ExecutionContext::shared(
             RuntimeEnv::for_test(Platform::Win64),
@@ -406,7 +311,7 @@ endlocal & if %RB_SECTION_ERRORLEVEL% neq 0 exit /b %RB_SECTION_ERRORLEVEL%
             Platform::WinArm64,
             Platform::WinArm64,
         );
-        let arm_command = runner.command_to_run_script(script, &x64_to_arm);
+        let arm_command = dialect.command_to_run_script(script, &x64_to_arm);
         assert_eq!(arm_command.program, "cmd.exe");
         assert_eq!(arm_command.args[..3], ["/d", "/v:on", "/c"]);
         assert!(arm_command.args[3].contains("/machine arm64"));
@@ -415,7 +320,7 @@ endlocal & if %RB_SECTION_ERRORLEVEL% neq 0 exit /b %RB_SECTION_ERRORLEVEL%
 
         let spaced_script = std::path::Path::new("work/conda build.bat");
         assert!(
-            runner
+            dialect
                 .command_to_run_script(spaced_script, &x64_to_arm)
                 .args[3]
                 .contains(r#"cmd.exe /d /c "conda build.bat""#)
@@ -427,7 +332,7 @@ endlocal & if %RB_SECTION_ERRORLEVEL% neq 0 exit /b %RB_SECTION_ERRORLEVEL%
             Platform::Win64,
             Platform::Win64,
         );
-        let x64_command = runner.command_to_run_script(script, &arm_to_x64);
+        let x64_command = dialect.command_to_run_script(script, &arm_to_x64);
         assert!(x64_command.args[3].contains("/machine amd64"));
 
         let x64_to_x86 = ExecutionContext::shared(
@@ -436,7 +341,7 @@ endlocal & if %RB_SECTION_ERRORLEVEL% neq 0 exit /b %RB_SECTION_ERRORLEVEL%
             Platform::Win32,
             Platform::Win32,
         );
-        let x86_command = runner.command_to_run_script(script, &x64_to_x86);
+        let x86_command = dialect.command_to_run_script(script, &x64_to_x86);
         assert!(x86_command.args[3].contains("/machine x86"));
         assert!(
             x86_command.args[3].contains(r"%SystemRoot%\SysWOW64\cmd.exe"),
@@ -451,7 +356,7 @@ endlocal & if %RB_SECTION_ERRORLEVEL% neq 0 exit /b %RB_SECTION_ERRORLEVEL%
             Platform::Win64,
         );
         assert_eq!(
-            runner.command_to_run_script(script, &same_arch).args,
+            dialect.command_to_run_script(script, &same_arch).args,
             ["/d", "/c", "work/conda_build.bat"]
         );
         assert_eq!(
@@ -488,7 +393,7 @@ endlocal & if %RB_SECTION_ERRORLEVEL% neq 0 exit /b %RB_SECTION_ERRORLEVEL%
     #[test]
     fn bash_preamble_enables_tracing_after_activation() {
         let preamble =
-            native_runner(Platform::Linux64).preamble(std::path::Path::new("build_env.sh"));
+            shell_dialect(Platform::Linux64).preamble(std::path::Path::new("build_env.sh"));
         let activation = preamble
             .find("source")
             .expect("preamble sources activation");

--- a/crates/rattler_build_script/src/windows_machine.rs
+++ b/crates/rattler_build_script/src/windows_machine.rs
@@ -1,0 +1,97 @@
+use rattler_conda_types::Platform;
+
+/// Requested Windows child process architecture for a supported transition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WindowsMachine {
+    X86,
+    Amd64,
+    Arm64,
+}
+
+impl WindowsMachine {
+    pub(crate) fn start_argument(self) -> &'static str {
+        match self {
+            Self::X86 => "x86",
+            Self::Amd64 => "amd64",
+            Self::Arm64 => "arm64",
+        }
+    }
+
+    pub(crate) fn processor_architecture(self) -> &'static str {
+        match self {
+            Self::X86 => "x86",
+            Self::Amd64 => "AMD64",
+            Self::Arm64 => "ARM64",
+        }
+    }
+
+    /// The `PROCESSOR_ARCHITEW6432` marker Windows exposes to an x86 child.
+    pub(crate) fn wow64_processor_architecture(self) -> Option<&'static str> {
+        (self != Self::X86).then(|| self.processor_architecture())
+    }
+
+    #[cfg(windows)]
+    fn from_image_file_machine(machine: u16) -> Option<Self> {
+        use windows_sys::Win32::System::SystemInformation::{
+            IMAGE_FILE_MACHINE_AMD64, IMAGE_FILE_MACHINE_ARM64, IMAGE_FILE_MACHINE_I386,
+        };
+
+        match machine {
+            IMAGE_FILE_MACHINE_I386 => Some(Self::X86),
+            IMAGE_FILE_MACHINE_AMD64 => Some(Self::Amd64),
+            IMAGE_FILE_MACHINE_ARM64 => Some(Self::Arm64),
+            _ => None,
+        }
+    }
+}
+
+/// Returns the requested child architecture when a supported Windows build
+/// process transition is needed. Rattler-build ships x64 and ARM64 binaries,
+/// and both can launch x86 build tools; x86 rattler-build processes are not
+/// supported as cross-architecture launchers.
+pub(crate) fn windows_machine_transition(
+    process_platform: Platform,
+    build_platform: Platform,
+) -> Option<WindowsMachine> {
+    match (process_platform, build_platform) {
+        (Platform::Win64, Platform::Win32) | (Platform::WinArm64, Platform::Win32) => {
+            Some(WindowsMachine::X86)
+        }
+        (Platform::Win64, Platform::WinArm64) => Some(WindowsMachine::Arm64),
+        (Platform::WinArm64, Platform::Win64) => Some(WindowsMachine::Amd64),
+        _ => None,
+    }
+}
+
+/// Detects the native Windows machine architecture without affecting launch
+/// selection. This is only used to reproduce the `PROCESSOR_ARCHITEW6432`
+/// value that Windows exposes to x86 WOW64 processes.
+#[cfg(windows)]
+pub(crate) fn native_windows_machine() -> Option<WindowsMachine> {
+    use windows_sys::Win32::System::{
+        SystemInformation::IMAGE_FILE_MACHINE_UNKNOWN,
+        Threading::{GetCurrentProcess, IsWow64Process2},
+    };
+
+    let mut process_machine = IMAGE_FILE_MACHINE_UNKNOWN;
+    let mut native_machine = IMAGE_FILE_MACHINE_UNKNOWN;
+    // `IsWow64Process2` is available on every Windows version that supports
+    // `start /machine`. A failure leaves the inherited WOW64 marker untouched.
+    if unsafe {
+        IsWow64Process2(
+            GetCurrentProcess(),
+            &mut process_machine,
+            &mut native_machine,
+        )
+    } == 0
+    {
+        return None;
+    }
+
+    WindowsMachine::from_image_file_machine(native_machine)
+}
+
+#[cfg(not(windows))]
+pub(crate) fn native_windows_machine() -> Option<WindowsMachine> {
+    None
+}


### PR DESCRIPTION
Rename the private shell-wrapper abstraction from `NativeShellRunner` to `ShellDialect`.

The recent Windows architecture support is not shell-dialect behavior, so it now lives in a dedicated `windows_machine` module. This leaves the shell dialect module focused on wrapper syntax and command construction while retaining all behavior and tests.

## Testing

- `pixi run cargo test -p rattler_build_script --lib`
- `pixi run cargo clippy -p rattler_build_script --all-targets --all-features -- -D warnings -Dclippy::dbg_macro`