### PR TITLE
feat: add runner to build configuration

### DIFF
--- a/crates/rattler_build_core/src/script.rs
+++ b/crates/rattler_build_core/src/script.rs
@@ -17,6 +17,10 @@ pub use rattler_build_script::{
     BuildScriptSection, ExecutionArgs, ExecutionContext, InterpreterError, ResolvedScriptContents,
     RuntimeEnv, SandboxArguments, SandboxConfiguration, Script, ScriptContent,
     platform_script_extensions,
+    runner::{
+        ExecSpec, ExecStatus, GuestInfo, GuestPath, HostPath, LocalRunner, Mount, OutputSink,
+        OutputStream, Runner, RunnerError, Session, SessionSpec,
+    },
 };
 
 use crate::{env_vars, metadata::Output};

--- a/crates/rattler_build_core/src/tool_configuration.rs
+++ b/crates/rattler_build_core/src/tool_configuration.rs
@@ -5,6 +5,7 @@ use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
 use clap::ValueEnum;
 use rattler::package_cache::PackageCache;
+use rattler_build_script::runner::{LocalRunner, Runner};
 use rattler_conda_types::{ChannelConfig, Platform};
 #[cfg(feature = "s3")]
 use rattler_networking::s3_middleware;
@@ -82,6 +83,9 @@ pub struct Configuration {
 
     /// The source cache for downloading and caching source code
     pub source_cache: Option<Arc<rattler_build_source_cache::SourceCache>>,
+
+    /// The runner that executes build, staging, and test scripts
+    pub runner: Arc<dyn Runner>,
 
     /// Set this to true if you want to keep the build directory after the build
     /// is done
@@ -185,6 +189,7 @@ pub struct ConfigurationBuilder {
     cache_dir: Option<PathBuf>,
     fancy_log_handler: Option<LoggingOutputHandler>,
     client: Option<rattler_build_networking::BaseClient>,
+    runner: Option<Arc<dyn Runner>>,
     no_clean: bool,
     no_test: bool,
     test_strategy: TestStrategy,
@@ -219,6 +224,7 @@ impl ConfigurationBuilder {
             cache_dir: None,
             fancy_log_handler: None,
             client: None,
+            runner: None,
             no_clean: false,
             no_test: false,
             test_strategy: TestStrategy::default(),
@@ -346,6 +352,14 @@ impl ConfigurationBuilder {
         }
     }
 
+    /// Sets the runner used to execute build, staging, and test scripts.
+    pub fn with_runner(self, runner: Arc<dyn Runner>) -> Self {
+        Self {
+            runner: Some(runner),
+            ..self
+        }
+    }
+
     /// Sets whether tests should be executed.
     pub fn with_testing(self, testing_enabled: bool) -> Self {
         Self {
@@ -462,6 +476,9 @@ impl ConfigurationBuilder {
             fancy_log_handler: self.fancy_log_handler.unwrap_or_default(),
             client,
             source_cache: None, // Built lazily on first use
+            runner: self
+                .runner
+                .unwrap_or_else(|| Arc::new(LocalRunner::default())),
             no_clean: self.no_clean,
             test_strategy,
             use_zstd: self.use_zstd,

--- a/crates/rattler_build_core/src/tool_configuration.rs
+++ b/crates/rattler_build_core/src/tool_configuration.rs
@@ -5,6 +5,7 @@ use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
 use clap::ValueEnum;
 use rattler::package_cache::PackageCache;
+use rattler_build_script::runner::{LocalRunner, Runner};
 use rattler_conda_types::{ChannelConfig, Platform};
 #[cfg(feature = "s3")]
 use rattler_networking::s3_middleware;
@@ -82,6 +83,9 @@ pub struct Configuration {
 
     /// The source cache for downloading and caching source code
     pub source_cache: Option<Arc<rattler_build_source_cache::SourceCache>>,
+
+    /// The runner that executes build, staging, and test scripts
+    pub runner: Arc<dyn Runner>,
 
     /// Set this to true if you want to keep the build directory after the build
     /// is done
@@ -185,6 +189,7 @@ pub struct ConfigurationBuilder {
     cache_dir: Option<PathBuf>,
     fancy_log_handler: Option<LoggingOutputHandler>,
     client: Option<rattler_build_networking::BaseClient>,
+    runner: Option<Arc<dyn Runner>>,
     no_clean: bool,
     no_test: bool,
     test_strategy: TestStrategy,
@@ -219,6 +224,7 @@ impl ConfigurationBuilder {
             cache_dir: None,
             fancy_log_handler: None,
             client: None,
+            runner: None,
             no_clean: false,
             no_test: false,
             test_strategy: TestStrategy::default(),
@@ -346,6 +352,14 @@ impl ConfigurationBuilder {
         }
     }
 
+    /// Sets the runner used to execute build, staging, and test scripts.
+    pub fn with_runner(self, runner: Arc<dyn Runner>) -> Self {
+        Self {
+            runner: Some(runner),
+            ..self
+        }
+    }
+
     /// Sets whether tests should be executed.
     pub fn with_testing(self, testing_enabled: bool) -> Self {
         Self {
@@ -462,6 +476,9 @@ impl ConfigurationBuilder {
             fancy_log_handler: self.fancy_log_handler.unwrap_or_default(),
             client,
             source_cache: None, // Built lazily on first use
+            runner: self
+                .runner
+                .unwrap_or_else(|| Arc::new(LocalRunner::default())),
             no_clean: self.no_clean,
             test_strategy,
             use_zstd: self.use_zstd,
@@ -565,4 +582,30 @@ pub async fn resolve_s3_credentials(
     );
     let resolved = rattler_s3::ResolvedS3Credentials::from_sdk().await?;
     Ok(resolved)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use rattler_build_script::runner::{LocalRunner, Runner};
+
+    use super::Configuration;
+
+    #[test]
+    fn configuration_default_runner_is_local() {
+        let configuration = Configuration::builder().finish();
+
+        assert_eq!(configuration.runner.name(), "local");
+    }
+
+    #[test]
+    fn with_runner_overrides_default() {
+        let runner: Arc<dyn Runner> = Arc::new(LocalRunner::default());
+        let configuration = Configuration::builder()
+            .with_runner(runner.clone())
+            .finish();
+
+        assert!(Arc::ptr_eq(&configuration.runner, &runner));
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,7 @@ use rattler_index::ensure_channel_initialized_s3;
 use rattler_solve::SolveStrategy;
 use rattler_virtual_packages::VirtualPackageOverrides;
 use render::resolved_dependencies::RunExportsDownload;
+use script::LocalRunner;
 use system_tools::SystemTools;
 use tool_configuration::{Configuration, ContinueOnFailure, SkipExisting, TestStrategy};
 use types::Directories;
@@ -234,6 +235,7 @@ pub fn get_tool_config(
 
     let configuration_builder = Configuration::builder()
         .with_keep_build(build_data.keep_build)
+        .with_runner(Arc::new(LocalRunner::new(build_data.env_isolation)))
         .with_compression_threads(build_data.compression_threads)
         .with_reqwest_client(client)
         .with_test_strategy(build_data.test)


### PR DESCRIPTION
The `Runner` API now exists in `rattler_build_script`, but the build configuration has no place to carry a runner. Library integrations that already pass `Configuration` through the build and test code would otherwise need to keep the execution backend as separate state.

This adds an `Arc<dyn Runner>` to `Configuration` and a `with_runner` builder method. The default stays `LocalRunner`, so existing callers keep the current behavior. CLI builds construct the local runner from the selected environment isolation mode, keeping those settings together. The runner types are also re-exported through the core script API.

This is configuration and API plumbing only. Existing script execution is unchanged.

## Testing

- `pixi run cargo-fmt-check`
- `pixi run cargo check --workspace --all-targets`
- `pixi run cargo clippy -p rattler_build_core --all-targets --all-features -- -D warnings -Dclippy::dbg_macro`
- `pixi run cargo check --manifest-path py-rattler-build/rust/Cargo.toml`
- `pixi run test`
