### PR TITLE
fix: deletion-only patches misdetected as already applied

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2223,9 +2223,9 @@ dependencies = [
 
 [[package]]
 name = "flickzeug"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c80b84a6c2a0750383008cd384de902d69b4a9c5009f784e092259b98803bc45"
+checksum = "f2c1e04a8becf792bb9adf44755de05f282c038c82e078c9a50e5f0c0f43ae6d"
 dependencies = [
  "nu-ansi-term",
  "strsim",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ unicode-normalization = "0.1.25"
 # Dependencies used in subcrates (workspace-level)
 clap-verbosity-flag = "3.0.4"
 comfy-table = "7.2.2"
-flickzeug = "0.5.2"
+flickzeug = "0.5.3"
 goblin = "0.10.7"
 ignore = "0.4.31"
 num_cpus = "1.17.0"

--- a/crates/rattler_build_core/src/source/patch.rs
+++ b/crates/rattler_build_core/src/source/patch.rs
@@ -654,6 +654,78 @@ mod tests {
     }
 
     #[test]
+    fn test_deletion_only_patch_is_applied() {
+        // A patch that only deletes lines must actually be applied, not be
+        // misdetected as "already applied" and skipped. Regression test for
+        // https://github.com/prefix-dev/rattler-build/issues/2693
+        let (tempdir, _) = setup_patch_test_dir();
+        let work_dir = tempdir.path().join("workdir");
+        let patches_dir = tempdir.path().join("patches");
+
+        apply_patches(
+            &[LateBoundPath::new("test_deletion_only.patch")],
+            &work_dir,
+            &patches_dir,
+            &patches_dir,
+            &patches_dir,
+            apply_patch_custom,
+        )
+        .expect("deletion-only patch should apply");
+
+        let content = fs_err::read_to_string(work_dir.join("deletion_only.cmake")).unwrap();
+        assert!(
+            !content.contains("add_compile_options(/MTd)"),
+            "deletion-only patch was not applied:\n{content}"
+        );
+        assert!(content.contains("add_compile_options(/utf-8)"));
+
+        // Re-applying it now must be detected as already applied and skipped.
+        apply_patches(
+            &[LateBoundPath::new("test_deletion_only.patch")],
+            &work_dir,
+            &patches_dir,
+            &patches_dir,
+            &patches_dir,
+            apply_patch_custom,
+        )
+        .expect("re-applying an already-applied deletion-only patch should not error");
+
+        let after_second = fs_err::read_to_string(work_dir.join("deletion_only.cmake")).unwrap();
+        assert_eq!(content, after_second);
+    }
+
+    #[test]
+    fn test_deletion_only_patch_with_stale_context_fails() {
+        // Same deletion-only patch shape, but its trailing context references a
+        // line that does not exist in the target file (patch written against a
+        // newer upstream). GNU patch rejects this; we must error out instead of
+        // skipping it as "already applied".
+        let (tempdir, _) = setup_patch_test_dir();
+        let work_dir = tempdir.path().join("workdir");
+        let patches_dir = tempdir.path().join("patches");
+
+        let before =
+            fs_err::read_to_string(work_dir.join("deletion_only_stale.cmake")).unwrap();
+
+        let result = apply_patches(
+            &[LateBoundPath::new("test_deletion_only_stale_context.patch")],
+            &work_dir,
+            &patches_dir,
+            &patches_dir,
+            &patches_dir,
+            apply_patch_custom,
+        );
+        assert!(
+            result.is_err(),
+            "patch with non-matching context must fail to apply"
+        );
+
+        // The target file must be left untouched.
+        let after = fs_err::read_to_string(work_dir.join("deletion_only_stale.cmake")).unwrap();
+        assert_eq!(before, after);
+    }
+
+    #[test]
     fn test_apply_patches_with_orig() {
         let (tempdir, _) = setup_patch_test_dir();
 

--- a/crates/rattler_build_core/src/source/patch.rs
+++ b/crates/rattler_build_core/src/source/patch.rs
@@ -704,8 +704,7 @@ mod tests {
         let work_dir = tempdir.path().join("workdir");
         let patches_dir = tempdir.path().join("patches");
 
-        let before =
-            fs_err::read_to_string(work_dir.join("deletion_only_stale.cmake")).unwrap();
+        let before = fs_err::read_to_string(work_dir.join("deletion_only_stale.cmake")).unwrap();
 
         let result = apply_patches(
             &[LateBoundPath::new("test_deletion_only_stale_context.patch")],

--- a/py-rattler-build/rust/Cargo.lock
+++ b/py-rattler-build/rust/Cargo.lock
@@ -2094,9 +2094,9 @@ dependencies = [
 
 [[package]]
 name = "flickzeug"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c80b84a6c2a0750383008cd384de902d69b4a9c5009f784e092259b98803bc45"
+checksum = "f2c1e04a8becf792bb9adf44755de05f282c038c82e078c9a50e5f0c0f43ae6d"
 dependencies = [
  "nu-ansi-term",
  "strsim",

--- a/test-data/patch_application/patches/test_deletion_only.patch
+++ b/test-data/patch_application/patches/test_deletion_only.patch
@@ -1,0 +1,17 @@
+diff --git a/deletion_only.cmake b/deletion_only.cmake
+index 4134fcf..975dc34 100644
+--- a/deletion_only.cmake
++++ b/deletion_only.cmake
+@@ -1,12 +1,6 @@
+ if(NOT MSVC)
+     add_compile_options(-Wall -Wextra -Wno-narrowing)
+ else()
+-    if (CMAKE_BUILD_TYPE MATCHES Debug)
+-        add_compile_options(/MTd)
+-    else()
+-        add_compile_options(/MT)
+-    endif()
+-
+     add_compile_options(/utf-8)
+     add_compile_definitions(-D_CRT_SECURE_NO_WARNINGS=1)
+ endif()

--- a/test-data/patch_application/patches/test_deletion_only_stale_context.patch
+++ b/test-data/patch_application/patches/test_deletion_only_stale_context.patch
@@ -1,0 +1,17 @@
+diff --git a/deletion_only_stale.cmake b/deletion_only_stale.cmake
+index 4134fcf..975dc34 100644
+--- a/deletion_only_stale.cmake
++++ b/deletion_only_stale.cmake
+@@ -1,13 +1,7 @@
+ if(NOT MSVC)
+     add_compile_options(-Wall -Wextra -Wno-narrowing)
+ else()
+-    if (CMAKE_BUILD_TYPE MATCHES Debug)
+-        add_compile_options(/MTd)
+-    else()
+-        add_compile_options(/MT)
+-    endif()
+-
+     add_compile_options(/utf-8)
+     add_compile_definitions(-D_CRT_SECURE_NO_WARNINGS=1)
+ endif()

--- a/test-data/patch_application/workdir/deletion_only.cmake
+++ b/test-data/patch_application/workdir/deletion_only.cmake
@@ -1,0 +1,12 @@
+if(NOT MSVC)
+    add_compile_options(-Wall -Wextra -Wno-narrowing)
+else()
+    if (CMAKE_BUILD_TYPE MATCHES Debug)
+        add_compile_options(/MTd)
+    else()
+        add_compile_options(/MT)
+    endif()
+
+    add_compile_options(/utf-8)
+    add_compile_definitions(-D_CRT_SECURE_NO_WARNINGS=1)
+endif()

--- a/test-data/patch_application/workdir/deletion_only_stale.cmake
+++ b/test-data/patch_application/workdir/deletion_only_stale.cmake
@@ -1,0 +1,11 @@
+if(NOT MSVC)
+    add_compile_options(-Wall -Wextra -Wno-narrowing)
+else()
+    if (CMAKE_BUILD_TYPE MATCHES Debug)
+        add_compile_options(/MTd)
+    else()
+        add_compile_options(/MT)
+    endif()
+
+    add_compile_definitions(-D_CRT_SECURE_NO_WARNINGS=1)
+endif()


### PR DESCRIPTION
## Problem

Fixes #2693.

The already-applied detection from #2635 uses flickzeug's `is_diff_applied_with_config`, which relied on a reverse round-trip heuristic: apply the reversed diff, then re-apply the forward diff and check it round-trips back to the input. That heuristic is unsound for deletion-heavy patches: the reverse of a deletion is an **insertion**, and an insertion also applies to the *un*patched file — it just duplicates the lines that are still present — after which the forward diff deletes them again, round-tripping perfectly. Result: deletion-only patches were reported as "already applied" and silently skipped.

It was compounded by flickzeug's loose per-line fuzzy matching (Levenshtein similarity > 0.8, whitespace ignored): in the libddwaf case, `add_compile_options(/MT)` matched the context line `add_compile_options(/utf-8)` at 0.85 similarity, giving the reversed insertion a landing spot.

Notably, the reported `win-rt.patch` does not even apply to libddwaf 1.30.1 — its trailing context references a line that only exists in newer upstream, and GNU `patch` rejects it (`Hunk #1 failed at 52`). Before #2635 rattler-build errored out on it; the buggy detection turned that hard failure into a silent skip.

## Fix

The real fix is in flickzeug: prefix-dev/flickzeug#20 replaces the round-trip with GNU-patch-style **post-image matching** — a diff counts as already applied only if every hunk's context + inserted lines are actually found, contiguously and strictly compared, in the target file. Verified against the real libddwaf 1.30.1 tarball + `win-rt.patch`: previously `AlreadyApplied`, now `Failed`, matching GNU patch.

This PR bumps flickzeug to 0.5.3 and adds regression tests:

- `test_deletion_only_patch_is_applied`: a deletion-only patch must actually be applied (and only a re-apply is skipped as already-applied). Fails against flickzeug 0.5.2.
- `test_deletion_only_patch_with_stale_context_fails`: the distilled libddwaf case — a deletion-only patch whose context doesn't match the target must error like GNU patch, leaving the file untouched. Fails against flickzeug 0.5.2.

## Status

- [x] prefix-dev/flickzeug#20 merged and released as 0.5.3; lockfiles updated (root and `py-rattler-build/rust`). All 203 `rattler_build_core` lib tests pass against the released crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)