### PR TITLE
chore: update flickzeug to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2213,10 +2213,11 @@ dependencies = [
 
 [[package]]
 name = "flickzeug"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb44f8d38184df06a8bd1bd6bf594a2b8a8a1a7a59768f8ce102d0510462355f"
+checksum = "193f9e0d733b59a9db196a6443d654c0ced3986faf000da429538998f2eecb7a"
 dependencies = [
+ "memchr",
  "nu-ansi-term",
  "strsim",
  "thiserror 2.0.20",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ unicode-normalization = "0.1.25"
 # Dependencies used in subcrates (workspace-level)
 clap-verbosity-flag = "3.0.4"
 comfy-table = "8.0.0"
-flickzeug = "0.5.4"
+flickzeug = "0.6.0"
 goblin = "0.10.7"
 ignore = "0.4.31"
 num_cpus = "1.17.0"

--- a/crates/rattler_build_core/src/source/patch.rs
+++ b/crates/rattler_build_core/src/source/patch.rs
@@ -12,8 +12,8 @@ use std::{
 };
 
 use flickzeug::{
-    ApplyConfig, ApplyError, ApplyOutcome, Diff, FuzzyConfig, HunkRangeStrategy, ParsePatchError,
-    ParserConfig, Patch, apply_bytes_reporting, apply_bytes_with_config,
+    ApplyConfig, ApplyError, ApplyOutcome, Diff, FuzzyConfig, HunkRangeStrategy, LineEndHandling,
+    ParsePatchError, ParserConfig, Patch, apply_bytes_reporting, apply_bytes_with_config,
     patch_from_bytes_with_config,
 };
 use fs_err::File;
@@ -171,12 +171,13 @@ fn patch_from_bytes_raw(input: &[u8]) -> Result<Patch<'_, [u8]>, ParsePatchError
 /// `apply` and the already-applied detection so both agree on what "applies".
 fn apply_config() -> ApplyConfig {
     ApplyConfig {
+        line_end_strategy: LineEndHandling::KeepOriginal,
         fuzzy_config: FuzzyConfig {
             max_fuzz: 2,
             ignore_whitespace: true,
             ignore_case: false,
+            similarity_threshold: 0.8,
         },
-        ..Default::default()
     }
 }
 
@@ -651,6 +652,83 @@ mod tests {
             after_first, after_second,
             "already-applied patch must not modify the file again"
         );
+    }
+
+    #[test]
+    fn test_trailing_newline_only_patch_is_applied() {
+        let tempdir = TempDir::new().unwrap();
+        let target = tempdir.path().join("file.txt");
+        let patch = tempdir.path().join("newline.patch");
+        fs_err::write(&target, b"gamma").unwrap();
+        fs_err::write(
+            &patch,
+            b"--- file.txt\n+++ file.txt\n@@ -1 +1 @@\n-gamma\n\\ No newline at end of file\n+gamma\n",
+        )
+        .unwrap();
+
+        apply_patch_custom(tempdir.path(), &patch).unwrap();
+        assert_eq!(fs_err::read(&target).unwrap(), b"gamma\n");
+
+        apply_patch_custom(tempdir.path(), &patch).unwrap();
+        assert_eq!(fs_err::read(&target).unwrap(), b"gamma\n");
+    }
+
+    #[test]
+    fn test_patch_preserves_mixed_line_endings() {
+        let tempdir = TempDir::new().unwrap();
+        let target = tempdir.path().join("file.txt");
+        let patch = tempdir.path().join("mixed-endings.patch");
+        fs_err::write(&target, b"keep\r\nold\r\nplain\nmore\r\n").unwrap();
+        fs_err::write(
+            &patch,
+            b"--- file.txt\n+++ file.txt\n@@ -2 +2 @@\n-old\n+new\n",
+        )
+        .unwrap();
+
+        apply_patch_custom(tempdir.path(), &patch).unwrap();
+        assert_eq!(
+            fs_err::read(&target).unwrap(),
+            b"keep\r\nnew\r\nplain\nmore\r\n"
+        );
+    }
+
+    #[test]
+    fn test_fuzzy_patch_does_not_delete_similar_line() {
+        let tempdir = TempDir::new().unwrap();
+        let target = tempdir.path().join("file.txt");
+        let patch = tempdir.path().join("similar-deletion.patch");
+        let content = b"context 1\nthe quick brown fox jumps\ncontext 2\n";
+        fs_err::write(&target, content).unwrap();
+        fs_err::write(
+            &patch,
+            b"--- file.txt\n+++ file.txt\n@@ -1,3 +1,2 @@\n context 1\n-the quick brown fox jumped\n context 2\n",
+        )
+        .unwrap();
+
+        assert!(matches!(
+            apply_patch_custom(tempdir.path(), &patch),
+            Err(SourceError::PatchApplyError(_))
+        ));
+        assert_eq!(fs_err::read(&target).unwrap(), content);
+    }
+
+    #[test]
+    fn test_malformed_later_hunk_does_not_partially_apply() {
+        let tempdir = TempDir::new().unwrap();
+        let target = tempdir.path().join("file.txt");
+        let patch = tempdir.path().join("malformed.patch");
+        fs_err::write(&target, b"old\n").unwrap();
+        fs_err::write(
+            &patch,
+            b"--- file.txt\n+++ file.txt\n@@ -1 +1 @@\n-old\n+new\n@@ -10,2 +10,2 XX broken header\n context\n-old\n+new\n",
+        )
+        .unwrap();
+
+        assert!(matches!(
+            apply_patch_custom(tempdir.path(), &patch),
+            Err(SourceError::PatchParseFailed(_))
+        ));
+        assert_eq!(fs_err::read(&target).unwrap(), b"old\n");
     }
 
     #[test]

--- a/py-rattler-build/rust/Cargo.lock
+++ b/py-rattler-build/rust/Cargo.lock
@@ -2084,10 +2084,11 @@ dependencies = [
 
 [[package]]
 name = "flickzeug"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb44f8d38184df06a8bd1bd6bf594a2b8a8a1a7a59768f8ce102d0510462355f"
+checksum = "193f9e0d733b59a9db196a6443d654c0ced3986faf000da429538998f2eecb7a"
 dependencies = [
+ "memchr",
  "nu-ansi-term",
  "strsim",
  "thiserror 2.0.19",


### PR DESCRIPTION
## Summary

- update flickzeug and both Rust lockfiles to 0.6.0
- preserve the existing fuzzy patch configuration with the new API
- add regressions for trailing newlines, mixed line endings, similar-line deletion, and malformed hunks

## Tests

- `cargo test -p rattler_build_core source::patch::tests -- --nocapture`
- `cargo check --workspace --all-targets`
- `cd py-rattler-build/rust && cargo check`
- `cargo clippy -p rattler_build_core --all-targets -- -D warnings`
- `cargo fmt --all -- --check`