### PR TITLE
chore: update rattler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4251,9 +4251,9 @@ dependencies = [
 
 [[package]]
 name = "path_resolver"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87b79fa64c9aac78dc850c3ac23f27de50be06cb7d2a051aa4324c3d4d7bcaeb"
+checksum = "9994183d6ed25258205ec5612143b3da8cf2a2027d5e532b0af961ebf32ea5a1"
 dependencies = [
  "ahash",
  "fs-err",
@@ -4742,9 +4742,9 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.48.3"
+version = "0.48.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accfedd36855dd35f96ce944c9ec186a3193fe00f27f2ac8f7cc09e2b669bb93"
+checksum = "6595b5f9878f0e2787da607235c158c7c125d4c4f145cfcc3febade9c66c3a4f"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -5221,9 +5221,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b8ea7ad44f970b12b7698225e7890b19e3f4dcbae7a7b8fe4d7a0326539677"
+checksum = "10e0c05d770d92af1f4230f6f549ab6c4cb47d5e5f7a65339f91fca7fc6b3545"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5256,9 +5256,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.50.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2becf7d5e10e770b597acc91de1c0b79d2a5ff83a5acabe3480f2eb71bdd865c"
+checksum = "654ccb4b723cd1e288bbbb8e798721b8316e19f0de3610ed90ebfbedabf45d45"
 dependencies = [
  "ahash",
  "core-foundation 0.10.1",
@@ -5299,9 +5299,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_config"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8cb547526f1bd3e84173b22f152628c9a5af451019b8969bf9932befcd1d3d"
+checksum = "e7cb7a3302ec74284640c5c7aa911269e1cfd65bd5e8da4299923453e50a0c78"
 dependencies = [
  "dirs",
  "fs-err",
@@ -5338,9 +5338,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_git"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b3e31df047a1415310d19427de0544ddc5ef88102df9bc43223e95ece378c1"
+checksum = "a9b7152dc6e591f5b1512ebcbb5b738cc0adddb61a519e98b62495c211065523"
 dependencies = [
  "astral-reqwest-middleware",
  "dashmap",
@@ -5360,9 +5360,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.31.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5beff6ddf8ad1b58ecba95b5b39f7905ccf00f9db046e92af76c585b487a66f5"
+checksum = "308fb45f4a01891e77e9a6ca585f493169586afee85b374e08f889b460951144"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5410,9 +5410,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7514de242935a48908dd7243c25191497fe0483b47ed1d6da01466d265ee57"
+checksum = "1a39794d7486efd34a701c4e33abd094cff04d78d1f3a9bf9f539a3193b3406c"
 dependencies = [
  "configparser",
  "dirs",
@@ -5441,9 +5441,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.30.5"
+version = "0.30.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769ff012fafdef054b2d697f3807d1a14a551f1b203fe365da6e81ea544b2268"
+checksum = "bad2167f271e0b3ad411a9623de1e948c12dadb05040cd7508015fed78f4e852"
 dependencies = [
  "ambient-id",
  "anyhow",
@@ -5480,9 +5480,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44ee9c39cab94ce1c8308c25b170eb8757d9837416c708be37a3cb60c66abc98"
+checksum = "364ad3b4bac0c95ae1f7c7bdfa33b679c8d64fde14fd47f6fb965836dbc94628"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-tokio-tar",
@@ -5548,9 +5548,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_redaction"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "068b9b88444342b01133c4eb1af90f44e3bc04463d738ac3fa3813df0096c177"
+checksum = "308e86344e78b42b96570e765f287d7cf87fab7f21ba2eb12508363c11b55f72"
 dependencies = [
  "astral-reqwest-middleware",
  "reqwest",
@@ -5559,9 +5559,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769106c5625e788197cfa2c5cb98c585fecf7fea92e8fff90d8d6e8014bb6e76"
+checksum = "50b705828891a4184451f8c5300b9b123bd946c76fa9f55c0057d81fab3f8d28"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5588,6 +5588,7 @@ dependencies = [
  "humantime",
  "itertools 0.15.0",
  "jiff",
+ "js-sys",
  "json-patch",
  "libc",
  "memmap2",
@@ -5603,6 +5604,7 @@ dependencies = [
  "retry-policies",
  "rmp-serde",
  "self_cell",
+ "send_wrapper",
  "serde",
  "serde_json",
  "serde_with",
@@ -5615,16 +5617,19 @@ dependencies = [
  "tokio-util",
  "tracing",
  "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
  "wasmtimer",
+ "web-sys",
  "windows-sys 0.61.2",
  "zstd",
 ]
 
 [[package]]
 name = "rattler_s3"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb450835967a6620a1b73d10db9d697838105d4570d9320c94d7101b2dc15cb3"
+checksum = "3b9701fa2e3a6666991f32fe3b8157afc73caee15c1248bfc08343fb103d9dba"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -5639,9 +5644,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.27.14"
+version = "0.27.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e6b47240a8bd326257e1804e2b521ad00f505db9c229c3b49b69939113f1f1a"
+checksum = "1d87277b0a7b7ccba831890810e903c35b56b3c1003952ad07374da9ebb0b46b"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -5661,9 +5666,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "9.0.2"
+version = "9.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc14e2b00952ae96b6356625cfd4083fb3f1de92a32aa3f2bd78e823bf16c95"
+checksum = "9c287fe2c2a57e66162cadc4430b7aa300251edd73034b1b7bf222a660a9a45e"
 dependencies = [
  "futures",
  "hex",
@@ -5681,9 +5686,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_upload"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ae9c5d57e5701bcc705a152f9703ecb64be96d83d258bf522a0ff3e253e437"
+checksum = "09043dd6c41243fbb8cb118e7809f0238a8f7eea198c728ca551167d67874841"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-reqwest-retry",
@@ -5720,9 +5725,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "5.0.1"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85109cb080a3232e181a360e1db1d140bbe3fabbea6f9cecafeb3b94e63f2608"
+checksum = "4c249324b90e9dcf985991ca4a066b6df72c4c9b300a70746c596e90abe8df2f"
 dependencies = [
  "archspec",
  "libloading",
@@ -6399,6 +6404,12 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ tracing-subscriber = { version = "0.3", features = [
 tracing-test = "0.2.6"
 
 # Rattler crates
-rattler_conda_types = { version = "0.50", default-features = false }
+rattler_conda_types = { version = "0.51", default-features = false }
 rattler_digest = { version = "1.3.2", default-features = false, features = [
   "serde",
 ] }
@@ -155,15 +155,15 @@ rattler_cache = { version = "0.10", default-features = false }
 rattler_index = { version = "0.31", default-features = false }
 rattler_upload = { version = "0.10", default-features = false }
 rattler_s3 = { version = "0.2.9" }
-rattler_redaction = { version = "0.2.2", default-features = false }
-rattler_repodata_gateway = { version = "0.32", default-features = false, features = [
+rattler_redaction = { version = "0.2.3", default-features = false }
+rattler_repodata_gateway = { version = "0.33", default-features = false, features = [
   "gateway",
 ] }
 rattler_solve = { version = "9.0", default-features = false, features = [
   "resolvo",
   "serde",
 ] }
-rattler_virtual_packages = { version = "5.0", default-features = false }
+rattler_virtual_packages = { version = "5.1", default-features = false }
 rattler_menuinst = "0.2"
 
 

--- a/crates/rattler_build_playground/Cargo.lock
+++ b/crates/rattler_build_playground/Cargo.lock
@@ -1536,7 +1536,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rattler_build_jinja"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "fs-err",
  "indexmap 2.14.0",
@@ -1580,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_build_recipe"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "fs-err",
  "globset",
@@ -1613,7 +1613,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_build_recipe_generator"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "async-once-cell",
  "async-recursion",
@@ -1642,7 +1642,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_build_script"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "clap",
  "console",
@@ -1653,7 +1653,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_build_types"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "globset",
  "itertools",
@@ -1667,7 +1667,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_build_variant_config"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "fs-err",
  "marked-yaml",
@@ -1686,7 +1686,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_build_yaml_parser"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "marked-yaml",
  "miette",
@@ -1697,9 +1697,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.50.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2becf7d5e10e770b597acc91de1c0b79d2a5ff83a5acabe3480f2eb71bdd865c"
+checksum = "654ccb4b723cd1e288bbbb8e798721b8316e19f0de3610ed90ebfbedabf45d45"
 dependencies = [
  "ahash",
  "core-foundation",
@@ -1768,9 +1768,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_redaction"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "068b9b88444342b01133c4eb1af90f44e3bc04463d738ac3fa3813df0096c177"
+checksum = "308e86344e78b42b96570e765f287d7cf87fab7f21ba2eb12508363c11b55f72"
 dependencies = [
  "url",
 ]

--- a/crates/rattler_build_playground/Cargo.toml
+++ b/crates/rattler_build_playground/Cargo.toml
@@ -26,7 +26,7 @@ rattler_build_jinja = { path = "../rattler_build_jinja" }
 rattler_build_types = { path = "../rattler_build_types" }
 rattler_build_yaml_parser = { path = "../rattler_build_yaml_parser" }
 indexmap = "2"
-rattler_conda_types = { version = "0.50", default-features = false }
+rattler_conda_types = { version = "0.51", default-features = false }
 serde_yaml = "0.9"
 arborium = { version = "2", default-features = false, features = ["lang-yaml"] }
 

--- a/py-rattler-build/rust/Cargo.lock
+++ b/py-rattler-build/rust/Cargo.lock
@@ -1787,7 +1787,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1984,7 +1984,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3175,7 +3175,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3544,7 +3544,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3658,7 +3658,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.17",
  "http 1.5.0",
@@ -4031,9 +4031,9 @@ dependencies = [
 
 [[package]]
 name = "path_resolver"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87b79fa64c9aac78dc850c3ac23f27de50be06cb7d2a051aa4324c3d4d7bcaeb"
+checksum = "9994183d6ed25258205ec5612143b3da8cf2a2027d5e532b0af961ebf32ea5a1"
 dependencies = [
  "ahash",
  "fs-err",
@@ -4446,7 +4446,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4572,9 +4572,9 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.48.3"
+version = "0.48.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accfedd36855dd35f96ce944c9ec186a3193fe00f27f2ac8f7cc09e2b669bb93"
+checksum = "6595b5f9878f0e2787da607235c158c7c125d4c4f145cfcc3febade9c66c3a4f"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -4997,9 +4997,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b8ea7ad44f970b12b7698225e7890b19e3f4dcbae7a7b8fe4d7a0326539677"
+checksum = "10e0c05d770d92af1f4230f6f549ab6c4cb47d5e5f7a65339f91fca7fc6b3545"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5032,9 +5032,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.50.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2becf7d5e10e770b597acc91de1c0b79d2a5ff83a5acabe3480f2eb71bdd865c"
+checksum = "654ccb4b723cd1e288bbbb8e798721b8316e19f0de3610ed90ebfbedabf45d45"
 dependencies = [
  "ahash",
  "core-foundation 0.10.1",
@@ -5075,9 +5075,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_config"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8cb547526f1bd3e84173b22f152628c9a5af451019b8969bf9932befcd1d3d"
+checksum = "e7cb7a3302ec74284640c5c7aa911269e1cfd65bd5e8da4299923453e50a0c78"
 dependencies = [
  "dirs",
  "fs-err",
@@ -5114,9 +5114,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_git"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b3e31df047a1415310d19427de0544ddc5ef88102df9bc43223e95ece378c1"
+checksum = "a9b7152dc6e591f5b1512ebcbb5b738cc0adddb61a519e98b62495c211065523"
 dependencies = [
  "astral-reqwest-middleware",
  "dashmap",
@@ -5136,9 +5136,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.31.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5beff6ddf8ad1b58ecba95b5b39f7905ccf00f9db046e92af76c585b487a66f5"
+checksum = "308fb45f4a01891e77e9a6ca585f493169586afee85b374e08f889b460951144"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5186,9 +5186,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7514de242935a48908dd7243c25191497fe0483b47ed1d6da01466d265ee57"
+checksum = "1a39794d7486efd34a701c4e33abd094cff04d78d1f3a9bf9f539a3193b3406c"
 dependencies = [
  "configparser",
  "dirs",
@@ -5217,9 +5217,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.30.5"
+version = "0.30.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769ff012fafdef054b2d697f3807d1a14a551f1b203fe365da6e81ea544b2268"
+checksum = "bad2167f271e0b3ad411a9623de1e948c12dadb05040cd7508015fed78f4e852"
 dependencies = [
  "ambient-id",
  "anyhow",
@@ -5256,9 +5256,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44ee9c39cab94ce1c8308c25b170eb8757d9837416c708be37a3cb60c66abc98"
+checksum = "364ad3b4bac0c95ae1f7c7bdfa33b679c8d64fde14fd47f6fb965836dbc94628"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-tokio-tar",
@@ -5324,9 +5324,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_redaction"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "068b9b88444342b01133c4eb1af90f44e3bc04463d738ac3fa3813df0096c177"
+checksum = "308e86344e78b42b96570e765f287d7cf87fab7f21ba2eb12508363c11b55f72"
 dependencies = [
  "astral-reqwest-middleware",
  "reqwest",
@@ -5335,9 +5335,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769106c5625e788197cfa2c5cb98c585fecf7fea92e8fff90d8d6e8014bb6e76"
+checksum = "50b705828891a4184451f8c5300b9b123bd946c76fa9f55c0057d81fab3f8d28"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5364,6 +5364,7 @@ dependencies = [
  "humantime",
  "itertools 0.15.0",
  "jiff",
+ "js-sys",
  "json-patch",
  "libc",
  "memmap2",
@@ -5379,6 +5380,7 @@ dependencies = [
  "retry-policies",
  "rmp-serde",
  "self_cell",
+ "send_wrapper",
  "serde",
  "serde_json",
  "serde_with",
@@ -5391,16 +5393,19 @@ dependencies = [
  "tokio-util",
  "tracing",
  "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
  "wasmtimer",
+ "web-sys",
  "windows-sys 0.61.2",
  "zstd",
 ]
 
 [[package]]
 name = "rattler_s3"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb450835967a6620a1b73d10db9d697838105d4570d9320c94d7101b2dc15cb3"
+checksum = "3b9701fa2e3a6666991f32fe3b8157afc73caee15c1248bfc08343fb103d9dba"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -5415,9 +5420,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.27.14"
+version = "0.27.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e6b47240a8bd326257e1804e2b521ad00f505db9c229c3b49b69939113f1f1a"
+checksum = "1d87277b0a7b7ccba831890810e903c35b56b3c1003952ad07374da9ebb0b46b"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -5437,9 +5442,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "9.0.2"
+version = "9.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc14e2b00952ae96b6356625cfd4083fb3f1de92a32aa3f2bd78e823bf16c95"
+checksum = "9c287fe2c2a57e66162cadc4430b7aa300251edd73034b1b7bf222a660a9a45e"
 dependencies = [
  "futures",
  "hex",
@@ -5457,9 +5462,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_upload"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ae9c5d57e5701bcc705a152f9703ecb64be96d83d258bf522a0ff3e253e437"
+checksum = "09043dd6c41243fbb8cb118e7809f0238a8f7eea198c728ca551167d67874841"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-reqwest-retry",
@@ -5496,9 +5501,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "5.0.1"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85109cb080a3232e181a360e1db1d140bbe3fabbea6f9cecafeb3b94e63f2608"
+checksum = "4c249324b90e9dcf985991ca4a066b6df72c4c9b300a70746c596e90abe8df2f"
 dependencies = [
  "archspec",
  "libloading",
@@ -5869,7 +5874,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5926,7 +5931,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6102,6 +6107,12 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
@@ -6942,7 +6953,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6952,7 +6963,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7734,7 +7745,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/py-rattler-build/rust/Cargo.toml
+++ b/py-rattler-build/rust/Cargo.toml
@@ -35,11 +35,11 @@ tokio = { version = "1.53.1", features = [
   "rt-multi-thread",
   "process",
 ] }
-rattler_conda_types = "0.50"
+rattler_conda_types = "0.51"
 rattler_config = "0.7"
 rattler_networking = { version = "0.30.3" }
 rattler_solve = "9.0"
-rattler_virtual_packages = "5.0.0"
+rattler_virtual_packages = "5.1.0"
 clap = "4.6.4"
 url = "2.5.8"
 jiff = "0.2.35"


### PR DESCRIPTION
### Description

Updates the rattler crates:

| crate | from | to |
| --- | --- | --- |
| `rattler_conda_types` | 0.50 | 0.51 |
| `rattler_redaction` | 0.2.2 | 0.2.3 |
| `rattler_repodata_gateway` | 0.32 | 0.33 |
| `rattler_virtual_packages` | 5.0 | 5.1 |


### How Has This Been Tested?

- `cargo check --workspace --all-targets` clean, no source changes needed.
- `cargo test --workspace --lib`: 831 pass.
- `cargo fmt --all --check` and `cargo clippy --workspace --all-targets` clean.
- Pointed pixi at this branch: its dependency graph resolves again and `cargo check --workspace` passes, picking up `rattler_virtual_packages` 5.1.0 from crates.io.
