### PR TITLE
feat: add system requirements and packaged variant pinnings

### DIFF
--- a/crates/rattler_build_recipe/src/stage0/evaluate.rs
+++ b/crates/rattler_build_recipe/src/stage0/evaluate.rs
@@ -2866,6 +2866,53 @@ fn evaluate_post_process_item(
     }
 }
 
+fn evaluate_system_requirements(
+    requirements: &crate::stage0::SystemRequirements,
+    context: &EvaluationContext,
+) -> Result<crate::stage1::SystemRequirements, ParseError> {
+    let evaluate = |value: &Option<crate::stage0::Value<String>>| {
+        value
+            .as_ref()
+            .map(|value| evaluate_string_value(value, context))
+            .transpose()
+    };
+    Ok(crate::stage1::SystemRequirements {
+        linux: evaluate(&requirements.linux)?,
+        macos: evaluate(&requirements.macos)?,
+        cuda: evaluate(&requirements.cuda)?,
+        libc: evaluate(&requirements.libc)?,
+        glibc: evaluate(&requirements.glibc)?,
+        archspec: evaluate(&requirements.archspec)?,
+    })
+}
+
+fn add_system_requirements(
+    system: &crate::stage1::SystemRequirements,
+    requirements: &mut crate::stage1::Requirements,
+) -> Result<(), ParseError> {
+    for (name, version) in [
+        ("__linux", system.linux.as_ref()),
+        ("__osx", system.macos.as_ref()),
+        ("__cuda", system.cuda.as_ref()),
+        ("__glibc", system.glibc.as_ref().or(system.libc.as_ref())),
+    ] {
+        if let Some(version) = version {
+            let spec = MatchSpec::from_str(&format!("{name} >={version}"), ParseStrictness::Strict)
+                .map_err(|error| {
+                    ParseError::invalid_value(
+                        "system_requirements",
+                        error.to_string(),
+                        Span::new_blank(),
+                    )
+                })?;
+            requirements
+                .run
+                .push(crate::stage1::Dependency::Spec(Box::new(spec)));
+        }
+    }
+    Ok(())
+}
+
 impl Evaluate for Stage0Recipe {
     type Output = Stage1Recipe;
 
@@ -2901,7 +2948,10 @@ impl Evaluate for Stage0Recipe {
         let package = self.package.evaluate(&context_with_vars)?;
         let build = self.build.evaluate(&context_with_vars)?;
         let about = self.about.evaluate(&context_with_vars)?;
-        let requirements = self.requirements.evaluate(&context_with_vars)?;
+        let mut requirements = self.requirements.evaluate(&context_with_vars)?;
+        let system_requirements =
+            evaluate_system_requirements(&self.system_requirements, &context_with_vars)?;
+        add_system_requirements(&system_requirements, &mut requirements)?;
         let extra = self.extra.evaluate(&context_with_vars)?;
 
         // Evaluate source list (conditionals expand to multiple sources)
@@ -3023,7 +3073,7 @@ impl Evaluate for Stage0Recipe {
         // added to the variant (which happens in variant_render.rs after evaluation).
         // The build string will remain unresolved until finalize_build_strings() is called.
 
-        Ok(Stage1Recipe::new(
+        let mut recipe = Stage1Recipe::new(
             package,
             build,
             about,
@@ -3033,7 +3083,9 @@ impl Evaluate for Stage0Recipe {
             tests,
             evaluated_context,
             actual_variant,
-        ))
+        );
+        recipe.system_requirements = system_requirements;
+        Ok(recipe)
     }
 }
 
@@ -3322,8 +3374,11 @@ fn evaluate_package_output_to_recipe(
         merge_stage1_about(toplevel_about, output_about)
     };
 
-    // Evaluate requirements
-    let requirements = output.requirements.evaluate(context)?;
+    // Evaluate requirements and materialize system requirements as virtual
+    // package run dependencies.
+    let mut requirements = output.requirements.evaluate(context)?;
+    let system_requirements = evaluate_system_requirements(&output.system_requirements, context)?;
+    add_system_requirements(&system_requirements, &mut requirements)?;
 
     // Use recipe-level extra (outputs don't have their own extra)
     let extra = recipe.extra.evaluate(context)?;
@@ -3454,7 +3509,7 @@ fn evaluate_package_output_to_recipe(
     // added to the variant (which happens in variant_render.rs after evaluation).
     // The build string will remain unresolved until finalize_build_strings() is called.
 
-    Ok(Some(Stage1Recipe::new(
+    let mut recipe = Stage1Recipe::new(
         package,
         build,
         about,
@@ -3464,7 +3519,9 @@ fn evaluate_package_output_to_recipe(
         tests,
         resolved_context,
         actual_variant,
-    )))
+    );
+    recipe.system_requirements = system_requirements;
+    Ok(Some(recipe))
 }
 
 /// Implement Evaluate for MultiOutputRecipe
@@ -6425,6 +6482,31 @@ package:
         let merged = merge_stage1_build(toplevel, output);
 
         assert_eq!(merged.plan.steps().map(<[_]>::len), Some(0));
+    }
+
+    #[test]
+    fn test_system_requirements_become_virtual_run_dependencies() {
+        let recipe = crate::stage0::parse_recipe_from_source(
+            r#"
+package:
+  name: system-package
+  version: 1.0
+system_requirements:
+  glibc: "2.37"
+  cuda: "12"
+"#,
+        )
+        .unwrap();
+        let evaluated = recipe.evaluate(&EvaluationContext::new()).unwrap();
+        let specs = evaluated
+            .requirements
+            .run
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>();
+        assert!(specs.iter().any(|spec| spec == "__glibc >=2.37"));
+        assert!(specs.iter().any(|spec| spec == "__cuda >=12"));
+        assert_eq!(evaluated.system_requirements.glibc.as_deref(), Some("2.37"));
     }
 
     #[test]

--- a/crates/rattler_build_recipe/src/stage0/evaluate.rs
+++ b/crates/rattler_build_recipe/src/stage0/evaluate.rs
@@ -2889,13 +2889,25 @@ fn evaluate_system_requirements(
 fn add_system_requirements(
     system: &crate::stage1::SystemRequirements,
     requirements: &mut crate::stage1::Requirements,
+    target_platform: rattler_conda_types::Platform,
 ) -> Result<(), ParseError> {
+    let applicable = |name| match name {
+        "__linux" | "__glibc" => target_platform.is_linux(),
+        "__osx" => target_platform.is_osx(),
+        // macOS has not supported CUDA since 2019. Pixi likewise permits CUDA
+        // requirements on Linux and Windows, but filters them from macOS.
+        "__cuda" => !target_platform.is_osx(),
+        _ => true,
+    };
     for (name, version) in [
         ("__linux", system.linux.as_ref()),
         ("__osx", system.macos.as_ref()),
         ("__cuda", system.cuda.as_ref()),
         ("__glibc", system.glibc.as_ref().or(system.libc.as_ref())),
     ] {
+        if !applicable(name) {
+            continue;
+        }
         if let Some(version) = version {
             let spec = MatchSpec::from_str(&format!("{name} >={version}"), ParseStrictness::Strict)
                 .map_err(|error| {
@@ -2951,7 +2963,11 @@ impl Evaluate for Stage0Recipe {
         let mut requirements = self.requirements.evaluate(&context_with_vars)?;
         let system_requirements =
             evaluate_system_requirements(&self.system_requirements, &context_with_vars)?;
-        add_system_requirements(&system_requirements, &mut requirements)?;
+        add_system_requirements(
+            &system_requirements,
+            &mut requirements,
+            context_with_vars.jinja_config().target_platform,
+        )?;
         let extra = self.extra.evaluate(&context_with_vars)?;
 
         // Evaluate source list (conditionals expand to multiple sources)
@@ -3378,7 +3394,11 @@ fn evaluate_package_output_to_recipe(
     // package run dependencies.
     let mut requirements = output.requirements.evaluate(context)?;
     let system_requirements = evaluate_system_requirements(&output.system_requirements, context)?;
-    add_system_requirements(&system_requirements, &mut requirements)?;
+    add_system_requirements(
+        &system_requirements,
+        &mut requirements,
+        context.jinja_config().target_platform,
+    )?;
 
     // Use recipe-level extra (outputs don't have their own extra)
     let extra = recipe.extra.evaluate(context)?;
@@ -6497,7 +6517,11 @@ system_requirements:
 "#,
         )
         .unwrap();
-        let evaluated = recipe.evaluate(&EvaluationContext::new()).unwrap();
+        let evaluated = recipe
+            .evaluate(&EvaluationContext::for_platform(
+                rattler_conda_types::Platform::Linux64,
+            ))
+            .unwrap();
         let specs = evaluated
             .requirements
             .run
@@ -6507,6 +6531,38 @@ system_requirements:
         assert!(specs.iter().any(|spec| spec == "__glibc >=2.37"));
         assert!(specs.iter().any(|spec| spec == "__cuda >=12"));
         assert_eq!(evaluated.system_requirements.glibc.as_deref(), Some("2.37"));
+    }
+
+    #[test]
+    fn test_system_requirements_are_filtered_for_the_output_platform() {
+        let recipe = crate::stage0::parse_recipe_from_source(
+            r#"
+package:
+  name: system-package
+  version: 1.0
+system_requirements:
+  linux: "5.10"
+  glibc: "2.37"
+  macos: "13"
+  cuda: "12"
+"#,
+        )
+        .unwrap();
+        let evaluated = recipe
+            .evaluate(&EvaluationContext::for_platform(
+                rattler_conda_types::Platform::OsxArm64,
+            ))
+            .unwrap();
+        let specs = evaluated
+            .requirements
+            .run
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>();
+        assert_eq!(specs, ["__osx >=13"]);
+        // Inapplicable values remain available as rendered metadata.
+        assert_eq!(evaluated.system_requirements.linux.as_deref(), Some("5.10"));
+        assert_eq!(evaluated.system_requirements.cuda.as_deref(), Some("12"));
     }
 
     #[test]

--- a/crates/rattler_build_recipe/src/stage0/mod.rs
+++ b/crates/rattler_build_recipe/src/stage0/mod.rs
@@ -11,6 +11,7 @@ mod package;
 mod parser;
 mod requirements;
 pub mod source;
+mod system_requirements;
 mod tests;
 mod types;
 
@@ -31,6 +32,7 @@ pub use parser::{
 };
 pub use requirements::Requirements;
 pub use source::Source;
+pub use system_requirements::SystemRequirements;
 pub use tests::{PythonVersion, TestType};
 pub use types::{
     Conditional, ConditionalList, ConditionalListOrItem, IncludeExclude, Item, JinjaExpression,

--- a/crates/rattler_build_recipe/src/stage0/output.rs
+++ b/crates/rattler_build_recipe/src/stage0/output.rs
@@ -12,6 +12,7 @@ use crate::stage0::{
     package::{Package, PackageMetadata},
     requirements::Requirements,
     source::Source,
+    system_requirements::SystemRequirements,
     tests::TestType,
     types::{ConditionalList, Item, Value},
 };
@@ -40,6 +41,9 @@ pub struct SingleOutputRecipe {
     pub package: Package,
     pub build: Build,
     pub requirements: Requirements,
+    /// Minimum system requirements for consumers of this output.
+    #[serde(default, skip_serializing_if = "SystemRequirements::is_empty")]
+    pub system_requirements: SystemRequirements,
     pub about: About,
     pub extra: crate::stage0::extra::Extra,
     #[serde(default, skip_serializing_if = "ConditionalList::is_empty")]
@@ -167,6 +171,10 @@ pub struct PackageOutput {
     #[serde(default)]
     pub requirements: Requirements,
 
+    /// Minimum system requirements for consumers of this output.
+    #[serde(default, skip_serializing_if = "SystemRequirements::is_empty")]
+    pub system_requirements: SystemRequirements,
+
     /// Build configuration for this output
     #[serde(default)]
     pub build: Build,
@@ -252,6 +260,7 @@ impl SingleOutputRecipe {
             package,
             build: Build::default(),
             requirements: Requirements::default(),
+            system_requirements: SystemRequirements::default(),
             about: About::default(),
             extra: crate::stage0::extra::Extra::default(),
             source: ConditionalList::default(),
@@ -267,6 +276,7 @@ impl SingleOutputRecipe {
             package,
             build,
             requirements,
+            system_requirements,
             about,
             extra,
             source,
@@ -276,6 +286,7 @@ impl SingleOutputRecipe {
         let mut vars = package.used_variables();
         vars.extend(build.used_variables());
         vars.extend(requirements.used_variables());
+        vars.extend(system_requirements.used_variables());
         vars.extend(about.used_variables());
         vars.extend(extra.used_variables());
         for src_item in source {
@@ -465,6 +476,7 @@ impl PackageOutput {
             inherit,
             source,
             requirements,
+            system_requirements,
             build,
             about,
             tests,
@@ -476,6 +488,7 @@ impl PackageOutput {
             vars.extend(collect_source_item_variables(src_item));
         }
         vars.extend(requirements.used_variables());
+        vars.extend(system_requirements.used_variables());
         vars.extend(build.used_variables());
         vars.extend(about.used_variables());
         for test_item in tests {

--- a/crates/rattler_build_recipe/src/stage0/parser/mod.rs
+++ b/crates/rattler_build_recipe/src/stage0/parser/mod.rs
@@ -26,7 +26,8 @@ mod unit_tests;
 use marked_yaml::{Node as MarkedNode, types::MarkedScalarNode};
 use rattler_build_jinja::Variable;
 use rattler_build_yaml_parser::{
-    ParseError, ParseResult, helpers::contains_jinja_template, parse_yaml, yaml::load_error_span,
+    ParseError, ParseResult, helpers::contains_jinja_template, parse_value_with_name, parse_yaml,
+    yaml::load_error_span,
 };
 use rattler_conda_types::RepodataRevision;
 
@@ -229,6 +230,12 @@ fn parse_single_output_recipe_with_config(
         crate::stage0::Requirements::default()
     };
 
+    let system_requirements = if let Some(node) = mapping.get("system_requirements") {
+        parse_system_requirements(node)?
+    } else {
+        crate::stage0::SystemRequirements::default()
+    };
+
     let extra = if let Some(extra_node) = mapping.get("extra") {
         parse_extra(extra_node)?
     } else {
@@ -259,6 +266,7 @@ fn parse_single_output_recipe_with_config(
                 | "build"
                 | "about"
                 | "requirements"
+                | "system_requirements"
                 | "extra"
                 | "source"
                 | "tests"
@@ -270,7 +278,7 @@ fn parse_single_output_recipe_with_config(
                 format!("unknown top-level field '{}'", key_str),
                 *key.span(),
             )
-            .with_suggestion("valid top-level fields are: package, build, about, requirements, extra, source, tests, schema_version, context"));
+            .with_suggestion("valid top-level fields are: package, build, about, requirements, system_requirements, extra, source, tests, schema_version, context"));
         }
     }
 
@@ -281,10 +289,55 @@ fn parse_single_output_recipe_with_config(
         build,
         about,
         requirements,
+        system_requirements,
         extra,
         source,
         tests,
     })
+}
+
+pub(crate) fn parse_system_requirements(
+    yaml: &MarkedNode,
+) -> ParseResult<crate::stage0::SystemRequirements> {
+    let mapping = yaml.as_mapping().ok_or_else(|| {
+        ParseError::expected_type("mapping", "non-mapping", helpers::get_span(yaml))
+            .with_message("system_requirements must be a mapping")
+    })?;
+    let parse = |key: &'static str| {
+        mapping
+            .get(key)
+            .map(|node| parse_value_with_name(node, key))
+            .transpose()
+    };
+    let requirements = crate::stage0::SystemRequirements {
+        linux: parse("linux")?,
+        macos: parse("macos")?,
+        cuda: parse("cuda")?,
+        libc: parse("libc")?,
+        glibc: parse("glibc")?,
+        archspec: parse("archspec")?,
+    };
+    if requirements.libc.is_some() && requirements.glibc.is_some() {
+        return Err(ParseError::invalid_value(
+            "system_requirements",
+            "`libc` and its `glibc` alias cannot both be specified",
+            helpers::get_span(yaml),
+        ));
+    }
+    for (key, _) in mapping.iter() {
+        if !matches!(
+            key.as_str(),
+            "linux" | "macos" | "cuda" | "libc" | "glibc" | "archspec"
+        ) {
+            return Err(ParseError::invalid_value(
+                "system_requirements",
+                format!("unknown system requirement `{}`", key.as_str()),
+                *key.span(),
+            )
+            .with_suggestion("Valid keys are: linux, macos, cuda, libc, glibc, archspec"));
+        }
+    }
+    Ok(requirements)
 }
 
 /// Parse the context section from YAML

--- a/crates/rattler_build_recipe/src/stage0/parser/output_parser.rs
+++ b/crates/rattler_build_recipe/src/stage0/parser/output_parser.rs
@@ -14,7 +14,8 @@ use crate::{
             StagingBuild, StagingMetadata, StagingOutput,
         },
         parser::{
-            ParseConfig, get_span, parse_about, parse_build, parse_extra, parse_source, parse_tests,
+            ParseConfig, get_span, parse_about, parse_build, parse_extra, parse_source,
+            parse_system_requirements, parse_tests,
         },
     },
 };
@@ -472,6 +473,12 @@ fn parse_package_output(
         crate::stage0::Requirements::default()
     };
 
+    let system_requirements = if let Some(node) = mapping.get("system_requirements") {
+        parse_system_requirements(node)?
+    } else {
+        crate::stage0::SystemRequirements::default()
+    };
+
     // Parse optional build
     let build = if let Some(build_node) = mapping.get("build") {
         parse_build(build_node)?
@@ -502,6 +509,7 @@ fn parse_package_output(
             "inherit",
             "source",
             "requirements",
+            "system_requirements",
             "build",
             "about",
             "tests",
@@ -513,6 +521,7 @@ fn parse_package_output(
         inherit,
         source,
         requirements,
+        system_requirements,
         build,
         about,
         tests,

--- a/crates/rattler_build_recipe/src/stage0/parser/recipe_tests.rs
+++ b/crates/rattler_build_recipe/src/stage0/parser/recipe_tests.rs
@@ -25,6 +25,30 @@ package:
 }
 
 #[test]
+fn test_parse_system_requirements() {
+    let recipe = parse_recipe_from_source(
+        r#"
+package:
+  name: system-package
+  version: 1.0
+system_requirements:
+  glibc: "2.37"
+  linux: "5.10"
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        recipe.system_requirements.glibc.unwrap().into_concrete(),
+        Some("2.37".to_string())
+    );
+    assert_eq!(
+        recipe.system_requirements.linux.unwrap().into_concrete(),
+        Some("5.10".to_string())
+    );
+}
+
+#[test]
 fn test_parse_full_recipe() {
     let yaml_str = r#"
 package:

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__error_tests__error_unknown_top_level_field.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__error_tests__error_unknown_top_level_field.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rattler_build_recipe/src/stage0/parser/error_tests.rs
+assertion_line: 87
 expression: error_with_source
 ---
   × invalid value for 'recipe': unknown top-level field 'unknown_section'
@@ -11,4 +12,4 @@ expression: error_with_source
  9 │   some_field: some_value
    ╰────
   help: valid top-level fields are: package, build, about, requirements,
-        extra, source, tests, schema_version, context
+        system_requirements, extra, source, tests, schema_version, context

--- a/crates/rattler_build_recipe/src/stage0/system_requirements.rs
+++ b/crates/rattler_build_recipe/src/stage0/system_requirements.rs
@@ -1,0 +1,62 @@
+use serde::{Deserialize, Serialize};
+
+use super::Value;
+
+/// Minimum virtual-package versions required by a package output.
+///
+/// Keys mirror Pixi's system requirements. `glibc` is accepted as a convenient
+/// alias for Pixi's scalar `libc` form.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct SystemRequirements {
+    /// Minimum Linux kernel version.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub linux: Option<Value<String>>,
+    /// Minimum macOS version.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub macos: Option<Value<String>>,
+    /// Minimum CUDA driver version.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cuda: Option<Value<String>>,
+    /// Minimum libc version (Pixi scalar form, which means glibc).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub libc: Option<Value<String>>,
+    /// Minimum glibc version; an alias for scalar `libc`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub glibc: Option<Value<String>>,
+    /// Required architecture specification.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub archspec: Option<Value<String>>,
+}
+
+impl SystemRequirements {
+    /// Returns true when no system requirement was declared.
+    pub fn is_empty(&self) -> bool {
+        self.linux.is_none()
+            && self.macos.is_none()
+            && self.cuda.is_none()
+            && self.libc.is_none()
+            && self.glibc.is_none()
+            && self.archspec.is_none()
+    }
+
+    /// Collect variables used by templated requirement values.
+    pub fn used_variables(&self) -> Vec<String> {
+        let mut variables = Vec::new();
+        for value in [
+            &self.linux,
+            &self.macos,
+            &self.cuda,
+            &self.libc,
+            &self.glibc,
+            &self.archspec,
+        ]
+        .into_iter()
+        .flatten()
+        {
+            variables.extend(value.used_variables());
+        }
+        variables.sort();
+        variables.dedup();
+        variables
+    }
+}

--- a/crates/rattler_build_recipe/src/stage1/mod.rs
+++ b/crates/rattler_build_recipe/src/stage1/mod.rs
@@ -23,6 +23,7 @@ pub mod package;
 pub mod recipe;
 pub mod requirements;
 pub mod source;
+pub mod system_requirements;
 pub mod tests;
 
 #[cfg(test)]
@@ -38,6 +39,7 @@ use rattler_build_yaml_parser::ParseError;
 pub use recipe::{InheritsFrom, Recipe, StagingCache};
 pub use requirements::{Dependency, PinCompatible, PinSubpackage, Requirements};
 pub use source::Source;
+pub use system_requirements::SystemRequirements;
 pub use tests::TestType;
 
 // Re-export glob types from rattler_build_types

--- a/crates/rattler_build_recipe/src/stage1/recipe.rs
+++ b/crates/rattler_build_recipe/src/stage1/recipe.rs
@@ -4,7 +4,7 @@ use indexmap::IndexMap;
 use rattler_build_jinja::Variable;
 use serde::{Deserialize, Serialize};
 
-use super::{About, Build, Extra, Package, Requirements, Source, TestType};
+use super::{About, Build, Extra, Package, Requirements, Source, SystemRequirements, TestType};
 
 /// Staging cache - a build artifact that doesn't produce a package
 ///
@@ -125,6 +125,10 @@ pub struct Recipe {
     #[serde(default)]
     pub requirements: Requirements,
 
+    /// Minimum system requirements for consumers of this output.
+    #[serde(default, skip_serializing_if = "SystemRequirements::is_empty")]
+    pub system_requirements: SystemRequirements,
+
     /// Tests (can be multiple tests)
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tests: Vec<TestType>,
@@ -176,6 +180,7 @@ impl Recipe {
             build,
             about,
             requirements,
+            system_requirements: SystemRequirements::default(),
             extra,
             source,
             tests,
@@ -207,6 +212,7 @@ impl Recipe {
             build,
             about,
             requirements,
+            system_requirements: SystemRequirements::default(),
             extra,
             source,
             tests,

--- a/crates/rattler_build_recipe/src/stage1/system_requirements.rs
+++ b/crates/rattler_build_recipe/src/stage1/system_requirements.rs
@@ -1,0 +1,36 @@
+use serde::{Deserialize, Serialize};
+
+/// Evaluated minimum system requirements for a package output.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SystemRequirements {
+    /// Minimum Linux kernel version.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub linux: Option<String>,
+    /// Minimum macOS version.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub macos: Option<String>,
+    /// Minimum CUDA driver version.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cuda: Option<String>,
+    /// Minimum libc version (Pixi scalar form, which means glibc).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub libc: Option<String>,
+    /// Minimum glibc version; an alias for scalar `libc`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub glibc: Option<String>,
+    /// Required architecture specification.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub archspec: Option<String>,
+}
+
+impl SystemRequirements {
+    /// Returns true when no system requirement was declared.
+    pub fn is_empty(&self) -> bool {
+        self.linux.is_none()
+            && self.macos.is_none()
+            && self.cuda.is_none()
+            && self.libc.is_none()
+            && self.glibc.is_none()
+            && self.archspec.is_none()
+    }
+}

--- a/docs/reference/cli/rattler-build/build.md
+++ b/docs/reference/cli/rattler-build/build.md
@@ -32,6 +32,9 @@ rattler-build build [OPTIONS]
 - <a id="arg---variant-config" href="#arg---variant-config">`--variant-config (-m) <VARIANT_CONFIG>`</a>
 :  Variant configuration files for the build
 <br>May be provided more than once.
+- <a id="arg---variant-config-package" href="#arg---variant-config-package">`--variant-config-package <VARIANT_CONFIG_PACKAGES>`</a>
+:  Load a `conda_build_config.yaml` from an installed package. May be specified multiple times; for example `conda-forge-pinning`
+<br>May be provided more than once.
 - <a id="arg---variant" href="#arg---variant">`--variant <VARIANT_OVERRIDES>`</a>
 :  Override specific variant values (e.g. --variant python=3.12 or --variant python=3.12,3.11). Multiple values separated by commas will create multiple build variants
 <br>May be provided more than once.

--- a/docs/reference/cli/rattler-build/publish.md
+++ b/docs/reference/cli/rattler-build/publish.md
@@ -38,6 +38,9 @@ rattler-build publish [OPTIONS] --to <TO> [PACKAGE_OR_RECIPE]...
 - <a id="arg---variant-config" href="#arg---variant-config">`--variant-config (-m) <VARIANT_CONFIG>`</a>
 :  Variant configuration files for the build
 <br>May be provided more than once.
+- <a id="arg---variant-config-package" href="#arg---variant-config-package">`--variant-config-package <VARIANT_CONFIG_PACKAGES>`</a>
+:  Load a `conda_build_config.yaml` from an installed package. May be specified multiple times; for example `conda-forge-pinning`
+<br>May be provided more than once.
 - <a id="arg---variant" href="#arg---variant">`--variant <VARIANT_OVERRIDES>`</a>
 :  Override specific variant values (e.g. --variant python=3.12 or --variant python=3.12,3.11). Multiple values separated by commas will create multiple build variants
 <br>May be provided more than once.

--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -1026,6 +1026,37 @@ the `package_metadata` by default. You can disable this by passing
     explanations and examples of the build keys documented above.
 
 
+## System requirements
+
+Package outputs can declare minimum host-system versions using Pixi-compatible
+keys. Rattler-build preserves the declaration in the rendered recipe and adds
+the corresponding virtual package to run requirements:
+
+```yaml
+system_requirements:
+  linux: "5.10"
+  glibc: "2.37"
+  cuda: "12"
+  macos: "13.0"
+  archspec: "zen3"
+```
+
+`libc: "2.37"` is the Pixi scalar form and means glibc; `glibc` is accepted as
+an explicit alias. Do not specify both. Linux, macOS, CUDA, and libc values
+become `__linux`, `__osx`, `__cuda`, and `__glibc` run dependencies. `archspec`
+is retained as metadata but, matching current Pixi behavior, is not materialized
+as a virtual-package dependency.
+
+In a multi-output recipe, place `system_requirements` on each package output:
+
+```yaml
+outputs:
+  - package:
+      name: compiled-output
+    system_requirements:
+      glibc: "2.37"
+```
+
 ## Requirements section
 
 Specifies the build and runtime requirements. Dependencies of these requirements

--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -1046,8 +1046,10 @@ an explicit alias. Do not specify both. Linux, macOS, CUDA, and libc values
 become `__linux`, `__osx`, `__cuda`, and `__glibc` run dependencies. They also
 override the corresponding detected/default virtual packages supplied to the
 host-environment solver, allowing cross-platform builds to solve against the
-declared baseline rather than the build machine's baseline. `archspec` overrides
-`__archspec` in the host solve and is retained in rendered metadata.
+declared baseline rather than the build machine's baseline. Requirements that do
+not apply to the output platform are retained as metadata but not materialized.
+`archspec` is retained as metadata but, matching current Pixi behavior, is
+deprecated and does not affect virtual packages.
 
 In a multi-output recipe, place `system_requirements` on each package output:
 

--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -1043,9 +1043,11 @@ system_requirements:
 
 `libc: "2.37"` is the Pixi scalar form and means glibc; `glibc` is accepted as
 an explicit alias. Do not specify both. Linux, macOS, CUDA, and libc values
-become `__linux`, `__osx`, `__cuda`, and `__glibc` run dependencies. `archspec`
-is retained as metadata but, matching current Pixi behavior, is not materialized
-as a virtual-package dependency.
+become `__linux`, `__osx`, `__cuda`, and `__glibc` run dependencies. They also
+override the corresponding detected/default virtual packages supplied to the
+host-environment solver, allowing cross-platform builds to solve against the
+declared baseline rather than the build machine's baseline. `archspec` overrides
+`__archspec` in the host solve and is retained in rendered metadata.
 
 In a multi-output recipe, place `system_requirements` on each package output:
 

--- a/docs/variants.md
+++ b/docs/variants.md
@@ -78,6 +78,29 @@ files, use the `--variant-config` or `-m` option:
 rattler-build build --variant-config ~/user_variants.yaml --variant-config /opt/rattler-build/global_variants.yaml --recipe myrecipe.yaml
 ```
 
+### Variant configuration packages
+
+Variant configurations can also be distributed as conda packages:
+
+```console
+rattler-build build \
+  --variant-config-package conda-forge-pinning \
+  --recipe ./recipe
+```
+
+Rattler-build solves and installs the package for the build platform, then loads
+`conda_build_config.yaml` from either the prefix root or
+`share/rattler-build/variants/conda_build_config.yaml`. The root layout is
+compatible with the published `conda-forge-pinning` package.
+
+Package configurations are baseline pinnings. Automatically discovered recipe
+files and explicit `--variant-config` files are merged afterward and therefore
+override package-provided keys. Multiple `--variant-config-package` arguments
+are processed in command-line order.
+
+The same behavior is available to library users through
+`load_variant_config_from_package` and `load_variant_config_from_prefix`.
+
 ### Merging of multiple variant configuration files
 
 When multiple variant configuration files are merged, the following rules apply:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -353,9 +353,6 @@ fn apply_system_requirements_to_host(
     {
         replace("__cuda", version, "0".to_string())?;
     }
-    if let Some(archspec) = &requirements.archspec {
-        replace("__archspec", "1", archspec.clone())?;
-    }
     platform
         .virtual_packages
         .sort_by(|left, right| left.name.cmp(&right.name));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,8 +55,8 @@ use rattler_build_core::consts;
 use rattler_build_recipe::{stage0, stage1::TestType};
 use rattler_build_variant_config::VariantConfig;
 use rattler_conda_types::{
-    MatchSpec, NamedChannelOrUrl, NoArchType, PackageName, Platform, RepodataRevision,
-    compression_level::CompressionLevel, package::CondaArchiveType,
+    MatchSpec, NamedChannelOrUrl, NoArchType, PackageName, ParseStrictness, Platform,
+    RepodataRevision, compression_level::CompressionLevel, package::CondaArchiveType,
 };
 use rattler_config::config::build::PackageFormatAndCompression;
 use rattler_index::ensure_channel_initialized_fs;
@@ -261,6 +261,59 @@ pub fn get_tool_config(
     Ok(configuration_builder.finish())
 }
 
+/// Load a package-provided variant configuration from an installed prefix.
+pub fn load_variant_config_from_prefix(
+    prefix: &Path,
+    target_platform: Platform,
+) -> miette::Result<VariantConfig> {
+    let candidates = [
+        prefix.join(consts::CONDA_BUILD_CONFIG_FILE),
+        prefix
+            .join("share/rattler-build/variants")
+            .join(consts::CONDA_BUILD_CONFIG_FILE),
+    ];
+    let path = candidates.iter().find(|path| path.is_file()).ok_or_else(|| {
+        miette::miette!(
+            "variant configuration prefix does not contain `{}` at the prefix root or under `share/rattler-build/variants`",
+            consts::CONDA_BUILD_CONFIG_FILE
+        )
+    })?;
+    tracing::info!("Loading variant configuration from {}", path.display());
+    VariantConfig::from_files(&[path], target_platform).map_err(miette::Report::new)
+}
+
+/// Install a package and load the variant configuration it provides.
+///
+/// Provider packages should place `conda_build_config.yaml` at the prefix root
+/// (as `conda-forge-pinning` does) or under
+/// `share/rattler-build/variants/conda_build_config.yaml`.
+pub async fn load_variant_config_from_package(
+    package: &str,
+    channels: &[rattler_conda_types::ChannelUrl],
+    platform: &PlatformWithVirtualPackages,
+    tool_configuration: &Configuration,
+) -> miette::Result<VariantConfig> {
+    let spec = MatchSpec::from_str(package, ParseStrictness::Strict)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("invalid variant configuration package `{package}`"))?;
+    let prefix = tempfile::tempdir().into_diagnostic()?;
+    render::solver::create_environment(
+        "variant configuration",
+        &[spec],
+        platform,
+        prefix.path(),
+        channels,
+        tool_configuration,
+        tool_configuration.channel_priority,
+        SolveStrategy::Highest,
+        None,
+    )
+    .await?;
+
+    load_variant_config_from_prefix(prefix.path(), platform.platform)
+        .wrap_err_with(|| format!("failed to load variant configuration from package `{package}`"))
+}
+
 /// Returns the output for the build.
 pub async fn get_build_output(
     build_data: &BuildData,
@@ -336,7 +389,30 @@ pub async fn get_build_output(
     let mut variant_configs = detected_variant_config.unwrap_or_default();
     variant_configs.extend(build_data.variant_config.clone());
 
-    let mut variant_config =
+    let mut packaged_variant_config = VariantConfig::default();
+    if !build_data.variant_config_packages.is_empty() {
+        let channels = build_data
+            .channels
+            .clone()
+            .unwrap_or_else(|| vec![NamedChannelOrUrl::Name("conda-forge".to_string())])
+            .into_iter()
+            .map(|channel| channel.into_base_url(&tool_config.channel_config))
+            .collect::<Result<Vec<_>, _>>()
+            .into_diagnostic()?;
+        let platform = PlatformWithVirtualPackages::detect_for_platform(
+            build_data.build_platform,
+            &VirtualPackageOverrides::from_env(),
+        )
+        .into_diagnostic()?;
+        for package in &build_data.variant_config_packages {
+            packaged_variant_config.merge(
+                load_variant_config_from_package(package, &channels, &platform, tool_config)
+                    .await?,
+            );
+        }
+    }
+
+    let local_variant_config =
         VariantConfig::from_files(&variant_configs, build_data.target_platform).map_err(|e| {
             // Check if this is a ParseError with a file path
             if let rattler_build_variant_config::VariantConfigError::ParseError { path, source } =
@@ -358,6 +434,9 @@ pub async fn get_build_output(
             // Fallback to original error if we can't provide source context
             miette::Report::new(e)
         })?;
+    // Local and CLI variant files override package-provided baseline pinnings.
+    packaged_variant_config.merge(local_variant_config);
+    let mut variant_config = packaged_variant_config;
 
     // Warn if target_platform is set in variant config - it's not supported and will be ignored
     let target_platform_variants = variant_config
@@ -1600,6 +1679,7 @@ pub async fn debug_recipe(
         test: TestStrategy::Skip,
         up_to: None,
         variant_config: debug_data.variant_config,
+        variant_config_packages: Vec::new(),
         variant_overrides: debug_data.variant_overrides,
         ignore_recipe_variants: debug_data.ignore_recipe_variants,
         render_only: false,
@@ -1710,4 +1790,22 @@ pub fn show_package_info(args: InspectOpts) -> miette::Result<()> {
 /// Extract a conda package to a directory
 pub async fn extract_package(args: opt::ExtractOpts) -> miette::Result<()> {
     rattler_build_core::package_info::extract_package(args.into()).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loads_variant_configuration_from_provider_prefix() {
+        let prefix = tempfile::tempdir().unwrap();
+        fs_err::write(
+            prefix.path().join(consts::CONDA_BUILD_CONFIG_FILE),
+            "python:\n  - '3.12'\n",
+        )
+        .unwrap();
+
+        let config = load_variant_config_from_prefix(prefix.path(), Platform::Linux64).unwrap();
+        assert!(config.get(&NormalizedKey::from("python")).is_some());
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ use rattler_build_recipe::{stage0, stage1::TestType};
 use rattler_build_variant_config::VariantConfig;
 use rattler_conda_types::{
     MatchSpec, NamedChannelOrUrl, NoArchType, PackageName, ParseStrictness, Platform,
-    RepodataRevision, compression_level::CompressionLevel, package::CondaArchiveType,
+    RepodataRevision, Version, compression_level::CompressionLevel, package::CondaArchiveType,
 };
 use rattler_config::config::build::PackageFormatAndCompression;
 use rattler_index::ensure_channel_initialized_fs;
@@ -312,6 +312,54 @@ pub async fn load_variant_config_from_package(
 
     load_variant_config_from_prefix(prefix.path(), platform.platform)
         .wrap_err_with(|| format!("failed to load variant configuration from package `{package}`"))
+}
+
+fn apply_system_requirements_to_host(
+    platform: &mut PlatformWithVirtualPackages,
+    requirements: &rattler_build_recipe::stage1::SystemRequirements,
+) -> miette::Result<()> {
+    let mut replace = |name: &str, version: &str, build_string: String| -> miette::Result<()> {
+        let version = Version::from_str(version)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("invalid system requirement version `{version}`"))?;
+        platform
+            .virtual_packages
+            .retain(|package| package.name.as_normalized() != name);
+        platform
+            .virtual_packages
+            .push(rattler_conda_types::GenericVirtualPackage {
+                name: PackageName::try_from(name).expect("static virtual package name is valid"),
+                version,
+                build_string,
+            });
+        Ok(())
+    };
+
+    if platform.platform.is_linux() {
+        if let Some(version) = &requirements.linux {
+            replace("__linux", version, "0".to_string())?;
+        }
+        if let Some(version) = requirements.glibc.as_ref().or(requirements.libc.as_ref()) {
+            replace("__glibc", version, "0".to_string())?;
+        }
+    }
+    if platform.platform.is_osx()
+        && let Some(version) = &requirements.macos
+    {
+        replace("__osx", version, "0".to_string())?;
+    }
+    if !platform.platform.is_osx()
+        && let Some(version) = &requirements.cuda
+    {
+        replace("__cuda", version, "0".to_string())?;
+    }
+    if let Some(archspec) = &requirements.archspec {
+        replace("__archspec", "1", archspec.clone())?;
+    }
+    platform
+        .virtual_packages
+        .sort_by(|left, right| left.name.cmp(&right.name));
+    Ok(())
 }
 
 /// Returns the output for the build.
@@ -626,15 +674,20 @@ pub async fn get_build_output(
             .into_diagnostic()?;
 
         let virtual_package_override = VirtualPackageOverrides::from_env();
+        let mut host_platform = PlatformWithVirtualPackages::detect_for_platform(
+            build_data.host_platform,
+            &virtual_package_override,
+        )
+        .into_diagnostic()?;
+        apply_system_requirements_to_host(
+            &mut host_platform,
+            &discovered_output.recipe.system_requirements,
+        )?;
         let output = Output {
             recipe: discovered_output.recipe.clone(),
             build_configuration: BuildConfiguration {
                 target_platform: discovered_output.target_platform,
-                host_platform: PlatformWithVirtualPackages::detect_for_platform(
-                    build_data.host_platform,
-                    &virtual_package_override,
-                )
-                .into_diagnostic()?,
+                host_platform,
                 build_platform: PlatformWithVirtualPackages::detect_for_platform(
                     build_data.build_platform,
                     &virtual_package_override,
@@ -1795,6 +1848,32 @@ pub async fn extract_package(args: opt::ExtractOpts) -> miette::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn system_requirements_override_host_virtual_packages() {
+        let mut platform = PlatformWithVirtualPackages {
+            platform: Platform::Linux64,
+            virtual_packages: vec![rattler_conda_types::GenericVirtualPackage {
+                name: PackageName::try_from("__glibc").unwrap(),
+                version: Version::from_str("2.17").unwrap(),
+                build_string: "0".to_string(),
+            }],
+        };
+        apply_system_requirements_to_host(
+            &mut platform,
+            &rattler_build_recipe::stage1::SystemRequirements {
+                glibc: Some("2.37".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let glibc = platform
+            .virtual_packages
+            .iter()
+            .find(|package| package.name.as_normalized() == "__glibc")
+            .unwrap();
+        assert_eq!(glibc.version.to_string(), "2.37");
+    }
 
     #[test]
     fn loads_variant_configuration_from_provider_prefix() {

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -612,6 +612,11 @@ pub struct BuildOpts {
     #[arg(short = 'm', long)]
     pub variant_config: Option<Vec<PathBuf>>,
 
+    /// Load a `conda_build_config.yaml` from an installed package.
+    /// May be specified multiple times; for example `conda-forge-pinning`.
+    #[arg(long = "variant-config-package", action = clap::ArgAction::Append)]
+    pub variant_config_packages: Vec<String>,
+
     /// Override specific variant values (e.g. --variant python=3.12 or --variant python=3.12,3.11).
     /// Multiple values separated by commas will create multiple build variants.
     #[arg(long = "variant", value_parser = parse_variant_override, action = clap::ArgAction::Append)]
@@ -899,6 +904,7 @@ pub struct BuildData {
     /// instead of conflicting with it.
     pub channels_from_config: bool,
     pub variant_config: Vec<PathBuf>,
+    pub variant_config_packages: Vec<String>,
     pub variant_overrides: HashMap<String, Vec<String>>,
     pub ignore_recipe_variants: bool,
     pub render_only: bool,
@@ -975,6 +981,7 @@ impl BuildData {
             channels,
             channels_from_config: false,
             variant_config: variant_config.unwrap_or_default(),
+            variant_config_packages: Vec::new(),
             variant_overrides,
             ignore_recipe_variants,
             render_only,
@@ -1013,6 +1020,7 @@ impl BuildData {
     /// BuildOpts have higher priority than the pixi config.
     pub fn from_opts_and_config(opts: BuildOpts, config: Option<Config>) -> Self {
         let explicit_channels = opts.channels.is_some();
+        let variant_config_packages = opts.variant_config_packages.clone();
         let mut build_data = Self::new(
             opts.up_to,
             opts.build_platform,
@@ -1059,6 +1067,7 @@ impl BuildData {
             opts.markdown_summary,
         );
         build_data.channels_from_config = !explicit_channels && build_data.channels.is_some();
+        build_data.variant_config_packages = variant_config_packages;
         build_data
     }
 }


### PR DESCRIPTION
## Summary

Add two independent recipe/variant authoring capabilities:

1. package-output system requirements using Pixi-compatible keys
2. loading baseline variant pinnings from conda packages

## System requirements

Single and multi-output package recipes can declare:

```yaml
system_requirements:
  linux: "5.10"
  glibc: "2.37"
  cuda: "12"
  macos: "13.0"
  archspec: "zen3"
```

`libc: "2.37"` is supported as Pixi's scalar libc form and means glibc; `glibc` is an explicit alias requested for recipe readability. The declaration is preserved in rendered output and materialized as `__linux`, `__glibc`, `__cuda`, and `__osx` run dependencies. It also replaces the corresponding detected/default virtual packages used by the host-environment solver (`archspec` replaces `__archspec` there). `archspec` is retained as metadata but is not materialized, matching current Pixi behavior.

## Variant configuration packages

```console
rattler-build build \
  --variant-config-package conda-forge-pinning \
  --recipe ./recipe
```

Rattler-build solves and installs the package for the build platform and loads `conda_build_config.yaml` from either:

```text
$PREFIX/conda_build_config.yaml
$PREFIX/share/rattler-build/variants/conda_build_config.yaml
```

Package pinnings form a baseline. Recipe-local and explicit `--variant-config` files override them. Multiple package arguments merge in command-line order.

Public library entry points:

- `load_variant_config_from_package`
- `load_variant_config_from_prefix`

## Validation

- recipe unit tests for parsing and virtual run dependency materialization
- host virtual-package override unit test
- prefix loader unit test
- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- manually rendered single- and multi-output recipes with `glibc: 2.37`
- manually installed and loaded the real `conda-forge-pinning` package successfully
- regenerated CLI documentation

Draft for schema and API review.

