### PR TITLE
feat: read the shared config layer instead of pixi's config files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4740,9 +4740,9 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.48.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e2584f561484f6642f4825b655b3ec9ba57e06a8b10d0f026886405de9312"
+checksum = "61bfdcb39e1719edbb27e562d40405c1a8130eb3fff8b11b489672b642a488af"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -5219,9 +5219,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc91045d53da3c63c81b7666119a1f73ed2a69473e7b451649b62397d9148b77"
+checksum = "b1ea7ff3474f2c5aceb5fe741061ad744f164e050de40dc25608c5ae0e66753c"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5254,9 +5254,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.49.0"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "776dcc9348ae7e1843e1320ad1c1afc375bd2b73faeaa1bb49b1e002575f7791"
+checksum = "058c739d6ea6b3f429443f9d7117022330049bdb1cdde7b46622662463bd5cc0"
 dependencies = [
  "ahash",
  "core-foundation 0.10.1",
@@ -5297,9 +5297,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_config"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66465befa4068f2b5ab01f4949f41e9bbb033d9d7e2833d9bde926fe2d0dfaf9"
+checksum = "1fadf5267a8dc82ac7e1ba0b42c778a2e3fb02cf4827507a26456f2e2ef42cf4"
 dependencies = [
  "dirs",
  "fs-err",
@@ -5336,9 +5336,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_git"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd2fb97c46b274efa086e255a2c872e618e196f015fa23f3840bd5cc1f4feab"
+checksum = "c0a952c9f6188e0d4a0f111edc52bc3392dfe249329b17ade79502abd11074fa"
 dependencies = [
  "astral-reqwest-middleware",
  "dashmap",
@@ -5358,9 +5358,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.30.10"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cb1a3521d90ba481daa79f4c665e8abcf1d89e01c594f86d0dbe46b784d83b"
+checksum = "4cadb312b82d369b4479c01a3eaa9386fa4834c950570fa8ea6e38237e3effb8"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5408,9 +5408,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.71"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ea27febfd73be21974ea7c3afde8a735e981dd8ceaa351081c829533a66284"
+checksum = "b6269634b94b5a9be52cf45bf9368819b33268a4372e76f9c8f9c64c9275a64a"
 dependencies = [
  "configparser",
  "dirs",
@@ -5439,9 +5439,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.30.3"
+version = "0.30.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1789dae98aabeedffa2d28f0fd218da55ca21746d7f4b8e909f80525cf3bef5"
+checksum = "e668ff6375b364d8835cf15d51179ac7366aced2a39d60877041d099a421fd06"
 dependencies = [
  "ambient-id",
  "anyhow",
@@ -5478,9 +5478,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.26.9"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bb89525bd5df28e9abcbba31e5c97b029175e66433a43ed9087792d5b0bdb7"
+checksum = "e7ca685c8e3a5ffecd6ad1e9c938753993ed05220c050a070a847ae541797a2e"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-tokio-tar",
@@ -5488,6 +5488,7 @@ dependencies = [
  "astral_async_zip",
  "async-compression",
  "async-spooled-tempfile",
+ "bytes",
  "bzip2",
  "filetime",
  "fs-err",
@@ -5533,9 +5534,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_pty"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae2c43bc4b13b017eba423c48aa99fa33aac7b63ffd720a12b1e7428397f7328"
+checksum = "c4bb899b6b8d316efe26fe43e003073ef93d230d9009a41d630e22473368c0e4"
 dependencies = [
  "libc",
  "nix",
@@ -5556,9 +5557,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a562674a44022e676a4608f29f2f7d35e71de0386148dc5bfa72765e72676684"
+checksum = "466a4335b63701b2eeb0888e66c82e034589998007ee68eceb30f75d5bc643b7"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5619,9 +5620,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_s3"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0274107867e75f151fdaaf361a15c06f24600cbe2ff5bab886be009c2f8baa27"
+checksum = "26736d14feafeb56b64b820d477fde693eebebd2738afc0549a59af13c3925f3"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -5636,9 +5637,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.27.11"
+version = "0.27.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9eda3170df19c28a7e7c42f52a0d99c68392bd985c0b7a04965f6227bb3340"
+checksum = "27e6d9e4b73759112b0560c85c3fe3c9619386ed11700daa7b068d02fcd0a766"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -5658,9 +5659,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "9.0.0"
+version = "9.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47428b4adefb08d4b7b915f29a3ea716f6a329b75723355ea1eb63fc0a4eaac2"
+checksum = "15139fa95d92a22fe4ba6b00ee89ed6b2375550f1c51036b202c51f771c0d29a"
 dependencies = [
  "futures",
  "hex",
@@ -5678,9 +5679,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_upload"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc094f9ea319310dcb2ed1e65707c0e40a3e9fb5b7e1b0841b7149b479211cc"
+checksum = "600dbf4a722767b77063601174e9750aac4d64d0a9e4f20b90aa7cbe9ba14582"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-reqwest-retry",
@@ -5717,9 +5718,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "4.1.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5bb5ca36e7e3c22c77ebb49737401d1ab4dd47a40fcdab19adb4a0319767b5"
+checksum = "3fbade435086e26b977cd2e2a06afa6e5815de03c34af6b39e5a309cbc731196"
 dependencies = [
  "archspec",
  "libloading",
@@ -5729,8 +5730,11 @@ dependencies = [
  "rattler_conda_types",
  "regex",
  "serde",
+ "serde_json",
+ "tempfile",
  "thiserror 2.0.19",
  "tracing",
+ "windows-sys 0.61.2",
  "winver",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,31 +139,31 @@ rattler_digest = { version = "1.3.2", default-features = false, features = [
   "serde",
 ] }
 rattler_networking = { version = "0.30", default-features = false }
-rattler_package_streaming = { version = "0.26", default-features = false }
+rattler_package_streaming = { version = "0.27", default-features = false }
 rattler_shell = { version = "0.27", default-features = false, features = [
   "sysinfo",
 ] }
-rattler_git = { version = "0.2" }
+rattler_git = { version = "0.3" }
 rattler_prefix_guard = { version = "0.1.2" }
 
-rattler_config = { version = "0.6" }
+rattler_config = { version = "0.7" }
 rattler = { version = "0.48", default-features = false, features = [
   "cli-tools",
   "indicatif",
 ] }
 rattler_cache = { version = "0.10", default-features = false }
-rattler_index = { version = "0.30", default-features = false }
+rattler_index = { version = "0.31", default-features = false }
 rattler_upload = { version = "0.10", default-features = false }
 rattler_s3 = { version = "0.2.9" }
 rattler_redaction = { version = "0.2.2", default-features = false }
-rattler_repodata_gateway = { version = "0.31", default-features = false, features = [
+rattler_repodata_gateway = { version = "0.32", default-features = false, features = [
   "gateway",
 ] }
 rattler_solve = { version = "9.0", default-features = false, features = [
   "resolvo",
   "serde",
 ] }
-rattler_virtual_packages = { version = "4.1", default-features = false }
+rattler_virtual_packages = { version = "5.0", default-features = false }
 rattler_menuinst = "0.2"
 
 

--- a/crates/rattler_build_core/src/types/mod.rs
+++ b/crates/rattler_build_core/src/types/mod.rs
@@ -75,7 +75,7 @@ impl PlatformWithVirtualPackages {
         platform: Platform,
         overrides: &VirtualPackageOverrides,
     ) -> Result<Self, DetectVirtualPackageError> {
-        let virtual_packages = VirtualPackages::detect_for_platform(platform, overrides)?
+        let virtual_packages = VirtualPackages::detect_for_platform(platform, overrides, None)?
             .into_generic_virtual_packages()
             .collect();
         Ok(Self {

--- a/crates/rattler_build_source_cache/src/cache.rs
+++ b/crates/rattler_build_source_cache/src/cache.rs
@@ -105,6 +105,7 @@ impl SourceCache {
             // the smudge filter during checkout; `Some(false)` force-skips the
             // smudge filter so checkouts contain pointer files only.
             lfs: Some(source.lfs),
+            ..Default::default()
         };
 
         let fetch_result = self

--- a/docs/config.md
+++ b/docs/config.md
@@ -2,17 +2,16 @@
 
 Rattler-Build shares its configuration format with pixi: the config file is of the same format as pixi's [global configuration file](https://pixi.sh/latest/reference/pixi_configuration/).
 
-By default (when no `--config-file` is passed), Rattler-Build automatically loads and merges configuration from the standard locations shared by all rattler based tools. Discovery is provided by `rattler_config`'s common `locations` helper, so the search order is identical to the one pixi and other tools use. The locations, in ascending order of precedence (values from later files override values from earlier files):
+By default (when no `--config-file` is passed), Rattler-Build automatically loads and merges configuration from the standard locations. Discovery is provided by `rattler_config`'s common `locations` helper, which combines two layers: the configuration shared by all rattler based tools, and Rattler-Build's own files. The locations, in ascending order of precedence (values from later files override values from earlier files):
 
-1. The system-wide configuration of each tool: `/etc/pixi/config.toml` followed by `/etc/rattler-build/config.toml` (on Windows: `C:\ProgramData\<tool>\config.toml`)
-2. The per-user configuration of each tool: the platform config directory (`$XDG_CONFIG_HOME/<tool>/config.toml`, e.g. `~/.config/pixi/config.toml`) and the tool home (`$PIXI_HOME` / `$RATTLER_BUILD_HOME`, defaulting to `~/.pixi/config.toml` / `~/.rattler-build/config.toml`), for `pixi` first and then `rattler-build`
+1. The system-wide shared configuration: `/etc/rattler/config.toml` (on Windows: `C:\ProgramData\rattler\config.toml`)
+2. The system-wide Rattler-Build configuration: `/etc/rattler-build/config.toml`
+3. The per-user shared configuration: `$XDG_CONFIG_HOME/rattler/config.toml`, plus `$RATTLER_HOME/config.toml` when the variable is set
+4. The per-user Rattler-Build configuration: the platform config directory (`$XDG_CONFIG_HOME/rattler-build/config.toml`) followed by the tool home (`$RATTLER_BUILD_HOME`, defaulting to `~/.rattler-build/config.toml`)
 
-In other words all system-wide files are read before any per-user file, and within each group pixi's files are overridden by Rattler-Build's own files. This means that settings such as default channels, mirrors, or S3 options that you have configured for pixi are picked up by Rattler-Build automatically, and can be overridden in Rattler-Build's own configuration files.
+The shared files may only contain the keys every rattler based tool understands — default channels, mirrors, S3 options, and so on. Tool-specific keys in a shared file are ignored with a warning. Settings meant for every tool (pixi and Rattler-Build alike) belong in the shared files; settings meant only for Rattler-Build belong in its own files, which override the shared ones.
 
-Alternatively, a single configuration file can be specified explicitly with `--config-file` (e.g. `--config-file ~/.pixi/config.toml`), which disables the automatic discovery and loads only that file. To disable configuration entirely — so that only built-in defaults and command-line arguments apply — pass `--no-config` (mutually exclusive with `--config-file`).
-
-!!! note "Behavior change"
-    Earlier versions of Rattler-Build only loaded configuration when `--config-file` was passed. Automatic discovery of the locations above is new: if you already have a pixi configuration, Rattler-Build now picks it up by default. Pass `--no-config` to restore the old behavior and skip all configuration loading, or `--config-file` to load only a specific file.
+Alternatively, a single configuration file can be specified explicitly with `--config-file`, which disables the automatic discovery and loads only that file. To disable configuration entirely — so that only built-in defaults and command-line arguments apply — pass `--no-config` (mutually exclusive with `--config-file`).
 
 ## Seeing which configuration was loaded
 

--- a/py-rattler-build/rust/Cargo.lock
+++ b/py-rattler-build/rust/Cargo.lock
@@ -4284,7 +4284,7 @@ dependencies = [
  "rattler_config",
  "rattler_networking",
  "rattler_package_streaming",
- "rattler_solve 9.0.0",
+ "rattler_solve",
  "rattler_upload",
  "rattler_virtual_packages",
  "serde_json",
@@ -4572,9 +4572,9 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.48.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e2584f561484f6642f4825b655b3ec9ba57e06a8b10d0f026886405de9312"
+checksum = "61bfdcb39e1719edbb27e562d40405c1a8130eb3fff8b11b489672b642a488af"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -4667,7 +4667,7 @@ dependencies = [
  "rattler_networking",
  "rattler_package_streaming",
  "rattler_repodata_gateway",
- "rattler_solve 9.0.0",
+ "rattler_solve",
  "rattler_upload",
  "rattler_virtual_packages",
  "reqwest",
@@ -4736,7 +4736,7 @@ dependencies = [
  "rattler_repodata_gateway",
  "rattler_s3",
  "rattler_shell",
- "rattler_solve 9.0.0",
+ "rattler_solve",
  "rattler_upload",
  "rattler_virtual_packages",
  "rayon",
@@ -4997,9 +4997,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc91045d53da3c63c81b7666119a1f73ed2a69473e7b451649b62397d9148b77"
+checksum = "b1ea7ff3474f2c5aceb5fe741061ad744f164e050de40dc25608c5ae0e66753c"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5032,9 +5032,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.49.0"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "776dcc9348ae7e1843e1320ad1c1afc375bd2b73faeaa1bb49b1e002575f7791"
+checksum = "058c739d6ea6b3f429443f9d7117022330049bdb1cdde7b46622662463bd5cc0"
 dependencies = [
  "ahash",
  "core-foundation 0.10.1",
@@ -5075,9 +5075,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_config"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66465befa4068f2b5ab01f4949f41e9bbb033d9d7e2833d9bde926fe2d0dfaf9"
+checksum = "1fadf5267a8dc82ac7e1ba0b42c778a2e3fb02cf4827507a26456f2e2ef42cf4"
 dependencies = [
  "dirs",
  "fs-err",
@@ -5114,9 +5114,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_git"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd2fb97c46b274efa086e255a2c872e618e196f015fa23f3840bd5cc1f4feab"
+checksum = "c0a952c9f6188e0d4a0f111edc52bc3392dfe249329b17ade79502abd11074fa"
 dependencies = [
  "astral-reqwest-middleware",
  "dashmap",
@@ -5136,9 +5136,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.30.10"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cb1a3521d90ba481daa79f4c665e8abcf1d89e01c594f86d0dbe46b784d83b"
+checksum = "4cadb312b82d369b4479c01a3eaa9386fa4834c950570fa8ea6e38237e3effb8"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5186,9 +5186,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.71"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ea27febfd73be21974ea7c3afde8a735e981dd8ceaa351081c829533a66284"
+checksum = "b6269634b94b5a9be52cf45bf9368819b33268a4372e76f9c8f9c64c9275a64a"
 dependencies = [
  "configparser",
  "dirs",
@@ -5217,9 +5217,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.30.3"
+version = "0.30.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1789dae98aabeedffa2d28f0fd218da55ca21746d7f4b8e909f80525cf3bef5"
+checksum = "e668ff6375b364d8835cf15d51179ac7366aced2a39d60877041d099a421fd06"
 dependencies = [
  "ambient-id",
  "anyhow",
@@ -5256,9 +5256,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.26.9"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bb89525bd5df28e9abcbba31e5c97b029175e66433a43ed9087792d5b0bdb7"
+checksum = "e7ca685c8e3a5ffecd6ad1e9c938753993ed05220c050a070a847ae541797a2e"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-tokio-tar",
@@ -5266,6 +5266,7 @@ dependencies = [
  "astral_async_zip",
  "async-compression",
  "async-spooled-tempfile",
+ "bytes",
  "bzip2",
  "filetime",
  "fs-err",
@@ -5311,9 +5312,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_pty"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae2c43bc4b13b017eba423c48aa99fa33aac7b63ffd720a12b1e7428397f7328"
+checksum = "c4bb899b6b8d316efe26fe43e003073ef93d230d9009a41d630e22473368c0e4"
 dependencies = [
  "libc",
  "nix",
@@ -5334,9 +5335,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a562674a44022e676a4608f29f2f7d35e71de0386148dc5bfa72765e72676684"
+checksum = "466a4335b63701b2eeb0888e66c82e034589998007ee68eceb30f75d5bc643b7"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5397,9 +5398,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_s3"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0274107867e75f151fdaaf361a15c06f24600cbe2ff5bab886be009c2f8baa27"
+checksum = "26736d14feafeb56b64b820d477fde693eebebd2738afc0549a59af13c3925f3"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -5414,9 +5415,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.27.11"
+version = "0.27.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9eda3170df19c28a7e7c42f52a0d99c68392bd985c0b7a04965f6227bb3340"
+checksum = "27e6d9e4b73759112b0560c85c3fe3c9619386ed11700daa7b068d02fcd0a766"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -5436,26 +5437,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "8.0.0"
+version = "9.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee4c0be3272cf446477be2f6f0b2d5d9d659f5338ab907cea082095a86e6ed3"
-dependencies = [
- "hex",
- "itertools 0.15.0",
- "jiff",
- "rattler_conda_types",
- "rattler_digest",
- "tempfile",
- "thiserror 2.0.19",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "rattler_solve"
-version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47428b4adefb08d4b7b915f29a3ea716f6a329b75723355ea1eb63fc0a4eaac2"
+checksum = "15139fa95d92a22fe4ba6b00ee89ed6b2375550f1c51036b202c51f771c0d29a"
 dependencies = [
  "futures",
  "hex",
@@ -5473,9 +5457,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_upload"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8490a2f8d30587498d1b00532d0800ff3e90ee26ffc463c3af7305ce3905b588"
+checksum = "600dbf4a722767b77063601174e9750aac4d64d0a9e4f20b90aa7cbe9ba14582"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-reqwest-retry",
@@ -5494,7 +5478,7 @@ dependencies = [
  "rattler_package_streaming",
  "rattler_redaction",
  "rattler_s3",
- "rattler_solve 8.0.0",
+ "rattler_solve",
  "reqwest",
  "serde",
  "serde_json",
@@ -5512,9 +5496,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "4.1.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5bb5ca36e7e3c22c77ebb49737401d1ab4dd47a40fcdab19adb4a0319767b5"
+checksum = "3fbade435086e26b977cd2e2a06afa6e5815de03c34af6b39e5a309cbc731196"
 dependencies = [
  "archspec",
  "libloading",
@@ -5524,8 +5508,11 @@ dependencies = [
  "rattler_conda_types",
  "regex",
  "serde",
+ "serde_json",
+ "tempfile",
  "thiserror 2.0.19",
  "tracing",
+ "windows-sys 0.61.2",
  "winver",
 ]
 

--- a/py-rattler-build/rust/Cargo.toml
+++ b/py-rattler-build/rust/Cargo.toml
@@ -36,16 +36,16 @@ tokio = { version = "1.53.1", features = [
   "process",
 ] }
 rattler_conda_types = "0.49"
-rattler_config = "0.6"
+rattler_config = "0.7"
 rattler_networking = { version = "0.30.3" }
 rattler_solve = "9.0"
-rattler_virtual_packages = "4.1.0"
+rattler_virtual_packages = "5.0.0"
 clap = "4.6.4"
 url = "2.5.8"
 jiff = "0.2.35"
 hex = "0.4.3"
 rattler_upload = "0.10"
-rattler_package_streaming = { version = "0.26.9", default-features = false }
+rattler_package_streaming = { version = "0.27.0", default-features = false }
 miette = "7.6.0"
 tempfile = "3.27.0"
 serde_yaml = "0.9"

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,12 +18,11 @@
 //! implicitly. They must construct a [`Config`] themselves (e.g.
 //! [`Config::default`] or [`ConfigBase::load_from_files`]) and pass it in.
 //! This keeps library use free of surprising reads of the user's global
-//! pixi/rattler-build configuration; the embedding application stays in full
-//! control of where configuration comes from.
-
-use std::path::PathBuf;
+//! shared/rattler-build configuration; the embedding application stays in
+//! full control of where configuration comes from.
 
 use rattler_config::config::{ConfigBase, LoadError, MergeError};
+use rattler_config::locations::ConfigLocation;
 
 /// rattler-build specific configuration keys.
 /// Extend this struct to add configuration that only makes sense for
@@ -45,31 +44,32 @@ impl rattler_config::config::Config for RattlerBuildConfig {
 /// other rattler based tools, extended with rattler-build specific keys.
 pub type Config = ConfigBase<RattlerBuildConfig>;
 
-/// The tools whose configuration `rattler-build` reads, in ascending order of
-/// precedence: pixi's configuration is picked up automatically and can be
-/// overridden by rattler-build specific files.
-const CONFIG_TOOLS: &[&str] = &["pixi", "rattler-build"];
-
 /// All default configuration file locations, in ascending order of precedence
 /// (values from later files override values from earlier files).
 ///
 /// This is a thin wrapper around
 /// [`rattler_config::locations::config_search_paths`], the shared discovery
-/// logic used by all rattler based tools. For the tools
-/// `["pixi", "rattler-build"]` it yields, lowest precedence first:
+/// logic used by all rattler based tools. It yields, lowest precedence first:
 ///
-/// 1. the system-wide configuration of every tool
-///    (`/etc/pixi/config.toml`, `/etc/rattler-build/config.toml`, or the
-///    `C:\ProgramData\<tool>\config.toml` equivalents on Windows),
-/// 2. the per-user configuration of every tool: the platform config directory
-///    (`$XDG_CONFIG_HOME/<tool>/config.toml`) followed by the tool home
-///    (`$PIXI_HOME` / `$RATTLER_BUILD_HOME`, defaulting to `~/.pixi` /
+/// 1. the system-wide shared configuration (`/etc/rattler/config.toml`, or
+///    the `C:\ProgramData\rattler\config.toml` equivalent on Windows),
+/// 2. the system-wide rattler-build configuration
+///    (`/etc/rattler-build/config.toml`),
+/// 3. the per-user shared configuration
+///    (`$XDG_CONFIG_HOME/rattler/config.toml`, plus
+///    `$RATTLER_HOME/config.toml` when the variable is set),
+/// 4. the per-user rattler-build configuration: the platform config
+///    directory (`$XDG_CONFIG_HOME/rattler-build/config.toml`) followed by
+///    the tool home (`$RATTLER_BUILD_HOME`, defaulting to
 ///    `~/.rattler-build`).
 ///
-/// Within each group the tools are ordered as listed, so rattler-build's
-/// configuration overrides pixi's.
-pub fn default_config_paths() -> Vec<PathBuf> {
-    rattler_config::locations::config_search_paths(CONFIG_TOOLS)
+/// Shared files may only contain the keys shared by all rattler based tools;
+/// tool-specific keys in them are ignored with a warning. rattler-build's
+/// own files accept the shared keys plus the [`RattlerBuildConfig`] keys.
+/// Configuration in pixi's own files (`~/.pixi/config.toml`, …) is no longer
+/// read: settings meant for every tool belong in the shared files.
+pub fn default_config_paths() -> Vec<ConfigLocation> {
+    rattler_config::locations::config_search_paths("rattler-build")
 }
 
 /// Load the configuration from the default locations (see
@@ -91,17 +91,17 @@ pub fn load_default_config() -> Result<Option<Config>, LoadError> {
     let candidates = default_config_paths();
     tracing::debug!("Configuration search paths (lowest precedence first): {candidates:?}");
 
-    let paths = candidates
+    let locations = candidates
         .into_iter()
-        .filter(|p| p.is_file())
+        .filter(|location| location.path.is_file())
         .collect::<Vec<_>>();
 
-    if paths.is_empty() {
+    if locations.is_empty() {
         tracing::debug!("No configuration file found in any default location");
         return Ok(None);
     }
 
-    Config::load_from_files(&paths).map(Some)
+    Config::load_from_locations(locations).map(Some)
 }
 
 #[cfg(test)]
@@ -111,48 +111,52 @@ mod tests {
     use std::str::FromStr;
 
     /// The `default_config_paths` wrapper must preserve the precedence
-    /// guaranteed by the shared `locations` helper (lowest precedence first):
-    /// all system-wide files come before all per-user files, and within each
-    /// group pixi's file is overridden by rattler-build's. We assert on the
-    /// positions of the paths reported by the upstream helpers rather than
-    /// depending on the real home directory.
+    /// guaranteed by the shared `locations` helper (lowest precedence
+    /// first): system shared, system rattler-build, user shared, user
+    /// rattler-build. We assert on the positions of the paths reported by
+    /// the upstream helpers rather than depending on the real home
+    /// directory.
     #[test]
     fn test_default_config_paths_ordering() {
-        use rattler_config::locations::{system_config_path, user_config_paths};
+        use rattler_config::locations::{
+            shared_system_config_path, shared_user_config_paths, system_config_path,
+            user_config_paths,
+        };
 
         let paths = default_config_paths();
-        let position = |needle: &std::path::Path| paths.iter().position(|p| p == needle);
+        let position =
+            |needle: &std::path::Path| paths.iter().position(|location| location.path == needle);
 
-        let system_pixi = system_config_path("pixi");
-        let system_rb = system_config_path("rattler-build");
-        let pos_system_pixi = position(&system_pixi).expect("system pixi config present");
-        let pos_system_rb = position(&system_rb).expect("system rattler-build config present");
+        let pos_system_shared =
+            position(&shared_system_config_path()).expect("system shared config present");
+        let pos_system_rb = position(&system_config_path("rattler-build"))
+            .expect("system rattler-build config present");
 
-        // Within the system group, rattler-build overrides pixi.
+        // Within the system group, rattler-build overrides the shared file.
         assert!(
-            pos_system_pixi < pos_system_rb,
-            "system rattler-build config must override system pixi config"
+            pos_system_shared < pos_system_rb,
+            "system rattler-build config must override system shared config"
         );
 
-        // All system-wide files come before all per-user files.
-        if let Some(first_user) = user_config_paths("pixi").first().and_then(|p| position(p)) {
+        // The per-user shared files come after all system files…
+        if let Some(first_user_shared) =
+            shared_user_config_paths().first().and_then(|p| position(p))
+        {
             assert!(
-                pos_system_rb < first_user,
-                "system configs must come before per-user configs"
+                pos_system_rb < first_user_shared,
+                "per-user shared config must override system configs"
             );
-        }
 
-        // Within the per-user group, rattler-build overrides pixi.
-        if let (Some(last_user_pixi), Some(first_user_rb)) = (
-            user_config_paths("pixi").last().and_then(|p| position(p)),
-            user_config_paths("rattler-build")
+            // …and rattler-build's own per-user files override them.
+            if let Some(first_user_rb) = user_config_paths("rattler-build")
                 .first()
-                .and_then(|p| position(p)),
-        ) {
-            assert!(
-                last_user_pixi < first_user_rb,
-                "per-user rattler-build config must override per-user pixi config"
-            );
+                .and_then(|p| position(p))
+            {
+                assert!(
+                    first_user_shared < first_user_rb,
+                    "per-user rattler-build config must override per-user shared config"
+                );
+            }
         }
     }
 


### PR DESCRIPTION
Pixi and Rattler-Build understand largely the same settings: mirrors, S3 options, default channels, and TLS. With conda/rattler#2645 there is now a shared home for these config keys: `/etc/rattler/config.toml` and `$XDG_CONFIG_HOME/rattler/config.toml`.

Rattler-Build reads the shared layer plus its own files. Pixi's config files are no longer read: they warned about every pixi-only key and leaked Pixi settings such as `default-channels` into builds. Settings meant for every tool belong in the shared files.

This now uses the released Rattler crates, including `rattler_config` 0.7.0, and no longer requires git patches.