### PR TITLE
feat: Add an option --pass-all-variants-as-env

### DIFF
--- a/crates/rattler_build_core/src/env_vars.rs
+++ b/crates/rattler_build_core/src/env_vars.rs
@@ -545,24 +545,6 @@ pub fn env_vars_from_variant(
         .collect()
 }
 
-/// Convert the variant keys that only have a single possible value into
-/// environment variables, excluding language-specific keys that are handled
-/// separately. `all_variants` is expected to hold every key and all of its
-/// possible values from the variant configuration, not just the ones a
-/// recipe uses.
-pub fn env_vars_from_single_value_variants(
-    all_variants: &BTreeMap<NormalizedKey, Vec<Variable>>,
-) -> HashMap<String, Option<String>> {
-    let single_value_variants: BTreeMap<NormalizedKey, Variable> = all_variants
-        .iter()
-        .filter_map(|(k, values)| match values.as_slice() {
-            [value] => Some((k.clone(), value.clone())),
-            _ => None,
-        })
-        .collect();
-    env_vars_from_variant(&single_value_variants)
-}
-
 #[cfg(test)]
 mod test {
     use super::*;

--- a/crates/rattler_build_core/src/env_vars.rs
+++ b/crates/rattler_build_core/src/env_vars.rs
@@ -545,6 +545,24 @@ pub fn env_vars_from_variant(
         .collect()
 }
 
+/// Convert the variant keys that only have a single possible value into
+/// environment variables, excluding language-specific keys that are handled
+/// separately. `all_variants` is expected to hold every key and all of its
+/// possible values from the variant configuration, not just the ones a
+/// recipe uses.
+pub fn env_vars_from_single_value_variants(
+    all_variants: &BTreeMap<NormalizedKey, Vec<Variable>>,
+) -> HashMap<String, Option<String>> {
+    let single_value_variants: BTreeMap<NormalizedKey, Variable> = all_variants
+        .iter()
+        .filter_map(|(k, values)| match values.as_slice() {
+            [value] => Some((k.clone(), value.clone())),
+            _ => None,
+        })
+        .collect();
+    env_vars_from_variant(&single_value_variants)
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/crates/rattler_build_core/src/packaging.rs
+++ b/crates/rattler_build_core/src/packaging.rs
@@ -402,8 +402,10 @@ fn write_recipe_folder(
     // write the variant config to the appropriate file
     let variant_config_file = recipe_folder.join("variant_config.yaml");
     let mut variant_config = File::create(&variant_config_file)?;
-    variant_config
-        .write_all(serde_yaml::to_string(&output.build_configuration.variant)?.as_bytes())?;
+    variant_config.write_all(
+        serde_yaml::to_string(&output.build_configuration.variant_with_single_value_extras())?
+            .as_bytes(),
+    )?;
     files.push(variant_config_file);
 
     let mut output_clean = output.clone();

--- a/crates/rattler_build_core/src/script.rs
+++ b/crates/rattler_build_core/src/script.rs
@@ -185,6 +185,9 @@ impl Output {
             context.runtime(),
         ));
         env_vars.extend(env_vars::env_vars_from_variant(self.variant()));
+        env_vars.extend(env_vars::env_vars_from_single_value_variants(
+            &self.build_configuration.all_variants,
+        ));
         prepare_build_plan_execution_args(
             &build.plan,
             &self.recipe.context,

--- a/crates/rattler_build_core/src/script.rs
+++ b/crates/rattler_build_core/src/script.rs
@@ -185,8 +185,8 @@ impl Output {
             context.runtime(),
         ));
         env_vars.extend(env_vars::env_vars_from_variant(self.variant()));
-        env_vars.extend(env_vars::env_vars_from_single_value_variants(
-            &self.build_configuration.all_variants,
+        env_vars.extend(env_vars::env_vars_from_variant(
+            &self.build_configuration.single_value_variants(),
         ));
         prepare_build_plan_execution_args(
             &build.plan,

--- a/crates/rattler_build_core/src/staging.rs
+++ b/crates/rattler_build_core/src/staging.rs
@@ -299,6 +299,9 @@ impl Output {
         // inheriting output may not directly reference variant keys (like
         // CONDA_BUILD_SYSROOT) that the staging cache's compilers depend on.
         env_vars.extend(env_vars::env_vars_from_variant(&staging.used_variant));
+        env_vars.extend(env_vars::env_vars_from_single_value_variants(
+            &self.build_configuration.all_variants,
+        ));
 
         // A staging cache does not produce a package, so the PKG_* vars
         // (which would otherwise carry the inheriting output's identity) are

--- a/crates/rattler_build_core/src/staging.rs
+++ b/crates/rattler_build_core/src/staging.rs
@@ -299,8 +299,8 @@ impl Output {
         // inheriting output may not directly reference variant keys (like
         // CONDA_BUILD_SYSROOT) that the staging cache's compilers depend on.
         env_vars.extend(env_vars::env_vars_from_variant(&staging.used_variant));
-        env_vars.extend(env_vars::env_vars_from_single_value_variants(
-            &self.build_configuration.all_variants,
+        env_vars.extend(env_vars::env_vars_from_variant(
+            &self.build_configuration.single_value_variants(),
         ));
 
         // A staging cache does not produce a package, so the PKG_* vars

--- a/crates/rattler_build_core/src/types/build_configuration.rs
+++ b/crates/rattler_build_core/src/types/build_configuration.rs
@@ -107,4 +107,29 @@ impl BuildConfiguration {
             recipe_path: None,
         }
     }
+
+    /// Variant keys from `all_variants` that only have a single possible
+    /// value (empty unless `--pass-all-variants-as-env` was passed).
+    pub fn single_value_variants(&self) -> BTreeMap<NormalizedKey, Variable> {
+        self.all_variants
+            .iter()
+            .filter_map(|(key, values)| match values.as_slice() {
+                [value] => Some((key.clone(), value.clone())),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// The variant keys the recipe actually uses, plus (only when
+    /// `--pass-all-variants-as-env` was passed) any additional variant keys
+    /// that only have a single possible value. Used for provenance data
+    /// (e.g. the `variant_config.yaml` stored in the package) rather than
+    /// hashing or build-string computation.
+    pub fn variant_with_single_value_extras(&self) -> BTreeMap<NormalizedKey, Variable> {
+        let mut variant = self.variant.clone();
+        for (key, value) in self.single_value_variants() {
+            variant.entry(key).or_insert(value);
+        }
+        variant
+    }
 }

--- a/crates/rattler_build_core/src/types/build_configuration.rs
+++ b/crates/rattler_build_core/src/types/build_configuration.rs
@@ -73,6 +73,15 @@ pub struct BuildConfiguration {
     /// Repodata revision to target when writing package metadata.
     #[serde(skip_serializing, default)]
     pub repodata_revision: RepodataRevision,
+
+    /// All variant keys and their possible values from the variant
+    /// configuration (not just the ones the recipe actually uses). When
+    /// `--pass-all-variants-as-env` is passed, the keys among these
+    /// that only have a single possible value are exported as environment
+    /// variables to the build script in addition to the variant keys the
+    /// recipe actually uses. Empty unless that flag is set.
+    #[serde(skip_serializing, default)]
+    pub all_variants: BTreeMap<NormalizedKey, Vec<Variable>>,
 }
 
 impl BuildConfiguration {

--- a/py-rattler-build/rust/src/build.rs
+++ b/py-rattler-build/rust/src/build.rs
@@ -229,6 +229,7 @@ pub(crate) fn output_from_rendered_variant(
             sandbox_config: None,
             exclude_newer,
             repodata_revision: repodata_revision.into(),
+            all_variants: Default::default(),
         },
         finalized_dependencies: None,
         finalized_sources: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -418,6 +418,18 @@ pub async fn get_build_output(
         ..RenderConfig::default()
     };
 
+    // All variant keys and their possible values, kept around so that when
+    // opted in via `--pass-all-variants-as-env` the keys among them
+    // that only have a single possible value can be exported as environment
+    // variables to the build script, even if the recipe doesn't otherwise
+    // reference them.
+    let all_variants: BTreeMap<NormalizedKey, Vec<Variable>> =
+        if build_data.pass_all_variants_as_env {
+            variant_config.variants.clone()
+        } else {
+            BTreeMap::new()
+        };
+
     let FoundVariants {
         outputs: outputs_and_variants,
         recipe_name,
@@ -591,6 +603,7 @@ pub async fn get_build_output(
                 sandbox_config: build_data.sandbox_configuration.clone(),
                 exclude_newer: build_data.exclude_newer,
                 repodata_revision: repodata_revision_from_v3_flag(build_data.common.v3),
+                all_variants: all_variants.clone(),
             },
             finalized_dependencies: None,
             finalized_sources: None,
@@ -1602,6 +1615,7 @@ pub async fn debug_recipe(
         variant_config: debug_data.variant_config,
         variant_overrides: debug_data.variant_overrides,
         ignore_recipe_variants: debug_data.ignore_recipe_variants,
+        pass_all_variants_as_env: false,
         render_only: false,
         with_solve: true,
         no_build_id: false,

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -621,6 +621,12 @@ pub struct BuildOpts {
     #[arg(long)]
     pub ignore_recipe_variants: bool,
 
+    /// Expose every variant key that only has a single possible value as an
+    /// environment variable to the build script, even if the recipe does not
+    /// otherwise reference it.
+    #[arg(long)]
+    pub pass_all_variants_as_env: bool,
+
     /// Render the recipe files without executing the build.
     #[arg(long)]
     pub render_only: bool,
@@ -901,6 +907,7 @@ pub struct BuildData {
     pub variant_config: Vec<PathBuf>,
     pub variant_overrides: HashMap<String, Vec<String>>,
     pub ignore_recipe_variants: bool,
+    pub pass_all_variants_as_env: bool,
     pub render_only: bool,
     pub with_solve: bool,
     pub keep_build: bool,
@@ -939,6 +946,7 @@ impl BuildData {
         variant_config: Option<Vec<PathBuf>>,
         variant_overrides: HashMap<String, Vec<String>>,
         ignore_recipe_variants: bool,
+        pass_all_variants_as_env: bool,
         render_only: bool,
         with_solve: bool,
         keep_build: bool,
@@ -977,6 +985,7 @@ impl BuildData {
             variant_config: variant_config.unwrap_or_default(),
             variant_overrides,
             ignore_recipe_variants,
+            pass_all_variants_as_env,
             render_only,
             with_solve,
             keep_build,
@@ -1026,6 +1035,7 @@ impl BuildData {
             opts.variant_config,
             opts.variant_overrides.into_iter().collect(),
             opts.ignore_recipe_variants,
+            opts.pass_all_variants_as_env,
             opts.render_only,
             opts.with_solve,
             opts.keep_build,


### PR DESCRIPTION
usually only used variables are sent to build scripts as env variables. this options sends all single element variables to build scripts. this is useful for conda-forge for variables like CROSSCOMPILING_EMULATOR