### PR TITLE
docs: Correct target package name

### DIFF
--- a/docs/snippets/recipes/r-knitr.yaml
+++ b/docs/snippets/recipes/r-knitr.yaml
@@ -42,4 +42,5 @@ about:
     Provides a general-purpose tool for dynamic report
     generation in R using Literate Programming techniques.
   license: GPL-2.0-only
+  license_file: ${{ PREFIX }}/lib/R/share/licenses/GPL-2
   repository: https://github.com/cran/knitr

--- a/docs/tutorials/r.md
+++ b/docs/tutorials/r.md
@@ -7,7 +7,7 @@ Packaging a R package is similar to packaging a Python package!
 You can use Rattler-Build to generate a starting point for your recipe from the metadata on CRAN.
 
 ```bash
-rattler-build generate-recipe cran r-knitr
+rattler-build generate-recipe cran knitr
 ```
 
 ## Building a R Package


### PR DESCRIPTION
* The target package name of `rattler-build generate-recipe cran <PACKAGE>` is the name of the package on the target R package "universe", not the name of the conda package on conda-forge (which uses the 'r-' prefix).
* Add the license file path to the `r-knitr.yaml` example.