### PR TITLE
feat: load packaged actions through the action compiler

### DIFF
--- a/crates/rattler_build_core/src/lib.rs
+++ b/crates/rattler_build_core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod render;
 pub mod script;
 pub mod source;
 pub mod staging;
+pub mod step_provider;
 pub mod system_tools;
 pub mod tool_configuration;
 

--- a/crates/rattler_build_core/src/packaging.rs
+++ b/crates/rattler_build_core/src/packaging.rs
@@ -9,7 +9,7 @@ use std::{
 use fs_err as fs;
 use fs_err::File;
 use indicatif::HumanBytes;
-use metadata::clean_url;
+pub(crate) use metadata::clean_url;
 use rattler_build_types::{GlobVec, LateBoundGlobVec};
 use rattler_conda_types::{
     ChannelUrl, Platform,

--- a/crates/rattler_build_core/src/render/solver.rs
+++ b/crates/rattler_build_core/src/render/solver.rs
@@ -253,6 +253,44 @@ pub async fn install_packages(
     target_prefix: &Path,
     tool_configuration: &tool_configuration::Configuration,
 ) -> miette::Result<()> {
+    install_packages_with_link_scripts(
+        name,
+        required_packages,
+        target_platform,
+        target_prefix,
+        tool_configuration,
+        true,
+    )
+    .await
+}
+
+/// Install a data-only environment without running package link scripts.
+pub async fn install_packages_without_link_scripts(
+    name: &str,
+    required_packages: &[RepoDataRecord],
+    target_platform: Platform,
+    target_prefix: &Path,
+    tool_configuration: &tool_configuration::Configuration,
+) -> miette::Result<()> {
+    install_packages_with_link_scripts(
+        name,
+        required_packages,
+        target_platform,
+        target_prefix,
+        tool_configuration,
+        false,
+    )
+    .await
+}
+
+async fn install_packages_with_link_scripts(
+    name: &str,
+    required_packages: &[RepoDataRecord],
+    target_platform: Platform,
+    target_prefix: &Path,
+    tool_configuration: &tool_configuration::Configuration,
+    execute_link_scripts: bool,
+) -> miette::Result<()> {
     let span_msg = format!("Installing {name} environment");
     let span = tracing::info_span!("", message = %span_msg);
     let _enter = span.enter();
@@ -299,7 +337,7 @@ pub async fn install_packages(
     Installer::new()
         .with_download_client(tool_configuration.client.get_client().clone())
         .with_target_platform(target_platform)
-        .with_execute_link_scripts(true)
+        .with_execute_link_scripts(execute_link_scripts)
         .with_package_cache(tool_configuration.package_cache.clone())
         .with_installed_packages(installed_packages)
         .with_io_concurrency_limit(tool_configuration.io_concurrency_limit.unwrap_or_default())

--- a/crates/rattler_build_core/src/step_provider.rs
+++ b/crates/rattler_build_core/src/step_provider.rs
@@ -1,9 +1,14 @@
 //! Transport for packaged action sources consumed by the recipe compiler.
 
-use std::{collections::HashMap, path::{Path, PathBuf}};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
 
 use miette::{IntoDiagnostic, WrapErr};
-use rattler_build_recipe::actions::{ActionProvenance, ActionRequest, ActionSource, ActionSources, ResolvedProvider};
+use rattler_build_recipe::actions::{
+    ActionProvenance, ActionRequest, ActionSource, ActionSources, ResolvedProvider,
+};
 use rattler_conda_types::{ChannelUrl, MatchSpec, ParseStrictness, RepoDataRecord};
 use rattler_solve::{ChannelPriority, SolveStrategy};
 use sha2::{Digest, Sha256};
@@ -24,10 +29,15 @@ struct ProviderEnvironment {
 /// Solve settings for the independent build-platform provider environment.
 /// Provider dependencies are never added to recipe build or host requirements.
 pub struct ProviderSolveConfig<'a> {
+    /// Build platform and virtual packages used to solve the provider environment.
     pub build_platform: &'a PlatformWithVirtualPackages,
+    /// Ordered channels searched for provider packages.
     pub channels: &'a [ChannelUrl],
+    /// Channel priority applied during the provider solve.
     pub channel_priority: ChannelPriority,
+    /// Package-version selection strategy for the provider solve.
     pub solve_strategy: SolveStrategy,
+    /// Latest permitted package timestamp.
     pub exclude_newer: Option<jiff::Timestamp>,
 }
 
@@ -45,27 +55,49 @@ struct PackageReference<'a> {
 }
 
 fn package_reference(reference: &str) -> miette::Result<PackageReference<'_>> {
-    let invalid = || miette::miette!(
-        "invalid packaged action reference `{reference}`; expected `provider:step[@version]`"
-    );
+    let invalid = || {
+        miette::miette!(
+            "invalid packaged action reference `{reference}`; expected `provider:step[@version]`"
+        )
+    };
     let (provider, step_and_version) = reference.split_once(':').ok_or_else(invalid)?;
-    let (step, version) = step_and_version.split_once('@')
-        .map_or((step_and_version, None), |(step, version)| (step, Some(version)));
-    let valid = |value: &str| !value.is_empty() && value.chars().all(|character| {
-        character.is_ascii_alphanumeric() || matches!(character, '-' | '_')
-    });
-    if !valid(provider) || !valid(step) || version.is_some_and(|v| v.trim().is_empty() || v.contains('@')) {
+    let (step, version) = step_and_version
+        .split_once('@')
+        .map_or((step_and_version, None), |(step, version)| {
+            (step, Some(version))
+        });
+    let valid = |value: &str| {
+        !value.is_empty()
+            && value.chars().all(|character| {
+                character.is_ascii_alphanumeric() || matches!(character, '-' | '_')
+            })
+    };
+    if !valid(provider)
+        || !valid(step)
+        || version.is_some_and(|v| v.trim().is_empty() || v.contains('@'))
+    {
         return Err(invalid());
     }
-    Ok(PackageReference { provider, step, version })
+    Ok(PackageReference {
+        provider,
+        step,
+        version,
+    })
 }
 
 fn provider_step_path(prefix: &Path, provider: &str, step: &str) -> miette::Result<PathBuf> {
-    let path = prefix.join("etc/rattler-build/steps").join(provider).join(step);
+    let path = prefix
+        .join("etc/rattler-build/steps")
+        .join(provider)
+        .join(step);
     let path = [path.with_extension("yaml"), path.with_extension("yml")]
         .into_iter()
         .find(|candidate| candidate.is_file())
-        .ok_or_else(|| miette::miette!("provider `{provider}` does not contain action `{step}` (.yaml or .yml)"))?;
+        .ok_or_else(|| {
+            miette::miette!(
+                "provider `{provider}` does not contain action `{step}` (.yaml or .yml)"
+            )
+        })?;
     fs_err::canonicalize(path).into_diagnostic()
 }
 
@@ -74,10 +106,12 @@ fn sha256_bytes(bytes: &[u8]) -> String {
 }
 
 fn resolved_provider(record: &RepoDataRecord) -> ResolvedProvider {
-    let channel = record.channel.as_deref()
+    let channel = record
+        .channel
+        .as_deref()
         .and_then(|channel| channel.parse::<url::Url>().ok())
         .map(ChannelUrl::from)
-        .map(|channel| crate::packaging::metadata::clean_url(&channel))
+        .map(|channel| crate::packaging::clean_url(&channel))
         .unwrap_or_else(|| record.channel.clone().unwrap_or_default());
     ResolvedProvider {
         name: record.package_record.name.as_normalized().to_string(),
@@ -91,12 +125,17 @@ fn resolved_provider(record: &RepoDataRecord) -> ResolvedProvider {
 }
 
 fn environment_hash(platform: &str, records: &[RepoDataRecord]) -> miette::Result<String> {
-    let mut identities = records.iter().map(|record| {
-        // Both hashes participate: MD5-only repodata must not collapse distinct artifacts.
-        serde_json::to_string(&resolved_provider(record)).into_diagnostic()
-    }).collect::<miette::Result<Vec<_>>>()?;
+    let mut identities = records
+        .iter()
+        .map(|record| {
+            // Both hashes participate: MD5-only repodata must not collapse distinct artifacts.
+            serde_json::to_string(&resolved_provider(record)).into_diagnostic()
+        })
+        .collect::<miette::Result<Vec<_>>>()?;
     identities.sort();
-    Ok(sha256_bytes(format!("{platform}\n{}", identities.join("\n")).as_bytes()))
+    Ok(sha256_bytes(
+        format!("{platform}\n{}", identities.join("\n")).as_bytes(),
+    ))
 }
 
 impl StepProviderResolver {
@@ -108,35 +147,69 @@ impl StepProviderResolver {
     ) -> miette::Result<ProviderEnvironment> {
         let build_platform = settings.build_platform;
         let package_name = format!("{}-rattler-build-steps", reference.provider);
-        let key = format!("{}|{}|{}@{}|{:?}|{:?}|{:?}",
+        let key = format!(
+            "{}|{}|{}@{}|{:?}|{:?}|{:?}",
             build_platform.platform,
-            settings.channels.iter().map(ToString::to_string).collect::<Vec<_>>().join("|"),
-            package_name, reference.version.unwrap_or("*"),
-            settings.channel_priority, settings.solve_strategy, settings.exclude_newer,
+            settings
+                .channels
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join("|"),
+            package_name,
+            reference.version.unwrap_or("*"),
+            settings.channel_priority,
+            settings.solve_strategy,
+            settings.exclude_newer,
         );
         if let Some(environment) = self.providers.get(&key) {
             return Ok(environment.clone());
         }
-        let spec = MatchSpec::from_str(&reference.version.map_or_else(
-            || package_name.clone(), |version| format!("{package_name} {version}"),
-        ), ParseStrictness::Strict).into_diagnostic()?;
+        let spec = MatchSpec::from_str(
+            &reference.version.map_or_else(
+                || package_name.clone(),
+                |version| format!("{package_name} {version}"),
+            ),
+            ParseStrictness::Strict,
+        )
+        .into_diagnostic()?;
         let records = solve_environment(
-            &format!("action provider {}", reference.provider), &[spec], build_platform,
-            settings.channels, tool_configuration, settings.channel_priority,
-            settings.solve_strategy, settings.exclude_newer,
-        ).await?;
-        let provider_record = records.iter()
+            &format!("action provider {}", reference.provider),
+            &[spec],
+            build_platform,
+            settings.channels,
+            tool_configuration,
+            settings.channel_priority,
+            settings.solve_strategy,
+            settings.exclude_newer,
+        )
+        .await?;
+        let provider_record = records
+            .iter()
             .find(|record| record.package_record.name.as_normalized() == package_name)
-            .ok_or_else(|| miette::miette!("action provider solve did not return `{package_name}`"))?;
+            .ok_or_else(|| {
+                miette::miette!("action provider solve did not return `{package_name}`")
+            })?;
         let provider = resolved_provider(provider_record);
         let fingerprint = environment_hash(&build_platform.platform.to_string(), &records)?;
-        let prefix = tool_configuration.cache_dir.join("rattler-build")
-            .join("step-providers").join(&fingerprint);
+        let prefix = tool_configuration
+            .cache_dir
+            .join("rattler-build")
+            .join("step-providers")
+            .join(&fingerprint);
         install_packages_without_link_scripts(
-            &format!("action provider {}", reference.provider), &records,
-            build_platform.platform, &prefix, tool_configuration,
-        ).await?;
-        let environment = ProviderEnvironment { prefix, provider, fingerprint };
+            &format!("action provider {}", reference.provider),
+            &records,
+            build_platform.platform,
+            &prefix,
+            tool_configuration,
+        )
+        .await?;
+        let environment = ProviderEnvironment {
+            prefix,
+            provider,
+            fingerprint,
+        };
         self.providers.insert(key, environment.clone());
         Ok(environment)
     }
@@ -152,9 +225,12 @@ impl StepProviderResolver {
         tool_configuration: &Configuration,
     ) -> miette::Result<()> {
         let reference = package_reference(&request.reference)?;
-        let environment = self.resolve(&reference, settings, tool_configuration).await?;
+        let environment = self
+            .resolve(&reference, settings, tool_configuration)
+            .await?;
         let path = provider_step_path(&environment.prefix, reference.provider, reference.step)?;
-        let contents = fs_err::read_to_string(&path).into_diagnostic()
+        let contents = fs_err::read_to_string(&path)
+            .into_diagnostic()
             .wrap_err_with(|| format!("failed to read packaged action `{}`", request.reference))?;
         let content_sha256 = sha256_bytes(contents.as_bytes());
         let provenance = ActionProvenance {
@@ -163,9 +239,15 @@ impl StepProviderResolver {
             content_sha256,
             fingerprint: Some(environment.fingerprint.clone()),
         };
-        sources.register(request, ActionSource {
-            path, contents, fingerprint: Some(environment.fingerprint), provenance: Some(provenance),
-        });
+        sources.register(
+            request,
+            ActionSource {
+                path,
+                contents,
+                fingerprint: Some(environment.fingerprint),
+                provenance: Some(provenance),
+            },
+        );
         Ok(())
     }
 }
@@ -177,8 +259,21 @@ mod tests {
     #[test]
     fn versioned_reference_preserves_conda_constraint() {
         let parsed = package_reference("cmake:build@>=0.3,<0.4").unwrap();
-        assert_eq!(parsed, PackageReference { provider: "cmake", step: "build", version: Some(">=0.3,<0.4") });
-        for reference in ["cmake:../build", "../cmake:build", "cmake:build@", "cmake:build@1@2", "C:\\build.yaml"] {
+        assert_eq!(
+            parsed,
+            PackageReference {
+                provider: "cmake",
+                step: "build",
+                version: Some(">=0.3,<0.4")
+            }
+        );
+        for reference in [
+            "cmake:../build",
+            "../cmake:build",
+            "cmake:build@",
+            "cmake:build@1@2",
+            "C:\\build.yaml",
+        ] {
             assert!(package_reference(reference).is_err(), "{reference}");
         }
     }
@@ -190,7 +285,10 @@ mod tests {
         fs_err::create_dir_all(&directory).unwrap();
         let path = directory.join("build.yml");
         fs_err::write(&path, "steps: []\n").unwrap();
-        assert_eq!(provider_step_path(prefix.path(), "test", "build").unwrap(), fs_err::canonicalize(path).unwrap());
+        assert_eq!(
+            provider_step_path(prefix.path(), "test", "build").unwrap(),
+            fs_err::canonicalize(path).unwrap()
+        );
         assert!(provider_step_path(prefix.path(), "test", "missing").is_err());
     }
 

--- a/crates/rattler_build_core/src/step_provider.rs
+++ b/crates/rattler_build_core/src/step_provider.rs
@@ -1,0 +1,218 @@
+//! Transport for packaged action sources consumed by the recipe compiler.
+
+use std::{collections::HashMap, path::{Path, PathBuf}};
+
+use miette::{IntoDiagnostic, WrapErr};
+use rattler_build_recipe::actions::{ActionProvenance, ActionRequest, ActionSource, ActionSources, ResolvedProvider};
+use rattler_conda_types::{ChannelUrl, MatchSpec, ParseStrictness, RepoDataRecord};
+use rattler_solve::{ChannelPriority, SolveStrategy};
+use sha2::{Digest, Sha256};
+
+use crate::{
+    metadata::PlatformWithVirtualPackages,
+    render::solver::{install_packages_without_link_scripts, solve_environment},
+    tool_configuration::Configuration,
+};
+
+#[derive(Clone)]
+struct ProviderEnvironment {
+    prefix: PathBuf,
+    provider: ResolvedProvider,
+    fingerprint: String,
+}
+
+/// Solve settings for the independent build-platform provider environment.
+/// Provider dependencies are never added to recipe build or host requirements.
+pub struct ProviderSolveConfig<'a> {
+    pub build_platform: &'a PlatformWithVirtualPackages,
+    pub channels: &'a [ChannelUrl],
+    pub channel_priority: ChannelPriority,
+    pub solve_strategy: SolveStrategy,
+    pub exclude_newer: Option<jiff::Timestamp>,
+}
+
+/// Command-scoped cache of independently installed provider environments.
+#[derive(Default)]
+pub struct StepProviderResolver {
+    providers: HashMap<String, ProviderEnvironment>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct PackageReference<'a> {
+    provider: &'a str,
+    step: &'a str,
+    version: Option<&'a str>,
+}
+
+fn package_reference(reference: &str) -> miette::Result<PackageReference<'_>> {
+    let invalid = || miette::miette!(
+        "invalid packaged action reference `{reference}`; expected `provider:step[@version]`"
+    );
+    let (provider, step_and_version) = reference.split_once(':').ok_or_else(invalid)?;
+    let (step, version) = step_and_version.split_once('@')
+        .map_or((step_and_version, None), |(step, version)| (step, Some(version)));
+    let valid = |value: &str| !value.is_empty() && value.chars().all(|character| {
+        character.is_ascii_alphanumeric() || matches!(character, '-' | '_')
+    });
+    if !valid(provider) || !valid(step) || version.is_some_and(|v| v.trim().is_empty() || v.contains('@')) {
+        return Err(invalid());
+    }
+    Ok(PackageReference { provider, step, version })
+}
+
+fn provider_step_path(prefix: &Path, provider: &str, step: &str) -> miette::Result<PathBuf> {
+    let path = prefix.join("etc/rattler-build/steps").join(provider).join(step);
+    let path = [path.with_extension("yaml"), path.with_extension("yml")]
+        .into_iter()
+        .find(|candidate| candidate.is_file())
+        .ok_or_else(|| miette::miette!("provider `{provider}` does not contain action `{step}` (.yaml or .yml)"))?;
+    fs_err::canonicalize(path).into_diagnostic()
+}
+
+fn sha256_bytes(bytes: &[u8]) -> String {
+    hex::encode(Sha256::digest(bytes))
+}
+
+fn resolved_provider(record: &RepoDataRecord) -> ResolvedProvider {
+    let channel = record.channel.as_deref()
+        .and_then(|channel| channel.parse::<url::Url>().ok())
+        .map(ChannelUrl::from)
+        .map(|channel| crate::packaging::metadata::clean_url(&channel))
+        .unwrap_or_else(|| record.channel.clone().unwrap_or_default());
+    ResolvedProvider {
+        name: record.package_record.name.as_normalized().to_string(),
+        version: record.package_record.version.to_string(),
+        build: record.package_record.build.clone(),
+        subdir: record.package_record.subdir.clone(),
+        channel,
+        sha256: record.package_record.sha256.map(hex::encode),
+        md5: record.package_record.md5.map(hex::encode),
+    }
+}
+
+fn environment_hash(platform: &str, records: &[RepoDataRecord]) -> miette::Result<String> {
+    let mut identities = records.iter().map(|record| {
+        // Both hashes participate: MD5-only repodata must not collapse distinct artifacts.
+        serde_json::to_string(&resolved_provider(record)).into_diagnostic()
+    }).collect::<miette::Result<Vec<_>>>()?;
+    identities.sort();
+    Ok(sha256_bytes(format!("{platform}\n{}", identities.join("\n")).as_bytes()))
+}
+
+impl StepProviderResolver {
+    async fn resolve(
+        &mut self,
+        reference: &PackageReference<'_>,
+        settings: &ProviderSolveConfig<'_>,
+        tool_configuration: &Configuration,
+    ) -> miette::Result<ProviderEnvironment> {
+        let build_platform = settings.build_platform;
+        let package_name = format!("{}-rattler-build-steps", reference.provider);
+        let key = format!("{}|{}|{}@{}|{:?}|{:?}|{:?}",
+            build_platform.platform,
+            settings.channels.iter().map(ToString::to_string).collect::<Vec<_>>().join("|"),
+            package_name, reference.version.unwrap_or("*"),
+            settings.channel_priority, settings.solve_strategy, settings.exclude_newer,
+        );
+        if let Some(environment) = self.providers.get(&key) {
+            return Ok(environment.clone());
+        }
+        let spec = MatchSpec::from_str(&reference.version.map_or_else(
+            || package_name.clone(), |version| format!("{package_name} {version}"),
+        ), ParseStrictness::Strict).into_diagnostic()?;
+        let records = solve_environment(
+            &format!("action provider {}", reference.provider), &[spec], build_platform,
+            settings.channels, tool_configuration, settings.channel_priority,
+            settings.solve_strategy, settings.exclude_newer,
+        ).await?;
+        let provider_record = records.iter()
+            .find(|record| record.package_record.name.as_normalized() == package_name)
+            .ok_or_else(|| miette::miette!("action provider solve did not return `{package_name}`"))?;
+        let provider = resolved_provider(provider_record);
+        let fingerprint = environment_hash(&build_platform.platform.to_string(), &records)?;
+        let prefix = tool_configuration.cache_dir.join("rattler-build")
+            .join("step-providers").join(&fingerprint);
+        install_packages_without_link_scripts(
+            &format!("action provider {}", reference.provider), &records,
+            build_platform.platform, &prefix, tool_configuration,
+        ).await?;
+        let environment = ProviderEnvironment { prefix, provider, fingerprint };
+        self.providers.insert(key, environment.clone());
+        Ok(environment)
+    }
+
+    /// Fulfil exactly the external request produced by synchronous compilation.
+    /// Parsing, conditions, input validation, recursion and requirements belong to
+    /// the compiler; this adapter only installs packages and registers source bytes.
+    pub async fn register_requested(
+        &mut self,
+        request: ActionRequest,
+        sources: &ActionSources,
+        settings: &ProviderSolveConfig<'_>,
+        tool_configuration: &Configuration,
+    ) -> miette::Result<()> {
+        let reference = package_reference(&request.reference)?;
+        let environment = self.resolve(&reference, settings, tool_configuration).await?;
+        let path = provider_step_path(&environment.prefix, reference.provider, reference.step)?;
+        let contents = fs_err::read_to_string(&path).into_diagnostic()
+            .wrap_err_with(|| format!("failed to read packaged action `{}`", request.reference))?;
+        let content_sha256 = sha256_bytes(contents.as_bytes());
+        let provenance = ActionProvenance {
+            reference: request.reference.clone(),
+            provider: Some(environment.provider),
+            content_sha256,
+            fingerprint: Some(environment.fingerprint.clone()),
+        };
+        sources.register(request, ActionSource {
+            path, contents, fingerprint: Some(environment.fingerprint), provenance: Some(provenance),
+        });
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn versioned_reference_preserves_conda_constraint() {
+        let parsed = package_reference("cmake:build@>=0.3,<0.4").unwrap();
+        assert_eq!(parsed, PackageReference { provider: "cmake", step: "build", version: Some(">=0.3,<0.4") });
+        for reference in ["cmake:../build", "../cmake:build", "cmake:build@", "cmake:build@1@2", "C:\\build.yaml"] {
+            assert!(package_reference(reference).is_err(), "{reference}");
+        }
+    }
+
+    #[test]
+    fn package_lookup_accepts_yml() {
+        let prefix = tempfile::tempdir().unwrap();
+        let directory = prefix.path().join("etc/rattler-build/steps/test");
+        fs_err::create_dir_all(&directory).unwrap();
+        let path = directory.join("build.yml");
+        fs_err::write(&path, "steps: []\n").unwrap();
+        assert_eq!(provider_step_path(prefix.path(), "test", "build").unwrap(), fs_err::canonicalize(path).unwrap());
+        assert!(provider_step_path(prefix.path(), "test", "missing").is_err());
+    }
+
+    #[test]
+    fn md5_only_artifacts_have_distinct_environment_identities() {
+        let mut value = serde_json::json!({
+            "name": "test-rattler-build-steps",
+            "version": "1.0.0",
+            "build": "0",
+            "build_number": 0,
+            "subdir": "noarch",
+            "fn": "test-rattler-build-steps-1.0.0-0.conda",
+            "url": "https://example.com/noarch/test-rattler-build-steps-1.0.0-0.conda",
+            "channel": "https://example.com/",
+            "md5": "00000000000000000000000000000001"
+        });
+        let first: RepoDataRecord = serde_json::from_value(value.clone()).unwrap();
+        value["md5"] = serde_json::json!("00000000000000000000000000000002");
+        let second: RepoDataRecord = serde_json::from_value(value).unwrap();
+        assert_ne!(
+            environment_hash("linux-64", &[first]).unwrap(),
+            environment_hash("linux-64", &[second]).unwrap(),
+        );
+    }
+}

--- a/crates/rattler_build_core/src/tool_configuration.rs
+++ b/crates/rattler_build_core/src/tool_configuration.rs
@@ -124,6 +124,9 @@ pub struct Configuration {
     /// Concurrency limit for I/O operations
     pub io_concurrency_limit: Option<usize>,
 
+    /// Root directory used for package, repodata, and standalone tool caches.
+    pub cache_dir: PathBuf,
+
     /// The package cache to use to store packages in.
     pub package_cache: PackageCache,
 
@@ -527,6 +530,7 @@ impl ConfigurationBuilder {
             channel_config,
             compression_threads: self.compression_threads,
             io_concurrency_limit: self.io_concurrency_limit,
+            cache_dir,
             package_cache,
             repodata_gateway,
             displayed_channel_notices: Arc::new(Mutex::new(HashSet::new())),

--- a/docs/build_script.md
+++ b/docs/build_script.md
@@ -186,6 +186,44 @@ Selection and dependencies are resolved before flattening, including empty
 groups. Rendered recipes contain only executable run steps and native execution
 bindings; rebuilding them does not load action source documents.
 
+### Packaged actions
+
+Package references use `provider:step` syntax and may include a conda version
+constraint after `@`:
+
+```yaml
+- name: cargo-build
+  uses: cargo:build@>=0.3,<0.4
+```
+
+The invocation name remains a CLI target: `rattler-build run cargo-build`.
+During recipe compilation, an included invocation resolves
+`cargo-rattler-build-steps` for the build platform and installs it into a
+content-addressed prefix under the global cache. The cache identity includes the
+platform and complete solved package records, channels, and artifact checksums,
+using MD5 when SHA-256 is unavailable. Provider packages and their dependencies
+do not enter the recipe build or host environment.
+
+The compiler loads `etc/rattler-build/steps/cargo/build.yaml` (or `build.yml`)
+from that prefix using the same action schema as local documents.
+Nested `./helper.yaml` and `../shared/helper.yml` references resolve relative to
+their containing document; nested packaged references use the same transport.
+An invocation excluded by `if` does not resolve or install its provider.
+
+The rendered recipe contains the flat executable plan, native execution bindings,
+and portable provider provenance: reference, document SHA-256, package version,
+build, subdir, channel, and available artifact checksums. Cached absolute source
+paths are not serialized. Rebuild executes this embedded plan without reading
+action sources or resolving providers again.
+
+Provider installation does not execute package link scripts.
+Only action-owned `requirements.build` and `requirements.host` participate in
+the recipe's normal variant expansion and environment solve. Provider package
+dependencies are transport dependencies, not action requirements; tools such as
+`cargo` belong in the action document's `requirements.build`.
+Complete CMake, Meson, Rust, and Go recipes are available in
+[`examples/step-providers`](https://github.com/prefix-dev/rattler-build/tree/main/examples/step-providers).
+
 
 !!! warning "Windows multiline steps"
     On Windows, a multiline `run: |` block is emitted as one command-list item.

--- a/examples/step-providers/README.md
+++ b/examples/step-providers/README.md
@@ -24,7 +24,26 @@ shorthand inputs or invocation-level run fields must be updated before use.
 The references use compatible version ranges so provider updates are explicit
 and reproducible in the rendered recipe and package hash:
 
-- `cmake:build@0.3.*`
-- `meson:build@0.3.*`
-- `rust:build@0.3.*`
-- `go:build@0.4.*`
+- `cmake:build@0.4.*`
+- `meson:build@0.4.*`
+- `rust:build@0.4.*`
+- `go:build@0.5.*`
+
+## Building the provider packages
+
+Provider sources and package recipes live in `providers/{cmake,meson,rust,go}`.
+From the repository root, build and publish a provider with:
+
+```console
+rattler-build build --recipe examples/step-providers/providers/cmake --output-dir output/providers
+rattler-build publish output/providers/noarch/cmake-rattler-build-steps-0.4.0-*.conda --to prefix://beta.prefix.dev/wolfv/rattler-build-steps
+```
+
+For a local channel, replace `--to` with a directory path and pass its `file://`
+URL as the consumer's first channel. Publishing remotely requires upload access.
+
+These versions replace the old whole-document Jinja providers. Conditions now
+use step `if` selectors, and list inputs declare their scalar `items` type.
+The Go license collector emits the post-build `OUTPUT_FILE` protocol and requires
+rattler-build's post-build metadata support. It belongs on a package output,
+not a staging output.

--- a/examples/step-providers/README.md
+++ b/examples/step-providers/README.md
@@ -1,0 +1,30 @@
+# Reusable step-provider examples
+
+These small, self-contained recipes demonstrate the CMake, Meson, Rust, and Go
+providers published to `beta.prefix.dev/wolfv/rattler-build-steps`.
+
+Build one with the experimental reusable-step support enabled:
+
+```bash
+rattler-build build \
+  --experimental \
+  --channel https://beta.prefix.dev/wolfv/rattler-build-steps \
+  --channel conda-forge \
+  --recipe examples/step-providers/cmake
+```
+
+Replace `cmake` with `meson`, `rust`, or `go` for the other examples. Provider
+packages are resolved into independent build-platform environments. Tools
+declared in each action document's `requirements.build`, such as CMake or Cargo,
+are added to the recipe build environment; provider package dependencies are not.
+Provider documents must use the strict action schema (`inputs`, action-owned
+`requirements`, and a required `steps` list). Older provider documents using
+shorthand inputs or invocation-level run fields must be updated before use.
+
+The references use compatible version ranges so provider updates are explicit
+and reproducible in the rendered recipe and package hash:
+
+- `cmake:build@0.3.*`
+- `meson:build@0.3.*`
+- `rust:build@0.3.*`
+- `go:build@0.4.*`

--- a/examples/step-providers/cmake/CMakeLists.txt
+++ b/examples/step-providers/cmake/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.15)
+project(provider_example_cmake LANGUAGES C)
+add_executable(hello-cmake main.c)
+install(TARGETS hello-cmake RUNTIME DESTINATION bin)

--- a/examples/step-providers/cmake/LICENSE
+++ b/examples/step-providers/cmake/LICENSE
@@ -1,0 +1,10 @@
+MIT License
+
+Copyright (c) 2026 rattler-build contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.

--- a/examples/step-providers/cmake/main.c
+++ b/examples/step-providers/cmake/main.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main(void) {
+    puts("hello from the CMake provider");
+    return 0;
+}

--- a/examples/step-providers/cmake/recipe.yaml
+++ b/examples/step-providers/cmake/recipe.yaml
@@ -1,0 +1,32 @@
+schema_version: 1
+
+package:
+  name: provider-example-cmake
+  version: 0.1.0
+
+source:
+  path: .
+
+build:
+  skip: win
+  steps:
+    - uses: cmake:build@0.3.*
+      with:
+        build_type: RelWithDebInfo
+        extra_args:
+          - -DBUILD_TESTING=OFF
+        build_args:
+          - --verbose
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+
+tests:
+  - script:
+      - hello-cmake
+
+about:
+  license: MIT
+  license_file: LICENSE
+  summary: Minimal recipe using the CMake reusable build-step provider

--- a/examples/step-providers/cmake/recipe.yaml
+++ b/examples/step-providers/cmake/recipe.yaml
@@ -10,7 +10,7 @@ source:
 build:
   skip: win
   steps:
-    - uses: cmake:build@0.3.*
+    - uses: cmake:build@0.4.*
       with:
         build_type: RelWithDebInfo
         extra_args:

--- a/examples/step-providers/go/LICENSE
+++ b/examples/step-providers/go/LICENSE
@@ -1,0 +1,10 @@
+MIT License
+
+Copyright (c) 2026 rattler-build contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.

--- a/examples/step-providers/go/go.mod
+++ b/examples/step-providers/go/go.mod
@@ -1,0 +1,5 @@
+module example.com/hello-go
+
+go 1.23
+
+require github.com/google/uuid v1.6.0

--- a/examples/step-providers/go/go.sum
+++ b/examples/step-providers/go/go.sum
@@ -1,0 +1,2 @@
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/examples/step-providers/go/main.go
+++ b/examples/step-providers/go/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+func main() {
+	fmt.Printf("hello from the Go provider (%s)\n", uuid.New())
+}

--- a/examples/step-providers/go/recipe.yaml
+++ b/examples/step-providers/go/recipe.yaml
@@ -1,0 +1,34 @@
+schema_version: 1
+
+package:
+  name: provider-example-go
+  version: 0.1.0
+
+source:
+  path: .
+
+build:
+  skip: win
+  steps:
+    - uses: go:build@0.4.*
+      with:
+        packages: ./...
+        collect_licenses: true
+        # The package's own LICENSE is already declared below; collect licenses
+        # for its dependency graph without asking go-licenses to classify it.
+        license_args:
+          - --ignore
+          - example.com/hello-go
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+
+tests:
+  - script:
+      - hello-go
+
+about:
+  license: MIT
+  license_file: LICENSE
+  summary: Minimal recipe using the Go reusable build-step provider

--- a/examples/step-providers/go/recipe.yaml
+++ b/examples/step-providers/go/recipe.yaml
@@ -10,7 +10,7 @@ source:
 build:
   skip: win
   steps:
-    - uses: go:build@0.4.*
+    - uses: go:build@0.5.*
       with:
         packages: ./...
         collect_licenses: true

--- a/examples/step-providers/meson/LICENSE
+++ b/examples/step-providers/meson/LICENSE
@@ -1,0 +1,10 @@
+MIT License
+
+Copyright (c) 2026 rattler-build contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.

--- a/examples/step-providers/meson/main.c
+++ b/examples/step-providers/meson/main.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main(void) {
+    puts("hello from the Meson provider");
+    return 0;
+}

--- a/examples/step-providers/meson/meson.build
+++ b/examples/step-providers/meson/meson.build
@@ -1,0 +1,2 @@
+project('provider-example-meson', 'c', version: '0.1.0')
+executable('hello-meson', 'main.c', install: true)

--- a/examples/step-providers/meson/recipe.yaml
+++ b/examples/step-providers/meson/recipe.yaml
@@ -1,0 +1,32 @@
+schema_version: 1
+
+package:
+  name: provider-example-meson
+  version: 0.1.0
+
+source:
+  path: .
+
+build:
+  skip: win
+  steps:
+    - uses: meson:build@0.3.*
+      with:
+        build_type: debugoptimized
+        extra_args:
+          - -Dwarning_level=3
+        compile_args:
+          - --verbose
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+
+tests:
+  - script:
+      - hello-meson
+
+about:
+  license: MIT
+  license_file: LICENSE
+  summary: Minimal recipe using the Meson reusable build-step provider

--- a/examples/step-providers/meson/recipe.yaml
+++ b/examples/step-providers/meson/recipe.yaml
@@ -10,7 +10,7 @@ source:
 build:
   skip: win
   steps:
-    - uses: meson:build@0.3.*
+    - uses: meson:build@0.4.*
       with:
         build_type: debugoptimized
         extra_args:

--- a/examples/step-providers/providers/cmake/build.yaml
+++ b/examples/step-providers/providers/cmake/build.yaml
@@ -1,0 +1,33 @@
+schema_version: 1
+
+inputs:
+  build_type:
+    type: string
+    default: Release
+  extra_args:
+    type: list
+    items: string
+    default: []
+  build_args:
+    type: list
+    items: string
+    default: []
+  install_args:
+    type: list
+    items: string
+    default: []
+  install:
+    type: boolean
+    default: true
+steps:
+  - name: cmake-configure
+    requirements:
+      build: [cmake, ninja]
+    run: cmake -S "$SRC_DIR" -B "$BUILD_DIR/cmake" -G Ninja -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} -DCMAKE_INSTALL_PREFIX="$PREFIX" ${{ inputs.extra_args | join(' ') }} ${CMAKE_ARGS:-}
+  - name: cmake-build
+    depends_on: [cmake-configure]
+    run: cmake --build "$BUILD_DIR/cmake" --parallel ${{ inputs.build_args | join(' ') }} ${CMAKE_BUILD_ARGS:-}
+  - name: cmake-install
+    if: inputs.install
+    depends_on: [cmake-build]
+    run: cmake --install "$BUILD_DIR/cmake" ${{ inputs.install_args | join(' ') }} ${CMAKE_INSTALL_ARGS:-}

--- a/examples/step-providers/providers/cmake/recipe.yaml
+++ b/examples/step-providers/providers/cmake/recipe.yaml
@@ -1,0 +1,28 @@
+schema_version: 1
+
+package:
+  name: cmake-rattler-build-steps
+  version: 0.4.0
+
+source:
+  path: build.yaml
+
+build:
+  noarch: generic
+  script:
+    interpreter: python
+    content: |
+      import os
+      from pathlib import Path
+      import shutil
+
+      target = Path(os.environ["PREFIX"]) / "etc/rattler-build/steps/cmake"
+      target.mkdir(parents=True, exist_ok=True)
+      shutil.copy2(Path(os.environ["SRC_DIR"]) / "build.yaml", target / "build.yaml")
+
+requirements:
+  build: [python]
+
+about:
+  license: BSD-3-Clause
+  summary: Experimental CMake build action for rattler-build

--- a/examples/step-providers/providers/go/build.yaml
+++ b/examples/step-providers/providers/go/build.yaml
@@ -1,0 +1,31 @@
+schema_version: 1
+
+inputs:
+  packages:
+    type: string
+    default: ./...
+  build_args:
+    type: list
+    items: string
+    default: []
+  collect_licenses:
+    type: boolean
+    default: false
+  license_args:
+    type: list
+    items: string
+    default: []
+steps:
+  - name: go-build
+    requirements:
+      build: [go]
+    run: mkdir -p "$PREFIX/bin" && GOBIN="$PREFIX/bin" go install ${{ inputs.build_args | join(' ') }} ${GO_BUILD_ARGS:-} ${{ inputs.packages }}
+  - name: go-licenses
+    if: inputs.collect_licenses
+    depends_on: [go-build]
+    requirements:
+      build: [go-licenses]
+    run: |
+      rm -rf "$BUILD_DIR/go-dependencies" && go-licenses save ${{ inputs.packages }} --save_path "$BUILD_DIR/go-dependencies" ${{ inputs.license_args | join(' ') }} ${GO_LICENSE_ARGS:-} && mkdir -p "$BUILD_DIR/go-dependencies"
+      dollar='$'
+      printf 'about.license_file.include.append "%s{{ BUILD_DIR }}/go-dependencies/**"\n' "$dollar" >> "$OUTPUT_FILE"

--- a/examples/step-providers/providers/go/recipe.yaml
+++ b/examples/step-providers/providers/go/recipe.yaml
@@ -1,0 +1,28 @@
+schema_version: 1
+
+package:
+  name: go-rattler-build-steps
+  version: 0.5.0
+
+source:
+  path: build.yaml
+
+build:
+  noarch: generic
+  script:
+    interpreter: python
+    content: |
+      import os
+      from pathlib import Path
+      import shutil
+
+      target = Path(os.environ["PREFIX"]) / "etc/rattler-build/steps/go"
+      target.mkdir(parents=True, exist_ok=True)
+      shutil.copy2(Path(os.environ["SRC_DIR"]) / "build.yaml", target / "build.yaml")
+
+requirements:
+  build: [python]
+
+about:
+  license: BSD-3-Clause
+  summary: Experimental Go build action for rattler-build

--- a/examples/step-providers/providers/meson/build.yaml
+++ b/examples/step-providers/providers/meson/build.yaml
@@ -1,0 +1,29 @@
+schema_version: 1
+
+inputs:
+  build_type:
+    type: string
+    default: release
+  extra_args:
+    type: list
+    items: string
+    default: []
+  compile_args:
+    type: list
+    items: string
+    default: []
+  install:
+    type: boolean
+    default: true
+steps:
+  - name: meson-setup
+    requirements:
+      build: [meson, ninja, pkg-config]
+    run: meson setup "$BUILD_DIR/meson" "$SRC_DIR" --buildtype=${{ inputs.build_type }} --prefix="$PREFIX" --libdir=lib ${{ inputs.extra_args | join(' ') }}
+  - name: meson-compile
+    depends_on: [meson-setup]
+    run: meson compile -C "$BUILD_DIR/meson" ${{ inputs.compile_args | join(' ') }} ${MESON_COMPILE_ARGS:-}
+  - name: meson-install
+    if: inputs.install
+    depends_on: [meson-compile]
+    run: meson install -C "$BUILD_DIR/meson" ${MESON_INSTALL_ARGS:-}

--- a/examples/step-providers/providers/meson/recipe.yaml
+++ b/examples/step-providers/providers/meson/recipe.yaml
@@ -1,0 +1,28 @@
+schema_version: 1
+
+package:
+  name: meson-rattler-build-steps
+  version: 0.4.0
+
+source:
+  path: build.yaml
+
+build:
+  noarch: generic
+  script:
+    interpreter: python
+    content: |
+      import os
+      from pathlib import Path
+      import shutil
+
+      target = Path(os.environ["PREFIX"]) / "etc/rattler-build/steps/meson"
+      target.mkdir(parents=True, exist_ok=True)
+      shutil.copy2(Path(os.environ["SRC_DIR"]) / "build.yaml", target / "build.yaml")
+
+requirements:
+  build: [python]
+
+about:
+  license: BSD-3-Clause
+  summary: Experimental Meson build action for rattler-build

--- a/examples/step-providers/providers/rust/build.yaml
+++ b/examples/step-providers/providers/rust/build.yaml
@@ -1,0 +1,22 @@
+schema_version: 1
+
+inputs:
+  features:
+    type: list
+    items: string
+    default: []
+  locked:
+    type: boolean
+    default: true
+  install:
+    type: boolean
+    default: true
+steps:
+  - name: cargo-build
+    requirements:
+      build: [rust]
+    run: cargo build --release ${{ '--locked' if inputs.locked else '' }} ${{ '--features ' ~ (inputs.features | join(',')) if inputs.features else '' }} ${CARGO_BUILD_ARGS:-}
+  - name: cargo-install
+    if: inputs.install
+    depends_on: [cargo-build]
+    run: cargo install --path . --root "$PREFIX" ${{ '--locked' if inputs.locked else '' }} ${{ '--features ' ~ (inputs.features | join(',')) if inputs.features else '' }} ${CARGO_INSTALL_ARGS:-}

--- a/examples/step-providers/providers/rust/recipe.yaml
+++ b/examples/step-providers/providers/rust/recipe.yaml
@@ -1,0 +1,28 @@
+schema_version: 1
+
+package:
+  name: rust-rattler-build-steps
+  version: 0.4.0
+
+source:
+  path: build.yaml
+
+build:
+  noarch: generic
+  script:
+    interpreter: python
+    content: |
+      import os
+      from pathlib import Path
+      import shutil
+
+      target = Path(os.environ["PREFIX"]) / "etc/rattler-build/steps/rust"
+      target.mkdir(parents=True, exist_ok=True)
+      shutil.copy2(Path(os.environ["SRC_DIR"]) / "build.yaml", target / "build.yaml")
+
+requirements:
+  build: [python]
+
+about:
+  license: BSD-3-Clause
+  summary: Experimental Rust build action for rattler-build

--- a/examples/step-providers/rust/Cargo.toml
+++ b/examples/step-providers/rust/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "hello-rust"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+
+[workspace]
+
+[features]
+default = []
+enthusiastic = []

--- a/examples/step-providers/rust/LICENSE
+++ b/examples/step-providers/rust/LICENSE
@@ -1,0 +1,10 @@
+MIT License
+
+Copyright (c) 2026 rattler-build contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.

--- a/examples/step-providers/rust/recipe.yaml
+++ b/examples/step-providers/rust/recipe.yaml
@@ -1,0 +1,26 @@
+schema_version: 1
+
+package:
+  name: provider-example-rust
+  version: 0.1.0
+
+source:
+  path: .
+
+build:
+  skip: win
+  steps:
+    - uses: rust:build@0.3.*
+      with:
+        locked: false
+        features:
+          - enthusiastic
+
+tests:
+  - script:
+      - hello-rust
+
+about:
+  license: MIT
+  license_file: LICENSE
+  summary: Minimal recipe using the Rust reusable build-step provider

--- a/examples/step-providers/rust/recipe.yaml
+++ b/examples/step-providers/rust/recipe.yaml
@@ -10,7 +10,7 @@ source:
 build:
   skip: win
   steps:
-    - uses: rust:build@0.3.*
+    - uses: rust:build@0.4.*
       with:
         locked: false
         features:

--- a/examples/step-providers/rust/src/main.rs
+++ b/examples/step-providers/rust/src/main.rs
@@ -1,0 +1,6 @@
+fn main() {
+    #[cfg(feature = "enthusiastic")]
+    println!("hello from the Rust provider!");
+    #[cfg(not(feature = "enthusiastic"))]
+    println!("hello from the Rust provider");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,9 +166,10 @@ async fn find_variants(
                         .map(|channel| NamedChannelOrUrl::from_str(channel).into_diagnostic())
                         .collect::<miette::Result<Vec<_>>>()?
                 } else {
-                    build_data.channels.clone().unwrap_or_else(|| {
-                        vec![NamedChannelOrUrl::Name("conda-forge".to_string())]
-                    })
+                    build_data
+                        .channels
+                        .clone()
+                        .unwrap_or_else(|| vec![NamedChannelOrUrl::Name("conda-forge".to_string())])
                 };
                 let channels = channels
                     .into_iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,7 @@ use crate::publish::{
     resolve_channel_for_repodata, upload_and_index_channel,
 };
 use indexmap::IndexSet;
+use rattler_build_core::step_provider::{ProviderSolveConfig, StepProviderResolver};
 use rattler_build_recipe::topological_sort_by_dependencies;
 
 /// Convert the CLI `--v3` boolean flag into a [`RepodataRevision`].
@@ -102,11 +103,14 @@ struct FoundVariants {
 }
 
 /// Find all variants from the recipe and variant config
-fn find_variants(
+async fn find_variants(
     variant_config: &VariantConfig,
     recipe_path: &std::path::Path,
     recipe_content: &str,
     render_config: RenderConfig,
+    build_data: &BuildData,
+    tool_config: &Configuration,
+    provider_resolver: &mut StepProviderResolver,
 ) -> Result<FoundVariants, miette::Error> {
     // Parse the recipe
     let source = rattler_build_recipe::source_code::Source::from_string(
@@ -134,10 +138,71 @@ fn find_variants(
 
     let target_platform = render_config.target_platform;
 
-    // Render with variant config (handles both single and multi-output recipes)
-    let rendered_variants =
-        rattler_build_recipe::render_recipe(&source, &stage0_recipe, variant_config, render_config)
-            .wrap_err("Failed to render recipe with variants")?;
+    let sources = render_config.action_sources.clone();
+    let rendered_variants = loop {
+        match rattler_build_recipe::render_recipe(
+            &source,
+            &stage0_recipe,
+            variant_config,
+            render_config.clone(),
+        ) {
+            Ok(rendered) => break rendered,
+            Err(error) => {
+                let Some(request) = sources.take_pending() else {
+                    return Err(error).wrap_err("Failed to render recipe with variants");
+                };
+                if request.channel_sources.is_some()
+                    && build_data.channels.is_some()
+                    && !build_data.channels_from_config
+                {
+                    return Err(miette::miette!(
+                        "channel_sources and channels cannot both be set at the same time"
+                    ));
+                }
+                let channels = if let Some(channel_sources) = &request.channel_sources {
+                    channel_sources
+                        .split(',')
+                        .map(str::trim)
+                        .map(|channel| NamedChannelOrUrl::from_str(channel).into_diagnostic())
+                        .collect::<miette::Result<Vec<_>>>()?
+                } else {
+                    build_data.channels.clone().unwrap_or_else(|| {
+                        vec![NamedChannelOrUrl::Name("conda-forge".to_string())]
+                    })
+                };
+                let channels = channels
+                    .into_iter()
+                    .map(|channel| channel.into_base_url(&tool_config.channel_config))
+                    .collect::<Result<Vec<_>, _>>()
+                    .into_diagnostic()?;
+                let build_platform = PlatformWithVirtualPackages::detect_for_platform(
+                    build_data.build_platform,
+                    &VirtualPackageOverrides::from_env(),
+                )
+                .into_diagnostic()?;
+                let previous_sources = sources.len();
+                provider_resolver
+                    .register_requested(
+                        request,
+                        &sources,
+                        &ProviderSolveConfig {
+                            build_platform: &build_platform,
+                            channels: &channels,
+                            channel_priority: tool_config.channel_priority,
+                            solve_strategy: SolveStrategy::Highest,
+                            exclude_newer: build_data.exclude_newer,
+                        },
+                        tool_config,
+                    )
+                    .await?;
+                if sources.len() <= previous_sources {
+                    return Err(miette::miette!(
+                        "action provider resolution made no source registry progress"
+                    ));
+                }
+            }
+        }
+    };
 
     // Convert to DiscoveredOutputs
     let mut recipes = IndexSet::new();
@@ -425,10 +490,20 @@ pub async fn get_build_output(
         ..RenderConfig::default()
     };
 
+    let mut step_provider_resolver = StepProviderResolver::default();
     let FoundVariants {
         outputs: outputs_and_variants,
         recipe_name,
-    } = find_variants(&variant_config, recipe_path, &recipe_content, render_config)?;
+    } = find_variants(
+        &variant_config,
+        recipe_path,
+        &recipe_content,
+        render_config,
+        build_data,
+        tool_config,
+        &mut step_provider_resolver,
+    )
+    .await?;
 
     tracing::info!("Found {} variants\n", outputs_and_variants.len());
     for discovered_output in &outputs_and_variants {

--- a/test-data/recipes/step_provider/recipe.yaml
+++ b/test-data/recipes/step_provider/recipe.yaml
@@ -1,0 +1,11 @@
+schema_version: 1
+package:
+  name: test-rattler-build-steps
+  version: 1.0.0
+build:
+  noarch: generic
+  script: >-
+    python -c "import os,pathlib,shutil; p=pathlib.Path(os.environ['PREFIX'])/'etc/rattler-build/steps/test'; shutil.copytree(pathlib.Path(os.environ['RECIPE_DIR'])/'steps',p)"
+requirements:
+  build: [python]
+  run: [six]

--- a/test-data/recipes/step_provider/steps/build.yml
+++ b/test-data/recipes/step_provider/steps/build.yml
@@ -1,0 +1,28 @@
+schema_version: 1
+action:
+  name: provider-build
+inputs:
+  message:
+    type: string
+    default: provider-worked
+  enabled:
+    type: boolean
+  count:
+    type: integer
+  labels:
+    type: list
+    items: string
+steps:
+  - uses: ./nested/emit.yaml
+    with:
+      message: ${{ inputs.message }}
+      enabled: ${{ inputs.enabled }}
+      count: ${{ inputs.count }}
+      labels: ${{ inputs.labels }}
+  - uses: test:finish@=1.0.0
+    with:
+      message: ${{ inputs.message }}
+  - if: false
+    uses: missing-provider:missing
+    with:
+      undeclared: ignored

--- a/test-data/recipes/step_provider/steps/finish.yaml
+++ b/test-data/recipes/step_provider/steps/finish.yaml
@@ -1,0 +1,11 @@
+schema_version: 1
+inputs:
+  message:
+    type: string
+steps:
+  - interpreter: python
+    run: |
+      import os
+      from pathlib import Path
+      marker = Path(os.environ['PREFIX']) / 'share' / 'step-provider'
+      (marker / 'nested.txt').write_text('${{ inputs.message }}')

--- a/test-data/recipes/step_provider/steps/nested/emit.yaml
+++ b/test-data/recipes/step_provider/steps/nested/emit.yaml
@@ -1,0 +1,22 @@
+schema_version: 1
+inputs:
+  message:
+    type: string
+  enabled:
+    type: boolean
+  count:
+    type: integer
+  labels:
+    type: list
+    items: string
+requirements:
+  build: [python]
+steps:
+  - interpreter: python
+    run: |
+      import os
+      from pathlib import Path
+      marker = Path(os.environ['PREFIX']) / 'share' / 'step-provider'
+      marker.mkdir(parents=True, exist_ok=True)
+      (marker / 'marker.txt').write_text('${{ inputs.message }}')
+      (marker / 'typed.txt').write_text('${{ inputs.enabled | lower }}:${{ inputs.count + 1 }}:${{ inputs.labels | join(",") }}')

--- a/test-data/recipes/step_provider_consumer/recipe.yaml
+++ b/test-data/recipes/step_provider_consumer/recipe.yaml
@@ -1,0 +1,16 @@
+schema_version: 1
+package:
+  name: step-provider-consumer
+  version: 1.0.0
+build:
+  steps:
+    - uses: test:build@=1.0.0
+      with:
+        message: exact-provider-worked
+        enabled: true
+        count: 7
+        labels: [first, second]
+    - if: false
+      uses: nonexistent-provider:build
+      with:
+        invalid: ${{ recipe_private_variable }}

--- a/test/end-to-end/test_actions.py
+++ b/test/end-to-end/test_actions.py
@@ -41,6 +41,34 @@ def run_action(rattler_build: RattlerBuild, project: Path, output: Path, name="t
     )
 
 
+@pytest.mark.parametrize("provider", ["cmake", "meson", "rust", "go"])
+@pytest.mark.parametrize("enabled", [False, True])
+def test_example_providers_use_typed_actions_and_step_conditions(
+    rattler_build: RattlerBuild,
+    recipes: Path,
+    tmp_path: Path,
+    provider: str,
+    enabled: bool,
+):
+    source = recipes.parents[1] / "examples" / "step-providers" / "providers" / provider
+    flag = "collect_licenses" if provider == "go" else "install"
+    project = action_project(
+        tmp_path,
+        yaml.safe_load((source / "build.yaml").read_text()),
+        arguments={flag: enabled},
+    )
+    rendered = rattler_build.render(
+        project, tmp_path / "output", extra_args=["--experimental"]
+    )
+    steps = rendered[0]["recipe"]["build"]["steps"]
+    optional_step = (
+        "go-licenses"
+        if provider == "go"
+        else f"{'cargo' if provider == 'rust' else provider}-install"
+    )
+    assert any(step["name"].endswith("/" + optional_step) for step in steps) == enabled
+
+
 def test_nested_action_selection_and_relative_resolution(
     rattler_build: RattlerBuild, tmp_path: Path
 ):

--- a/test/end-to-end/test_build_steps.py
+++ b/test/end-to-end/test_build_steps.py
@@ -1,6 +1,9 @@
 from pathlib import Path
+import shutil
 
-from helpers import RattlerBuild, get_extracted_package
+import yaml
+
+from helpers import RattlerBuild, get_extracted_package, get_package
 
 
 def test_build_steps(rattler_build: RattlerBuild, recipes: Path, tmp_path: Path):
@@ -40,3 +43,85 @@ def test_default_build_script_still_runs(
     marker = pkg / "share" / "default_build_script" / "marker.txt"
     assert marker.exists(), "default build script did not run"
     assert "default-build-script" in marker.read_text()
+
+
+def test_packaged_step_provider_uses_standalone_environment(
+    rattler_build: RattlerBuild, recipes: Path, tmp_path: Path, monkeypatch
+):
+    """Packaged actions compile recursively before variants and rebuild source-free."""
+    cache = tmp_path / "cache"
+    monkeypatch.setenv("RATTLER_CACHE_DIR", str(cache))
+    provider_recipe = tmp_path / "provider-recipe"
+    consumer_recipe = tmp_path / "consumer-recipe"
+    shutil.copytree(recipes / "step_provider", provider_recipe)
+    shutil.copytree(recipes / "step_provider_consumer", consumer_recipe)
+    provider_output = tmp_path / "provider-output"
+    channel = tmp_path / "channel"
+    consumer_output = tmp_path / "consumer-output"
+    rattler_build.build(provider_recipe, provider_output)
+    provider_package = get_package(provider_output, "test-rattler-build-steps")
+    rattler_build("publish", str(provider_package), "--to", str(channel))
+
+    variants = tmp_path / "variants.yaml"
+    variants.write_text('python: ["3.11", "3.12"]\n')
+    rendered = rattler_build.render(
+        consumer_recipe,
+        consumer_output,
+        variant_config=variants,
+        custom_channels=[channel.as_uri(), "conda-forge"],
+        extra_args=["--experimental"],
+    )
+    assert {
+        output["build_configuration"]["variant"]["python"] for output in rendered
+    } == {"3.11", "3.12"}
+    assert {
+        requirement
+        for output in rendered
+        for requirement in output["recipe"]["requirements"]["build"]
+    } == {"python 3.11.*", "python 3.12.*"}
+
+    rattler_build.build(
+        consumer_recipe,
+        consumer_output,
+        custom_channels=[channel.as_uri(), "conda-forge"],
+        extra_args=["--experimental"],
+    )
+    pkg = get_extracted_package(consumer_output, "step-provider-consumer")
+    assert (
+        pkg / "share" / "step-provider" / "marker.txt"
+    ).read_text().strip() == "exact-provider-worked"
+    assert not any(pkg.rglob("test-rattler-build-steps*"))
+    assert (pkg / "share/step-provider/typed.txt").read_text() == "true:8:first,second"
+    assert (
+        pkg / "share/step-provider/nested.txt"
+    ).read_text() == "exact-provider-worked"
+    stored = yaml.safe_load((pkg / "info/recipe/rendered_recipe.yaml").read_text())
+    assert not {"six", "test-rattler-build-steps"}.intersection(
+        record["name"]
+        for record in stored["finalized_dependencies"]["build"]["resolved"]
+    )
+    assert all("uses" not in step for step in stored["recipe"]["build"]["steps"])
+    assert str(cache) not in yaml.safe_dump(stored["recipe"]["build"])
+
+    # Remove both installed documents and their channel: a rebuild must execute
+    # the embedded flat plan, not silently retrieve the provider a second time.
+    shutil.rmtree(provider_recipe)
+    shutil.rmtree(consumer_recipe)
+    shutil.rmtree(channel)
+    shutil.rmtree(cache)
+    rebuilt_output = tmp_path / "rebuilt-output"
+    rattler_build(
+        "rebuild",
+        "--package-file",
+        str(get_package(consumer_output, "step-provider-consumer")),
+        "--output-dir",
+        str(rebuilt_output),
+        "--experimental",
+    )
+    rebuilt = get_extracted_package(rebuilt_output, "step-provider-consumer")
+    assert (
+        rebuilt / "share/step-provider/typed.txt"
+    ).read_text() == "true:8:first,second"
+    assert (
+        rebuilt / "share/step-provider/nested.txt"
+    ).read_text() == "exact-provider-worked"

--- a/test/end-to-end/test_build_steps.py
+++ b/test/end-to-end/test_build_steps.py
@@ -67,6 +67,7 @@ def test_packaged_step_provider_uses_standalone_environment(
     rendered = rattler_build.render(
         consumer_recipe,
         consumer_output,
+        with_solve=True,
         variant_config=variants,
         custom_channels=[channel.as_uri(), "conda-forge"],
         extra_args=["--experimental"],
@@ -74,11 +75,12 @@ def test_packaged_step_provider_uses_standalone_environment(
     assert {
         output["build_configuration"]["variant"]["python"] for output in rendered
     } == {"3.11", "3.12"}
-    assert {
-        requirement
-        for output in rendered
-        for requirement in output["recipe"]["requirements"]["build"]
-    } == {"python 3.11.*", "python 3.12.*"}
+    for output in rendered:
+        assert {
+            ".".join(record["version"].split(".")[:2])
+            for record in output["finalized_dependencies"]["build"]["resolved"]
+            if record["name"] == "python"
+        } == {output["build_configuration"]["variant"]["python"]}
 
     rattler_build.build(
         consumer_recipe,

--- a/test/end-to-end/test_build_steps.py
+++ b/test/end-to-end/test_build_steps.py
@@ -1,8 +1,7 @@
-from pathlib import Path
 import shutil
+from pathlib import Path
 
 import yaml
-
 from helpers import RattlerBuild, get_extracted_package, get_package
 
 


### PR DESCRIPTION
Actions should be distributable in conda packages without putting the provider package and its transport dependencies into the recipe's build environment.

This adds `provider:step@version` source resolution to the shared action compiler. Providers are solved for the build platform and installed into content-addressed cache prefixes without running link scripts. The resolver supplies document bytes and provenance; parsing, typed inputs, recursion, selection, and requirement collection stay in the compiler.

Both `.yaml` and `.yml` documents are supported, including relative and packaged nested references. Provider identity and artifact checksums participate in provenance, with MD5 retained when SHA-256 is unavailable. Post-build output handling has moved to the cache/output PR rather than remaining part of source transport.

A Windows debug build, three focused provider tests, and 39 action/provider CLI scenarios pass. The provider scenario checks Python variant constraints against the solved environment, then deletes the provider cache, recipes, and channel before rebuilding from the stored executable plan.

Part of PFX-1808. Native stack 2808, bottom to top: #2763 → #2807 → #2764 → #2765 → #2767.