### PR TITLE
fix: emit canonical MatchSpecs for v3 packages

### DIFF
--- a/crates/rattler_build_core/src/packaging.rs
+++ b/crates/rattler_build_core/src/packaging.rs
@@ -95,6 +95,14 @@ pub enum PackagingError {
     #[error("Invalid Metadata: {0}")]
     InvalidMetadata(String),
 
+    #[error("could not render {field} MatchSpec `{spec}` canonically: {source}")]
+    CanonicalMatchSpec {
+        field: String,
+        spec: String,
+        #[source]
+        source: rattler_conda_types::CanonicalMatchSpecError,
+    },
+
     #[error("Invalid MenuInst schema file: {0} - {1}")]
     InvalidMenuInstSchema(PathBuf, serde_json::Error),
 

--- a/crates/rattler_build_core/src/packaging/metadata.rs
+++ b/crates/rattler_build_core/src/packaging/metadata.rs
@@ -29,8 +29,12 @@ use super::{PackagingError, TempFiles};
 use crate::metadata::Output;
 use rattler_build_recipe::stage1::HashInput;
 
-/// Returns whether package dependency MatchSpecs must use CEP 48's canonical
-/// representation for the serialized index record.
+/// Returns whether dependency MatchSpecs are written in the canonical
+/// `name[key="value"]` form.
+///
+/// CEP 48 mandates that form for `depends`, `constrains` and `extra_depends`
+/// in repodata records of revision 3 and up. Writing it into `index.json` too
+/// keeps the package metadata identical to the record indexed from it.
 fn uses_canonical_matchspec_format(revision: Option<RepodataRevision>) -> bool {
     revision.is_some_and(|revision| revision.as_u64() >= RepodataRevision::V3.as_u64())
 }

--- a/crates/rattler_build_core/src/packaging/metadata.rs
+++ b/crates/rattler_build_core/src/packaging/metadata.rs
@@ -29,6 +29,12 @@ use super::{PackagingError, TempFiles};
 use crate::metadata::Output;
 use rattler_build_recipe::stage1::HashInput;
 
+/// Returns whether package dependency MatchSpecs must use CEP 48's canonical
+/// representation for the serialized index record.
+fn uses_canonical_matchspec_format(revision: Option<RepodataRevision>) -> bool {
+    revision.is_some_and(|revision| revision.as_u64() >= RepodataRevision::V3.as_u64())
+}
+
 /// Safely check if a symlink resolves to a regular file, with basic loop protection
 fn is_symlink_to_file(path: &Path) -> bool {
     // Simple approach: try to canonicalize the path, which handles cycles gracefully
@@ -361,6 +367,24 @@ impl Output {
             );
         }
 
+        let repodata_revision = match self.build_configuration.repodata_revision {
+            RepodataRevision::Legacy => None,
+            revision => Some(revision),
+        };
+        let uses_canonical_matchspecs = uses_canonical_matchspec_format(repodata_revision);
+        let format_matchspec = |field: &str, spec: &rattler_conda_types::MatchSpec| {
+            if uses_canonical_matchspecs {
+                spec.to_canonical_string()
+                    .map_err(|source| PackagingError::CanonicalMatchSpec {
+                        field: field.to_string(),
+                        spec: spec.to_string(),
+                        source,
+                    })
+            } else {
+                Ok(spec.to_string())
+            }
+        };
+
         Ok(IndexJson {
             name: self
                 .name()
@@ -380,14 +404,18 @@ impl Output {
                 .run
                 .depends
                 .iter()
-                .map(|dep| dep.spec().to_string())
+                .map(|dep| format_matchspec("depends", dep.spec()))
+                .collect::<Result<Vec<_>, _>>()?
+                .into_iter()
                 .unique()
                 .collect(),
             constrains: finalized_dependencies
                 .run
                 .constraints
                 .iter()
-                .map(|dep| dep.spec().to_string())
+                .map(|dep| format_matchspec("constrains", dep.spec()))
+                .collect::<Result<Vec<_>, _>>()?
+                .into_iter()
                 .unique()
                 .collect(),
             extra_depends: finalized_dependencies
@@ -395,25 +423,25 @@ impl Output {
                 .extra_depends
                 .iter()
                 .map(|(name, deps)| {
-                    (
+                    let field = format!("extra_depends.{name}");
+                    Ok((
                         name.clone(),
                         deps.iter()
-                            .map(|dep| dep.spec().to_string())
+                            .map(|dep| format_matchspec(&field, dep.spec()))
+                            .collect::<Result<Vec<_>, _>>()?
+                            .into_iter()
                             .unique()
                             .collect(),
-                    )
+                    ))
                 })
-                .collect(),
+                .collect::<Result<BTreeMap<_, _>, PackagingError>>()?,
             noarch,
             track_features,
             flags: recipe.build().flags.clone(),
             features: None,
             python_site_packages_path: recipe.build().python.site_packages_path.clone(),
             purls: None,
-            repodata_revision: match self.build_configuration.repodata_revision {
-                RepodataRevision::Legacy => None,
-                revision => Some(revision),
-            },
+            repodata_revision,
         })
     }
 
@@ -605,7 +633,7 @@ impl Output {
 #[cfg(test)]
 mod test {
     use content_inspector::ContentType;
-    use rattler_conda_types::{ChannelUrl, Platform};
+    use rattler_conda_types::{ChannelUrl, Platform, RepodataRevision};
     use url::Url;
 
     #[cfg(unix)]
@@ -613,6 +641,23 @@ mod test {
     use super::fs;
     use super::{contains_prefix_text, create_prefix_placeholder};
     use crate::packaging::metadata::clean_url;
+
+    #[test]
+    fn test_canonical_matchspec_format_revision_threshold() {
+        assert!(!super::uses_canonical_matchspec_format(None));
+        assert!(!super::uses_canonical_matchspec_format(Some(
+            RepodataRevision::Legacy
+        )));
+        assert!(!super::uses_canonical_matchspec_format(Some(
+            RepodataRevision::Unknown(2)
+        )));
+        assert!(super::uses_canonical_matchspec_format(Some(
+            RepodataRevision::V3
+        )));
+        assert!(super::uses_canonical_matchspec_format(Some(
+            RepodataRevision::Unknown(4)
+        )));
+    }
 
     #[test]
     fn detect_prefix() {

--- a/crates/rattler_build_recipe/src/stage0/evaluate.rs
+++ b/crates/rattler_build_recipe/src/stage0/evaluate.rs
@@ -795,7 +795,7 @@ fn evaluate_flag_list(
         }
     })?;
 
-    if !flags.is_empty() && context.repodata_revision() != RepodataRevision::V3 {
+    if !flags.is_empty() && !stage0::supports_v3_repodata_features(context.repodata_revision()) {
         return Err(ParseError::invalid_value(
             "build.flags",
             "package flags require the --v3 flag",
@@ -1198,7 +1198,7 @@ fn ensure_matchspec_v3_allowed(
     context: &EvaluationContext,
     span: Option<&Span>,
 ) -> Result<(), ParseError> {
-    if context.repodata_revision() != RepodataRevision::V3
+    if !stage0::supports_v3_repodata_features(context.repodata_revision())
         && spec.required_repodata_revision() == RepodataRevision::V3
     {
         return Err(ParseError::invalid_value(

--- a/crates/rattler_build_recipe/src/stage0/mod.rs
+++ b/crates/rattler_build_recipe/src/stage0/mod.rs
@@ -1,6 +1,8 @@
 //! The stage0 recipe that contains the un-evaluated recipe information.
 //! This means, it still contains Jinja templates and if-else statements.
 
+use rattler_conda_types::RepodataRevision;
+
 mod about;
 mod build;
 pub mod evaluate;
@@ -40,6 +42,12 @@ pub use types::{
 /// Backwards compatibility alias for Stage0Recipe
 /// This is now the same as SingleOutputRecipe
 pub type Stage0Recipe = SingleOutputRecipe;
+
+/// Returns whether a repodata revision supports the CEP 48 v3 MatchSpec and
+/// recipe-field additions.
+pub(crate) fn supports_v3_repodata_features(revision: RepodataRevision) -> bool {
+    revision.as_u64() >= RepodataRevision::V3.as_u64()
+}
 
 #[cfg(test)]
 mod test {

--- a/crates/rattler_build_recipe/src/stage0/parser/requirements.rs
+++ b/crates/rattler_build_recipe/src/stage0/parser/requirements.rs
@@ -13,6 +13,7 @@ use crate::{
         parser::ParseConfig,
         parser::helpers::get_span,
         requirements::{IgnoreRunExports, Requirements, RunExports},
+        supports_v3_repodata_features,
     },
 };
 
@@ -38,7 +39,7 @@ impl NodeConverter<SerializableMatchSpec> for MatchSpecConverter {
         .map_err(|e| {
             let reason = e.to_string();
             let err = ParseError::invalid_value(field_name, &reason, *scalar.span());
-            if self.repodata_revision != RepodataRevision::V3
+            if !supports_v3_repodata_features(self.repodata_revision)
                 && reason.contains("invalid bracket key")
             {
                 err.with_suggestion(

--- a/crates/rattler_build_recipe/src/variant_render.rs
+++ b/crates/rattler_build_recipe/src/variant_render.rs
@@ -1659,6 +1659,58 @@ requirements:
     }
 
     #[test]
+    fn test_render_future_repodata_revision_supports_v3_features() {
+        let recipe_yaml = r#"
+package:
+  name: test-pkg
+  version: "1.0.0"
+
+build:
+  flags:
+    - cuda
+
+requirements:
+  run:
+    - 'foo[when="python >=3.11"]'
+    - 'bar[flags=[cuda]]'
+  extras:
+    dev:
+      - 'pytest[extras=[test]]'
+"#;
+
+        let revision = RepodataRevision::Unknown(4);
+        let stage0_recipe = stage0::parse_recipe_or_multi_from_source_with_config(
+            recipe_yaml,
+            stage0::ParseConfig {
+                repodata_revision: revision,
+            },
+        )
+        .unwrap();
+
+        let rendered = render_recipe_with_variant_config(
+            &stage0_recipe,
+            &VariantConfig::default(),
+            RenderConfig::new().with_repodata_revision(revision),
+        )
+        .unwrap();
+
+        assert_eq!(rendered.len(), 1);
+        assert_eq!(rendered[0].recipe.build.flags[0].as_str(), "cuda");
+        assert_eq!(
+            rendered[0].recipe.requirements.run[0].to_string(),
+            "foo[when=\"python>=3.11\"]"
+        );
+        assert_eq!(
+            rendered[0].recipe.requirements.run[1].to_string(),
+            "bar[flags=[cuda]]"
+        );
+        assert_eq!(
+            rendered[0].recipe.requirements.extras["dev"][0].to_string(),
+            "pytest[extras=[test]]"
+        );
+    }
+
+    #[test]
     fn test_render_multi_output_simple() {
         let recipe_yaml = r#"
 schema_version: 1

--- a/test-data/recipes/legacy-index-shape/recipe.yaml
+++ b/test-data/recipes/legacy-index-shape/recipe.yaml
@@ -8,6 +8,12 @@ requirements:
   extras:
     test:
       - pytest >=8
+  run:
+    - python >=3.10
+    - python >=3.10
+  run_constraints:
+    - python <4
+    - python <4
 
 build:
   script:

--- a/test-data/v3-recipes/v3-index-shape/recipe.yaml
+++ b/test-data/v3-recipes/v3-index-shape/recipe.yaml
@@ -18,11 +18,16 @@ build:
 requirements:
   run:
     - python >=3.10
+    - python >=3.10
     - scipy[when="python >=3.10"]
     - blas-provider[flags=[blas:*]]
+  run_constraints:
+    - python <4
+    - python <4
   extras:
     plot:
       - matplotlib >=3.8
     full:
+      - pandas >=2
       - pandas >=2
       - rich[extras=[jupyter]]

--- a/test/end-to-end/test_v3_repodata.py
+++ b/test/end-to-end/test_v3_repodata.py
@@ -146,9 +146,11 @@ def _read_map(data: bytes, offset: int, length: int) -> tuple[dict[Any, Any], in
 def assert_v3_index_json(index_json: dict[str, Any]) -> None:
     assert index_json["repodata_revision"] == 3
     assert index_json["flags"] == ["cuda", "blas:openblas"]
+    assert index_json["depends"].count('python[version=">=3.10"]') == 1
+    assert index_json["constrains"] == ['python[version="<4"]']
     assert index_json["extra_depends"] == {
-        "full": ["pandas >=2", "rich[extras=[jupyter]]"],
-        "plot": ["matplotlib >=3.8"],
+        "full": ['pandas[version=">=2"]', "rich[extras=[jupyter]]"],
+        "plot": ['matplotlib[version=">=3.8"]'],
     }
     assert 'scipy[when="python>=3.10"]' in index_json["depends"]
     assert "blas-provider[flags=[blas:*]]" in index_json["depends"]
@@ -157,6 +159,8 @@ def assert_v3_index_json(index_json: dict[str, Any]) -> None:
 def assert_legacy_index_json(index_json: dict[str, Any]) -> None:
     assert "repodata_revision" not in index_json
     assert "flags" not in index_json
+    assert index_json["depends"].count("python >=3.10") == 1
+    assert index_json["constrains"] == ["python <4"]
 
 
 def test_v3_build_writes_v3_index_json(rattler_build: RattlerBuild, tmp_path: Path):


### PR DESCRIPTION
## Why

This closes a gap in our CEP 48 implementation. Packages marked with `repodata_revision: 3` were still writing positional legacy MatchSpecs to `info/index.json`, even though their v3 records require the canonical `name[...]` representation.

For revision 3 and newer, rattler-build now writes canonical MatchSpecs for `depends`, `constrains`, and `extra_depends`. Legacy packages keep their existing positional representation. The recipe parser uses the same revision threshold, so future revisions consistently support the v3 recipe fields too.

The index-shape tests also cover duplicate dependencies to make sure canonicalization does not change the existing deduplication behavior.

Related rattler indexer change: https://github.com/conda/rattler/pull/2718

## Testing

- `pixi run cargo test -p rattler_build_core test_canonical_matchspec_format_revision_threshold`
- `pixi run cargo test -p rattler_build_recipe test_render_future_repodata_revision_supports_v3_features`
- `pixi run cargo check -p rattler_build_core -p rattler_build_recipe`
- `RUSTC_WRAPPER= pixi run build-release`
- `pixi run pytest test/end-to-end/test_v3_repodata.py -v` (7 passed)
- `pixi run cargo fmt --check`
