### PR TITLE
chore: release 0.72.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.72.1] - 2026-07-31
+### ✨ Highlights
+
+This patch release updates `flickzeug` to fix applying patches that only delete lines. It also handles metadata-copy errors for reflinked files and makes explicit `channel_sources` override configured `default-channels`.
+
+
+
+### Fixed
+
+- Update `flickzeug` to fix deletion-only patch application by @wolfv in [#2704](https://github.com/prefix-dev/rattler-build/pull/2704)
+- Handle copy_metadata errors for reflinked files by @jmakovicka in [#2703](https://github.com/prefix-dev/rattler-build/pull/2703)
+- Let `channel_sources` win over `default-channels` from the config file by @Hofer-Julian in [#2705](https://github.com/prefix-dev/rattler-build/pull/2705)
+
+
+### New Contributors
+* @jmakovicka made their first contribution in [#2703](https://github.com/prefix-dev/rattler-build/pull/2703)
+
 ## [0.72.0] - 2026-07-28
 ### ✨ Highlights
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4793,7 +4793,7 @@ dependencies = [
 
 [[package]]
 name = "rattler-build"
-version = "0.72.0"
+version = "0.72.1"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler-build"
-version = "0.72.0"
+version = "0.72.1"
 authors = ["rattler-build contributors <hi@prefix.dev>"]
 repository = "https://github.com/prefix-dev/rattler-build"
 edition = "2024"

--- a/py-rattler-build/pyproject.toml
+++ b/py-rattler-build/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "py-rattler-build"
-version = "0.72.0"
+version = "0.72.1"
 requires-python = ">=3.10"
 description = "The fastest way to build conda packages programatically"
 readme = "README.md"

--- a/py-rattler-build/rust/Cargo.lock
+++ b/py-rattler-build/rust/Cargo.lock
@@ -4261,7 +4261,7 @@ dependencies = [
 
 [[package]]
 name = "py-rattler-build"
-version = "0.72.0"
+version = "0.72.1"
 dependencies = [
  "clap",
  "fs-err",
@@ -4625,7 +4625,7 @@ dependencies = [
 
 [[package]]
 name = "rattler-build"
-version = "0.72.0"
+version = "0.72.1"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",

--- a/py-rattler-build/rust/Cargo.toml
+++ b/py-rattler-build/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-rattler-build"
-version = "0.72.0"
+version = "0.72.1"
 edition = "2024"
 license = "BSD-3-Clause"
 publish = false

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/prefix-dev/rattler-build"
 
 [version]
-current = "0.72.0"
+current = "0.72.1"
 
 # Example of a semver regexp.
 # Make sure this matches current_version before


### PR DESCRIPTION
## [0.72.1] - 2026-07-31
### ✨ Highlights

This patch release updates `flickzeug` to fix applying patches that only delete lines. It also handles metadata-copy errors for reflinked files and makes explicit `channel_sources` override configured `default-channels`.



### Fixed

- Update `flickzeug` to fix deletion-only patch application by @wolfv in [#2704](https://github.com/prefix-dev/rattler-build/pull/2704)
- Handle copy_metadata errors for reflinked files by @jmakovicka in [#2703](https://github.com/prefix-dev/rattler-build/pull/2703)
- Let `channel_sources` win over `default-channels` from the config file by @Hofer-Julian in [#2705](https://github.com/prefix-dev/rattler-build/pull/2705)


### New Contributors
* @jmakovicka made their first contribution in [#2703](https://github.com/prefix-dev/rattler-build/pull/2703)