### PR TITLE
fix: disable trusted signing dependency cache

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -178,6 +178,9 @@ jobs:
           file-digest: SHA256
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
           timestamp-digest: SHA256
+          # Avoid stale/corrupt PowerShell module caches. A cache hit skips the
+          # install even when Invoke-ArtifactSigning is unavailable.
+          cache-dependencies: false
 
       - name: Copy signed Windows binary back
         if: contains(matrix.target, 'pc-windows')


### PR DESCRIPTION
The 0.73.0 release workflow restored the `ArtifactSigning-0.1.8` cache and consequently skipped installing the PowerShell module, but `Invoke-ArtifactSigning` was unavailable.

Disable dependency caching for the Azure signing action so it installs a fresh module. This also follows Azure's pending security hardening to disable executable dependency caches by default (Azure/artifact-signing-action#152).

After merging, rerun the Release artifacts workflow.