### PR TITLE
fix: authenticate private channel reads with trusted publishing

### DIFF
--- a/crates/rattler_build_networking/src/lib.rs
+++ b/crates/rattler_build_networking/src/lib.rs
@@ -281,7 +281,9 @@ fn build_middleware_client(
         std::collections::HashMap<String, rattler_networking::s3_middleware::S3Config>,
     >,
 ) -> ClientWithMiddleware {
-    use rattler_networking::{AuthenticationMiddleware, mirror_middleware::MirrorMiddleware};
+    use rattler_networking::{
+        AuthChallengeMiddleware, AuthenticationMiddleware, mirror_middleware::MirrorMiddleware,
+    };
 
     let mut builder =
         reqwest_middleware::ClientBuilder::new(reqwest_client(user_agent, timeout_secs, dangerous));
@@ -295,6 +297,9 @@ fn build_middleware_client(
             auth_storage.clone(),
         ));
     }
+    // Stored credentials take precedence. If none are available, react to a prefix.dev
+    // authentication challenge by acquiring and caching a token from ambient CI OIDC.
     builder = builder.with(AuthenticationMiddleware::from_auth_storage(auth_storage));
+    builder = builder.with(AuthChallengeMiddleware::default());
     builder.with(retry_middleware()).build()
 }


### PR DESCRIPTION
## Summary

Install `AuthChallengeMiddleware` in rattler-build’s shared HTTP clients. This allows private prefix.dev repodata requests to react to an authentication challenge, exchange ambient CI OIDC credentials, and replay the request.

Previously, trusted publishing was used by the upload path, but channel reads during solving or `--skip-existing all` failed with HTTP 401 unless an explicit API key was configured. Stored credentials continue to take precedence over ambient OIDC.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p rattler_build_networking`