### PR TITLE
fix: select compatible Python for downstream tests

### DIFF
--- a/crates/rattler_build_core/src/package_test/run_test.rs
+++ b/crates/rattler_build_core/src/package_test/run_test.rs
@@ -684,7 +684,20 @@ pub async fn run_test(
                         .await?
                 }
                 TestType::Python { python } => {
-                    run_python_test(&python, &pkg, &package_folder, &test_prefix, &config).await?
+                    // A downstream package's Python test matrix describes the Python
+                    // versions supported by that package in isolation. When testing it
+                    // against a specific upstream artifact, let that artifact's
+                    // dependencies select the compatible Python version instead.
+                    let apply_python_version = downstream_package.is_none();
+                    run_python_test(
+                        &python,
+                        &pkg,
+                        &package_folder,
+                        &test_prefix,
+                        &config,
+                        apply_python_version,
+                    )
+                    .await?
                 }
                 TestType::Perl { perl } => {
                     run_perl_test(&perl, &pkg, &package_folder, &test_prefix, &config).await?
@@ -729,6 +742,7 @@ async fn run_python_test(
     path: &Path,
     prefix: &Path,
     config: &TestConfiguration,
+    apply_python_version: bool,
 ) -> Result<(), TestError> {
     let pkg_id = format!(
         "{}-{}-{}",
@@ -744,7 +758,12 @@ async fn run_python_test(
     // - python_version: null -> { "": ["mypackage=xx=xx"]}
     // - python_version: 3.12 -> { "3.12": ["python=3.12", "mypackage=xx=xx"]}
     // - python_version: [3.12, 3.13] -> { "3.12": ["python=3.12", "mypackage=xx=xx"], "3.13": ["python=3.13", "mypackage=xx=xx"]}
-    let mut dependencies_map: HashMap<String, Vec<MatchSpec>> = match &python_test.python_version {
+    let python_version = if apply_python_version {
+        &python_test.python_version
+    } else {
+        &PythonVersion::None
+    };
+    let mut dependencies_map: HashMap<String, Vec<MatchSpec>> = match python_version {
         PythonVersion::Multiple(versions) => versions
             .iter()
             .map(|version| {

--- a/test-data/recipes/downstream_test/succeed.yaml
+++ b/test-data/recipes/downstream_test/succeed.yaml
@@ -4,6 +4,11 @@ outputs:
       version: 1.0.0
     build:
       string: "good"
+    requirements:
+      run:
+        # Make this artifact specific to Python 3.10 so the downstream
+        # package's full Python test matrix is not compatible with it.
+        - python 3.10.*
 
     tests:
       - script:
@@ -15,12 +20,24 @@ outputs:
       version: 1.0.0
     build:
       string: "good"
+      noarch: python
     requirements:
       host:
         - upstream-good
       run:
         - upstream-good
+        - python
 
     tests:
       - script:
           - echo "Running test in downstream package"
+      - python:
+          imports:
+            - time
+          pip_check: false
+          # A direct test of this noarch package covers both versions. During
+          # an upstream downstream-test, only the Python version compatible
+          # with that particular upstream artifact should be used.
+          python_version:
+            - 3.10.*
+            - 3.14.*

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -1465,13 +1465,17 @@ def test_noarch_flask(
 def test_downstream_test(
     rattler_build: RattlerBuild, recipes: Path, tmp_path: Path, snapshot_json
 ):
+    # The downstream noarch package's own Python test matrix includes a version
+    # incompatible with the arch-specific upstream artifact. Build both outputs
+    # first, then verify the downstream test selects the compatible version.
     rattler_build.build(
         recipes / "downstream_test/succeed.yaml",
         tmp_path,
+        extra_args=["--no-test"],
     )
 
     pkg = next(tmp_path.rglob("**/upstream-good-*"))
-    test_result = rattler_build.test(pkg, "-c", str(tmp_path))
+    test_result = rattler_build.test(pkg, "-c", str(tmp_path), "-c", "conda-forge")
 
     assert "Running downstream test for package: downstream-good" in test_result
     assert "Downstream test could not run" not in test_result


### PR DESCRIPTION
## Summary

- ignore a downstream package's declared Python test matrix when testing it against a specific upstream artifact
- let the upstream and downstream runtime dependencies select a mutually compatible Python version
- add a regression test for an arch-specific Python 3.10 upstream testing a `noarch: python` downstream whose own matrix includes Python 3.10 and 3.14

This prevents downstream tests from trying every Python version supported by the downstream package even when some versions are incompatible with the particular upstream artifact under test.

## Tests

- `cargo check -p rattler_build_core`
- `cargo test -p rattler_build_core package_test::run_test::tests --lib`
- `pixi run pytest test/end-to-end/test_simple.py::test_downstream_test -q`
- `cargo fmt --check`
