### PR TITLE
chore: release 0.73.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.73.0] - 2026-08-13
+### ✨ Highlights
+
+This release improves downstream-test reliability by selecting compatible Python builds, preserves executable-relative macOS rpaths, and makes test cleanup more robust. It also migrates the documentation toolchain from MkDocs to Zensical and corrects a documented target package name.
+
+### Documentation
+
+- Switch from mkdocs to zensical by @Hofer-Julian in [#2720](https://github.com/prefix-dev/rattler-build/pull/2720)
+- Correct target package name by @matthewfeickert in [#2726](https://github.com/prefix-dev/rattler-build/pull/2726)
+
+
+### Fixed
+
+- Preserve executable-relative macOS rpaths by @wolfv in [#2718](https://github.com/prefix-dev/rattler-build/pull/2718)
+- Select compatible Python for downstream tests by @wolfv in [#2725](https://github.com/prefix-dev/rattler-build/pull/2725)
+- Use `remove_dir_all_force` helper in `run_test.rs` by @lucascolley in [#2729](https://github.com/prefix-dev/rattler-build/pull/2729)
+
+
+
 ## [0.72.2] - 2026-07-31
 ### ✨ Highlights
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4793,7 +4793,7 @@ dependencies = [
 
 [[package]]
 name = "rattler-build"
-version = "0.72.2"
+version = "0.73.0"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler-build"
-version = "0.72.2"
+version = "0.73.0"
 authors = ["rattler-build contributors <hi@prefix.dev>"]
 repository = "https://github.com/prefix-dev/rattler-build"
 edition = "2024"

--- a/py-rattler-build/pyproject.toml
+++ b/py-rattler-build/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "py-rattler-build"
-version = "0.72.2"
+version = "0.73.0"
 requires-python = ">=3.10"
 description = "The fastest way to build conda packages programatically"
 readme = "README.md"

--- a/py-rattler-build/rust/Cargo.lock
+++ b/py-rattler-build/rust/Cargo.lock
@@ -4261,7 +4261,7 @@ dependencies = [
 
 [[package]]
 name = "py-rattler-build"
-version = "0.72.2"
+version = "0.73.0"
 dependencies = [
  "clap",
  "fs-err",
@@ -4625,7 +4625,7 @@ dependencies = [
 
 [[package]]
 name = "rattler-build"
-version = "0.72.2"
+version = "0.73.0"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",

--- a/py-rattler-build/rust/Cargo.toml
+++ b/py-rattler-build/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-rattler-build"
-version = "0.72.2"
+version = "0.73.0"
 edition = "2024"
 license = "BSD-3-Clause"
 publish = false

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/prefix-dev/rattler-build"
 
 [version]
-current = "0.72.2"
+current = "0.73.0"
 
 # Example of a semver regexp.
 # Make sure this matches current_version before


### PR DESCRIPTION
## [0.73.0] - 2026-08-13
### ✨ Highlights

This release improves downstream-test reliability by selecting compatible Python builds, preserves executable-relative macOS rpaths, and makes test cleanup more robust. It also migrates the documentation toolchain from MkDocs to Zensical and corrects a documented target package name.

### Documentation

- Switch from mkdocs to zensical by @Hofer-Julian in [#2720](https://github.com/prefix-dev/rattler-build/pull/2720)
- Correct target package name by @matthewfeickert in [#2726](https://github.com/prefix-dev/rattler-build/pull/2726)


### Fixed

- Preserve executable-relative macOS rpaths by @wolfv in [#2718](https://github.com/prefix-dev/rattler-build/pull/2718)
- Select compatible Python for downstream tests by @wolfv in [#2725](https://github.com/prefix-dev/rattler-build/pull/2725)
- Use `remove_dir_all_force` helper in `run_test.rs` by @lucascolley in [#2729](https://github.com/prefix-dev/rattler-build/pull/2729)