### PR TITLE
fix: allow legacy-compatible optional dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4742,9 +4742,9 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.48.4"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6595b5f9878f0e2787da607235c158c7c125d4c4f145cfcc3febade9c66c3a4f"
+checksum = "2c15b3a9ff3a90a018a35810cc4cd2dab365963193667e418671766d3c7a8e19"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -5221,9 +5221,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10e0c05d770d92af1f4230f6f549ab6c4cb47d5e5f7a65339f91fca7fc6b3545"
+checksum = "74e007faa0849941cc7e7ca48a7221bbce81e0203d94783ea7b68f11af934345"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5256,9 +5256,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.51.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "654ccb4b723cd1e288bbbb8e798721b8316e19f0de3610ed90ebfbedabf45d45"
+checksum = "4a444e01a363e75100c3d363fdd60a251c4068a3b5b8f0fc9348f7bda1a2a0f9"
 dependencies = [
  "ahash",
  "core-foundation 0.10.1",
@@ -5276,6 +5276,7 @@ dependencies = [
  "nom",
  "nom-language",
  "purl",
+ "rattler_conda_version",
  "rattler_digest",
  "rattler_macros",
  "rattler_redaction",
@@ -5298,10 +5299,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "rattler_config"
-version = "0.7.2"
+name = "rattler_conda_version"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7cb7a3302ec74284640c5c7aa911269e1cfd65bd5e8da4299923453e50a0c78"
+checksum = "46fd80ddd753d6499a742e42ee657b4c5f334dd806a59585c8b8923ecc479fc7"
+dependencies = [
+ "itertools 0.15.0",
+ "nom",
+ "serde",
+ "smallvec",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "rattler_config"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c719c62dfa2a4032d5c2a9bce3061d0f12513d21c1c824f221adbc697fe7637"
 dependencies = [
  "dirs",
  "fs-err",
@@ -5338,9 +5352,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_git"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b7152dc6e591f5b1512ebcbb5b738cc0adddb61a519e98b62495c211065523"
+checksum = "4ca421965135fd9d4c4584d604da11130b3c5e4d42beb8371e41b6e9f3d73314"
 dependencies = [
  "astral-reqwest-middleware",
  "dashmap",
@@ -5360,9 +5374,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308fb45f4a01891e77e9a6ca585f493169586afee85b374e08f889b460951144"
+checksum = "d2c05d22bb5904e11f719a0f793eb08d0b7e2880c095fef60fcd1dfde2abe58d"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5410,9 +5424,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.75"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a39794d7486efd34a701c4e33abd094cff04d78d1f3a9bf9f539a3193b3406c"
+checksum = "651e4f2d4e35beba78a48fab3169ca48f5a7d859796b412726a2a905f3c1c8d9"
 dependencies = [
  "configparser",
  "dirs",
@@ -5441,9 +5455,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.30.6"
+version = "0.30.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad2167f271e0b3ad411a9623de1e948c12dadb05040cd7508015fed78f4e852"
+checksum = "b061f2fc9520c36182b164b5aec3eedcf96c3da663cc54a874c37cac30215af6"
 dependencies = [
  "ambient-id",
  "anyhow",
@@ -5480,9 +5494,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.27.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "364ad3b4bac0c95ae1f7c7bdfa33b679c8d64fde14fd47f6fb965836dbc94628"
+checksum = "1a4dc099870b508e0e95f26ebd135049bf7bc75247180182693ad8385d986609"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-tokio-tar",
@@ -5548,9 +5562,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_redaction"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308e86344e78b42b96570e765f287d7cf87fab7f21ba2eb12508363c11b55f72"
+checksum = "74a5906fa32ae8cf93930c4ac63c9201e4b5b33be66698dcd1f864b38631fda4"
 dependencies = [
  "astral-reqwest-middleware",
  "reqwest",
@@ -5559,9 +5573,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.33.0"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b705828891a4184451f8c5300b9b123bd946c76fa9f55c0057d81fab3f8d28"
+checksum = "e92ee296449b010ac24959e333f510f308a451607ebee900dc8747cb31c49927"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5627,9 +5641,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_s3"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9701fa2e3a6666991f32fe3b8157afc73caee15c1248bfc08343fb103d9dba"
+checksum = "fd0b2c4f38428b582323ba86bf7d9467c6b580d3a93a8c9a7889f16f231a4fc1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -5644,9 +5658,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.27.15"
+version = "0.27.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d87277b0a7b7ccba831890810e903c35b56b3c1003952ad07374da9ebb0b46b"
+checksum = "c28efe69b77079a26d7490bbb5e8569ed58c6289d2282a0b28ac10a9666f84af"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -5666,9 +5680,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "9.0.3"
+version = "9.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c287fe2c2a57e66162cadc4430b7aa300251edd73034b1b7bf222a660a9a45e"
+checksum = "9c3d50e303472d9709fa072ef9c658b35a0d99296c41ab4f41632e33b3e81e10"
 dependencies = [
  "futures",
  "hex",
@@ -5686,9 +5700,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_upload"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09043dd6c41243fbb8cb118e7809f0238a8f7eea198c728ca551167d67874841"
+checksum = "174e5f883e11153e1affe4f01c5db193535841ceab818224195afd9c6d8a0555"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-reqwest-retry",
@@ -5725,9 +5739,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "5.1.0"
+version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c249324b90e9dcf985991ca4a066b6df72c4c9b300a70746c596e90abe8df2f"
+checksum = "d22f645893f957382891a2b50d868fde56735461277ba93911f0311d47aba2f7"
 dependencies = [
  "archspec",
  "libloading",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ tracing-subscriber = { version = "0.3", features = [
 tracing-test = "0.2.6"
 
 # Rattler crates
-rattler_conda_types = { version = "0.51", default-features = false }
+rattler_conda_types = { version = "0.52", default-features = false }
 rattler_digest = { version = "1.3.2", default-features = false, features = [
   "serde",
 ] }

--- a/crates/rattler_build_playground/Cargo.lock
+++ b/crates/rattler_build_playground/Cargo.lock
@@ -1536,7 +1536,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rattler_build_jinja"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "fs-err",
  "indexmap 2.14.0",
@@ -1580,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_build_recipe"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "fs-err",
  "globset",
@@ -1613,7 +1613,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_build_recipe_generator"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "async-once-cell",
  "async-recursion",
@@ -1642,7 +1642,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_build_script"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "clap",
  "console",
@@ -1653,7 +1653,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_build_types"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "globset",
  "itertools",
@@ -1667,7 +1667,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_build_variant_config"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "fs-err",
  "marked-yaml",
@@ -1686,7 +1686,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_build_yaml_parser"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "marked-yaml",
  "miette",
@@ -1697,9 +1697,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.51.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "654ccb4b723cd1e288bbbb8e798721b8316e19f0de3610ed90ebfbedabf45d45"
+checksum = "4a444e01a363e75100c3d363fdd60a251c4068a3b5b8f0fc9348f7bda1a2a0f9"
 dependencies = [
  "ahash",
  "core-foundation",
@@ -1717,6 +1717,7 @@ dependencies = [
  "nom",
  "nom-language",
  "purl",
+ "rattler_conda_version",
  "rattler_digest",
  "rattler_macros",
  "rattler_redaction",
@@ -1735,6 +1736,19 @@ dependencies = [
  "tracing",
  "typed-path",
  "url",
+]
+
+[[package]]
+name = "rattler_conda_version"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46fd80ddd753d6499a742e42ee657b4c5f334dd806a59585c8b8923ecc479fc7"
+dependencies = [
+ "itertools",
+ "nom",
+ "serde",
+ "smallvec",
+ "thiserror",
 ]
 
 [[package]]
@@ -1768,9 +1782,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_redaction"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308e86344e78b42b96570e765f287d7cf87fab7f21ba2eb12508363c11b55f72"
+checksum = "74a5906fa32ae8cf93930c4ac63c9201e4b5b33be66698dcd1f864b38631fda4"
 dependencies = [
  "url",
 ]

--- a/crates/rattler_build_playground/Cargo.toml
+++ b/crates/rattler_build_playground/Cargo.toml
@@ -26,7 +26,7 @@ rattler_build_jinja = { path = "../rattler_build_jinja" }
 rattler_build_types = { path = "../rattler_build_types" }
 rattler_build_yaml_parser = { path = "../rattler_build_yaml_parser" }
 indexmap = "2"
-rattler_conda_types = { version = "0.51", default-features = false }
+rattler_conda_types = { version = "0.52", default-features = false }
 serde_yaml = "0.9"
 arborium = { version = "2", default-features = false, features = ["lang-yaml"] }
 

--- a/crates/rattler_build_recipe/src/stage0/evaluate.rs
+++ b/crates/rattler_build_recipe/src/stage0/evaluate.rs
@@ -1804,15 +1804,6 @@ impl Evaluate for Stage0Requirements {
     type Output = Stage1Requirements;
 
     fn evaluate(&self, context: &EvaluationContext) -> Result<Self::Output, ParseError> {
-        if !self.extras.is_empty() && context.repodata_revision() != RepodataRevision::V3 {
-            return Err(ParseError::invalid_value(
-                "requirements.extras",
-                "optional dependency groups require the --v3 flag",
-                Span::new_blank(),
-            )
-            .with_suggestion("Enable --v3 to use requirements.extras."));
-        }
-
         let extras = self
             .extras
             .iter()

--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -1158,18 +1158,13 @@ This is the version bound consistent with CentOS 6. Software built against glibc
 `mamba`, `conda` or `pixi` tell the user that a given package can't be installed if their system
 glibc version is too old.
 
-### Optional dependencies / extras (V3, beta)
+### Optional dependencies / extras
 
-!!! warning "Beta — opt in with `--v3`"
-    `requirements.extras` is part of the V3 repodata revision and is only
-    accepted when Rattler-Build is invoked with `--v3`. Without the flag,
-    recipes that declare an `extras` mapping fail to evaluate. See
-    [V3 packages](../v3.md) for background.
-
-`extras` is a mapping from a group name to a list of dependencies that are
-*not* installed by default. Consumers opt in via the V3 `extras=[…]`
-`MatchSpec` key. This mirrors the optional-dependencies idea from
-`pyproject.toml`.
+`requirements.extras` is supported in both legacy and V3 packages. `extras`
+is a mapping from a group name to a list of dependencies that are *not*
+installed by default. Consumers opt in via the V3-only `extras=[…]`
+`MatchSpec` key, which requires `--v3`. This mirrors the
+optional-dependencies idea from `pyproject.toml`.
 
 ```yaml
 requirements:

--- a/docs/v3.md
+++ b/docs/v3.md
@@ -3,8 +3,8 @@
 !!! danger "Beta — not for production use"
     V3 is an **opt-in preview** of the next conda repodata revision and is
     still under active development. The on-disk repodata format, the
-    `index.json` layout, recipe fields (`build.flags`, `requirements.extras`,
-    …) and the `MatchSpec` bracket syntax described on this page **can and
+    `index.json` layout, V3-only recipe fields such as `build.flags`, and the
+    `MatchSpec` bracket syntax described on this page **can and
     will change in backwards-incompatible ways** before V3 is finalized.
     Concretely, this means:
 
@@ -22,11 +22,10 @@
     [rattler-build issue tracker](https://github.com/prefix-dev/rattler-build/issues)
     before depending on it.
 
-V3 is a new revision of the conda repodata format. It extends the existing
-package record with two new fields and adds a richer `MatchSpec` bracket
-syntax that lets you express conditional, optional and variant-tagged
-dependencies. Rattler-Build can produce V3 packages and parse V3 recipes,
-but only when the feature is explicitly enabled.
+V3 is a new revision of the conda repodata format. It adds package flags and
+a richer `MatchSpec` bracket syntax that lets you express conditional, optional
+and variant-tagged dependencies. Rattler-Build can produce V3 packages and
+parse V3 recipes, but only when the feature is explicitly enabled.
 
 ## Opting in
 
@@ -45,8 +44,8 @@ V3 is gated behind a single flag. There are two ways to turn it on:
 When the flag is **off** (the default), Rattler-Build behaves exactly like
 before:
 
-- Recipes that use V3-only fields (`build.flags`, `requirements.extras`) fail
-  to evaluate with an error pointing at `--v3`.
+- Recipes that use V3-only fields (`build.flags`) fail to evaluate with an
+  error pointing at `--v3`.
 - `MatchSpec` strings that use V3-only bracket keys (`flags=[…]`,
   `extras=[…]`, `when="…"`) fail to parse with the same error.
 - Built packages get the legacy `index.json` shape — there is no
@@ -54,13 +53,13 @@ before:
 
 When the flag is **on**:
 
-- The new recipe fields are accepted and round-tripped through Stage 0/Stage 1
+- V3-only recipe fields are accepted and round-tripped through Stage 0/Stage 1
   evaluation.
 - V3 `MatchSpec` syntax is parsed everywhere a dependency string is allowed
   (`requirements.{build,host,run,run_constraints,extras}`, `run_exports`).
 - Built packages are tagged with `repodata_revision: 3` in `index.json` and
-  carry their declared variant flags in a top-level `flags` array. Optional
-  dependency groups are written into the `extra_depends` mapping.
+  carry their declared variant flags in a top-level `flags` array. Declared
+  optional dependency groups are written into the `extra_depends` mapping.
 
 ## What V3 adds
 
@@ -93,10 +92,11 @@ build:
 Flags that depend on a Jinja variable participate in variant hashing, so
 each flag combination produces its own build hash.
 
-### `requirements.extras` — optional dependency groups
+### Optional dependency groups
 
-`extras` is a mapping from a group name to a list of dependencies. The group
-is *not* installed by default — consumers opt in via the `extras=[…]`
+`requirements.extras` is supported in both legacy and V3 packages. `extras`
+is a mapping from a group name to a list of dependencies. The group is *not*
+installed by default — consumers opt in via the V3-only `extras=[…]`
 `MatchSpec` bracket key. This mirrors the "optional dependencies" idea from
 `pyproject.toml`.
 

--- a/py-rattler-build/rust/Cargo.lock
+++ b/py-rattler-build/rust/Cargo.lock
@@ -4572,9 +4572,9 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.48.4"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6595b5f9878f0e2787da607235c158c7c125d4c4f145cfcc3febade9c66c3a4f"
+checksum = "2c15b3a9ff3a90a018a35810cc4cd2dab365963193667e418671766d3c7a8e19"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -4997,9 +4997,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10e0c05d770d92af1f4230f6f549ab6c4cb47d5e5f7a65339f91fca7fc6b3545"
+checksum = "74e007faa0849941cc7e7ca48a7221bbce81e0203d94783ea7b68f11af934345"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5032,9 +5032,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.51.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "654ccb4b723cd1e288bbbb8e798721b8316e19f0de3610ed90ebfbedabf45d45"
+checksum = "4a444e01a363e75100c3d363fdd60a251c4068a3b5b8f0fc9348f7bda1a2a0f9"
 dependencies = [
  "ahash",
  "core-foundation 0.10.1",
@@ -5052,6 +5052,7 @@ dependencies = [
  "nom",
  "nom-language",
  "purl",
+ "rattler_conda_version",
  "rattler_digest",
  "rattler_macros",
  "rattler_redaction",
@@ -5074,10 +5075,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "rattler_config"
-version = "0.7.2"
+name = "rattler_conda_version"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7cb7a3302ec74284640c5c7aa911269e1cfd65bd5e8da4299923453e50a0c78"
+checksum = "46fd80ddd753d6499a742e42ee657b4c5f334dd806a59585c8b8923ecc479fc7"
+dependencies = [
+ "itertools 0.15.0",
+ "nom",
+ "serde",
+ "smallvec",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "rattler_config"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c719c62dfa2a4032d5c2a9bce3061d0f12513d21c1c824f221adbc697fe7637"
 dependencies = [
  "dirs",
  "fs-err",
@@ -5114,9 +5128,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_git"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b7152dc6e591f5b1512ebcbb5b738cc0adddb61a519e98b62495c211065523"
+checksum = "4ca421965135fd9d4c4584d604da11130b3c5e4d42beb8371e41b6e9f3d73314"
 dependencies = [
  "astral-reqwest-middleware",
  "dashmap",
@@ -5136,9 +5150,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308fb45f4a01891e77e9a6ca585f493169586afee85b374e08f889b460951144"
+checksum = "d2c05d22bb5904e11f719a0f793eb08d0b7e2880c095fef60fcd1dfde2abe58d"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5186,9 +5200,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.75"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a39794d7486efd34a701c4e33abd094cff04d78d1f3a9bf9f539a3193b3406c"
+checksum = "651e4f2d4e35beba78a48fab3169ca48f5a7d859796b412726a2a905f3c1c8d9"
 dependencies = [
  "configparser",
  "dirs",
@@ -5217,9 +5231,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.30.6"
+version = "0.30.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad2167f271e0b3ad411a9623de1e948c12dadb05040cd7508015fed78f4e852"
+checksum = "b061f2fc9520c36182b164b5aec3eedcf96c3da663cc54a874c37cac30215af6"
 dependencies = [
  "ambient-id",
  "anyhow",
@@ -5256,9 +5270,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.27.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "364ad3b4bac0c95ae1f7c7bdfa33b679c8d64fde14fd47f6fb965836dbc94628"
+checksum = "1a4dc099870b508e0e95f26ebd135049bf7bc75247180182693ad8385d986609"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-tokio-tar",
@@ -5324,9 +5338,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_redaction"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308e86344e78b42b96570e765f287d7cf87fab7f21ba2eb12508363c11b55f72"
+checksum = "74a5906fa32ae8cf93930c4ac63c9201e4b5b33be66698dcd1f864b38631fda4"
 dependencies = [
  "astral-reqwest-middleware",
  "reqwest",
@@ -5335,9 +5349,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.33.0"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b705828891a4184451f8c5300b9b123bd946c76fa9f55c0057d81fab3f8d28"
+checksum = "e92ee296449b010ac24959e333f510f308a451607ebee900dc8747cb31c49927"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5403,9 +5417,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_s3"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9701fa2e3a6666991f32fe3b8157afc73caee15c1248bfc08343fb103d9dba"
+checksum = "fd0b2c4f38428b582323ba86bf7d9467c6b580d3a93a8c9a7889f16f231a4fc1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -5420,9 +5434,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.27.15"
+version = "0.27.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d87277b0a7b7ccba831890810e903c35b56b3c1003952ad07374da9ebb0b46b"
+checksum = "c28efe69b77079a26d7490bbb5e8569ed58c6289d2282a0b28ac10a9666f84af"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -5442,9 +5456,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "9.0.3"
+version = "9.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c287fe2c2a57e66162cadc4430b7aa300251edd73034b1b7bf222a660a9a45e"
+checksum = "9c3d50e303472d9709fa072ef9c658b35a0d99296c41ab4f41632e33b3e81e10"
 dependencies = [
  "futures",
  "hex",
@@ -5462,9 +5476,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_upload"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09043dd6c41243fbb8cb118e7809f0238a8f7eea198c728ca551167d67874841"
+checksum = "174e5f883e11153e1affe4f01c5db193535841ceab818224195afd9c6d8a0555"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-reqwest-retry",
@@ -5501,9 +5515,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "5.1.0"
+version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c249324b90e9dcf985991ca4a066b6df72c4c9b300a70746c596e90abe8df2f"
+checksum = "d22f645893f957382891a2b50d868fde56735461277ba93911f0311d47aba2f7"
 dependencies = [
  "archspec",
  "libloading",

--- a/py-rattler-build/rust/Cargo.toml
+++ b/py-rattler-build/rust/Cargo.toml
@@ -35,7 +35,7 @@ tokio = { version = "1.53.1", features = [
   "rt-multi-thread",
   "process",
 ] }
-rattler_conda_types = "0.51"
+rattler_conda_types = "0.52"
 rattler_config = "0.7"
 rattler_networking = { version = "0.30.3" }
 rattler_solve = "9.0"

--- a/test-data/recipes/legacy-index-shape/recipe.yaml
+++ b/test-data/recipes/legacy-index-shape/recipe.yaml
@@ -4,6 +4,11 @@ package:
   name: legacy-index-shape
   version: 1.0.0
 
+requirements:
+  extras:
+    test:
+      - pytest >=8
+
 build:
   script:
     - if: win

--- a/test-data/v3-recipes/v3-extra-matchspec-rejected/recipe.yaml
+++ b/test-data/v3-recipes/v3-extra-matchspec-rejected/recipe.yaml
@@ -1,10 +1,10 @@
 schema_version: 1
 
 package:
-  name: v3-extras-rejected
+  name: v3-extra-matchspec-rejected
   version: 1.0.0
 
 requirements:
   extras:
     plot:
-      - matplotlib >=3.8
+      - scipy[when="python >=3.10"]

--- a/test-data/v3-recipes/v3-extras-matchspec-rejected/recipe.yaml
+++ b/test-data/v3-recipes/v3-extras-matchspec-rejected/recipe.yaml
@@ -1,0 +1,9 @@
+schema_version: 1
+
+package:
+  name: v3-extras-matchspec-rejected
+  version: 1.0.0
+
+requirements:
+  run:
+    - foo [extras=["bla"]]

--- a/test/end-to-end/test_v3_repodata.py
+++ b/test/end-to-end/test_v3_repodata.py
@@ -157,7 +157,6 @@ def assert_v3_index_json(index_json: dict[str, Any]) -> None:
 def assert_legacy_index_json(index_json: dict[str, Any]) -> None:
     assert "repodata_revision" not in index_json
     assert "flags" not in index_json
-    assert "extra_depends" not in index_json
 
 
 def test_v3_build_writes_v3_index_json(rattler_build: RattlerBuild, tmp_path: Path):
@@ -208,7 +207,10 @@ def test_v3_local_publish_writes_v3_repodata_and_shards(
 
     record = repodata["v3"][v3_submap][package_record_name]
     assert record["flags"] == ["cuda", "blas:openblas"]
-    assert record["extra_depends"] == index_json["extra_depends"]
+    assert record["extra_depends"] == {
+        "full": ['pandas[version=">=2"]', "rich[extras=[jupyter]]"],
+        "plot": ['matplotlib[version=">=3.8"]'],
+    }
     assert 'scipy[when="python>=3.10"]' in record["depends"]
 
     shard_index_path = channel_dir / subdir / "repodata_shards.msgpack.zst"
@@ -238,6 +240,7 @@ def test_legacy_build_keeps_legacy_index_json(
     extracted = get_extracted_package(output_dir, "legacy-index-shape")
     index_json = json.loads((extracted / "info/index.json").read_text())
     assert_legacy_index_json(index_json)
+    assert index_json["extra_depends"] == {"test": ["pytest >=8"]}
 
 
 @pytest.mark.parametrize(
@@ -249,9 +252,9 @@ def test_legacy_build_keeps_legacy_index_json(
             "Enable --v3 to use build.flags.",
         ),
         (
-            "v3-extras-rejected",
-            "requirements.extras",
-            "Enable --v3 to use requirements.extras.",
+            "v3-extra-matchspec-rejected",
+            "invalid bracket key: when",
+            "Enable --v3 to use V3 MatchSpec keys",
         ),
         (
             "v3-conditional-matchspec-rejected",
@@ -261,6 +264,11 @@ def test_legacy_build_keeps_legacy_index_json(
         (
             "v3-flags-matchspec-rejected",
             "invalid bracket key: flags",
+            "Enable --v3 to use V3 MatchSpec keys",
+        ),
+        (
+            "v3-extras-matchspec-rejected",
+            "invalid bracket key: extras",
             "Enable --v3 to use V3 MatchSpec keys",
         ),
     ],


### PR DESCRIPTION
Plain `requirements.extras` produces additive `extra_depends` metadata, which can be represented in legacy packages. Requiring `--v3` prevented recipes from publishing those optional dependency groups without using the V3 repodata layout.

This removes the blanket gate and keeps the MatchSpec-level V3 checks. An extra containing `when`, `flags`, or `extras` still needs `--v3`.

This also updates to the latest rattler release. Every manifest that directly uses `rattler_conda_types` moves to the new 0.52 minor release; the other released rattler crate patches stay in their respective `Cargo.lock` files. V3 repodata now canonicalizes MatchSpecs, so the local publish assertion expects the canonical extra dependency strings.

This is the rattler-build follow-up to conda/rattler#2721.

## Testing

- `pixi run build-release`
- `pixi run python -m pytest test/end-to-end/test_v3_repodata.py -q --snapshot-warn-unused --snapshot-details`
- `pixi run cargo test -p rattler_build_recipe --all-targets`
- `pixi run --environment lint cargo-clippy`
- `pixi run cargo check --manifest-path py-rattler-build/rust/Cargo.toml`
- `pixi run cargo check --manifest-path crates/rattler_build_playground/Cargo.toml`

I also built a no-`--v3` package with `extra_depends` and verified its `info/index.json` has no `repodata_revision`. A fresh local channel indexed with `conda-index` preserved the `extra_depends` record in `repodata.json` and likewise has no `repodata_revision`. Prefix.dev currently rejects the upload to the `baszalmstra` channel as a V3 repodata upload. That is the same stale revision classification addressed by conda/rattler#2721, so the hosted validation needs that change deployed first.
