### PR TITLE
fix: use `remove_dir_all_force` helper in `run_test.rs`

### DIFF
--- a/crates/rattler_build_core/src/package_test/run_test.rs
+++ b/crates/rattler_build_core/src/package_test/run_test.rs
@@ -47,7 +47,7 @@ use rattler_cache::validation::ValidationMode;
 
 use crate::{
     env_vars, metadata::PlatformWithVirtualPackages, render::solver::create_environment,
-    source::copy_dir::CopyDir, tool_configuration,
+    source::copy_dir::CopyDir, tool_configuration, utils::remove_dir_all_force,
 };
 
 /// Builds a `MatchSpec` that exactly matches the just-built artifact from its
@@ -722,7 +722,7 @@ pub async fn run_test(
             }
 
             if !config.keep_test_prefix {
-                fs::remove_dir_all(test_prefix)?;
+                remove_dir_all_force(&test_prefix)?;
             }
         }
 


### PR DESCRIPTION
I've been having some troubles recently which seem similar to https://github.com/prefix-dev/rattler-build/issues/2657. Claude Opus 5 reckoned this might be a fix.