### PR TITLE
chore: mark the variant hash as usedforsecurity=False

### DIFF
--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -398,7 +398,11 @@ def host_subdir():
 
 def variant_hash(variant):
     hash_length = 7
-    m = hashlib.sha1()
+    # Mirrors conda's variant hash, which is defined by the ecosystem to be
+    # SHA1. This is a build-identity fingerprint used to assert that a built
+    # package is named correctly -- not a security control -- so it is marked
+    # usedforsecurity=False. That also keeps it working under FIPS.
+    m = hashlib.sha1(usedforsecurity=False)
     m.update(json.dumps(variant, sort_keys=True).encode())
     return f"h{m.hexdigest()[:hash_length]}"
 


### PR DESCRIPTION
One line, plus a comment explaining why.

`variant_hash()` in `test/end-to-end/test_simple.py` reproduces **conda's variant hash** — the `h<7 hex>` suffix in package filenames — so the tests can assert a built package is named correctly:

```python
def variant_hash(variant):
    hash_length = 7
    m = hashlib.sha1()
    m.update(json.dumps(variant, sort_keys=True).encode())
    return f"h{m.hexdigest()[:hash_length]}"
```

Static analysis flags the bare `hashlib.sha1()` as weak-hash usage. It isn't a security control — it's a build-identity fingerprint — and it **cannot** move to SHA256, because the conda ecosystem defines this hash as SHA1. Changing it would break the assertion.

`usedforsecurity=False` is the annotation for precisely this case. It records the intent where the code lives rather than as a standing exception in a scanning dashboard, and it keeps the call working on FIPS-enabled builds, where unannotated SHA1 is rejected outright.

**The digest does not change** — the flag only affects the FIPS policy check. Verified:

```
plain      : hb0f4dca
annotated  : hb0f4dca
identical  : True
```

Checked: `ruff check` passes, `ast.parse` clean, and this is the only `hashlib.sha1`/`md5` call site in the repo's Python. `usedforsecurity` needs Python ≥3.9; `pixi.toml` pins `>=3.14.6,<3.15`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
