### PR TITLE
fix: Handle copy_metadata errors for reflinked files

### DIFF
--- a/crates/rattler_build_core/src/source/copy_dir.rs
+++ b/crates/rattler_build_core/src/source/copy_dir.rs
@@ -443,7 +443,12 @@ where
             // File has been reflinked
             #[cfg(target_os = "linux")]
             {
-                copy_metadata(from, to.as_ref())?;
+                match copy_metadata(from, to.as_ref()) {
+                    Ok(()) => {}
+                    Err(e) => {
+                        tracing::debug!("Failed to copy metadata for {:?} {:?}", to.as_ref(), e);
+                    }
+                }
             }
         }
         Ok(Some(_)) => {

--- a/crates/rattler_build_core/src/source/copy_dir.rs
+++ b/crates/rattler_build_core/src/source/copy_dir.rs
@@ -45,7 +45,12 @@ fn copy_metadata(from: &Path, to: &Path) -> std::io::Result<()> {
         .set_accessed(metadata.accessed()?)
         .set_modified(metadata.modified()?);
 
-    let file = std::fs::OpenOptions::new().write(true).open(to)?;
+    let mut options = std::fs::OpenOptions::new();
+    #[cfg(target_os = "linux")]
+    options.read(true);
+    #[cfg(not(target_os = "linux"))]
+    options.write(true);
+    let file = options.open(to)?;
     file.set_times(file_times)?;
     file.set_permissions(metadata.permissions())?;
 
@@ -443,12 +448,7 @@ where
             // File has been reflinked
             #[cfg(target_os = "linux")]
             {
-                match copy_metadata(from, to.as_ref()) {
-                    Ok(()) => {}
-                    Err(e) => {
-                        tracing::debug!("Failed to copy metadata for {:?} {:?}", to.as_ref(), e);
-                    }
-                }
+                copy_metadata(from, to.as_ref())?;
             }
         }
         Ok(Some(_)) => {
@@ -552,6 +552,39 @@ mod test {
 
     use super::GlobVec;
     use std::collections::HashSet;
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn copy_metadata_to_read_only_file() {
+        use std::{
+            fs::FileTimes,
+            os::unix::fs::PermissionsExt,
+            time::{Duration, UNIX_EPOCH},
+        };
+
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let source = tmp_dir.path().join("source");
+        let destination = tmp_dir.path().join("destination");
+        fs::write(&source, "source").unwrap();
+        fs::write(&destination, "destination").unwrap();
+
+        File::open(&source)
+            .unwrap()
+            .set_times(FileTimes::new().set_modified(UNIX_EPOCH + Duration::from_secs(1_000_000)))
+            .unwrap();
+        fs::set_permissions(&source, std::fs::Permissions::from_mode(0o444)).unwrap();
+        fs::set_permissions(&destination, std::fs::Permissions::from_mode(0o400)).unwrap();
+
+        super::copy_metadata(&source, &destination).unwrap();
+
+        let source_metadata = fs::metadata(source).unwrap();
+        let destination_metadata = fs::metadata(destination).unwrap();
+        assert_eq!(
+            source_metadata.modified().unwrap(),
+            destination_metadata.modified().unwrap()
+        );
+        assert_eq!(destination_metadata.permissions().mode() & 0o777, 0o444);
+    }
 
     #[test]
     fn test_copy_dir() {


### PR DESCRIPTION
With rattler-build 0.68 and later, using git sources, copying of git objects from cache to the working directory fails with

FileSystem error: 'Permission denied (os error 13)'