### PR TITLE
fix: use backslashes in Windows SP_DIR path

### DIFF
--- a/crates/rattler_build_core/src/env_vars.rs
+++ b/crates/rattler_build_core/src/env_vars.rs
@@ -585,7 +585,8 @@ mod test {
         let record_linux = make_record("lib/python3.13t/site-packages");
         let vars_linux = python_vars_from_records(&[record_linux], prefix, Platform::Linux64);
         assert_eq!(
-            vars_linux.get("SP_DIR")
+            vars_linux
+                .get("SP_DIR")
                 .and_then(|value| value.as_deref())
                 .map(Path::new),
             Some(prefix.join("lib/python3.13t/site-packages").as_path())
@@ -594,8 +595,7 @@ mod test {
         let record_win = make_record("Lib/site-packages");
         let vars_win = python_vars_from_records(&[record_win], prefix, Platform::Win64);
         assert_eq!(
-            vars_win.get("SP_DIR")
-                .and_then(|value| value.as_deref()),
+            vars_win.get("SP_DIR").and_then(|value| value.as_deref()),
             Some(format!("{}\\Lib\\site-packages", prefix.to_string_lossy()).as_str())
         );
     }

--- a/crates/rattler_build_core/src/env_vars.rs
+++ b/crates/rattler_build_core/src/env_vars.rs
@@ -40,7 +40,17 @@ fn get_sitepackages_dir(
 ) -> PathBuf {
     python_site_packages_path.map_or_else(
         || get_stdlib_dir(prefix, platform, py_ver).join("site-packages"),
-        |path| prefix.join(path),
+        |path| {
+            if platform.is_windows() {
+                PathBuf::from(format!(
+                    "{}\\{}",
+                    prefix.to_string_lossy(),
+                    path.replace('/', "\\")
+                ))
+            } else {
+                prefix.join(path)
+            }
+        },
     )
 }
 
@@ -555,28 +565,38 @@ mod test {
         use std::str::FromStr;
         use url::Url;
 
-        let mut package_record = PackageRecord::new(
-            PackageName::from_str("python").unwrap(),
-            "3.13.1".parse::<VersionWithSource>().unwrap(),
-            "cp313t".to_string(),
-        );
-        package_record.python_site_packages_path =
-            Some("lib/python3.13t/site-packages".to_string());
-        let record = RepoDataRecord {
-            package_record,
-            identifier: "python-3.13.1-cp313t.conda".parse().unwrap(),
-            url: Url::parse("https://example.com/python-3.13.1-cp313t.conda").unwrap(),
-            channel: None,
-        };
+        fn make_record(site_packages_path: &str) -> RepoDataRecord {
+            let mut package_record = PackageRecord::new(
+                PackageName::from_str("python").unwrap(),
+                "3.13.1".parse::<VersionWithSource>().unwrap(),
+                "cp313t".to_string(),
+            );
+            package_record.python_site_packages_path = Some(site_packages_path.to_string());
+            RepoDataRecord {
+                package_record,
+                identifier: "python-3.13.1-cp313t.conda".parse().unwrap(),
+                url: Url::parse("https://example.com/python-3.13.1-cp313t.conda").unwrap(),
+                channel: None,
+            }
+        }
 
         let prefix = Path::new("prefix");
-        let vars = python_vars_from_records(&[record], prefix, Platform::Linux64);
 
+        let record_linux = make_record("lib/python3.13t/site-packages");
+        let vars_linux = python_vars_from_records(&[record_linux], prefix, Platform::Linux64);
         assert_eq!(
-            vars.get("SP_DIR")
+            vars_linux.get("SP_DIR")
                 .and_then(|value| value.as_deref())
                 .map(Path::new),
             Some(prefix.join("lib/python3.13t/site-packages").as_path())
+        );
+
+        let record_win = make_record("Lib/site-packages");
+        let vars_win = python_vars_from_records(&[record_win], prefix, Platform::Win64);
+        assert_eq!(
+            vars_win.get("SP_DIR")
+                .and_then(|value| value.as_deref()),
+            Some(format!("{}\\Lib\\site-packages", prefix.to_string_lossy()).as_str())
         );
     }
 

--- a/crates/rattler_build_core/src/env_vars.rs
+++ b/crates/rattler_build_core/src/env_vars.rs
@@ -40,17 +40,7 @@ fn get_sitepackages_dir(
 ) -> PathBuf {
     python_site_packages_path.map_or_else(
         || get_stdlib_dir(prefix, platform, py_ver).join("site-packages"),
-        |path| {
-            if platform.is_windows() {
-                PathBuf::from(format!(
-                    "{}\\{}",
-                    prefix.to_string_lossy(),
-                    path.replace('/', "\\")
-                ))
-            } else {
-                prefix.join(path)
-            }
-        },
+        |path| prefix.join(path.replace('/', std::path::MAIN_SEPARATOR_STR)),
     )
 }
 
@@ -594,9 +584,10 @@ mod test {
 
         let record_win = make_record("Lib/site-packages");
         let vars_win = python_vars_from_records(&[record_win], prefix, Platform::Win64);
+        let expected_win = prefix.join("Lib").join("site-packages");
         assert_eq!(
             vars_win.get("SP_DIR").and_then(|value| value.as_deref()),
-            Some(format!("{}\\Lib\\site-packages", prefix.to_string_lossy()).as_str())
+            Some(expected_win.to_string_lossy().as_ref())
         );
     }
 


### PR DESCRIPTION
Addresses forward-slashes incorrectly appearing in https://github.com/conda-forge/cupy-feedstock/pull/335 for [py313](https://github.com/conda-forge/cupy-feedstock/actions/runs/33214997128/job/98996535464?pr=335) and [py314](https://github.com/conda-forge/cupy-feedstock/actions/runs/33214997128/job/98996535357?pr=335) builds on Windows platform.