### PR TITLE
fix: decode build output lossily instead of failing on non-UTF-8

### DIFF
--- a/crates/rattler_build_script/src/execution.rs
+++ b/crates/rattler_build_script/src/execution.rs
@@ -10,7 +10,7 @@ use crate::{
     execution_context::ExecutionContext, runner::resolve_process_env, runtime::RuntimeEnv,
 };
 use fs_err as fs;
-use futures::TryStreamExt;
+use futures::{StreamExt, TryStreamExt};
 use indexmap::IndexMap;
 use rattler_shell::shell::Shell;
 use serde::{Deserialize, Serialize};
@@ -21,8 +21,8 @@ use std::fmt;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWriteExt};
-use tokio_util::bytes::BytesMut;
+use tokio::io::{AsyncRead, AsyncWriteExt};
+use tokio_util::bytes::{Buf, BytesMut};
 use tokio_util::codec::{Decoder, FramedRead};
 use tokio_util::compat::FuturesAsyncReadCompatExt;
 
@@ -386,7 +386,7 @@ pub(crate) struct OutputLine {
     pub(crate) is_stderr: bool,
 }
 
-type NormalizedLines = tokio::io::Lines<tokio::io::BufReader<Box<dyn AsyncRead + Send + Unpin>>>;
+type NormalizedLines = FramedRead<Box<dyn AsyncRead + Send + Unpin>, LossyLineDecoder>;
 
 /// A spawned script process streaming CRLF-normalized output lines.
 pub(crate) struct SpawnedProcess {
@@ -429,8 +429,8 @@ pub(crate) fn spawn_process(
 
     Ok(SpawnedProcess {
         child,
-        stdout: tokio::io::BufReader::new(stdout).lines(),
-        stderr: tokio::io::BufReader::new(stderr).lines(),
+        stdout: FramedRead::new(stdout, LossyLineDecoder),
+        stderr: FramedRead::new(stderr, LossyLineDecoder),
         stdout_closed: false,
         stderr_closed: false,
     })
@@ -441,15 +441,15 @@ impl SpawnedProcess {
     pub(crate) async fn next_line(&mut self) -> Option<io::Result<OutputLine>> {
         loop {
             tokio::select! {
-                line = self.stdout.next_line(), if !self.stdout_closed => match line {
-                    Ok(Some(text)) => return Some(Ok(OutputLine { text, is_stderr: false })),
-                    Ok(None) => self.stdout_closed = true,
-                    Err(error) => return Some(Err(error)),
+                line = self.stdout.next(), if !self.stdout_closed => match line {
+                    Some(Ok(text)) => return Some(Ok(OutputLine { text, is_stderr: false })),
+                    None => self.stdout_closed = true,
+                    Some(Err(error)) => return Some(Err(error)),
                 },
-                line = self.stderr.next_line(), if !self.stderr_closed => match line {
-                    Ok(Some(text)) => return Some(Ok(OutputLine { text, is_stderr: true })),
-                    Ok(None) => self.stderr_closed = true,
-                    Err(error) => return Some(Err(error)),
+                line = self.stderr.next(), if !self.stderr_closed => match line {
+                    Some(Ok(text)) => return Some(Ok(OutputLine { text, is_stderr: true })),
+                    None => self.stderr_closed = true,
+                    Some(Err(error)) => return Some(Err(error)),
                 },
                 else => return None,
             }
@@ -474,6 +474,63 @@ impl SpawnedProcess {
     /// Waits for the process to exit. Call after draining its output.
     pub(crate) async fn wait(&mut self) -> io::Result<std::process::ExitStatus> {
         self.child.wait().await
+    }
+}
+
+/// Upper bound on a single output line, in bytes.
+///
+/// A build step that writes a binary blob (or a very long line) to stdout would
+/// otherwise buffer the whole thing in memory before a newline shows up. Past
+/// this many bytes the pending buffer is emitted as a line of its own.
+const MAX_LINE_LENGTH: usize = 1024 * 1024;
+
+/// Codec that splits CRLF-normalized output into lines.
+///
+/// Build scripts are not obliged to write UTF-8: on Windows compilers and other
+/// tools emit diagnostics in the active code page, and a build can print raw
+/// bytes on purpose. Decoding is therefore lossy — invalid sequences become
+/// U+FFFD instead of failing the read, which used to abort output capture for
+/// the rest of the build with `stream did not contain valid UTF-8`.
+pub(crate) struct LossyLineDecoder;
+
+impl LossyLineDecoder {
+    /// Removes the first `length` bytes from `src` and decodes them lossily.
+    fn take_line(src: &mut BytesMut, length: usize) -> String {
+        let line = src.split_to(length);
+        String::from_utf8_lossy(&line).into_owned()
+    }
+}
+
+impl Decoder for LossyLineDecoder {
+    type Item = String;
+    type Error = io::Error;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        if let Some(index) = src.iter().position(|byte| *byte == b'\n') {
+            let line = Self::take_line(src, index);
+            // Discard the newline itself.
+            src.advance(1);
+            return Ok(Some(line));
+        }
+
+        if src.len() >= MAX_LINE_LENGTH {
+            return Ok(Some(Self::take_line(src, MAX_LINE_LENGTH)));
+        }
+
+        Ok(None)
+    }
+
+    fn decode_eof(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        if let Some(line) = self.decode(src)? {
+            return Ok(Some(line));
+        }
+
+        // Trailing bytes without a final newline still form a line.
+        if src.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(Self::take_line(src, src.len())))
+        }
     }
 }
 
@@ -928,6 +985,11 @@ pub(crate) async fn run_process_with_replacements(
             }
             Err(e) => {
                 tracing::warn!("Error reading output: {:?}", e);
+                // Drain what is left so the child does not block writing into a
+                // full pipe while we wait for it to exit.
+                if let Err(e) = process.drain_output().await {
+                    tracing::warn!("Error draining output: {:?}", e);
+                }
                 break;
             }
         }
@@ -1101,6 +1163,50 @@ mod tests {
             script.contains("if %errorlevel% neq 0 exit /b %errorlevel%"),
             "cmd section script must propagate errors between commands, got:\n{script}"
         );
+    }
+
+    /// Build tools are not obliged to write UTF-8. A single invalid byte must
+    /// not fail the read — that used to abort output capture for the remainder
+    /// of the build with `stream did not contain valid UTF-8`.
+    #[test]
+    fn test_lossy_line_decoder_replaces_invalid_utf8() {
+        let mut decoder = LossyLineDecoder;
+        // `Fehler: ung\xFCltig` — an umlaut in Windows' cp1252, invalid UTF-8.
+        let mut buffer = BytesMut::from(&b"Fehler: ung\xFCltig\nnext line\n"[..]);
+
+        assert_eq!(
+            decoder.decode(&mut buffer).unwrap().unwrap(),
+            "Fehler: ung\u{FFFD}ltig"
+        );
+        // Output after the undecodable line keeps flowing.
+        assert_eq!(decoder.decode(&mut buffer).unwrap().unwrap(), "next line");
+        assert!(decoder.decode(&mut buffer).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_lossy_line_decoder_splits_lines() {
+        let mut decoder = LossyLineDecoder;
+        let mut buffer = BytesMut::from("line1\n\nline2");
+
+        assert_eq!(decoder.decode(&mut buffer).unwrap().unwrap(), "line1");
+        assert_eq!(decoder.decode(&mut buffer).unwrap().unwrap(), "");
+        // No newline yet, so `line2` is still pending.
+        assert!(decoder.decode(&mut buffer).unwrap().is_none());
+        // ... and is flushed as a line of its own at EOF.
+        assert_eq!(decoder.decode_eof(&mut buffer).unwrap().unwrap(), "line2");
+        assert!(decoder.decode_eof(&mut buffer).unwrap().is_none());
+    }
+
+    /// A process writing a binary blob without newlines must not buffer
+    /// unboundedly.
+    #[test]
+    fn test_lossy_line_decoder_caps_line_length() {
+        let mut decoder = LossyLineDecoder;
+        let mut buffer = BytesMut::from(vec![b'a'; MAX_LINE_LENGTH + 8].as_slice());
+
+        let line = decoder.decode(&mut buffer).unwrap().unwrap();
+        assert_eq!(line.len(), MAX_LINE_LENGTH);
+        assert_eq!(buffer.len(), 8);
     }
 
     #[test]

--- a/crates/rattler_build_script/src/runner/local.rs
+++ b/crates/rattler_build_script/src/runner/local.rs
@@ -315,9 +315,12 @@ mod tests {
         );
     }
 
+    /// Non-UTF-8 output — Windows tools writing in the active code page, or a
+    /// build printing raw bytes — must not abort output capture for the rest of
+    /// the script.
     #[cfg(unix)]
     #[tokio::test]
-    async fn output_decode_error_preserves_exit_status() {
+    async fn invalid_utf8_output_is_decoded_lossily() {
         let temp_dir = tempfile::tempdir().unwrap();
         let runner = LocalRunner::new(EnvironmentIsolation::None);
         let mut session = start_local_session(&runner, temp_dir.path()).await;
@@ -327,7 +330,7 @@ mod tests {
             std::time::Duration::from_secs(10),
             session.exec(
                 ExecSpec {
-                    argv: shell_command("printf '\\377\\n'; head -c 1048576 /dev/zero"),
+                    argv: shell_command("printf 'before\\n\\377\\nafter\\n'; exit 7"),
                     cwd: GuestPath(temp_dir.path().to_path_buf()),
                     env: IndexMap::new(),
                 },
@@ -335,11 +338,17 @@ mod tests {
             ),
         )
         .await
-        .expect("draining invalid output must not hang")
+        .expect("reading invalid output must not hang")
         .unwrap();
 
-        assert!(status.success());
-        assert!(sink.0.is_empty());
+        assert_eq!(status.code, Some(7));
+        let stdout = sink
+            .0
+            .iter()
+            .filter(|(stream, _)| *stream == OutputStream::Stdout)
+            .map(|(_, line)| line.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(stdout, vec!["before", "\u{FFFD}", "after"]);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
Replace the standard `BufReader::lines()` implementation with a custom `LossyLineDecoder` that handles non-UTF-8 output gracefully and prevents unbounded buffering of long lines without newlines.

## Key Changes
- **Custom Decoder Implementation**: Introduced `LossyLineDecoder` struct implementing `tokio_util::codec::Decoder` that:
  - Decodes output lossily using `String::from_utf8_lossy()` instead of failing on invalid UTF-8
  - Caps individual line length at 1MB to prevent unbounded memory usage when processing binary blobs or very long lines
  - Properly handles trailing bytes without final newlines via `decode_eof()`

- **Output Stream Refactoring**: 
  - Changed `NormalizedLines` type from `tokio::io::Lines<BufReader<...>>` to `FramedRead<..., LossyLineDecoder>`
  - Updated `spawn_process()` to use `FramedRead::new()` with the custom decoder instead of `BufReader::lines()`
  - Updated `next_line()` to use `StreamExt::next()` instead of `AsyncBufReadExt::next_line()`

- **Error Handling**: Added output draining in `run_process_with_replacements()` when read errors occur to prevent child processes from blocking on full pipes

- **Import Updates**: Added `StreamExt` and `Buf` imports to support the new implementation

- **Test Coverage**: Added three comprehensive tests for the new decoder:
  - `test_lossy_line_decoder_replaces_invalid_utf8()`: Validates lossy UTF-8 decoding
  - `test_lossy_line_decoder_splits_lines()`: Validates line splitting and EOF handling
  - `test_lossy_line_decoder_caps_line_length()`: Validates unbounded buffering prevention
  - Updated `invalid_utf8_output_is_decoded_lossily()` test to verify non-UTF-8 output is captured and decoded lossily rather than aborting

## Notable Details
- The decoder replaces invalid UTF-8 sequences with U+FFFD (replacement character) instead of failing, preventing output capture from aborting mid-build
- The 1MB line length cap prevents memory exhaustion when build tools write binary data or extremely long lines without newlines
- The implementation maintains backward compatibility with the existing output line interface while improving robustness

https://claude.ai/code/session_0147QS7TpW1m5ehTFGu754ot