### PR TITLE
chore: release 0.75.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.75.0] - 2026-08-26
+### ✨ Highlights
+
+This release features CEP-6 channel notices and various bug fixes.
+
+
+### Added
+
+- Display CEP-6 channel notices by @wolfv in [#2749](https://github.com/prefix-dev/rattler-build/pull/2749)
+
+
+### Fixed
+
+- Select platform-appropriate legacy test scripts by @jezdez in [#2751](https://github.com/prefix-dev/rattler-build/pull/2751)
+- Allow legacy-compatible optional dependencies by @baszalmstra in [#2768](https://github.com/prefix-dev/rattler-build/pull/2768)
+
+
+### New Contributors
+* @jezdez made their first contribution in [#2751](https://github.com/prefix-dev/rattler-build/pull/2751)
+
 ## [0.74.0] - 2026-08-17
 ### ✨ Highlights
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4796,7 +4796,7 @@ dependencies = [
 
 [[package]]
 name = "rattler-build"
-version = "0.74.0"
+version = "0.75.0"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler-build"
-version = "0.74.0"
+version = "0.75.0"
 authors = ["rattler-build contributors <hi@prefix.dev>"]
 repository = "https://github.com/prefix-dev/rattler-build"
 edition = "2024"

--- a/py-rattler-build/pyproject.toml
+++ b/py-rattler-build/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "py-rattler-build"
-version = "0.74.0"
+version = "0.75.0"
 requires-python = ">=3.10"
 description = "The fastest way to build conda packages programatically"
 readme = "README.md"

--- a/py-rattler-build/rust/Cargo.lock
+++ b/py-rattler-build/rust/Cargo.lock
@@ -4262,7 +4262,7 @@ dependencies = [
 
 [[package]]
 name = "py-rattler-build"
-version = "0.74.0"
+version = "0.75.0"
 dependencies = [
  "clap",
  "fs-err",
@@ -4626,7 +4626,7 @@ dependencies = [
 
 [[package]]
 name = "rattler-build"
-version = "0.74.0"
+version = "0.75.0"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",

--- a/py-rattler-build/rust/Cargo.toml
+++ b/py-rattler-build/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-rattler-build"
-version = "0.74.0"
+version = "0.75.0"
 edition = "2024"
 license = "BSD-3-Clause"
 publish = false

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/prefix-dev/rattler-build"
 
 [version]
-current = "0.74.0"
+current = "0.75.0"
 
 # Example of a semver regexp.
 # Make sure this matches current_version before


### PR DESCRIPTION
## [0.75.0] - 2026-08-26
### ✨ Highlights

This release features CEP-6 channel notices and various bug fixes.


### Added

- Display CEP-6 channel notices by @wolfv in [#2749](https://github.com/prefix-dev/rattler-build/pull/2749)


### Fixed

- Select platform-appropriate legacy test scripts by @jezdez in [#2751](https://github.com/prefix-dev/rattler-build/pull/2751)
- Allow legacy-compatible optional dependencies by @baszalmstra in [#2768](https://github.com/prefix-dev/rattler-build/pull/2768)


### New Contributors
* @jezdez made their first contribution in [#2751](https://github.com/prefix-dev/rattler-build/pull/2751)