### PR TITLE
fix: let `channel_sources` win over `default-channels` from the config file

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -522,9 +522,15 @@ pub async fn get_build_output(
         // 3. channels from pixi_config
         // 4. conda-forge as fallback
         if variant_channels.is_some() && build_data.channels.is_some() {
-            return Err(miette::miette!(
-                "channel_sources and channels cannot both be set at the same time"
-            ));
+            if build_data.channels_from_config {
+                tracing::debug!(
+                    "ignoring `default-channels` from the configuration file because the variant config sets `channel_sources`"
+                );
+            } else {
+                return Err(miette::miette!(
+                    "channel_sources and channels cannot both be set at the same time"
+                ));
+            }
         }
         let channels = variant_channels.unwrap_or_else(|| {
             build_data
@@ -1587,6 +1593,7 @@ pub async fn debug_recipe(
         target_platform: debug_data.target_platform,
         host_platform: debug_data.host_platform,
         channels: debug_data.channels,
+        channels_from_config: false,
         common: debug_data.common,
         keep_build: true,
         test: TestStrategy::Skip,

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -893,6 +893,11 @@ pub struct BuildData {
     pub target_platform: Platform,
     pub host_platform: Platform,
     pub channels: Option<Vec<NamedChannelOrUrl>>,
+    /// Whether `channels` was filled from the configuration file's
+    /// `default-channels` rather than passed explicitly. Config channels are a
+    /// fallback, so they lose against `channel_sources` from a variant config
+    /// instead of conflicting with it.
+    pub channels_from_config: bool,
     pub variant_config: Vec<PathBuf>,
     pub variant_overrides: HashMap<String, Vec<String>>,
     pub ignore_recipe_variants: bool,
@@ -968,6 +973,7 @@ impl BuildData {
                 .or(target_platform)
                 .unwrap_or(Platform::current()),
             channels,
+            channels_from_config: false,
             variant_config: variant_config.unwrap_or_default(),
             variant_overrides,
             ignore_recipe_variants,
@@ -1006,7 +1012,8 @@ impl BuildData {
     /// Generate a new BuildData struct from BuildOpts and an optional pixi config.
     /// BuildOpts have higher priority than the pixi config.
     pub fn from_opts_and_config(opts: BuildOpts, config: Option<Config>) -> Self {
-        Self::new(
+        let explicit_channels = opts.channels.is_some();
+        let mut build_data = Self::new(
             opts.up_to,
             opts.build_platform,
             opts.target_platform, // todo: read this from config as well
@@ -1050,7 +1057,9 @@ impl BuildData {
             None, // build_num_override — set by caller (BuildOnlyOpts or PublishOpts)
             None, // build_string_prefix — set by caller (BuildOnlyOpts or PublishOpts)
             opts.markdown_summary,
-        )
+        );
+        build_data.channels_from_config = !explicit_channels && build_data.channels.is_some();
+        build_data
     }
 }
 

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -2148,6 +2148,27 @@ def test_channel_sources(
     ]
 
 
+def test_channel_sources_with_default_channels_config(
+    rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
+):
+    # default-channels from the configuration file is a fallback, so
+    # channel_sources takes precedence instead of raising a conflict error
+    config = tmp_path / "config.toml"
+    config.write_text('default-channels = ["https://prefix.dev/conda-forge"]\n')
+
+    output = rattler_build.build(
+        recipes / "channel_sources",
+        tmp_path,
+        extra_args=["--render-only", "--config-file", str(config)],
+    )
+
+    output_json = json.loads(output)
+    assert output_json[0]["build_configuration"]["channels"] == [
+        "https://conda.anaconda.org/conda-forge/label/rust_dev",
+        "https://conda.anaconda.org/conda-forge",
+    ]
+
+
 def test_relative_file_loading(
     rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
 ):


### PR DESCRIPTION
With `default-channels` set in `~/.pixi/config.toml`, any recipe whose variant config sets `channel_sources` fails with `channel_sources and channels cannot both be set at the same time`. This breaks `conda-smithy rerender` on every conda-forge feedstock for users with that config key, even though the config channels are documented as a fallback below `channel_sources`.

- Track in `BuildData` whether `channels` was filled from the configuration file rather than passed explicitly
- Let `channel_sources` take precedence over config channels instead of erroring; an explicit `--channel` flag still conflicts
- Add an end-to-end test combining `channel_sources` with `default-channels` from a `--config-file`

Fixes prefix-dev/pixi#6731
