### PR TITLE
refactor: add an execution view for Directories

### DIFF
--- a/crates/rattler_build_core/src/env_vars.rs
+++ b/crates/rattler_build_core/src/env_vars.rs
@@ -337,7 +337,7 @@ pub fn vars(output: &Output, build_state: &str) -> HashMap<String, Option<String
         insert!(vars, "ARCH", host_arch);
     }
 
-    let directories = &output.build_configuration.directories;
+    let directories = output.build_configuration.directories.exec_view();
     insert!(
         vars,
         "CONDA_DEFAULT_ENV",

--- a/crates/rattler_build_core/src/types/directories.rs
+++ b/crates/rattler_build_core/src/types/directories.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 
 use fs_err as fs;
 use jiff::Timestamp;
+use rattler_conda_types::Platform;
 use serde::{Deserialize, Serialize};
 
 use dunce::canonicalize;
@@ -15,6 +16,7 @@ pub struct DirectoriesBuilder<'a> {
     recipe_path: &'a Path,
     output_dir: &'a Path,
     timestamp: &'a Timestamp,
+    platform: Platform,
     no_build_id: bool,
     merge_build_and_host: bool,
     skip_directory_creation: bool,
@@ -27,12 +29,14 @@ impl<'a> DirectoriesBuilder<'a> {
         recipe_path: &'a Path,
         output_dir: &'a Path,
         timestamp: &'a Timestamp,
+        platform: Platform,
     ) -> Self {
         Self {
             name,
             recipe_path,
             output_dir,
             timestamp,
+            platform,
             no_build_id: false,
             merge_build_and_host: false,
             skip_directory_creation: false,
@@ -60,15 +64,7 @@ impl<'a> DirectoriesBuilder<'a> {
 
     /// Build the [`Directories`] struct.
     pub fn build(self) -> Result<Directories, std::io::Error> {
-        Directories::setup_internal(
-            self.name,
-            self.recipe_path,
-            self.output_dir,
-            self.no_build_id,
-            self.timestamp,
-            self.merge_build_and_host,
-            self.skip_directory_creation,
-        )
+        Directories::setup_internal(self)
     }
 }
 
@@ -100,6 +96,52 @@ pub struct Directories {
     pub output_dir: PathBuf,
 }
 
+/// The build tree as the executing build script sees it. Identical to the
+/// physical layout when the script executes directly on this machine.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecutionDirectories {
+    /// Host dependency prefix as observed by the build script.
+    pub host_prefix: PathBuf,
+    /// Build dependency prefix as observed by the build script.
+    pub build_prefix: PathBuf,
+    /// Working directory as observed by the build script.
+    pub work_dir: PathBuf,
+    /// Build directory as observed by the build script.
+    pub build_dir: PathBuf,
+    /// Recipe directory as observed by the build script.
+    pub recipe_dir: PathBuf,
+}
+
+impl ExecutionDirectories {
+    /// Path to the file a build script may use to override packaged files.
+    pub fn package_files_list_path(&self) -> PathBuf {
+        self.build_dir.join(crate::consts::PACKAGE_FILES_LIST_NAME)
+    }
+}
+
+/// Host prefix directory under `build_dir` for the given platform. Windows
+/// uses the short `h_env`; other platforms pad `host_env` with `_placehold`
+/// repetitions so the absolute prefix path is 255 characters long.
+pub fn padded_host_prefix(build_dir: &Path, platform: Platform) -> PathBuf {
+    if platform.is_windows() {
+        build_dir.join("h_env")
+    } else {
+        let placeholder_template = "_placehold";
+        let mut placeholder = String::new();
+        let placeholder_length: usize = 255;
+
+        while placeholder.len() < placeholder_length {
+            placeholder.push_str(placeholder_template);
+        }
+
+        let placeholder = placeholder
+            [0..placeholder_length - build_dir.join("host_env").as_os_str().len()]
+            .to_string();
+
+        build_dir.join(format!("host_env{placeholder}"))
+    }
+}
+
 fn get_build_dir(
     output_dir: &Path,
     name: &str,
@@ -123,20 +165,24 @@ impl Directories {
         recipe_path: &'a Path,
         output_dir: &'a Path,
         timestamp: &'a Timestamp,
+        platform: Platform,
     ) -> DirectoriesBuilder<'a> {
-        DirectoriesBuilder::new(name, recipe_path, output_dir, timestamp)
+        DirectoriesBuilder::new(name, recipe_path, output_dir, timestamp, platform)
     }
 
     /// Internal setup function called by the builder.
-    fn setup_internal(
-        name: &str,
-        recipe_path: &Path,
-        output_dir: &Path,
-        no_build_id: bool,
-        timestamp: &Timestamp,
-        merge_build_and_host: bool,
-        skip_directory_creation: bool,
-    ) -> Result<Directories, std::io::Error> {
+    fn setup_internal(builder: DirectoriesBuilder<'_>) -> Result<Directories, std::io::Error> {
+        let DirectoriesBuilder {
+            name,
+            recipe_path,
+            output_dir,
+            timestamp,
+            platform,
+            no_build_id,
+            merge_build_and_host,
+            skip_directory_creation,
+        } = builder;
+
         let output_dir = if skip_directory_creation {
             output_dir.to_path_buf()
         } else {
@@ -166,23 +212,7 @@ impl Directories {
             })?
             .to_path_buf();
 
-        let host_prefix = if cfg!(target_os = "windows") {
-            build_dir.join("h_env")
-        } else {
-            let placeholder_template = "_placehold";
-            let mut placeholder = String::new();
-            let placeholder_length: usize = 255;
-
-            while placeholder.len() < placeholder_length {
-                placeholder.push_str(placeholder_template);
-            }
-
-            let placeholder = placeholder
-                [0..placeholder_length - build_dir.join("host_env").as_os_str().len()]
-                .to_string();
-
-            build_dir.join(format!("host_env{}", placeholder))
-        };
+        let host_prefix = padded_host_prefix(&build_dir, platform);
 
         let directories = Directories {
             build_dir: build_dir.clone(),
@@ -212,6 +242,17 @@ impl Directories {
     /// end up in the final package.
     pub fn package_files_list_path(&self) -> PathBuf {
         self.build_dir.join(crate::consts::PACKAGE_FILES_LIST_NAME)
+    }
+
+    /// The path strings the build script observes.
+    pub fn exec_view(&self) -> ExecutionDirectories {
+        ExecutionDirectories {
+            host_prefix: self.host_prefix.clone(),
+            build_prefix: self.build_prefix.clone(),
+            work_dir: self.work_dir.clone(),
+            build_dir: self.build_dir.clone(),
+            recipe_dir: self.recipe_dir.clone(),
+        }
     }
 
     /// Remove all directories except for the cache directory
@@ -334,6 +375,53 @@ mod tests {
     }
 
     #[test]
+    fn padded_host_prefix_follows_the_platform() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let build_dir = tempdir.path().join("build");
+
+        for platform in [Platform::Linux64, Platform::OsxArm64] {
+            assert_eq!(
+                padded_host_prefix(&build_dir, platform).as_os_str().len(),
+                255
+            );
+        }
+        assert_eq!(
+            padded_host_prefix(&build_dir, Platform::Win64),
+            build_dir.join("h_env")
+        );
+    }
+
+    #[test]
+    fn current_platform_padding_matches_built_directories() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let directories = Directories::builder(
+            "name",
+            &tempdir.path().join("recipe"),
+            &tempdir.path().join("output"),
+            &Timestamp::now(),
+            Platform::current(),
+        )
+        .build()
+        .unwrap();
+
+        assert_eq!(
+            directories.host_prefix,
+            padded_host_prefix(&directories.build_dir, Platform::current())
+        );
+
+        let execution = directories.exec_view();
+        assert_eq!(execution.host_prefix, directories.host_prefix);
+        assert_eq!(execution.build_prefix, directories.build_prefix);
+        assert_eq!(execution.work_dir, directories.work_dir);
+        assert_eq!(execution.build_dir, directories.build_dir);
+        assert_eq!(execution.recipe_dir, directories.recipe_dir);
+        assert_eq!(
+            execution.package_files_list_path(),
+            directories.package_files_list_path()
+        );
+    }
+
+    #[test]
     fn test_clean_skips_pending_rm_dirs() {
         let tempdir = tempfile::tempdir().unwrap();
 
@@ -342,6 +430,7 @@ mod tests {
             &tempdir.path().join("recipe"),
             &tempdir.path().join("output"),
             &Timestamp::now(),
+            Platform::current(),
         )
         .build()
         .unwrap();
@@ -375,6 +464,7 @@ mod tests {
             &tempdir.path().join("recipe"),
             &tempdir.path().join("output"),
             &Timestamp::now(),
+            Platform::current(),
         )
         .build()
         .unwrap();

--- a/crates/rattler_build_core/src/types/mod.rs
+++ b/crates/rattler_build_core/src/types/mod.rs
@@ -23,7 +23,7 @@ mod directories;
 
 pub use build_configuration::BuildConfiguration;
 pub use build_output::BuildOutput as Output;
-pub use directories::Directories;
+pub use directories::{Directories, ExecutionDirectories, padded_host_prefix};
 
 /// Settings when creating the package (compression etc.)
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/py-rattler-build/rust/src/build.rs
+++ b/py-rattler-build/rust/src/build.rs
@@ -204,6 +204,7 @@ pub(crate) fn output_from_rendered_variant(
                 &safe_recipe_path,
                 output_dir,
                 &timestamp,
+                Platform::current(),
             )
             .no_build_id(no_build_id)
             .build()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -560,6 +560,7 @@ pub async fn get_build_output(
                     recipe_path,
                     &output_dir,
                     &timestamp,
+                    Platform::current(),
                 )
                 .no_build_id(build_data.no_build_id)
                 .merge_build_and_host(recipe.build().merge_build_and_host_envs)


### PR DESCRIPTION
Separate the physical build-tree layout from the directory paths exposed to build scripts.

`Directories::exec_view()` is identity-by-clone today and is used only when constructing script-visible environment variables. This creates one future translation point without changing filesystem operations, source resolution, packaging, or serialization.

Host-prefix padding now takes an explicit platform. Existing production callers pass `Platform::current()` to retain the prior host-dependent layout, while tests cover Linux, macOS, and Windows selection independently of the test host.

This adds a required `Platform` parameter to the public `Directories::builder` API; the in-repository CLI and Python callers are updated.

## Testing

- `pixi run cargo test -p rattler_build_core --lib types::directories::tests`
- `pixi run cargo test -p rattler_build_core --lib env_vars::test`
- `pixi run cargo check --workspace --all-targets`
- `pixi run cargo clippy -p rattler_build_core --all-targets --all-features -- -D warnings -Dclippy::dbg_macro`
- `cargo check` in `py-rattler-build/rust` was attempted but blocked by the local `aws-lc-sys` CMake build missing generated jitterentropy headers.