### PR TITLE
ci: publish source archive for releases

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -248,8 +248,11 @@ jobs:
     permissions:
       contents: write
     steps:
+      # Check out the tagged tree so CHANGELOG.md and the source archive match
+      # the release exactly.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ needs.prepare.outputs.tag }}
           fetch-depth: 0
           persist-credentials: false
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0

--- a/scripts/create_release.py
+++ b/scripts/create_release.py
@@ -8,6 +8,7 @@ Usage:
 """
 
 import argparse
+import hashlib
 import re
 import subprocess
 import sys
@@ -19,6 +20,35 @@ ROOT = Path(__file__).resolve().parent.parent
 def run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
     print(f"  → {' '.join(cmd)}")
     return subprocess.run(cmd, check=True, text=True, **kwargs)
+
+
+def sha256(path: Path) -> str:
+    """Compute the SHA-256 digest of a file."""
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def build_source_archive(tag: str, assets_dir: Path) -> None:
+    """Create a source archive and checksum from the tagged tree."""
+    archive = assets_dir / "source.tar.gz"
+    run(
+        [
+            "git",
+            "archive",
+            "--format=tar.gz",
+            f"--prefix=rattler-build-{tag.lstrip('v')}/",
+            "--output",
+            str(archive),
+            tag,
+        ],
+        cwd=ROOT,
+    )
+    (assets_dir / "source.tar.gz.sha256").write_text(
+        f"{sha256(archive)}  {archive.name}\n"
+    )
 
 
 def get_changelog(version: str) -> str:
@@ -48,6 +78,10 @@ def main() -> None:
 
     tag: str = args.tag
     assets_dir: Path = args.assets_dir
+
+    # GitHub's automatically generated source archives are not covered by
+    # immutable release attestations, so publish our own archive from the tag.
+    build_source_archive(tag, assets_dir)
 
     # Aggregate all per-asset .sha256 files into a single sha256.sum
     aggregate = assets_dir / "sha256.sum"


### PR DESCRIPTION
## Summary

- build `source.tar.gz` directly from the newly created release tag, matching Pixi’s release implementation
- use a versioned `rattler-build-<version>/` top-level directory
- publish `source.tar.gz.sha256` and include it in the aggregate `sha256.sum`
- check out the tagged tree when creating the release so the changelog and source archive match exactly

GitHub’s automatically generated source archives are not included in immutable release attestations, while this explicit release asset is.