### PR TITLE
feat: add nested output subpackages

### DIFF
--- a/crates/rattler_build_core/src/consts.rs
+++ b/crates/rattler_build_core/src/consts.rs
@@ -22,3 +22,12 @@ pub const RATTLER_BUILD_PACKAGE_FILES: &str = "RATTLER_BUILD_PACKAGE_FILES";
 /// and namespaced so that build scripts are extremely unlikely to clobber it
 /// by accident.
 pub const PACKAGE_FILES_LIST_NAME: &str = ".rattler-build-package-files";
+
+/// Selector-script output containing prefix-relative paths/globs for one nested subpackage.
+pub const RATTLER_BUILD_SUBPACKAGE_FILES: &str = "RATTLER_BUILD_SUBPACKAGE_FILES";
+
+/// Directory under the restored work tree holding generated subpackage selections.
+pub const SUBPACKAGE_FILES_DIR: &str = ".rattler-build-subpackage-files";
+
+/// Cached copy of the parent build's explicit package file list.
+pub const SUBPACKAGE_PARENT_FILES: &str = "parent-package-files.txt";

--- a/crates/rattler_build_core/src/packaging.rs
+++ b/crates/rattler_build_core/src/packaging.rs
@@ -1,7 +1,7 @@
 //! This module contains the functions to package a conda package from a given
 //! output.
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     io::Write,
     path::{Component, Path, PathBuf},
 };
@@ -103,6 +103,20 @@ pub enum PackagingError {
 
     #[error("Package file `{0}` listed in $RATTLER_BUILD_PACKAGE_FILES does not exist")]
     PackageFileMissing(PathBuf),
+
+    #[error(
+        "Invalid generated subpackage pattern `{0}`: patterns must be prefix-relative and cannot contain `..`"
+    )]
+    InvalidSubpackagePattern(String),
+
+    #[error("Generated subpackage selection `{0}` must be a regular file")]
+    InvalidSubpackageSelectionFile(PathBuf),
+
+    #[error("Subpackage selector did not produce `{0}`")]
+    MissingSubpackageSelectionFile(PathBuf),
+
+    #[error("File `{path}` is selected by more than one subpackage: {packages}")]
+    OverlappingSubpackageSelection { path: PathBuf, packages: String },
 }
 
 /// Split a path into the longest leading directory prefix that contains no glob
@@ -1002,6 +1016,103 @@ fn create_empty_build_folder(
     Ok(())
 }
 
+fn generated_subpackage_globs(
+    output: &Output,
+    selection: &rattler_build_recipe::stage1::SubpackageSelection,
+) -> Result<Option<GlobVec>, PackagingError> {
+    let path = output
+        .build_configuration
+        .directories
+        .work_dir
+        .join(crate::consts::SUBPACKAGE_FILES_DIR)
+        .join(format!("{}.txt", selection.name.as_normalized()));
+    let file_type = match fs::symlink_metadata(&path) {
+        Ok(metadata) => metadata.file_type(),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            if selection.script.is_default() {
+                return Ok(None);
+            }
+            return Err(PackagingError::MissingSubpackageSelectionFile(path));
+        }
+        Err(error) => return Err(error.into()),
+    };
+    if !file_type.is_file() || file_type.is_symlink() {
+        return Err(PackagingError::InvalidSubpackageSelectionFile(path));
+    }
+
+    let mut patterns = Vec::new();
+    for line in fs::read_to_string(path)?.lines() {
+        let pattern = line.trim();
+        if pattern.is_empty() || pattern.starts_with('#') {
+            continue;
+        }
+        let candidate = Path::new(pattern);
+        if candidate.is_absolute()
+            || candidate.components().any(|component| {
+                matches!(
+                    component,
+                    Component::ParentDir | Component::RootDir | Component::Prefix(_)
+                )
+            })
+        {
+            return Err(PackagingError::InvalidSubpackagePattern(
+                pattern.to_string(),
+            ));
+        }
+        patterns.push(pattern.to_string());
+    }
+    Ok(Some(GlobVec::from_strings(patterns, Vec::new())?))
+}
+
+fn apply_subpackage_split(output: &Output, files: &mut Files) -> Result<(), PackagingError> {
+    let Some(split) = &output.recipe.subpackage_split else {
+        return Ok(());
+    };
+
+    let generated = split
+        .children
+        .iter()
+        .map(|child| generated_subpackage_globs(output, child))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut selected_by = BTreeMap::<PathBuf, Vec<&str>>::new();
+    for file in &files.new_files {
+        let relative = file.strip_prefix(&files.prefix)?;
+        for (child, generated) in split.children.iter().zip(&generated) {
+            if child.files.is_match(relative)
+                || generated
+                    .as_ref()
+                    .is_some_and(|patterns| patterns.is_match(relative))
+            {
+                selected_by
+                    .entry(file.clone())
+                    .or_default()
+                    .push(child.name.as_normalized());
+            }
+        }
+    }
+
+    if let Some((path, packages)) = selected_by.iter().find(|(_, packages)| packages.len() > 1) {
+        return Err(PackagingError::OverlappingSubpackageSelection {
+            path: path.strip_prefix(&files.prefix)?.to_path_buf(),
+            packages: packages.join(", "),
+        });
+    }
+
+    if split.current == split.parent {
+        files
+            .new_files
+            .retain(|file| !selected_by.contains_key(file));
+    } else {
+        files.new_files.retain(|file| {
+            selected_by
+                .get(file)
+                .is_some_and(|packages| packages == &[split.current.as_normalized()])
+        });
+    }
+    Ok(())
+}
+
 impl Output {
     /// Create a conda package from any new files in the host prefix. Note: the
     /// previous stages should have been completed before calling this
@@ -1015,12 +1126,34 @@ impl Output {
         let _enter = span.enter();
 
         let host_prefix = &self.build_configuration.directories.host_prefix;
-        let package_files_list = self
+        let default_package_files_list = self
             .build_configuration
             .directories
             .package_files_list_path();
+        let cached_parent_files = self
+            .build_configuration
+            .directories
+            .work_dir
+            .join(crate::consts::SUBPACKAGE_FILES_DIR)
+            .join(crate::consts::SUBPACKAGE_PARENT_FILES);
+        let package_files_list = self
+            .recipe
+            .subpackage_split
+            .as_ref()
+            .filter(|split| split.current == split.parent && cached_parent_files.is_file())
+            .map(|_| &cached_parent_files)
+            .unwrap_or(&default_package_files_list);
 
-        let files_after = match read_package_files_list(&package_files_list)? {
+        // Split families need the complete produced-file set so overlap validation and the
+        // parent's complement are independent of the parent's own `build.files` filter.
+        let unfiltered = GlobVec::default();
+        let files_filter = if self.recipe.subpackage_split.is_some() {
+            &unfiltered
+        } else {
+            &self.recipe.build().files
+        };
+
+        let mut files_after = match read_package_files_list(package_files_list)? {
             Some(paths) => {
                 tracing::info!(
                     "Using {} explicit package file(s) from {}",
@@ -1031,17 +1164,26 @@ impl Output {
                     host_prefix,
                     paths,
                     &self.recipe.build().always_include_files,
-                    &self.recipe.build().files,
+                    files_filter,
                 )?
             }
             None => Files::from_prefix(
                 host_prefix,
                 &self.recipe.build().always_include_files,
-                &self.recipe.build().files,
+                files_filter,
                 post_install_files,
             )?,
         };
 
+        apply_subpackage_split(self, &mut files_after)?;
+        if self.recipe.subpackage_split.is_some() && !self.recipe.build().files.is_empty() {
+            files_after.new_files.retain(|file| {
+                self.recipe.build().files.is_match(
+                    file.strip_prefix(&files_after.prefix)
+                        .expect("package files live below the prefix"),
+                )
+            });
+        }
         package_conda(self, tool_configuration, &files_after)
     }
 }

--- a/crates/rattler_build_core/src/packaging/file_finder.rs
+++ b/crates/rattler_build_core/src/packaging/file_finder.rs
@@ -214,11 +214,7 @@ impl Files {
 
         let mut new_files = HashSet::new();
         for path in paths {
-            let resolved = if path.is_absolute() {
-                path
-            } else {
-                prefix.join(path)
-            };
+            let resolved = crate::utils::to_lexical_absolute(&path, prefix);
 
             if resolved.strip_prefix(prefix).is_err() {
                 return Err(PackagingError::PackageFileOutsidePrefix(resolved));
@@ -501,6 +497,26 @@ mod test {
         let err = Files::from_paths(
             prefix,
             vec![outside_file],
+            &Default::default(),
+            &Default::default(),
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            crate::packaging::PackagingError::PackageFileOutsidePrefix(_)
+        ));
+    }
+
+    #[test]
+    fn test_files_from_paths_relative_traversal_errors() {
+        let tempdir = tempfile::TempDir::new().unwrap();
+        let prefix = tempdir.path().join("prefix");
+        fs_err::create_dir_all(&prefix).unwrap();
+        fs_err::write(tempdir.path().join("escape.txt"), b"nope").unwrap();
+
+        let err = Files::from_paths(
+            &prefix,
+            vec![PathBuf::from("../escape.txt")],
             &Default::default(),
             &Default::default(),
         )

--- a/crates/rattler_build_core/src/staging.rs
+++ b/crates/rattler_build_core/src/staging.rs
@@ -12,16 +12,17 @@ use std::{
 use fs_err as fs;
 use miette::{Context, IntoDiagnostic};
 use rattler_build_jinja::Variable;
-use rattler_build_recipe::stage1::{InheritsFrom, StagingCache};
+use rattler_build_recipe::stage1::{BuildPlan, InheritsFrom, StagingCache};
 use rattler_build_script::{ExecutionContext, RuntimeEnv};
 use rattler_build_types::NormalizedKey;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::{
+    consts::{RATTLER_BUILD_SUBPACKAGE_FILES, SUBPACKAGE_FILES_DIR, SUBPACKAGE_PARENT_FILES},
     env_vars,
     metadata::{Output, build_reindexed_channels},
-    packaging::Files,
+    packaging::{Files, read_package_files_list},
     post_process::package_nature::{LibraryNameMap, PrefixInfo},
     render::resolved_dependencies::{
         FinalizedDependencies, RunExportsDownload, install_environments, resolve_dependencies,
@@ -300,17 +301,39 @@ impl Output {
         // CONDA_BUILD_SYSROOT) that the staging cache's compilers depend on.
         env_vars.extend(env_vars::env_vars_from_variant(&staging.used_variant));
 
-        // A staging cache does not produce a package, so the PKG_* vars
-        // (which would otherwise carry the inheriting output's identity) are
-        // misleading here.
-        for key in [
-            "PKG_NAME",
-            "PKG_VERSION",
-            "PKG_BUILDNUM",
-            "PKG_BUILD_STRING",
-            "PKG_HASH",
-        ] {
-            env_vars.remove(key);
+        if let Some(identity) = &staging.package_identity {
+            // An implicit subpackage staging build is the parent package's one real build.
+            // Always use the finalized parent identity, even when only a child was requested.
+            env_vars.insert(
+                "PKG_NAME".to_string(),
+                Some(identity.package.name.as_normalized().to_string()),
+            );
+            env_vars.insert(
+                "PKG_VERSION".to_string(),
+                Some(identity.package.version.to_string()),
+            );
+            env_vars.insert(
+                "PKG_BUILDNUM".to_string(),
+                Some(identity.build_number.to_string()),
+            );
+            if let Some(build_string) = &identity.build_string {
+                env_vars.insert("PKG_BUILD_STRING".to_string(), Some(build_string.clone()));
+            }
+            if let Some(hash) = &identity.hash {
+                env_vars.insert("PKG_HASH".to_string(), Some(hash.clone()));
+            }
+        } else {
+            // An explicit staging cache does not produce a package, so inheritor PKG_* vars
+            // would be misleading.
+            for key in [
+                "PKG_NAME",
+                "PKG_VERSION",
+                "PKG_BUILDNUM",
+                "PKG_BUILD_STRING",
+                "PKG_HASH",
+            ] {
+                env_vars.remove(key);
+            }
         }
 
         let context = if staging.build.merge_build_and_host_envs {
@@ -334,10 +357,10 @@ impl Output {
             &staging.build.plan,
             self.recipe.context(),
             self.build_configuration.selector_config(),
-            env_vars,
+            env_vars.clone(),
             self.build_configuration.directories.work_dir.clone(),
             &self.build_configuration.directories.recipe_dir,
-            context,
+            context.clone(),
             self.build_configuration.sandbox_config().cloned(),
             self.build_configuration.env_isolation,
             self.build_configuration.experimental,
@@ -346,6 +369,81 @@ impl Output {
         rattler_build_script::run_script(exec_args)
             .await
             .into_diagnostic()?;
+
+        // Dynamic split selectors run after the common build in the same environment. Their
+        // outputs live in the work tree so they are persisted and restored with the cache.
+        let selection_dir = self
+            .build_configuration
+            .directories
+            .work_dir
+            .join(SUBPACKAGE_FILES_DIR);
+        fs::create_dir_all(&selection_dir).into_diagnostic()?;
+        let parent_files = self
+            .build_configuration
+            .directories
+            .package_files_list_path();
+        let cached_parent_files = selection_dir.join(SUBPACKAGE_PARENT_FILES);
+        if cached_parent_files.exists() {
+            fs::remove_file(&cached_parent_files).into_diagnostic()?;
+        }
+        if let Some(paths) = read_package_files_list(&parent_files).into_diagnostic()? {
+            let mut normalized = String::new();
+            for path in paths {
+                let relative = if path.is_absolute() {
+                    path.strip_prefix(self.prefix())
+                        .into_diagnostic()
+                        .context("$RATTLER_BUILD_PACKAGE_FILES entry is outside the split prefix")?
+                } else {
+                    path.as_path()
+                };
+                normalized.push_str(&relative.to_string_lossy());
+                normalized.push('\n');
+            }
+            fs::write(cached_parent_files, normalized).into_diagnostic()?;
+        }
+        for selector in &staging.subpackage_selectors {
+            if selector.script.is_default() {
+                continue;
+            }
+            let output_file = selection_dir.join(format!("{}.txt", selector.name.as_normalized()));
+            if output_file.exists() {
+                fs::remove_file(&output_file).into_diagnostic()?;
+            }
+
+            let mut script = selector.script.clone();
+            script.env.insert(
+                RATTLER_BUILD_SUBPACKAGE_FILES.to_string(),
+                output_file.to_string_lossy().into_owned(),
+            );
+            let selector_plan = BuildPlan::Script(script);
+            let exec_args = prepare_build_plan_execution_args(
+                &selector_plan,
+                self.recipe.context(),
+                self.build_configuration.selector_config(),
+                env_vars.clone(),
+                self.build_configuration.directories.work_dir.clone(),
+                &self.build_configuration.directories.recipe_dir,
+                context.clone(),
+                self.build_configuration.sandbox_config().cloned(),
+                self.build_configuration.env_isolation,
+                self.build_configuration.experimental,
+            )
+            .into_diagnostic()?;
+            rattler_build_script::run_script(exec_args)
+                .await
+                .into_diagnostic()?;
+            let output_type = fs::symlink_metadata(&output_file)
+                .map(|metadata| metadata.file_type())
+                .ok();
+            if !output_type.is_some_and(|file_type| file_type.is_file() && !file_type.is_symlink())
+            {
+                miette::bail!(
+                    "subpackage selector for '{}' did not create a regular {} file",
+                    selector.name.as_normalized(),
+                    RATTLER_BUILD_SUBPACKAGE_FILES
+                );
+            }
+        }
 
         // Find the new files in the prefix
         let new_files = Files::from_prefix(

--- a/crates/rattler_build_recipe/src/stage0/evaluate.rs
+++ b/crates/rattler_build_recipe/src/stage0/evaluate.rs
@@ -3037,6 +3037,178 @@ impl Evaluate for Stage0Recipe {
     }
 }
 
+fn no_op_build_plan() -> Stage1BuildPlan {
+    Stage1BuildPlan::Script(rattler_build_script::Script {
+        content: ScriptContent::Commands(Vec::new()),
+        ..Default::default()
+    })
+}
+
+fn package_runtime_requirements(mut requirements: Stage1Requirements) -> Stage1Requirements {
+    requirements.build.clear();
+    requirements.host.clear();
+    requirements.ignore_run_exports = Stage1IgnoreRunExports::default();
+    requirements
+}
+
+fn staging_requirements(mut requirements: Stage1Requirements) -> Stage1Requirements {
+    requirements.run.clear();
+    requirements.run_constraints.clear();
+    requirements.extras.clear();
+    requirements.run_exports = Stage1RunExports::default();
+    requirements
+}
+
+fn augment_used_variant(
+    recipe: &mut Stage1Recipe,
+    context: &EvaluationContext,
+    requirements: &Stage1Requirements,
+) {
+    let accessed = context.accessed_variables();
+    let free_specs = requirements
+        .free_specs()
+        .into_iter()
+        .map(NormalizedKey::from)
+        .collect::<HashSet<_>>();
+    for (key, value) in context.variables() {
+        if accessed.contains(key) || free_specs.contains(&NormalizedKey::from(key.as_str())) {
+            recipe
+                .used_variant
+                .insert(NormalizedKey::from(key.as_str()), value.clone());
+        }
+    }
+}
+
+fn evaluate_subpackage_family(
+    mut parent: Stage1Recipe,
+    output: &stage0::PackageOutput,
+    context: &EvaluationContext,
+) -> Result<Vec<Stage1Recipe>, ParseError> {
+    context.clear_accessed();
+    let mut selections = Vec::with_capacity(output.subpackages.len());
+    for subpackage in &output.subpackages {
+        let name = PackageName::from_str(&evaluate_value_to_string(
+            &subpackage.package.name,
+            context,
+        )?)
+        .map_err(|error| {
+            ParseError::invalid_value("subpackage name", error.to_string(), Span::new_blank())
+        })?;
+        let files = evaluate_glob_vec(&subpackage.split.files, context)?;
+        let script = evaluate_script(&subpackage.split.script, context)?;
+        selections.push(stage1::SubpackageSelection {
+            name,
+            files,
+            script,
+        });
+    }
+
+    let parent_name = parent.package.name.clone();
+    let mut seen = HashSet::from([parent_name.as_normalized().to_string()]);
+    for selection in &selections {
+        if !seen.insert(selection.name.as_normalized().to_string()) {
+            return Err(ParseError::invalid_value(
+                "subpackages",
+                format!(
+                    "duplicate split package name '{}'",
+                    selection.name.as_normalized()
+                ),
+                Span::new_blank(),
+            ));
+        }
+    }
+
+    let parent_requirements = parent.requirements.clone();
+    augment_used_variant(&mut parent, context, &parent_requirements);
+
+    let cache_name = format!("__rattler_build_split_{}", parent_name.as_normalized());
+    let mut cache = stage1::StagingCache::new(
+        cache_name.clone(),
+        parent.build.clone(),
+        staging_requirements(parent.requirements.clone()),
+        parent.source.clone(),
+        parent.used_variant.clone(),
+    );
+    // The common cache must retain every produced file. The parent's `build.files`
+    // filter is applied only when packaging the parent; children may select files outside it.
+    cache.build.files = GlobVec::default();
+    cache.subpackage_selectors = selections.clone();
+    cache.package_identity = Some(stage1::StagingPackageIdentity {
+        package: parent.package.clone(),
+        build_number: parent.build.number.unwrap_or(0),
+        build_string: None,
+        hash: None,
+    });
+
+    let split_for = |current: PackageName| stage1::SubpackageSplit {
+        parent: parent_name.clone(),
+        current,
+        children: selections.clone(),
+    };
+
+    parent.build.plan = no_op_build_plan();
+    parent.requirements = package_runtime_requirements(parent.requirements);
+    parent.source.clear();
+    parent.staging_caches = vec![cache.clone()];
+    parent.inherits_from = Some(stage1::InheritsFrom::new(cache_name.clone()));
+    parent.subpackage_split = Some(split_for(parent_name.clone()));
+    let parent_runtime_requirements = parent.requirements.clone();
+    let parent_about = parent.about.clone();
+    let parent_tests = parent.tests.clone();
+
+    let mut result = vec![parent.clone()];
+    for (subpackage, selection) in output.subpackages.iter().zip(&selections) {
+        context.clear_accessed();
+        let mut child = parent.clone();
+        child.package.name = selection.name.clone();
+        if let Some(version) = &subpackage.package.version {
+            child.package.version = VersionWithSource::from_str(&evaluate_value_to_string(
+                version, context,
+            )?)
+            .map_err(|error| {
+                ParseError::invalid_value(
+                    "subpackage version",
+                    error.to_string(),
+                    Span::new_blank(),
+                )
+            })?;
+        }
+
+        child.requirements = if let Some(requirements) = &subpackage.requirements {
+            requirements.evaluate(context)?
+        } else {
+            parent_runtime_requirements.clone()
+        };
+        if let Some(build) = &subpackage.build {
+            child.build = merge_stage1_build(child.build, build.evaluate(context)?);
+        }
+        child.build.plan = no_op_build_plan();
+        child.build.files = GlobVec::default();
+        child.about = if let Some(about) = &subpackage.about {
+            merge_stage1_about(parent_about.clone(), about.evaluate(context)?)
+        } else {
+            parent_about.clone()
+        };
+        child.tests = if let Some(tests) = &subpackage.tests {
+            let mut evaluated = Vec::new();
+            for test in tests {
+                evaluated.extend(evaluate_test(test, context)?);
+            }
+            evaluated
+        } else {
+            parent_tests.clone()
+        };
+        child.subpackage_split = Some(split_for(selection.name.clone()));
+        child.inherits_from = Some(stage1::InheritsFrom::new(cache_name.clone()));
+        child.staging_caches = vec![cache.clone()];
+        let child_requirements = child.requirements.clone();
+        augment_used_variant(&mut child, context, &child_requirements);
+        result.push(child);
+    }
+
+    Ok(result)
+}
+
 fn build_plan_inherits_from_toplevel(toplevel: &Stage1BuildPlan, output: &Stage1BuildPlan) -> bool {
     matches!(
         output,
@@ -3586,6 +3758,15 @@ impl Evaluate for crate::stage0::MultiOutputRecipe {
                 };
 
                 recipe.context = evaluated_context.clone();
+
+                if !pkg_output.subpackages.is_empty() {
+                    evaluated_outputs.extend(evaluate_subpackage_family(
+                        recipe,
+                        pkg_output,
+                        &context_with_vars,
+                    )?);
+                    continue;
+                }
 
                 // Set staging_caches and inherits_from based on the inherit field
                 match &pkg_output.inherit {
@@ -6463,6 +6644,79 @@ package:
         let r = render_template(r#"${{ foo | default("x") | upper }}"#, &ctx, None);
         assert!(r.is_ok(), "default then upper must work: {:?}", r.err());
         assert_eq!(r.unwrap(), "X");
+    }
+
+    #[test]
+    fn nested_subpackages_expand_to_one_staging_build_and_split_outputs() {
+        let yaml = r#"
+recipe:
+  version: 1.2.3
+about:
+  license: MIT
+  summary: parent
+outputs:
+  - package:
+      name: demo
+    build:
+      script: echo build
+    requirements:
+      run: [runtime]
+    subpackages:
+      - package:
+          name: demo-dev
+        split:
+          files: [include/**]
+          script: echo 'lib/cmake/**' >> "$RATTLER_BUILD_SUBPACKAGE_FILES"
+        requirements: {}
+        about:
+          summary: development
+"#;
+        let parsed = parse_recipe_or_multi_from_source(yaml).unwrap();
+        let stage0::Recipe::MultiOutput(recipe) = parsed else {
+            panic!("expected multi-output recipe");
+        };
+        let recipes = recipe
+            .evaluate(&EvaluationContext::for_platform(
+                rattler_conda_types::Platform::Linux64,
+            ))
+            .unwrap();
+
+        assert_eq!(recipes.len(), 2);
+        let parent = &recipes[0];
+        let child = &recipes[1];
+        assert_eq!(parent.package.name.as_normalized(), "demo");
+        assert_eq!(child.package.name.as_normalized(), "demo-dev");
+        assert_eq!(parent.staging_caches.len(), 1);
+        assert_eq!(child.staging_caches.len(), 1);
+        assert_eq!(parent.staging_caches[0].subpackage_selectors.len(), 1);
+        assert!(parent.source.is_empty());
+        assert!(
+            parent
+                .requirements
+                .run
+                .iter()
+                .any(|dep| dep.to_string() == "runtime")
+        );
+        assert!(child.requirements.is_empty());
+        assert_eq!(child.about.summary.as_deref(), Some("development"));
+        assert_eq!(
+            child
+                .about
+                .license
+                .as_ref()
+                .map(ToString::to_string)
+                .as_deref(),
+            Some("MIT")
+        );
+        assert_eq!(
+            child
+                .subpackage_split
+                .as_ref()
+                .unwrap()
+                .parent
+                .as_normalized(),
+            "demo"
+        );
     }
 
     #[test]

--- a/crates/rattler_build_recipe/src/stage0/mod.rs
+++ b/crates/rattler_build_recipe/src/stage0/mod.rs
@@ -20,7 +20,8 @@ pub use extra::Extra;
 pub use match_spec::SerializableMatchSpec;
 pub use output::{
     CacheInherit, Inherit, MultiOutputRecipe, Output, PackageOutput, Recipe, RecipeMetadata,
-    SingleOutputRecipe, StagingBuild, StagingMetadata, StagingOutput,
+    SingleOutputRecipe, StagingBuild, StagingMetadata, StagingOutput, SubpackageOutput,
+    SubpackageSplit,
 };
 pub use package::{Package, PackageMetadata};
 pub use parser::{

--- a/crates/rattler_build_recipe/src/stage0/output.rs
+++ b/crates/rattler_build_recipe/src/stage0/output.rs
@@ -13,7 +13,7 @@ use crate::stage0::{
     requirements::Requirements,
     source::Source,
     tests::TestType,
-    types::{ConditionalList, Item, Value},
+    types::{ConditionalList, IncludeExclude, Item, Script, Value},
 };
 
 /// A recipe can be either a single-output or multi-output recipe
@@ -178,6 +178,49 @@ pub struct PackageOutput {
     /// Tests for this output
     #[serde(default, skip_serializing_if = "ConditionalList::is_empty")]
     pub tests: ConditionalList<TestType>,
+
+    /// Packages split from the files produced by this output.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub subpackages: Vec<SubpackageOutput>,
+}
+
+/// A package split from a parent package output without rerunning its build.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct SubpackageOutput {
+    /// Package identity. The version defaults to the parent package version.
+    pub package: PackageMetadata,
+
+    /// File selection and optional dynamic selector.
+    pub split: SubpackageSplit,
+
+    /// Replacement requirements. Omitted requirements inherit from the parent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requirements: Option<Requirements>,
+
+    /// Build metadata overrides. Executable plans are not allowed here.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub build: Option<Build>,
+
+    /// About metadata overlaid on the parent metadata.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub about: Option<About>,
+
+    /// Replacement tests. Omitted tests inherit from the parent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tests: Option<ConditionalList<TestType>>,
+}
+
+/// How files are selected for a subpackage.
+#[derive(Debug, Clone, PartialEq, Serialize, Default)]
+pub struct SubpackageSplit {
+    /// Static include/exclude globs, relative to the package prefix.
+    #[serde(default)]
+    pub files: IncludeExclude,
+
+    /// Optional selector script that writes additional paths/globs to the file
+    /// named by `RATTLER_BUILD_SUBPACKAGE_FILES`.
+    #[serde(default, skip_serializing_if = "Script::is_default")]
+    pub script: Script,
 }
 
 /// Serialize TopLevel as null
@@ -460,47 +503,81 @@ impl StagingOutput {
 impl PackageOutput {
     /// Get all used variables in this package output
     pub fn used_variables(&self) -> Vec<String> {
-        let PackageOutput {
-            package,
-            inherit,
-            source,
-            requirements,
-            build,
-            about,
-            tests,
-        } = self;
-
-        let mut vars = package.used_variables();
-        vars.extend(inherit.used_variables());
-        for src_item in source {
+        let mut vars = self.package.used_variables();
+        vars.extend(self.inherit.used_variables());
+        for src_item in &self.source {
             vars.extend(collect_source_item_variables(src_item));
         }
-        vars.extend(requirements.used_variables());
-        vars.extend(build.used_variables());
-        vars.extend(about.used_variables());
-        for test_item in tests {
+        vars.extend(self.requirements.used_variables());
+        vars.extend(self.build.used_variables());
+        vars.extend(self.about.used_variables());
+        for test_item in &self.tests {
             vars.extend(collect_test_item_variables(test_item));
+        }
+        for subpackage in &self.subpackages {
+            vars.extend(subpackage.used_variables());
         }
         vars.sort();
         vars.dedup();
         vars
     }
 
-    /// Get all free specs (specs without version or build constraints) in this package output
+    /// Get all free specs (specs without version or build constraints) in this output and its splits.
     pub fn free_specs(&self) -> Vec<rattler_conda_types::PackageName> {
-        self.requirements.free_specs()
+        let mut specs = self.requirements.free_specs();
+        for subpackage in &self.subpackages {
+            if let Some(requirements) = &subpackage.requirements {
+                specs.extend(requirements.free_specs());
+            }
+        }
+        specs
     }
 
-    /// Get all use_keys from build.variant.use_keys
-    ///
-    /// These are variant keys that should be forcibly included in the variant matrix.
+    /// Get all use_keys from build.variant.use_keys in this output and its splits.
     pub fn use_keys(&self) -> Vec<String> {
-        self.build
+        let mut keys = self
+            .build
             .variant
             .use_keys
             .iter()
             .filter_map(|item| item.as_value().and_then(|v| v.as_concrete().cloned()))
-            .collect()
+            .collect::<Vec<_>>();
+        for subpackage in &self.subpackages {
+            if let Some(build) = &subpackage.build {
+                keys.extend(
+                    build
+                        .variant
+                        .use_keys
+                        .iter()
+                        .filter_map(|item| item.as_value().and_then(|v| v.as_concrete().cloned())),
+                );
+            }
+        }
+        keys
+    }
+}
+
+impl SubpackageOutput {
+    /// Get all template and selector variables used by this subpackage.
+    pub fn used_variables(&self) -> Vec<String> {
+        let mut vars = self.package.used_variables();
+        vars.extend(self.split.files.used_variables());
+        vars.extend(self.split.script.used_variables());
+        if let Some(requirements) = &self.requirements {
+            vars.extend(requirements.used_variables());
+        }
+        if let Some(build) = &self.build {
+            vars.extend(build.used_variables());
+        }
+        if let Some(about) = &self.about {
+            vars.extend(about.used_variables());
+        }
+        if let Some(tests) = &self.tests {
+            for test in tests {
+                vars.extend(collect_test_item_variables(test));
+            }
+        }
+        vars
     }
 }
 

--- a/crates/rattler_build_recipe/src/stage0/parser/build.rs
+++ b/crates/rattler_build_recipe/src/stage0/parser/build.rs
@@ -559,7 +559,7 @@ pub(crate) fn reject_script_and_steps(
     Ok(())
 }
 
-fn parse_build_files(node: &Node) -> Result<IncludeExclude, ParseError> {
+pub(crate) fn parse_build_files(node: &Node) -> Result<IncludeExclude, ParseError> {
     // Try parsing as a mapping with include/exclude first
     if let Some(mapping) = node.as_mapping() {
         let mut include = None;

--- a/crates/rattler_build_recipe/src/stage0/parser/output_parser.rs
+++ b/crates/rattler_build_recipe/src/stage0/parser/output_parser.rs
@@ -11,7 +11,7 @@ use crate::{
         ConditionalList, Requirements, Value,
         output::{
             CacheInherit, Inherit, MultiOutputRecipe, Output, PackageOutput, RecipeMetadata,
-            StagingBuild, StagingMetadata, StagingOutput,
+            StagingBuild, StagingMetadata, StagingOutput, SubpackageOutput, SubpackageSplit,
         },
         parser::{
             ParseConfig, get_span, parse_about, parse_build, parse_extra, parse_source, parse_tests,
@@ -440,6 +440,102 @@ fn parse_package_metadata(yaml: &MarkedNode) -> ParseResult<crate::stage0::Packa
     Ok(crate::stage0::PackageMetadata { name, version })
 }
 
+fn parse_subpackages(yaml: &MarkedNode, config: ParseConfig) -> ParseResult<Vec<SubpackageOutput>> {
+    let sequence = yaml.as_sequence().ok_or_else(|| {
+        ParseError::expected_type("sequence", "non-sequence", get_span(yaml))
+            .with_message("subpackages must be a list")
+    })?;
+
+    sequence
+        .iter()
+        .map(|item| {
+            let mapping = item.as_mapping().ok_or_else(|| {
+                ParseError::expected_type("mapping", "non-mapping", get_span(item))
+                    .with_message("each subpackage must be a mapping")
+            })?;
+
+            let package = parse_package_metadata(mapping.get("package").ok_or_else(|| {
+                ParseError::missing_field("package", get_span(item))
+            })?)?;
+
+            let split_node = mapping.get("split").ok_or_else(|| {
+                ParseError::missing_field("split", get_span(item)).with_suggestion(
+                    "add `split: {files: [...]}` or a `split.script` selector",
+                )
+            })?;
+            let split_mapping = split_node.as_mapping().ok_or_else(|| {
+                ParseError::expected_type("mapping", "non-mapping", get_span(split_node))
+                    .with_message("split must be a mapping")
+            })?;
+            split_node.validate_keys("subpackage split", &["files", "script"])?;
+            let files = split_mapping
+                .get("files")
+                .map(super::build::parse_build_files)
+                .transpose()?
+                .unwrap_or_default();
+            let script = split_mapping
+                .get("script")
+                .map(super::build::parse_script)
+                .transpose()?
+                .unwrap_or_default();
+            if files == Default::default() && script.is_default() {
+                return Err(ParseError::invalid_value(
+                    "split",
+                    "a subpackage split needs static files or a selector script",
+                    get_span(split_node),
+                ));
+            }
+
+            let requirements = mapping
+                .get("requirements")
+                .map(|node| super::requirements::parse_requirements_with_config(node, config))
+                .transpose()?;
+            let build = mapping.get("build").map(parse_build).transpose()?;
+            if let Some(build) = &build {
+                let build_span = get_span(mapping.get("build").expect("checked above"));
+                if !build.plan.is_default() {
+                    return Err(ParseError::invalid_value(
+                        "subpackage build",
+                        "subpackage build sections cannot contain script or steps",
+                        build_span,
+                    )
+                    .with_suggestion("put file-discovery commands under `split.script`; the parent build runs only once"));
+                }
+                if build.files != Default::default() {
+                    return Err(ParseError::invalid_value(
+                        "subpackage build.files",
+                        "use split.files to select subpackage contents",
+                        build_span,
+                    ));
+                }
+                if !build.skip.is_empty() {
+                    return Err(ParseError::invalid_value(
+                        "subpackage build.skip",
+                        "conditional nested subpackages are not supported yet",
+                        build_span,
+                    ));
+                }
+            }
+            let about = mapping.get("about").map(parse_about).transpose()?;
+            let tests = mapping.get("tests").map(parse_tests).transpose()?;
+
+            item.validate_keys(
+                "subpackage",
+                &["package", "split", "requirements", "build", "about", "tests"],
+            )?;
+
+            Ok(SubpackageOutput {
+                package,
+                split: SubpackageSplit { files, script },
+                requirements,
+                build,
+                about,
+                tests,
+            })
+        })
+        .collect()
+}
+
 /// Parse a package output
 fn parse_package_output(
     mapping: &marked_yaml::types::MarkedMappingNode,
@@ -493,6 +589,20 @@ fn parse_package_output(
         ConditionalList::default()
     };
 
+    let subpackages = mapping
+        .get("subpackages")
+        .map(|node| parse_subpackages(node, config))
+        .transpose()?
+        .unwrap_or_default();
+
+    if !subpackages.is_empty() && !matches!(inherit, Inherit::TopLevel) {
+        return Err(ParseError::invalid_value(
+            "subpackages",
+            "a package with subpackages cannot itself inherit from a staging output",
+            get_span(mapping.get("subpackages").expect("checked above")),
+        ));
+    }
+
     // Validate field names
     let node = MarkedNode::Mapping(mapping.clone());
     node.validate_keys(
@@ -505,6 +615,7 @@ fn parse_package_output(
             "build",
             "about",
             "tests",
+            "subpackages",
         ],
     )?;
 
@@ -516,6 +627,7 @@ fn parse_package_output(
         build,
         about,
         tests,
+        subpackages,
     })
 }
 

--- a/crates/rattler_build_recipe/src/stage1/mod.rs
+++ b/crates/rattler_build_recipe/src/stage1/mod.rs
@@ -35,7 +35,10 @@ pub use hash::{HashInfo, HashInput, compute_hash};
 use indexmap::IndexMap;
 pub use package::Package;
 use rattler_build_yaml_parser::ParseError;
-pub use recipe::{InheritsFrom, Recipe, StagingCache};
+pub use recipe::{
+    InheritsFrom, Recipe, StagingCache, StagingPackageIdentity, SubpackageSelection,
+    SubpackageSplit,
+};
 pub use requirements::{Dependency, PinCompatible, PinSubpackage, Requirements};
 pub use source::Source;
 pub use tests::TestType;

--- a/crates/rattler_build_recipe/src/stage1/recipe.rs
+++ b/crates/rattler_build_recipe/src/stage1/recipe.rs
@@ -2,6 +2,9 @@
 
 use indexmap::IndexMap;
 use rattler_build_jinja::Variable;
+use rattler_build_script::Script;
+use rattler_build_types::GlobVec;
+use rattler_conda_types::PackageName;
 use serde::{Deserialize, Serialize};
 
 use super::{About, Build, Extra, Package, Requirements, Source, TestType};
@@ -34,6 +37,14 @@ pub struct StagingCache {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub source: Vec<Source>,
 
+    /// Selector scripts used to discover files for nested subpackages.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub subpackage_selectors: Vec<SubpackageSelection>,
+
+    /// Parent package identity exposed while running an implicit split build.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub package_identity: Option<StagingPackageIdentity>,
+
     /// Used variant - the subset of variant variables that were actually accessed
     #[serde(skip)]
     pub used_variant: std::collections::BTreeMap<rattler_build_types::NormalizedKey, Variable>,
@@ -53,9 +64,54 @@ impl StagingCache {
             build,
             requirements,
             source,
+            subpackage_selectors: Vec::new(),
+            package_identity: None,
             used_variant,
         }
     }
+}
+
+/// Package variables exposed by an implicit split staging build.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StagingPackageIdentity {
+    /// Parent package identity.
+    pub package: Package,
+    /// Parent build number.
+    pub build_number: u64,
+    /// Final parent build string, populated after variant rendering.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub build_string: Option<String>,
+    /// Final parent package hash, populated after variant rendering.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hash: Option<String>,
+}
+
+/// One child file selection in a nested subpackage split.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SubpackageSelection {
+    /// Child package receiving the selected files.
+    pub name: PackageName,
+
+    /// Static prefix-relative include/exclude globs.
+    #[serde(default)]
+    pub files: GlobVec,
+
+    /// Optional script that writes more prefix-relative paths/globs.
+    #[serde(default, skip_serializing_if = "Script::is_default")]
+    pub script: Script,
+}
+
+/// Runtime split information attached to every package in a split family.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SubpackageSplit {
+    /// Package that owns all files not selected by a child.
+    pub parent: PackageName,
+
+    /// Current package in the split family.
+    pub current: PackageName,
+
+    /// All child selectors; needed to compute the parent's complement.
+    pub children: Vec<SubpackageSelection>,
 }
 
 /// Inheritance configuration for package outputs
@@ -150,6 +206,10 @@ pub struct Recipe {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub inherits_from: Option<InheritsFrom>,
 
+    /// File partition information for an output with nested subpackages.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subpackage_split: Option<SubpackageSplit>,
+
     /// Used variant - the subset of variant variables that were actually accessed
     /// during recipe evaluation (plus always-included variables like target_platform)
     #[serde(skip)]
@@ -182,6 +242,7 @@ impl Recipe {
             context,
             staging_caches: Vec::new(),
             inherits_from: None,
+            subpackage_split: None,
             used_variant,
         }
     }
@@ -213,6 +274,7 @@ impl Recipe {
             context,
             staging_caches,
             inherits_from,
+            subpackage_split: None,
             used_variant,
         }
     }

--- a/crates/rattler_build_recipe/src/variant_render.rs
+++ b/crates/rattler_build_recipe/src/variant_render.rs
@@ -777,8 +777,19 @@ fn discover_new_variant_keys_from_evaluation(
                 };
 
                 // Only evaluate requirements for non-skipped outputs
-                if !should_skip && let Ok(evaluated) = reqs.evaluate(&context_with_vars) {
-                    all_free_specs.extend(evaluated.free_specs());
+                if !should_skip {
+                    if let Ok(evaluated) = reqs.evaluate(&context_with_vars) {
+                        all_free_specs.extend(evaluated.free_specs());
+                    }
+                    if let stage0::Output::Package(package) = output {
+                        for subpackage in &package.subpackages {
+                            if let Some(requirements) = &subpackage.requirements
+                                && let Ok(evaluated) = requirements.evaluate(&context_with_vars)
+                            {
+                                all_free_specs.extend(evaluated.free_specs());
+                            }
+                        }
+                    }
                 }
             }
             all_free_specs
@@ -1018,7 +1029,40 @@ fn render_with_empty_combinations(
         finalize_build_string_single(&mut results[i], config)?;
     }
 
+    populate_subpackage_staging_identities(&mut results);
     Ok(results)
+}
+
+fn populate_subpackage_staging_identities(results: &mut [RenderedVariant]) {
+    let snapshot = results.to_vec();
+    for result in results {
+        let Some(split) = &result.recipe.subpackage_split else {
+            continue;
+        };
+        let matching = snapshot
+            .iter()
+            .filter(|candidate| candidate.recipe.package.name == split.parent)
+            .max_by_key(|candidate| {
+                result
+                    .full_combination
+                    .iter()
+                    .filter(|(key, value)| candidate.full_combination.get(*key) == Some(*value))
+                    .count()
+            });
+        let Some(parent) = matching else {
+            continue;
+        };
+        let build_string = parent.recipe.build.string.as_resolved().map(str::to_string);
+        let hash = parent.hash_info.as_ref().map(ToString::to_string);
+        for cache in &mut result.recipe.staging_caches {
+            if let Some(identity) = &mut cache.package_identity {
+                identity.package = parent.recipe.package.clone();
+                identity.build_number = parent.recipe.build.number.unwrap_or(0);
+                identity.build_string = build_string.clone();
+                identity.hash = hash.clone();
+            }
+        }
+    }
 }
 
 /// Helper function to finalize a single build string
@@ -1454,6 +1498,7 @@ fn render_with_variants(
         finalize_build_string_single(&mut results[i], &config)?;
     }
 
+    populate_subpackage_staging_identities(&mut results);
     Ok(results)
 }
 
@@ -1705,6 +1750,66 @@ outputs:
 
         assert!(names.contains(&"multi-pkg-lib".to_string()));
         assert!(names.contains(&"multi-pkg".to_string()));
+    }
+
+    #[test]
+    fn nested_subpackage_requirements_expand_variants_and_keep_parent_identity() {
+        let recipe_yaml = r#"
+recipe:
+  version: 1.0.0
+outputs:
+  - package:
+      name: split-parent
+    build:
+      string: py${{ python | replace(".", "") }}_0
+      script: echo build
+    subpackages:
+      - package:
+          name: split-child
+        split:
+          files: [include/**]
+        requirements:
+          host: [python]
+"#;
+        let stage0_recipe = stage0::parse_recipe_or_multi_from_source(recipe_yaml).unwrap();
+        let variant_config = VariantConfig::from_yaml_str(
+            r#"
+python:
+  - "3.11"
+  - "3.12"
+"#,
+        )
+        .unwrap();
+        let rendered =
+            render_recipe_with_variant_config(&stage0_recipe, &variant_config, RenderConfig::new())
+                .unwrap();
+
+        let parents = rendered
+            .iter()
+            .filter(|variant| variant.recipe.package.name.as_normalized() == "split-parent")
+            .collect::<Vec<_>>();
+        let children = rendered
+            .iter()
+            .filter(|variant| variant.recipe.package.name.as_normalized() == "split-child")
+            .collect::<Vec<_>>();
+        assert_eq!(parents.len(), 2);
+        assert_eq!(children.len(), 2);
+        for child in children {
+            let python = child.variant.get(&NormalizedKey::from("python")).unwrap();
+            let parent = parents
+                .iter()
+                .find(|parent| parent.variant.get(&NormalizedKey::from("python")) == Some(python))
+                .unwrap();
+            let identity = child.recipe.staging_caches[0]
+                .package_identity
+                .as_ref()
+                .unwrap();
+            assert_eq!(identity.package.name.as_normalized(), "split-parent");
+            assert_eq!(
+                identity.build_string.as_deref(),
+                parent.recipe.build.string.as_resolved()
+            );
+        }
     }
 
     #[test]

--- a/docs/build_script.md
+++ b/docs/build_script.md
@@ -463,6 +463,13 @@ noted, no variables are inherited from the shell environment in which you invoke
 
   [override-package-contents]: ./build_options.md#override-package-contents-from-the-build-script
 
+`RATTLER_BUILD_SUBPACKAGE_FILES`
+
+: Available only to a nested subpackage's `split.script`. The selector must
+  create this file and write one prefix-relative path or glob per line. These
+  entries are added to `split.files` and removed from the parent package. See
+  [Nested subpackages](reference/multi_output.md#nested-subpackages).
+
 `PKG_BUILDNUM`
 
 : Indicates the build number of the package currently being built.

--- a/docs/reference/multi_output.md
+++ b/docs/reference/multi_output.md
@@ -133,6 +133,94 @@ outputs:
 ```
 
 
+## Nested subpackages
+
+A package output can split files into nested `subpackages` without repeating its
+source preparation or build. Rattler-build turns the parent build into a private
+staging cache, restores the complete result for each package, and treats the
+family as a partition:
+
+- each child receives files matching its `split.files` globs and generated selectors;
+- the parent receives the complement after all child selections;
+- selecting one file for two children is an error rather than silently duplicating it.
+
+```yaml
+outputs:
+  - package:
+      name: mylib
+    build:
+      script:
+        - cmake -S . -B build -DCMAKE_INSTALL_PREFIX=$PREFIX
+        - cmake --build build --target install
+    requirements:
+      build:
+        - cmake
+        - ninja
+        - ${{ compiler("c") }}
+      run:
+        - runtime-dependency
+
+    subpackages:
+      - package:
+          name: mylib-dev
+        split:
+          files:
+            - include/**
+            - lib/pkgconfig/**
+        requirements:
+          run:
+            - ${{ pin_subpackage("mylib", exact=True) }}
+        about:
+          summary: Headers and development metadata for mylib
+
+      - package:
+          name: mylib-docs
+        split:
+          files:
+            - share/doc/mylib/**
+        requirements: {} # explicitly replace inherited requirements
+```
+
+A child inherits the parent's version, build metadata, requirements, tests, and
+`about` metadata by default. An explicitly present `requirements` or `tests`
+section replaces the inherited section. `about` and non-executable `build`
+settings overlay the parent field by field. Child `build.script` and
+`build.steps` are rejected because the defining property of a split is that the
+parent build runs once. Use the `split` section for file discovery instead.
+
+### Script-generated selections
+
+Static globs are not always enough (for example, a compiler or language tool may
+produce a manifest). A `split.script` runs once, immediately after the common
+build, in the same environment and work directory. The common build receives
+the parent package's `PKG_*` identity even if only a child output was requested.
+The selector must write one
+prefix-relative path or glob per line to `RATTLER_BUILD_SUBPACKAGE_FILES`:
+
+```yaml
+subpackages:
+  - package:
+      name: mylib-dev
+    split:
+      files:
+        - include/**
+      script: |
+        find "$PREFIX/lib/cmake" -type f -printf 'lib/cmake/%P\n' \
+          >> "$RATTLER_BUILD_SUBPACKAGE_FILES"
+```
+
+Blank lines and lines beginning with `#` are ignored. Generated entries are
+unioned with `split.files`. Absolute paths and `..` components are rejected so a
+cached selection is portable between prefixes. The selector must create the
+special file, even when its result is empty.
+
+Nested subpackages are intentionally one level deep and cannot currently use a
+subpackage-specific `build.skip`. A parent containing `subpackages` cannot also
+use explicit `inherit`, because it already owns an
+automatically generated private staging cache. The parent's `build.files` is
+applied after child files are removed; the private cache itself always retains
+the complete build result so children can select any produced file.
+
 ## Staging Outputs
 
 A staging output compiles code once and caches the result. Package outputs then

--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -1650,6 +1650,37 @@ Due to the variant config file, this will build two versions of `libtest`. We
 will also build two versions of `test`, one that depends on `libtest (openssl
 1)` and one that depends on `libtest (openssl 3)`.
 
+### Nested subpackages
+
+A package output may contain `subpackages:` whose files are split from the
+parent build. Each entry has `package` metadata and a required `split` mapping:
+
+```yaml
+outputs:
+  - package:
+      name: libtest
+    build:
+      script: install-everything
+    subpackages:
+      - package:
+          name: libtest-dev
+        split:
+          files:
+            - include/**
+        requirements:
+          run:
+            - ${{ pin_subpackage("libtest", exact=True) }}
+```
+
+The parent build executes once. Child selections are removed from the parent,
+and overlapping child selections are rejected. `split.files` accepts the same
+list or `include`/`exclude` mapping as `build.files`. An optional
+`split.script` can write additional prefix-relative paths or globs, one per
+line, to `$RATTLER_BUILD_SUBPACKAGE_FILES`.
+
+See [Nested subpackages](multi_output.md#nested-subpackages) for inheritance,
+overrides, dynamic selection, and current scope.
+
 ### Staging outputs
 
 !!!note

--- a/test-data/recipes/subpackages-overlap/recipe.yaml
+++ b/test-data/recipes/subpackages-overlap/recipe.yaml
@@ -1,0 +1,24 @@
+schema_version: 1
+recipe:
+  version: 1.0.0
+outputs:
+  - package:
+      name: overlapping-parent
+    build:
+      script:
+        - if: unix
+          then:
+            - mkdir -p "$PREFIX/include"
+            - echo header > "$PREFIX/include/shared.h"
+          else:
+            - mkdir "%PREFIX%\include"
+            - echo header> "%PREFIX%\include\shared.h"
+    subpackages:
+      - package:
+          name: overlapping-a
+        split:
+          files: [include/**]
+      - package:
+          name: overlapping-b
+        split:
+          files: [include/**]

--- a/test-data/recipes/subpackages-traversal/recipe.yaml
+++ b/test-data/recipes/subpackages-traversal/recipe.yaml
@@ -1,0 +1,23 @@
+schema_version: 1
+recipe:
+  version: 1.0.0
+outputs:
+  - package:
+      name: traversal-parent
+    build:
+      script:
+        - if: unix
+          then:
+            - mkdir -p "$PREFIX/share/traversal"
+            - echo data > "$PREFIX/share/traversal/data.txt"
+          else:
+            - mkdir "%PREFIX%\share\traversal"
+            - echo data> "%PREFIX%\share\traversal\data.txt"
+    subpackages:
+      - package:
+          name: traversal-child
+        split:
+          script:
+            - if: unix
+              then: echo '../outside' >> "$RATTLER_BUILD_SUBPACKAGE_FILES"
+              else: echo ..\outside>> "%RATTLER_BUILD_SUBPACKAGE_FILES%"

--- a/test-data/recipes/subpackages/recipe.yaml
+++ b/test-data/recipes/subpackages/recipe.yaml
@@ -1,0 +1,71 @@
+schema_version: 1
+
+recipe:
+  name: split-demo
+  version: 1.0.0
+
+about:
+  license: BSD-3-Clause
+  summary: Parent summary
+
+outputs:
+  - package:
+      name: split-demo
+    build:
+      script:
+        - if: unix
+          then:
+            - mkdir -p "$PREFIX/include/split-demo" "$PREFIX/lib/cmake/split-demo" "$PREFIX/share/split-demo/doc"
+            - echo header > "$PREFIX/include/split-demo/demo.h"
+            - echo cmake > "$PREFIX/lib/cmake/split-demo/SplitDemoConfig.cmake"
+            - echo "$PKG_NAME $PKG_VERSION $PKG_BUILDNUM $PKG_BUILD_STRING $PKG_HASH" > "$PREFIX/share/split-demo/runtime.txt"
+            - echo "$PKG_NAME $PKG_VERSION $PKG_BUILDNUM $PKG_BUILD_STRING $PKG_HASH" > "$PREFIX/share/split-demo/doc/readme.txt"
+          else:
+            - mkdir "%PREFIX%\include\split-demo" "%PREFIX%\lib\cmake\split-demo" "%PREFIX%\share\split-demo\doc"
+            - echo header> "%PREFIX%\include\split-demo\demo.h"
+            - echo cmake> "%PREFIX%\lib\cmake\split-demo\SplitDemoConfig.cmake"
+            - echo %PKG_NAME% %PKG_VERSION% %PKG_BUILDNUM% %PKG_BUILD_STRING% %PKG_HASH%> "%PREFIX%\share\split-demo\runtime.txt"
+            - echo %PKG_NAME% %PKG_VERSION% %PKG_BUILDNUM% %PKG_BUILD_STRING% %PKG_HASH%> "%PREFIX%\share\split-demo\doc\readme.txt"
+    tests:
+      - package_contents:
+          files:
+            - share/split-demo/runtime.txt
+          strict: true
+
+    subpackages:
+      - package:
+          name: split-demo-dev
+        split:
+          files:
+            - include/**
+          script:
+            - if: unix
+              then: echo 'lib/cmake/**' >> "$RATTLER_BUILD_SUBPACKAGE_FILES"
+              else: echo lib/cmake/**>> "%RATTLER_BUILD_SUBPACKAGE_FILES%"
+        requirements:
+          run:
+            - ${{ pin_subpackage("split-demo", exact=True) }}
+        build:
+          number: 7
+        about:
+          summary: Development files split from split-demo
+        tests:
+          - package_contents:
+              files:
+                - include/split-demo/demo.h
+                - lib/cmake/split-demo/SplitDemoConfig.cmake
+              strict: true
+
+      - package:
+          name: split-demo-docs
+        split:
+          files:
+            - share/split-demo/doc/**
+        requirements: {}
+        about:
+          summary: Documentation split from split-demo
+        tests:
+          - package_contents:
+              files:
+                - share/split-demo/doc/readme.txt
+              strict: true

--- a/test/end-to-end/test_subpackages.py
+++ b/test/end-to-end/test_subpackages.py
@@ -1,0 +1,120 @@
+"""End-to-end coverage for packages split from a parent output."""
+
+import json
+import sys
+from pathlib import Path
+
+from helpers import RattlerBuild, get_extracted_package
+
+
+def package_files(package: Path) -> set[str]:
+    paths = json.loads((package / "info/paths.json").read_text())["paths"]
+    return {entry["_path"] for entry in paths}
+
+
+def command_output(result) -> str:
+    return (result.stdout or "") + (result.stderr or "")
+
+
+def test_nested_subpackages_partition_one_build(
+    rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
+):
+    result = rattler_build(
+        *rattler_build.build_args(recipes / "subpackages", tmp_path),
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, command_output(result)
+    output = command_output(result)
+    # Windows CI currently sends rattler-build tracing directly to the console
+    # instead of the subprocess pipes.
+    if sys.platform != "win32":
+        assert (
+            output.count("Building new staging cache: __rattler_build_split_split-demo")
+            == 1
+        )
+
+    parent = get_extracted_package(tmp_path, "split-demo-1.0.0-")
+    development = get_extracted_package(tmp_path, "split-demo-dev-1.0.0-")
+    documentation = get_extracted_package(tmp_path, "split-demo-docs-1.0.0-")
+
+    parent_files = package_files(parent)
+    development_files = package_files(development)
+    documentation_files = package_files(documentation)
+
+    assert "share/split-demo/runtime.txt" in parent_files
+    identity = (parent / "share/split-demo/runtime.txt").read_text().split()
+    parent_index = json.loads((parent / "info/index.json").read_text())
+    assert identity[:3] == ["split-demo", "1.0.0", "0"]
+    assert identity[3] == parent_index["build"]
+    assert identity[4].startswith("h")
+    assert "include/split-demo/demo.h" not in parent_files
+    assert "lib/cmake/split-demo/SplitDemoConfig.cmake" not in parent_files
+    assert "share/split-demo/doc/readme.txt" not in parent_files
+
+    assert "include/split-demo/demo.h" in development_files
+    assert "lib/cmake/split-demo/SplitDemoConfig.cmake" in development_files
+    assert "share/split-demo/runtime.txt" not in development_files
+
+    assert documentation_files >= {"share/split-demo/doc/readme.txt"}
+    assert "share/split-demo/runtime.txt" not in documentation_files
+
+    dev_index = json.loads((development / "info/index.json").read_text())
+    assert any(
+        dependency.startswith("split-demo ==1.0.0")
+        for dependency in dev_index["depends"]
+    )
+    assert dev_index["name"] == "split-demo-dev"
+    assert dev_index["build_number"] == 7
+
+    dev_about = json.loads((development / "info/about.json").read_text())
+    assert dev_about["summary"] == "Development files split from split-demo"
+    assert dev_about["license"] == "BSD-3-Clause"
+
+
+def test_building_only_a_child_uses_parent_package_identity(
+    rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
+):
+    result = rattler_build(
+        *rattler_build.build_args(
+            recipes / "subpackages",
+            tmp_path,
+            extra_args=["--up-to", "split-demo-docs"],
+        ),
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, command_output(result)
+    documentation = get_extracted_package(tmp_path, "split-demo-docs-1.0.0-")
+    identity = (documentation / "share/split-demo/doc/readme.txt").read_text().split()
+    assert identity[:3] == ["split-demo", "1.0.0", "0"]
+    assert identity[3].startswith("h")
+    assert identity[4].startswith("h")
+
+
+def test_overlapping_subpackage_globs_fail(
+    rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
+):
+    result = rattler_build(
+        *rattler_build.build_args(recipes / "subpackages-overlap", tmp_path),
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    if sys.platform != "win32":
+        assert "selected by more than one subpackage" in command_output(result)
+
+
+def test_generated_subpackage_globs_cannot_escape_prefix(
+    rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
+):
+    result = rattler_build(
+        *rattler_build.build_args(recipes / "subpackages-traversal", tmp_path),
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    if sys.platform != "win32":
+        output = command_output(result)
+        assert "Invalid generated subpackage pattern" in output
+        assert "prefix-relative" in output


### PR DESCRIPTION
## Summary

Add nested `subpackages` to a package output. A parent output builds once, child packages select files from that result, and selected files are removed from the parent.

```yaml
outputs:
  - package:
      name: mylib
    build:
      script: cmake --install build --prefix "$PREFIX"

    subpackages:
      - package:
          name: mylib-dev
        split:
          files:
            - include/**
            - lib/pkgconfig/**
        requirements:
          run:
            - ${{ pin_subpackage("mylib", exact=True) }}
        about:
          summary: Development files for mylib
```

This is syntactic and semantic support for the common “build once, split runtime/dev/docs packages” case. It avoids hand-authoring a staging output plus several sibling package outputs and, importantly, defines what happens to the parent files.

## Semantics

- The parent source preparation and build execute exactly once in an automatically generated private staging cache.
- Every child receives the union of its static `split.files` selection and its generated selection.
- The parent receives the complement of all child selections, followed by its own `build.files` filter.
- A file selected by two children is an error. Splits are partitions, not an order-dependent copy operation.
- Child version, build metadata, requirements, tests, and `about` can be overridden:
  - version defaults to the parent version;
  - omitted requirements inherit the parent package-time requirements, while an explicit section (including `{}`) replaces them;
  - omitted tests inherit; an explicit tests section replaces them;
  - `about` and non-executable `build` fields overlay the parent;
  - child `build.script`, `build.steps`, `build.files`, and `build.skip` are rejected with targeted guidance.
- Common build/host requirements and run exports flow through the private staging cache. Explicit child build/host requirements remain possible for child-specific packaging/post-processing needs.
- The common build always sees the finalized parent `PKG_NAME`, `PKG_VERSION`, `PKG_BUILDNUM`, `PKG_BUILD_STRING`, and `PKG_HASH`, including when only a child is requested with `--up-to`.

## Dynamic selection protocol

A child may add `split.script`. It runs once after the common build, in the same environment and prepared work tree:

```yaml
split:
  files:
    - include/**
  script: |
    find "$PREFIX/lib/cmake" -type f -printf 'lib/cmake/%P\n' \
      >> "$RATTLER_BUILD_SUBPACKAGE_FILES"
```

The script must create `RATTLER_BUILD_SUBPACKAGE_FILES` and write one prefix-relative path or glob per line. Blank lines and comments are ignored. Absolute paths, `..`, missing manifests, and non-regular manifests are rejected. Generated manifests are cached with the common staging result and included in the staging cache identity through the selector configuration.

The existing `RATTLER_BUILD_PACKAGE_FILES` override is retained for the parent build and applied before taking the parent complement.

## Design thoughts

I looked at Melange/Wolfi for comparison. Melange models subpackages next to one origin package and gives each a pipeline; reusable pipelines such as `split/dev`, `split/static`, and `split/manpages` physically move files from `targets.destdir` to `targets.subpkgdir`. That model has two especially good ideas:

1. subpackages are structurally owned by the build that produced their files;
2. common policies should eventually be reusable presets rather than repeated glob lists.

Rattler-build differs because one recipe already has multiple independently buildable package outputs and staging outputs. Nesting under a **package output** therefore seems more precise than a second top-level subpackage system: each existing output can own a split family.

I chose a declarative partition rather than exposing a mutable child destination directory. It makes overlap an explicit error, removes ordering effects between children, is portable across restored staging prefixes, and allows rebuild/render metadata to describe the split. `split.script` is an escape hatch for discovery, but it emits a manifest rather than moving files itself.

Possible follow-ups, deliberately left out of this PR:

- reusable selection policies inspired by Melange, e.g. `split: {uses: dev}` for headers, pkg-config, CMake, unversioned linker symlinks, and static archives;
- conditional/range-generated subpackages;
- allowing a split family to consume an explicitly named staging output instead of owning a private one;
- deciding whether tests should inherit by default or default to empty (this PR chooses inheritance plus explicit replacement);
- supporting one syntax on single-output recipes as sugar for converting them to a multi-output recipe;
- richer generated-manifest operations such as explicit exclusions (static `split.files` already supports include/exclude mappings).

Current scope is intentionally one nested level. A parent with subpackages cannot also specify `inherit`, because the parent build itself is the source of the private staging cache.

## Correctness and safety details

- All produced files are retained in the private cache even when the parent has `build.files`; the parent filter is applied only after splitting.
- Child selectors participate in used-variable and variant discovery.
- Parent identities are matched and propagated after build-string finalization for each variant.
- Selection overlap reporting is deterministic.
- Generated entries cannot escape the package prefix and cached selector outputs cannot be symlinks.
- Existing `$RATTLER_BUILD_PACKAGE_FILES` entries are now lexically normalized, closing a relative `../` traversal gap while preserving absolute/relative in-prefix paths.
- Selector scripts and generated files are part of serialized rendered metadata, so package rebuilds preserve the behavior.

## Validation

- `cargo test --workspace`
- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- Rust formatting, Ruff, Prettier (YAML), Typos, and `git diff --check`
- 4 focused cross-platform E2E cases:
  - one common build partitioned into runtime, development, and docs artifacts;
  - static globs plus a script-generated CMake glob;
  - requirements/about/build-number overrides and exact parent pinning;
  - `--up-to` child-only build preserving parent `PKG_*` identity;
  - overlap rejection;
  - traversal rejection for generated manifests.

The normal package tests embedded in all three successful artifacts also pass.
