### PR TITLE
feat: wasm64 - skip link checks for wasm64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1874,7 +1874,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2103,7 +2103,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3338,7 +3338,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3735,7 +3735,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3849,7 +3849,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.21.7",
  "chrono",
  "getrandom 0.2.17",
  "http 1.5.0",
@@ -4614,7 +4614,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4740,9 +4740,9 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.48.2"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61bfdcb39e1719edbb27e562d40405c1a8130eb3fff8b11b489672b642a488af"
+checksum = "accfedd36855dd35f96ce944c9ec186a3193fe00f27f2ac8f7cc09e2b669bb93"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -5219,9 +5219,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1ea7ff3474f2c5aceb5fe741061ad744f164e050de40dc25608c5ae0e66753c"
+checksum = "28b8ea7ad44f970b12b7698225e7890b19e3f4dcbae7a7b8fe4d7a0326539677"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5254,9 +5254,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.49.1"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "058c739d6ea6b3f429443f9d7117022330049bdb1cdde7b46622662463bd5cc0"
+checksum = "2becf7d5e10e770b597acc91de1c0b79d2a5ff83a5acabe3480f2eb71bdd865c"
 dependencies = [
  "ahash",
  "core-foundation 0.10.1",
@@ -5297,9 +5297,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_config"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fadf5267a8dc82ac7e1ba0b42c778a2e3fb02cf4827507a26456f2e2ef42cf4"
+checksum = "7a8cb547526f1bd3e84173b22f152628c9a5af451019b8969bf9932befcd1d3d"
 dependencies = [
  "dirs",
  "fs-err",
@@ -5336,9 +5336,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_git"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0a952c9f6188e0d4a0f111edc52bc3392dfe249329b17ade79502abd11074fa"
+checksum = "00b3e31df047a1415310d19427de0544ddc5ef88102df9bc43223e95ece378c1"
 dependencies = [
  "astral-reqwest-middleware",
  "dashmap",
@@ -5358,9 +5358,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cadb312b82d369b4479c01a3eaa9386fa4834c950570fa8ea6e38237e3effb8"
+checksum = "5beff6ddf8ad1b58ecba95b5b39f7905ccf00f9db046e92af76c585b487a66f5"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5408,9 +5408,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6269634b94b5a9be52cf45bf9368819b33268a4372e76f9c8f9c64c9275a64a"
+checksum = "df7514de242935a48908dd7243c25191497fe0483b47ed1d6da01466d265ee57"
 dependencies = [
  "configparser",
  "dirs",
@@ -5439,9 +5439,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.30.4"
+version = "0.30.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e668ff6375b364d8835cf15d51179ac7366aced2a39d60877041d099a421fd06"
+checksum = "769ff012fafdef054b2d697f3807d1a14a551f1b203fe365da6e81ea544b2268"
 dependencies = [
  "ambient-id",
  "anyhow",
@@ -5478,9 +5478,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ca685c8e3a5ffecd6ad1e9c938753993ed05220c050a070a847ae541797a2e"
+checksum = "44ee9c39cab94ce1c8308c25b170eb8757d9837416c708be37a3cb60c66abc98"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-tokio-tar",
@@ -5557,9 +5557,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "466a4335b63701b2eeb0888e66c82e034589998007ee68eceb30f75d5bc643b7"
+checksum = "769106c5625e788197cfa2c5cb98c585fecf7fea92e8fff90d8d6e8014bb6e76"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5620,9 +5620,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_s3"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26736d14feafeb56b64b820d477fde693eebebd2738afc0549a59af13c3925f3"
+checksum = "eb450835967a6620a1b73d10db9d697838105d4570d9320c94d7101b2dc15cb3"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -5637,9 +5637,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.27.13"
+version = "0.27.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27e6d9e4b73759112b0560c85c3fe3c9619386ed11700daa7b068d02fcd0a766"
+checksum = "4e6b47240a8bd326257e1804e2b521ad00f505db9c229c3b49b69939113f1f1a"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -5659,9 +5659,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "9.0.1"
+version = "9.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15139fa95d92a22fe4ba6b00ee89ed6b2375550f1c51036b202c51f771c0d29a"
+checksum = "7fc14e2b00952ae96b6356625cfd4083fb3f1de92a32aa3f2bd78e823bf16c95"
 dependencies = [
  "futures",
  "hex",
@@ -5679,9 +5679,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_upload"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "600dbf4a722767b77063601174e9750aac4d64d0a9e4f20b90aa7cbe9ba14582"
+checksum = "f4ae9c5d57e5701bcc705a152f9703ecb64be96d83d258bf522a0ff3e253e437"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-reqwest-retry",
@@ -5718,9 +5718,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "5.0.0"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbade435086e26b977cd2e2a06afa6e5815de03c34af6b39e5a309cbc731196"
+checksum = "85109cb080a3232e181a360e1db1d140bbe3fabbea6f9cecafeb3b94e63f2608"
 dependencies = [
  "archspec",
  "libloading",
@@ -6136,7 +6136,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6193,7 +6193,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7277,7 +7277,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7287,7 +7287,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8153,7 +8153,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ tracing-subscriber = { version = "0.3", features = [
 tracing-test = "0.2.6"
 
 # Rattler crates
-rattler_conda_types = { version = "0.49", default-features = false }
+rattler_conda_types = { version = "0.50", default-features = false }
 rattler_digest = { version = "1.3.2", default-features = false, features = [
   "serde",
 ] }

--- a/crates/rattler_build_core/src/post_process/relink.rs
+++ b/crates/rattler_build_core/src/post_process/relink.rs
@@ -155,6 +155,7 @@ pub fn relink(temp_files: &TempFiles, output: &Output) -> Result<(), RelinkError
     if target_platform == Platform::NoArch
         // skip linking checks for wasm
         || target_platform.arch() == Some(Arch::Wasm32)
+        || target_platform.arch() == Some(Arch::Wasm64)
         || relocation_config.is_none()
     {
         return Ok(());

--- a/crates/rattler_build_playground/Cargo.lock
+++ b/crates/rattler_build_playground/Cargo.lock
@@ -1536,7 +1536,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rattler_build_jinja"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "fs-err",
  "indexmap 2.14.0",
@@ -1580,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_build_recipe"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "fs-err",
  "globset",
@@ -1613,7 +1613,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_build_recipe_generator"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "async-once-cell",
  "async-recursion",
@@ -1642,17 +1642,18 @@ dependencies = [
 
 [[package]]
 name = "rattler_build_script"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "clap",
  "console",
  "indexmap 2.14.0",
  "serde",
+ "windows-sys",
 ]
 
 [[package]]
 name = "rattler_build_types"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "globset",
  "itertools",
@@ -1666,7 +1667,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_build_variant_config"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "fs-err",
  "marked-yaml",
@@ -1685,7 +1686,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_build_yaml_parser"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "marked-yaml",
  "miette",
@@ -1696,9 +1697,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.49.0"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "776dcc9348ae7e1843e1320ad1c1afc375bd2b73faeaa1bb49b1e002575f7791"
+checksum = "2becf7d5e10e770b597acc91de1c0b79d2a5ff83a5acabe3480f2eb71bdd865c"
 dependencies = [
  "ahash",
  "core-foundation",
@@ -2337,9 +2338,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.3+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
@@ -2361,9 +2362,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]

--- a/crates/rattler_build_playground/Cargo.toml
+++ b/crates/rattler_build_playground/Cargo.toml
@@ -26,7 +26,7 @@ rattler_build_jinja = { path = "../rattler_build_jinja" }
 rattler_build_types = { path = "../rattler_build_types" }
 rattler_build_yaml_parser = { path = "../rattler_build_yaml_parser" }
 indexmap = "2"
-rattler_conda_types = { version = "0.49", default-features = false }
+rattler_conda_types = { version = "0.50", default-features = false }
 serde_yaml = "0.9"
 arborium = { version = "2", default-features = false, features = ["lang-yaml"] }
 

--- a/py-rattler-build/rust/Cargo.lock
+++ b/py-rattler-build/rust/Cargo.lock
@@ -1787,7 +1787,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1984,7 +1984,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3175,7 +3175,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3544,7 +3544,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3658,7 +3658,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.21.7",
  "chrono",
  "getrandom 0.2.17",
  "http 1.5.0",
@@ -4446,7 +4446,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4572,9 +4572,9 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.48.2"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61bfdcb39e1719edbb27e562d40405c1a8130eb3fff8b11b489672b642a488af"
+checksum = "accfedd36855dd35f96ce944c9ec186a3193fe00f27f2ac8f7cc09e2b669bb93"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -4997,9 +4997,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1ea7ff3474f2c5aceb5fe741061ad744f164e050de40dc25608c5ae0e66753c"
+checksum = "28b8ea7ad44f970b12b7698225e7890b19e3f4dcbae7a7b8fe4d7a0326539677"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5032,9 +5032,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.49.1"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "058c739d6ea6b3f429443f9d7117022330049bdb1cdde7b46622662463bd5cc0"
+checksum = "2becf7d5e10e770b597acc91de1c0b79d2a5ff83a5acabe3480f2eb71bdd865c"
 dependencies = [
  "ahash",
  "core-foundation 0.10.1",
@@ -5075,9 +5075,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_config"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fadf5267a8dc82ac7e1ba0b42c778a2e3fb02cf4827507a26456f2e2ef42cf4"
+checksum = "7a8cb547526f1bd3e84173b22f152628c9a5af451019b8969bf9932befcd1d3d"
 dependencies = [
  "dirs",
  "fs-err",
@@ -5114,9 +5114,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_git"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0a952c9f6188e0d4a0f111edc52bc3392dfe249329b17ade79502abd11074fa"
+checksum = "00b3e31df047a1415310d19427de0544ddc5ef88102df9bc43223e95ece378c1"
 dependencies = [
  "astral-reqwest-middleware",
  "dashmap",
@@ -5136,9 +5136,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cadb312b82d369b4479c01a3eaa9386fa4834c950570fa8ea6e38237e3effb8"
+checksum = "5beff6ddf8ad1b58ecba95b5b39f7905ccf00f9db046e92af76c585b487a66f5"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5186,9 +5186,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6269634b94b5a9be52cf45bf9368819b33268a4372e76f9c8f9c64c9275a64a"
+checksum = "df7514de242935a48908dd7243c25191497fe0483b47ed1d6da01466d265ee57"
 dependencies = [
  "configparser",
  "dirs",
@@ -5217,9 +5217,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.30.4"
+version = "0.30.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e668ff6375b364d8835cf15d51179ac7366aced2a39d60877041d099a421fd06"
+checksum = "769ff012fafdef054b2d697f3807d1a14a551f1b203fe365da6e81ea544b2268"
 dependencies = [
  "ambient-id",
  "anyhow",
@@ -5256,9 +5256,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ca685c8e3a5ffecd6ad1e9c938753993ed05220c050a070a847ae541797a2e"
+checksum = "44ee9c39cab94ce1c8308c25b170eb8757d9837416c708be37a3cb60c66abc98"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-tokio-tar",
@@ -5335,9 +5335,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "466a4335b63701b2eeb0888e66c82e034589998007ee68eceb30f75d5bc643b7"
+checksum = "769106c5625e788197cfa2c5cb98c585fecf7fea92e8fff90d8d6e8014bb6e76"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5398,9 +5398,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_s3"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26736d14feafeb56b64b820d477fde693eebebd2738afc0549a59af13c3925f3"
+checksum = "eb450835967a6620a1b73d10db9d697838105d4570d9320c94d7101b2dc15cb3"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -5415,9 +5415,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.27.13"
+version = "0.27.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27e6d9e4b73759112b0560c85c3fe3c9619386ed11700daa7b068d02fcd0a766"
+checksum = "4e6b47240a8bd326257e1804e2b521ad00f505db9c229c3b49b69939113f1f1a"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -5437,9 +5437,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "9.0.1"
+version = "9.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15139fa95d92a22fe4ba6b00ee89ed6b2375550f1c51036b202c51f771c0d29a"
+checksum = "7fc14e2b00952ae96b6356625cfd4083fb3f1de92a32aa3f2bd78e823bf16c95"
 dependencies = [
  "futures",
  "hex",
@@ -5457,9 +5457,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_upload"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "600dbf4a722767b77063601174e9750aac4d64d0a9e4f20b90aa7cbe9ba14582"
+checksum = "f4ae9c5d57e5701bcc705a152f9703ecb64be96d83d258bf522a0ff3e253e437"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-reqwest-retry",
@@ -5496,9 +5496,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "5.0.0"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbade435086e26b977cd2e2a06afa6e5815de03c34af6b39e5a309cbc731196"
+checksum = "85109cb080a3232e181a360e1db1d140bbe3fabbea6f9cecafeb3b94e63f2608"
 dependencies = [
  "archspec",
  "libloading",
@@ -5869,7 +5869,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5926,7 +5926,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6942,7 +6942,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6952,7 +6952,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7734,7 +7734,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/py-rattler-build/rust/Cargo.toml
+++ b/py-rattler-build/rust/Cargo.toml
@@ -35,7 +35,7 @@ tokio = { version = "1.53.1", features = [
   "rt-multi-thread",
   "process",
 ] }
-rattler_conda_types = "0.49"
+rattler_conda_types = "0.50"
 rattler_config = "0.7"
 rattler_networking = { version = "0.30.3" }
 rattler_solve = "9.0"


### PR DESCRIPTION
* skip link cheks for wasm64
* needs a new rattler release with  https://github.com/conda/rattler/pull/2680