### PR TITLE
feat: add Runner and Session execution interfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5114,6 +5114,7 @@ dependencies = [
 name = "rattler_build_script"
 version = "0.2.7"
 dependencies = [
+ "async-trait",
  "clap",
  "console",
  "fs-err",

--- a/crates/rattler_build_script/Cargo.toml
+++ b/crates/rattler_build_script/Cargo.toml
@@ -11,6 +11,7 @@ description = "Script execution and sandbox configuration for rattler-build, sup
 [features]
 default = ["execution"]
 execution = [
+  "async-trait",
   "itertools",
   "thiserror",
   "tracing",
@@ -35,6 +36,7 @@ console = { workspace = true }
 clap = { workspace = true }
 
 # Execution dependencies (optional)
+async-trait = { workspace = true, optional = true }
 itertools = { workspace = true, optional = true }
 thiserror = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
@@ -59,7 +61,7 @@ windows-sys = { workspace = true, features = [
 ] }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["rt", "macros", "fs"] }
+tokio = { workspace = true, features = ["rt", "macros", "fs", "time"] }
 insta = { workspace = true, features = ["yaml"] }
 serde_yaml = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/rattler_build_script/src/execution.rs
+++ b/crates/rattler_build_script/src/execution.rs
@@ -6,11 +6,12 @@
 
 use crate::sandbox::SandboxConfiguration;
 use crate::script::{Script, ScriptContent};
-use crate::{execution_context::ExecutionContext, runtime::RuntimeEnv};
+use crate::{
+    execution_context::ExecutionContext, runner::resolve_process_env, runtime::RuntimeEnv,
+};
 use fs_err as fs;
 use futures::TryStreamExt;
 use indexmap::IndexMap;
-use rattler_conda_types::Platform;
 use rattler_shell::shell::Shell;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
@@ -455,6 +456,21 @@ impl SpawnedProcess {
         }
     }
 
+    /// Discards all remaining output from both streams.
+    pub(crate) async fn drain_output(&mut self) -> io::Result<()> {
+        let mut stdout_sink = tokio::io::sink();
+        let mut stderr_sink = tokio::io::sink();
+        let (stdout_result, stderr_result) = tokio::join!(
+            tokio::io::copy(self.stdout.get_mut(), &mut stdout_sink),
+            tokio::io::copy(self.stderr.get_mut(), &mut stderr_sink),
+        );
+        self.stdout_closed = true;
+        self.stderr_closed = true;
+        stdout_result?;
+        stderr_result?;
+        Ok(())
+    }
+
     /// Waits for the process to exit. Call after draining its output.
     pub(crate) async fn wait(&mut self) -> io::Result<std::process::ExitStatus> {
         self.child.wait().await
@@ -834,93 +850,6 @@ fn find_rattler_sandbox(runtime: &RuntimeEnv) -> Option<PathBuf> {
     which::which_in_global("rattler-sandbox", Some(runtime.path()))
         .ok()?
         .next()
-}
-
-/// Environment variables that are passed through from the host environment
-/// into the build subprocess. These are variables that cannot be computed
-/// by rattler-build but are needed for builds to function correctly.
-const PASSTHROUGH_ENV_VARS: &[&str] = &[
-    // TLS certificates (needed for https in build scripts)
-    "SSL_CERT_FILE",
-    "SSL_CERT_DIR",
-    // Python requests CA bundle (needed for pip/requests in corporate environments)
-    "REQUESTS_CA_BUNDLE",
-    // SSH agent (needed for private git repo access)
-    "SSH_AUTH_SOCK",
-    // Display server (needed for GUI-related builds on Linux)
-    "DISPLAY",
-    // Proxy configuration (needed in corporate/CI environments)
-    "http_proxy",
-    "https_proxy",
-    "HTTP_PROXY",
-    "HTTPS_PROXY",
-    "no_proxy",
-    "NO_PROXY",
-];
-
-/// Platform-critical environment variables that must always be passed through
-/// to avoid breaking fundamental OS functionality.
-fn platform_passthrough_vars(platform: Platform) -> &'static [&'static str] {
-    if platform.is_windows() {
-        &[
-            // Required for Winsock/networking and DLL loading
-            "SYSTEMROOT",
-            "WINDIR",
-            // Command interpreter
-            "COMSPEC",
-            // Temp directories
-            "TEMP",
-            "TMP",
-            // Executable extension resolution
-            "PATHEXT",
-        ]
-    } else if platform.is_osx() {
-        &[
-            // macOS uses per-session temp directories
-            "TMPDIR",
-            // CoreFoundation text encoding
-            "__CF_USER_TEXT_ENCODING",
-        ]
-    } else {
-        &[]
-    }
-}
-
-/// Computes the complete child environment for the given isolation mode.
-///
-/// This reads only its arguments and never the ambient process environment.
-pub(crate) fn resolve_process_env(
-    env_isolation: EnvironmentIsolation,
-    env_vars: &IndexMap<String, String>,
-    secrets: &IndexMap<String, String>,
-    runtime: &RuntimeEnv,
-) -> IndexMap<String, String> {
-    match env_isolation {
-        EnvironmentIsolation::Strict | EnvironmentIsolation::CondaBuild => {
-            let mut process_env = IndexMap::new();
-
-            for var in PASSTHROUGH_ENV_VARS
-                .iter()
-                .chain(platform_passthrough_vars(runtime.process_platform()))
-            {
-                if let Some(value) = runtime.var(var) {
-                    process_env.insert((*var).to_owned(), value.to_owned());
-                }
-            }
-
-            process_env.extend(env_vars.clone());
-            process_env.extend(secrets.clone());
-            process_env
-        }
-        EnvironmentIsolation::None => {
-            let mut process_env = runtime
-                .vars()
-                .map(|(name, value)| (name.to_owned(), value.to_owned()))
-                .collect::<IndexMap<_, _>>();
-            process_env.extend(env_vars.clone());
-            process_env
-        }
-    }
 }
 
 /// Spawns a process and replaces the given strings in the output with the given replacements.

--- a/crates/rattler_build_script/src/lib.rs
+++ b/crates/rattler_build_script/src/lib.rs
@@ -26,6 +26,8 @@ mod execution_context;
 #[cfg(feature = "execution")]
 mod interpreter;
 #[cfg(feature = "execution")]
+pub mod runner;
+#[cfg(feature = "execution")]
 mod runtime;
 #[cfg(feature = "execution")]
 mod shell_dialect;

--- a/crates/rattler_build_script/src/runner/environment.rs
+++ b/crates/rattler_build_script/src/runner/environment.rs
@@ -1,0 +1,68 @@
+use indexmap::IndexMap;
+use rattler_conda_types::Platform;
+
+use crate::{EnvironmentIsolation, RuntimeEnv};
+
+/// Environment variables passed through from the host environment because they
+/// cannot be computed by rattler-build.
+const PASSTHROUGH_ENV_VARS: &[&str] = &[
+    "SSL_CERT_FILE",
+    "SSL_CERT_DIR",
+    "REQUESTS_CA_BUNDLE",
+    "SSH_AUTH_SOCK",
+    "DISPLAY",
+    "http_proxy",
+    "https_proxy",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "no_proxy",
+    "NO_PROXY",
+];
+
+/// Platform-critical environment variables required for basic OS functionality.
+fn platform_passthrough_vars(platform: Platform) -> &'static [&'static str] {
+    if platform.is_windows() {
+        &["SYSTEMROOT", "WINDIR", "COMSPEC", "TEMP", "TMP", "PATHEXT"]
+    } else if platform.is_osx() {
+        &["TMPDIR", "__CF_USER_TEXT_ENCODING"]
+    } else {
+        &[]
+    }
+}
+
+/// Computes the complete child environment for the given isolation mode.
+///
+/// This reads only its arguments and never the ambient process environment.
+pub(crate) fn resolve_process_env(
+    env_isolation: EnvironmentIsolation,
+    env_vars: &IndexMap<String, String>,
+    secrets: &IndexMap<String, String>,
+    runtime: &RuntimeEnv,
+) -> IndexMap<String, String> {
+    match env_isolation {
+        EnvironmentIsolation::Strict | EnvironmentIsolation::CondaBuild => {
+            let mut process_env = IndexMap::new();
+
+            for var in PASSTHROUGH_ENV_VARS
+                .iter()
+                .chain(platform_passthrough_vars(runtime.process_platform()))
+            {
+                if let Some(value) = runtime.var(var) {
+                    process_env.insert((*var).to_owned(), value.to_owned());
+                }
+            }
+
+            process_env.extend(env_vars.clone());
+            process_env.extend(secrets.clone());
+            process_env
+        }
+        EnvironmentIsolation::None => {
+            let mut process_env = runtime
+                .vars()
+                .map(|(name, value)| (name.to_owned(), value.to_owned()))
+                .collect::<IndexMap<_, _>>();
+            process_env.extend(env_vars.clone());
+            process_env
+        }
+    }
+}

--- a/crates/rattler_build_script/src/runner/local.rs
+++ b/crates/rattler_build_script/src/runner/local.rs
@@ -154,10 +154,6 @@ impl Session for LocalSession {
 
         Ok(None)
     }
-
-    async fn close(self: Box<Self>) -> Result<(), RunnerError> {
-        Ok(())
-    }
 }
 
 fn is_executable_file(path: &Path, _platform: rattler_conda_types::Platform) -> bool {
@@ -402,17 +398,6 @@ mod tests {
                 .unwrap(),
             None
         );
-    }
-
-    #[tokio::test]
-    async fn close_is_a_noop() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let runner = LocalRunner::default();
-        start_local_session(&runner, temp_dir.path())
-            .await
-            .close()
-            .await
-            .unwrap();
     }
 
     #[test]

--- a/crates/rattler_build_script/src/runner/local.rs
+++ b/crates/rattler_build_script/src/runner/local.rs
@@ -6,8 +6,8 @@ use async_trait::async_trait;
 use indexmap::IndexMap;
 
 use super::{
-    ExecSpec, ExecStatus, FilesystemAccess, GuestInfo, GuestPath, Keep, OutputSink, OutputStream,
-    Runner, RunnerError, Session, SessionSpec, resolve_process_env,
+    ExecSpec, ExecStatus, GuestInfo, GuestPath, OutputSink, OutputStream, Runner, RunnerError,
+    Session, SessionSpec, resolve_process_env,
 };
 use crate::RuntimeEnv;
 use crate::execution::{EnvironmentIsolation, spawn_process};
@@ -49,10 +49,6 @@ impl Runner for LocalRunner {
 
     fn execution_platform(&self) -> rattler_conda_types::Platform {
         self.runtime.process_platform()
-    }
-
-    fn filesystem(&self) -> FilesystemAccess {
-        FilesystemAccess::Shared
     }
 
     async fn check_usable(&self) -> Result<(), RunnerError> {
@@ -159,7 +155,7 @@ impl Session for LocalSession {
         Ok(None)
     }
 
-    async fn close(self: Box<Self>, _keep: Keep) -> Result<(), RunnerError> {
+    async fn close(self: Box<Self>) -> Result<(), RunnerError> {
         Ok(())
     }
 }
@@ -409,17 +405,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn close_accepts_both_keep_values() {
+    async fn close_is_a_noop() {
         let temp_dir = tempfile::tempdir().unwrap();
         let runner = LocalRunner::default();
         start_local_session(&runner, temp_dir.path())
             .await
-            .close(Keep::Nothing)
-            .await
-            .unwrap();
-        start_local_session(&runner, temp_dir.path())
-            .await
-            .close(Keep::Alive)
+            .close()
             .await
             .unwrap();
     }

--- a/crates/rattler_build_script/src/runner/local.rs
+++ b/crates/rattler_build_script/src/runner/local.rs
@@ -1,0 +1,461 @@
+use std::ffi::OsStr;
+use std::path::Path;
+use std::process::Stdio;
+
+use async_trait::async_trait;
+use indexmap::IndexMap;
+
+use super::{
+    ExecSpec, ExecStatus, FilesystemAccess, GuestInfo, GuestPath, Keep, OutputSink, OutputStream,
+    Runner, RunnerError, Session, SessionSpec, resolve_process_env,
+};
+use crate::RuntimeEnv;
+use crate::execution::{EnvironmentIsolation, spawn_process};
+
+/// A runner that executes commands directly on the local machine.
+pub struct LocalRunner {
+    isolation: EnvironmentIsolation,
+    runtime: RuntimeEnv,
+}
+
+impl LocalRunner {
+    /// Creates a local runner with the given environment isolation mode.
+    pub fn new(isolation: EnvironmentIsolation) -> Self {
+        Self {
+            isolation,
+            runtime: RuntimeEnv::current(),
+        }
+    }
+
+    /// Overrides the captured runtime environment.
+    #[must_use]
+    pub fn with_runtime(mut self, runtime: RuntimeEnv) -> Self {
+        self.runtime = runtime;
+        self
+    }
+}
+
+impl Default for LocalRunner {
+    fn default() -> Self {
+        Self::new(EnvironmentIsolation::default())
+    }
+}
+
+#[async_trait]
+impl Runner for LocalRunner {
+    fn name(&self) -> &str {
+        "local"
+    }
+
+    fn execution_platform(&self) -> rattler_conda_types::Platform {
+        self.runtime.process_platform()
+    }
+
+    fn filesystem(&self) -> FilesystemAccess {
+        FilesystemAccess::Shared
+    }
+
+    async fn check_usable(&self) -> Result<(), RunnerError> {
+        Ok(())
+    }
+
+    async fn probe(&self) -> Result<GuestInfo, RunnerError> {
+        Ok(GuestInfo {
+            platform: self.runtime.process_platform(),
+        })
+    }
+
+    async fn start_session(&self, spec: SessionSpec) -> Result<Box<dyn Session>, RunnerError> {
+        Ok(Box::new(LocalSession {
+            isolation: self.isolation,
+            runtime: self.runtime.clone(),
+            _spec: spec,
+        }))
+    }
+}
+
+struct LocalSession {
+    isolation: EnvironmentIsolation,
+    runtime: RuntimeEnv,
+    _spec: SessionSpec,
+}
+
+#[async_trait]
+impl Session for LocalSession {
+    async fn exec(
+        &mut self,
+        spec: ExecSpec,
+        sink: &mut dyn OutputSink,
+    ) -> Result<ExecStatus, RunnerError> {
+        let (program, args) = spec.argv.split_first().ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "cannot execute an empty argv",
+            )
+        })?;
+        let process_env =
+            resolve_process_env(self.isolation, &spec.env, &IndexMap::new(), &self.runtime);
+        let mut process = spawn_process(OsStr::new(program), args, &spec.cwd.0, &process_env)?;
+
+        while let Some(line) = process.next_line().await {
+            match line {
+                Ok(line) => {
+                    let stream = if line.is_stderr {
+                        OutputStream::Stderr
+                    } else {
+                        OutputStream::Stdout
+                    };
+                    sink.line(stream, &line.text);
+                }
+                Err(error) => {
+                    tracing::warn!("Error reading output: {:?}", error);
+                    if let Err(error) = process.drain_output().await {
+                        tracing::warn!("Error draining output: {:?}", error);
+                    }
+                    break;
+                }
+            }
+        }
+
+        Ok(process.wait().await?.into())
+    }
+
+    async fn exec_interactive(&mut self, spec: ExecSpec) -> Result<ExecStatus, RunnerError> {
+        let (program, args) = spec.argv.split_first().ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "cannot execute an empty argv",
+            )
+        })?;
+        let status = tokio::process::Command::new(program)
+            .args(args)
+            .envs(&spec.env)
+            .current_dir(&spec.cwd.0)
+            .stdin(Stdio::inherit())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .spawn()?
+            .wait()
+            .await?;
+
+        Ok(status.into())
+    }
+
+    async fn find_executable(
+        &mut self,
+        names: &[String],
+        search_paths: &[GuestPath],
+    ) -> Result<Option<GuestPath>, RunnerError> {
+        let suffix = self.runtime.exe_suffix();
+        for name in names {
+            for search_path in search_paths {
+                let executable = search_path.0.join(format!("{name}{suffix}"));
+                if is_executable_file(&executable, self.runtime.process_platform()) {
+                    return Ok(Some(GuestPath(executable)));
+                }
+            }
+        }
+
+        Ok(None)
+    }
+
+    async fn close(self: Box<Self>, _keep: Keep) -> Result<(), RunnerError> {
+        Ok(())
+    }
+}
+
+fn is_executable_file(path: &Path, _platform: rattler_conda_types::Platform) -> bool {
+    if !path.is_file() {
+        return false;
+    }
+
+    #[cfg(unix)]
+    if !_platform.is_windows() {
+        use std::os::unix::fs::PermissionsExt;
+        return path
+            .metadata()
+            .is_ok_and(|metadata| metadata.permissions().mode() & 0o111 != 0);
+    }
+
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+    #[cfg(unix)]
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    use indexmap::IndexMap;
+    use rattler_conda_types::Platform;
+
+    use super::*;
+    use crate::runner::{Mount, OutputSink, SessionSpec};
+
+    #[derive(Default)]
+    struct VecSink(Vec<(OutputStream, String)>);
+
+    impl OutputSink for VecSink {
+        fn line(&mut self, stream: OutputStream, line: &str) {
+            self.0.push((stream, line.to_string()));
+        }
+    }
+
+    fn session_spec(work_dir: &Path) -> SessionSpec {
+        SessionSpec {
+            platform: Platform::current(),
+            mounts: Vec::<Mount>::new(),
+            image: None,
+            work_dir: GuestPath(work_dir.to_path_buf()),
+        }
+    }
+
+    async fn start_local_session(runner: &LocalRunner, work_dir: &Path) -> Box<dyn Session> {
+        runner.start_session(session_spec(work_dir)).await.unwrap()
+    }
+
+    #[cfg(unix)]
+    fn shell_command(script: &str) -> Vec<String> {
+        vec!["/bin/sh".to_string(), "-c".to_string(), script.to_string()]
+    }
+
+    #[cfg(windows)]
+    fn shell_command(script: &str) -> Vec<String> {
+        vec![
+            r"C:\Windows\System32\cmd.exe".to_string(),
+            "/d".to_string(),
+            "/c".to_string(),
+            script.to_string(),
+        ]
+    }
+
+    #[tokio::test]
+    async fn local_session_execs_and_streams_lines() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let runner = LocalRunner::new(EnvironmentIsolation::None);
+        let mut session = start_local_session(&runner, temp_dir.path()).await;
+        let mut sink = VecSink::default();
+
+        #[cfg(unix)]
+        let argv = shell_command("echo stdout; echo stderr >&2");
+        #[cfg(windows)]
+        let argv = shell_command("echo stdout&>&2 echo stderr");
+
+        let status = session
+            .exec(
+                ExecSpec {
+                    argv,
+                    cwd: GuestPath(temp_dir.path().to_path_buf()),
+                    env: IndexMap::new(),
+                },
+                &mut sink,
+            )
+            .await
+            .unwrap();
+
+        assert!(status.success());
+        assert!(
+            sink.0
+                .iter()
+                .any(|(stream, line)| *stream == OutputStream::Stdout && line.trim() == "stdout"),
+            "unexpected output: {:?}",
+            sink.0
+        );
+        assert!(
+            sink.0
+                .iter()
+                .any(|(stream, line)| *stream == OutputStream::Stderr && line.trim() == "stderr"),
+            "unexpected output: {:?}",
+            sink.0
+        );
+    }
+
+    #[tokio::test]
+    async fn strict_isolation_applies_resolved_env() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let platform = if cfg!(windows) {
+            Platform::Win64
+        } else {
+            Platform::Linux64
+        };
+        let runner = LocalRunner::new(EnvironmentIsolation::Strict).with_runtime(
+            RuntimeEnv::for_test(platform)
+                .with_var("SSL_CERT_FILE", "allowlisted")
+                .with_var("RB_RUNNER_HIDDEN", "hidden"),
+        );
+        let mut session = start_local_session(&runner, temp_dir.path()).await;
+        let mut sink = VecSink::default();
+        let mut env = IndexMap::new();
+        env.insert("RB_RUNNER_EXPLICIT".to_string(), "visible".to_string());
+
+        #[cfg(unix)]
+        let argv = vec!["/usr/bin/env".to_string()];
+        #[cfg(windows)]
+        let argv = shell_command("set");
+
+        let status = session
+            .exec(
+                ExecSpec {
+                    argv,
+                    cwd: GuestPath(temp_dir.path().to_path_buf()),
+                    env,
+                },
+                &mut sink,
+            )
+            .await
+            .unwrap();
+
+        assert!(status.success());
+        let stdout = sink
+            .0
+            .iter()
+            .filter(|(stream, _)| *stream == OutputStream::Stdout)
+            .map(|(_, line)| line.as_str())
+            .collect::<Vec<_>>();
+        assert!(stdout.contains(&"RB_RUNNER_EXPLICIT=visible"));
+        assert!(stdout.contains(&"SSL_CERT_FILE=allowlisted"));
+        assert!(
+            !stdout
+                .iter()
+                .any(|line| line.starts_with("RB_RUNNER_HIDDEN=")),
+            "unexpected output: {stdout:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn output_decode_error_preserves_exit_status() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let runner = LocalRunner::new(EnvironmentIsolation::None);
+        let mut session = start_local_session(&runner, temp_dir.path()).await;
+        let mut sink = VecSink::default();
+
+        let status = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            session.exec(
+                ExecSpec {
+                    argv: shell_command("printf '\\377\\n'; head -c 1048576 /dev/zero"),
+                    cwd: GuestPath(temp_dir.path().to_path_buf()),
+                    env: IndexMap::new(),
+                },
+                &mut sink,
+            ),
+        )
+        .await
+        .expect("draining invalid output must not hang")
+        .unwrap();
+
+        assert!(status.success());
+        assert!(sink.0.is_empty());
+    }
+
+    #[tokio::test]
+    async fn find_executable_uses_runtime_platform_suffix() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let directory = temp_dir.path();
+        fs_err::write(directory.join("tool"), "").unwrap();
+        fs_err::write(directory.join("tool.exe"), "").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs_err::set_permissions(
+                directory.join("tool"),
+                std::fs::Permissions::from_mode(0o755),
+            )
+            .unwrap();
+        }
+        #[cfg(unix)]
+        let non_executable_dir = tempfile::tempdir().unwrap();
+        #[cfg(unix)]
+        fs_err::write(non_executable_dir.path().join("tool"), "").unwrap();
+        #[cfg(unix)]
+        let search_paths = vec![
+            GuestPath(non_executable_dir.path().to_path_buf()),
+            GuestPath(directory.to_path_buf()),
+        ];
+        #[cfg(not(unix))]
+        let search_paths = vec![GuestPath(directory.to_path_buf())];
+        let names = vec!["tool".to_string()];
+
+        let windows_runner = LocalRunner::new(EnvironmentIsolation::Strict)
+            .with_runtime(RuntimeEnv::for_test(Platform::Win64));
+        let mut windows_session = start_local_session(&windows_runner, directory).await;
+        assert_eq!(
+            windows_session
+                .find_executable(&names, &search_paths)
+                .await
+                .unwrap(),
+            Some(GuestPath(directory.join("tool.exe")))
+        );
+
+        let linux_runner = LocalRunner::new(EnvironmentIsolation::Strict)
+            .with_runtime(RuntimeEnv::for_test(Platform::Linux64));
+        let mut linux_session = start_local_session(&linux_runner, directory).await;
+        assert_eq!(
+            linux_session
+                .find_executable(&names, &search_paths)
+                .await
+                .unwrap(),
+            Some(GuestPath(directory.join("tool")))
+        );
+        assert_eq!(
+            linux_session
+                .find_executable(&["missing".to_string()], &search_paths)
+                .await
+                .unwrap(),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn close_accepts_both_keep_values() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let runner = LocalRunner::default();
+        start_local_session(&runner, temp_dir.path())
+            .await
+            .close(Keep::Nothing)
+            .await
+            .unwrap();
+        start_local_session(&runner, temp_dir.path())
+            .await
+            .close(Keep::Alive)
+            .await
+            .unwrap();
+    }
+
+    #[test]
+    fn runner_is_object_safe() {
+        let _: Arc<dyn Runner> = Arc::new(LocalRunner::default());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn exec_interactive_reports_exit_status_and_inherits_host_env() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let runner = LocalRunner::new(EnvironmentIsolation::Strict);
+        let mut session = start_local_session(&runner, temp_dir.path()).await;
+
+        let status = session
+            .exec_interactive(ExecSpec {
+                argv: shell_command("test -n \"$HOME\""),
+                cwd: GuestPath(PathBuf::from(temp_dir.path())),
+                env: IndexMap::new(),
+            })
+            .await
+            .unwrap();
+
+        assert!(status.success());
+
+        let status = session
+            .exec_interactive(ExecSpec {
+                argv: shell_command("exit 3"),
+                cwd: GuestPath(PathBuf::from(temp_dir.path())),
+                env: IndexMap::new(),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(status.code, Some(3));
+    }
+}

--- a/crates/rattler_build_script/src/runner/mod.rs
+++ b/crates/rattler_build_script/src/runner/mod.rs
@@ -15,26 +15,9 @@ pub use local::LocalRunner;
 /// Error returned while preparing or driving a runner session.
 #[derive(Debug, thiserror::Error)]
 pub enum RunnerError {
-    /// The runner cannot execute on this machine.
-    #[error("runner `{runner}` is not usable: {reason}")]
-    NotUsable {
-        /// The runner name.
-        runner: String,
-        /// The reason the runner is unavailable.
-        reason: String,
-    },
     /// An I/O failure while starting or driving a process.
     #[error(transparent)]
     Io(#[from] std::io::Error),
-}
-
-/// How a runner exposes the host filesystem to executing scripts.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum FilesystemAccess {
-    /// The host reaches the session's files directly through its mount mapping.
-    Shared,
-    /// File content crosses only through an explicit transfer transport.
-    Streamed,
 }
 
 /// A path on the machine rattler-build runs on.
@@ -84,15 +67,6 @@ pub struct ExecSpec {
     pub cwd: GuestPath,
     /// Explicit environment variables for the command.
     pub env: IndexMap<String, String>,
-}
-
-/// What to preserve when closing a session.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Keep {
-    /// Tear down everything the session created.
-    Nothing,
-    /// Keep backing resources alive.
-    Alive,
 }
 
 /// Exit status of an executed command.
@@ -149,9 +123,6 @@ pub trait Runner: Send + Sync {
     /// The platform scripts execute on.
     fn execution_platform(&self) -> Platform;
 
-    /// Filesystem relationship between host and guest.
-    fn filesystem(&self) -> FilesystemAccess;
-
     /// Performs a cheap availability check.
     async fn check_usable(&self) -> Result<(), RunnerError>;
 
@@ -183,5 +154,5 @@ pub trait Session: Send {
     ) -> Result<Option<GuestPath>, RunnerError>;
 
     /// Closes this session.
-    async fn close(self: Box<Self>, keep: Keep) -> Result<(), RunnerError>;
+    async fn close(self: Box<Self>) -> Result<(), RunnerError>;
 }

--- a/crates/rattler_build_script/src/runner/mod.rs
+++ b/crates/rattler_build_script/src/runner/mod.rs
@@ -1,0 +1,187 @@
+//! Script execution backends and their sessions.
+
+mod environment;
+mod local;
+
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+use indexmap::IndexMap;
+use rattler_conda_types::Platform;
+
+pub(crate) use environment::resolve_process_env;
+pub use local::LocalRunner;
+
+/// Error returned while preparing or driving a runner session.
+#[derive(Debug, thiserror::Error)]
+pub enum RunnerError {
+    /// The runner cannot execute on this machine.
+    #[error("runner `{runner}` is not usable: {reason}")]
+    NotUsable {
+        /// The runner name.
+        runner: String,
+        /// The reason the runner is unavailable.
+        reason: String,
+    },
+    /// An I/O failure while starting or driving a process.
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+
+/// How a runner exposes the host filesystem to executing scripts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FilesystemAccess {
+    /// The host reaches the session's files directly through its mount mapping.
+    Shared,
+    /// File content crosses only through an explicit transfer transport.
+    Streamed,
+}
+
+/// A path on the machine rattler-build runs on.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct HostPath(
+    /// The underlying path.
+    pub PathBuf,
+);
+
+/// A path as seen from inside a session.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct GuestPath(
+    /// The underlying path.
+    pub PathBuf,
+);
+
+/// One bind mount from host into guest.
+#[derive(Debug, Clone)]
+pub struct Mount {
+    /// The source path on the host.
+    pub host: HostPath,
+    /// The destination path in the guest.
+    pub guest: GuestPath,
+    /// Whether the guest may write through the mount.
+    pub writable: bool,
+}
+
+/// Everything needed to start a session.
+#[derive(Debug, Clone)]
+pub struct SessionSpec {
+    /// The platform scripts execute on.
+    pub platform: Platform,
+    /// The bind mounts the session must provide.
+    pub mounts: Vec<Mount>,
+    /// The container image for runners that need one.
+    pub image: Option<String>,
+    /// The session working directory as a guest path.
+    pub work_dir: GuestPath,
+}
+
+/// One command execution inside a session.
+#[derive(Debug, Clone)]
+pub struct ExecSpec {
+    /// The program followed by its arguments.
+    pub argv: Vec<String>,
+    /// The command's current directory as a guest path.
+    pub cwd: GuestPath,
+    /// Explicit environment variables for the command.
+    pub env: IndexMap<String, String>,
+}
+
+/// What to preserve when closing a session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Keep {
+    /// Tear down everything the session created.
+    Nothing,
+    /// Keep backing resources alive.
+    Alive,
+}
+
+/// Exit status of an executed command.
+#[derive(Debug, Clone, Copy)]
+pub struct ExecStatus {
+    /// The process exit code, or `None` when it was terminated by a signal.
+    pub code: Option<i32>,
+}
+
+impl ExecStatus {
+    /// Returns whether the command exited successfully.
+    pub fn success(&self) -> bool {
+        self.code == Some(0)
+    }
+}
+
+impl From<std::process::ExitStatus> for ExecStatus {
+    fn from(status: std::process::ExitStatus) -> Self {
+        Self {
+            code: status.code(),
+        }
+    }
+}
+
+/// Facts about the guest execution environment discovered by a runner.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct GuestInfo {
+    /// The platform scripts execute on.
+    pub platform: Platform,
+}
+
+/// Which stream a raw output line arrived on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputStream {
+    /// The standard output stream.
+    Stdout,
+    /// The standard error stream.
+    Stderr,
+}
+
+/// Receives raw, CRLF-normalized output lines from an executing command.
+pub trait OutputSink: Send {
+    /// Receives one line from `stream` without its trailing newline.
+    fn line(&mut self, stream: OutputStream, line: &str);
+}
+
+/// An execution backend for build, staging, and test scripts.
+#[async_trait]
+pub trait Runner: Send + Sync {
+    /// Short identifier for this runner.
+    fn name(&self) -> &str;
+
+    /// The platform scripts execute on.
+    fn execution_platform(&self) -> Platform;
+
+    /// Filesystem relationship between host and guest.
+    fn filesystem(&self) -> FilesystemAccess;
+
+    /// Performs a cheap availability check.
+    async fn check_usable(&self) -> Result<(), RunnerError>;
+
+    /// Discovers facts about the guest execution environment.
+    async fn probe(&self) -> Result<GuestInfo, RunnerError>;
+
+    /// Starts a session according to `spec`.
+    async fn start_session(&self, spec: SessionSpec) -> Result<Box<dyn Session>, RunnerError>;
+}
+
+/// A started execution context.
+#[async_trait]
+pub trait Session: Send {
+    /// Runs a command, streaming raw output lines into `sink`.
+    async fn exec(
+        &mut self,
+        spec: ExecSpec,
+        sink: &mut dyn OutputSink,
+    ) -> Result<ExecStatus, RunnerError>;
+
+    /// Runs a command with stdio attached to the invoking terminal.
+    async fn exec_interactive(&mut self, spec: ExecSpec) -> Result<ExecStatus, RunnerError>;
+
+    /// Finds the first `names` entry on the given guest search paths.
+    async fn find_executable(
+        &mut self,
+        names: &[String],
+        search_paths: &[GuestPath],
+    ) -> Result<Option<GuestPath>, RunnerError>;
+
+    /// Closes this session.
+    async fn close(self: Box<Self>, keep: Keep) -> Result<(), RunnerError>;
+}

--- a/crates/rattler_build_script/src/runner/mod.rs
+++ b/crates/rattler_build_script/src/runner/mod.rs
@@ -152,7 +152,4 @@ pub trait Session: Send {
         names: &[String],
         search_paths: &[GuestPath],
     ) -> Result<Option<GuestPath>, RunnerError>;
-
-    /// Closes this session.
-    async fn close(self: Box<Self>) -> Result<(), RunnerError>;
 }

--- a/py-rattler-build/rust/Cargo.lock
+++ b/py-rattler-build/rust/Cargo.lock
@@ -4902,6 +4902,7 @@ dependencies = [
 name = "rattler_build_script"
 version = "0.2.7"
 dependencies = [
+ "async-trait",
  "clap",
  "console",
  "fs-err",


### PR DESCRIPTION
Process execution in `rattler_build_script` is currently expressed as concrete local-process helpers. There is no type-level boundary between describing a command, starting it, and consuming its output, which makes the process lifecycle and environment rules awkward to test independently.

This PR adds object-safe `Runner` and `Session` APIs together with a `LocalRunner` implementation. `ExecSpec` describes the command, working directory, and environment; a session streams normalized output through an `OutputSink` and returns an `ExecStatus`. `LocalRunner` uses the existing environment resolver and spawn helper, preserving environment isolation, the `PWD` handling, CRLF normalization, and interactive environment inheritance.

This gives process execution a small, explicit interface and puts focused tests around local environment isolation, stream handling, executable lookup, interactive exit status, and output-drain behavior. Existing build and test script execution remains unchanged in this PR.

## Testing

- `pixi run cargo test -p rattler_build_script --lib`
- `pixi run cargo clippy -p rattler_build_script --all-targets --all-features -- -D warnings -Dclippy::dbg_macro`
- `pixi run cargo check --workspace --all-targets`

I also tried `cargo check -p rattler_build_script --no-default-features`. It is currently blocked in unchanged `script.rs` because `IndexMap` does not have serde enabled in that feature configuration.