### PR TITLE
fix: diagnose malformed `skip` expressions instead of ignoring them

### DIFF
--- a/crates/rattler_build_recipe/src/stage0/evaluate.rs
+++ b/crates/rattler_build_recipe/src/stage0/evaluate.rs
@@ -825,7 +825,7 @@ pub fn evaluate_skip_list(
     list: &ConditionalList<String>,
     context: &EvaluationContext,
 ) -> Result<bool, ParseError> {
-    let conditions: Vec<String> =
+    let conditions: Vec<(String, Option<Span>)> =
         evaluate_conditional_list(list.as_slice(), context, |value, ctx| {
             // Skip expressions are Jinja boolean expressions, not templates
             // We need to render them through Jinja to track accessed variables,
@@ -833,11 +833,15 @@ pub fn evaluate_skip_list(
             if let Some(expr_str) = value.as_concrete() {
                 // Wrap in ${{ }} to render as Jinja expression (for variable tracking)
                 let template = format!("${{{{ {} }}}}", expr_str);
-                // Ignore the result - we just want to trigger variable tracking
+                // Ignore the result - we just want to trigger variable tracking.
+                // A render failure is not fatal here: skip conditions may reference
+                // variant keys that are not part of this combination, which strict
+                // template rendering rejects but expression evaluation tolerates.
+                // Malformed expressions are reported by the evaluation below instead.
                 let _ = render_template(&template, ctx, value.span());
 
                 // Always return the original expression string
-                Ok(Some(expr_str.clone()))
+                Ok(Some((expr_str.clone(), value.span().copied())))
             } else if let Some(template) = value.as_template() {
                 // Already a template, render it
                 let rendered = render_template(template.source(), ctx, value.span())?;
@@ -845,37 +849,55 @@ pub fn evaluate_skip_list(
                 if rendered.is_empty() {
                     Ok(None)
                 } else {
-                    Ok(Some(rendered))
+                    Ok(Some((rendered, value.span().copied())))
                 }
             } else {
                 unreachable!("Value must be either concrete or template")
             }
         })?;
-    Ok(is_skipped(&conditions, context))
+    eval_skip_conditions(&conditions, context)
 }
 
 /// Check if any skip condition in the list evaluates to true
 ///
 /// Skip conditions are Jinja boolean expressions (e.g., "win", "unix", "platform == 'osx-64'").
 /// Returns true if ANY condition evaluates to true (OR logic).
-pub fn is_skipped(skip_conditions: &[String], context: &EvaluationContext) -> bool {
-    for condition in skip_conditions {
+///
+/// An expression that cannot be evaluated (for example one with unbalanced brackets)
+/// is a hard error: silently treating it as "not skipped" builds outputs the recipe
+/// author meant to exclude.
+pub fn is_skipped(
+    skip_conditions: &[String],
+    context: &EvaluationContext,
+) -> Result<bool, ParseError> {
+    let conditions: Vec<(String, Option<Span>)> = skip_conditions
+        .iter()
+        .map(|condition| (condition.clone(), None))
+        .collect();
+    eval_skip_conditions(&conditions, context)
+}
+
+/// Evaluate skip conditions, reporting failures against the span of the entry they came from.
+fn eval_skip_conditions(
+    skip_conditions: &[(String, Option<Span>)],
+    context: &EvaluationContext,
+) -> Result<bool, ParseError> {
+    for (condition, span) in skip_conditions {
         let jinja = context.to_jinja();
 
         // Evaluate the skip condition as a boolean expression
-        match jinja.eval(condition) {
-            Ok(value) => {
-                if value.is_true() {
-                    return true;
-                }
-            }
-            Err(_) => {
-                // If evaluation fails, we can't determine if it's skipped
-                // Continue to check other conditions
-            }
+        let value = jinja.eval(condition).map_err(|err| {
+            ParseError::jinja_error(
+                format!("failed to evaluate skip condition '{}': {}", condition, err),
+                span.unwrap_or_else(Span::new_blank),
+            )
+        })?;
+
+        if value.is_true() {
+            return Ok(true);
         }
     }
-    false
+    Ok(false)
 }
 
 /// Evaluate a string list, preserving templates with undefined variables
@@ -5903,6 +5925,54 @@ build:
     }
 
     #[test]
+    fn test_is_skipped_errors_on_malformed_expression() {
+        // Regression test for #2780: an expression that cannot be evaluated must not be
+        // silently treated as "not skipped".
+        let ctx = EvaluationContext::new();
+
+        let skip_conditions = vec![
+            "target_platform == \"win-arm64\") and target_platform != cross_target_platform"
+                .to_string(),
+        ];
+        let err = is_skipped(&skip_conditions, &ctx)
+            .expect_err("malformed skip condition should be an error");
+        assert!(
+            err.to_string().contains("skip condition"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_skip_template_rendering_to_malformed_expression_errors() {
+        use crate::stage0::parser::parse_recipe_from_source;
+
+        // A template can only be checked once rendered, so this one gets caught during
+        // evaluation rather than at parse time.
+        let recipe_yaml = r#"
+schema_version: 1
+context:
+  condition: 'unix and (osx'
+package:
+  name: test
+  version: 1.0.0
+build:
+  skip: ${{ condition }}
+"#;
+
+        let parsed = parse_recipe_from_source(recipe_yaml).unwrap();
+        let ctx = EvaluationContext::for_platform(rattler_conda_types::Platform::Linux64);
+        let err = parsed
+            .evaluate(&ctx)
+            .expect_err("malformed rendered skip condition should be an error");
+        assert!(
+            err.to_string().contains("skip condition"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
     fn test_is_skipped_with_literal_true() {
         // Direct test of is_skipped function with the string "true"
         let ctx = EvaluationContext::new();
@@ -5910,14 +5980,14 @@ build:
         // The string "true" should evaluate to boolean true in Jinja
         let skip_conditions = vec!["true".to_string()];
         assert!(
-            is_skipped(&skip_conditions, &ctx),
+            is_skipped(&skip_conditions, &ctx).unwrap(),
             "is_skipped should return true for skip condition 'true'"
         );
 
         // Also test "false" - should NOT skip
         let skip_conditions_false = vec!["false".to_string()];
         assert!(
-            !is_skipped(&skip_conditions_false, &ctx),
+            !is_skipped(&skip_conditions_false, &ctx).unwrap(),
             "is_skipped should return false for skip condition 'false'"
         );
     }

--- a/crates/rattler_build_recipe/src/stage0/evaluate.rs
+++ b/crates/rattler_build_recipe/src/stage0/evaluate.rs
@@ -835,9 +835,9 @@ pub fn evaluate_skip_list(
                 let template = format!("${{{{ {} }}}}", expr_str);
                 // Ignore the result - we just want to trigger variable tracking.
                 // A render failure is not fatal here: skip conditions may reference
-                // variant keys that are not part of this combination, which strict
-                // template rendering rejects but expression evaluation tolerates.
-                // Malformed expressions are reported by the evaluation below instead.
+                // variant keys that are not part of this combination. Broken
+                // expressions are reported by `eval_skip_conditions` below, and by
+                // the syntax check the parser runs over every concrete skip entry.
                 let _ = render_template(&template, ctx, value.span());
 
                 // Always return the original expression string
@@ -863,9 +863,10 @@ pub fn evaluate_skip_list(
 /// Skip conditions are Jinja boolean expressions (e.g., "win", "unix", "platform == 'osx-64'").
 /// Returns true if ANY condition evaluates to true (OR logic).
 ///
-/// An expression that cannot be evaluated (for example one with unbalanced brackets)
-/// is a hard error: silently treating it as "not skipped" builds outputs the recipe
-/// author meant to exclude.
+/// A condition that does not *parse* (for example one with unbalanced brackets) is a
+/// hard error: silently treating it as "not skipped" builds outputs the recipe author
+/// meant to exclude. Conditions that parse but fail to evaluate are tolerated, see
+/// [`eval_skip_conditions`].
 pub fn is_skipped(
     skip_conditions: &[String],
     context: &EvaluationContext,
@@ -878,6 +879,13 @@ pub fn is_skipped(
 }
 
 /// Evaluate skip conditions, reporting failures against the span of the entry they came from.
+///
+/// Only syntax errors are fatal. Under [`minijinja::UndefinedBehavior::Strict`] an
+/// undefined variable makes most operators fail (`python == "3.12"` errors outright when
+/// `python` is not part of the variant), and skip conditions are legitimately evaluated
+/// against incomplete variant combinations during variant discovery, so a condition that
+/// parses but cannot be evaluated keeps counting as "not skipped". A syntax error can
+/// never be caused by a missing variable, so it always indicates a broken recipe.
 fn eval_skip_conditions(
     skip_conditions: &[(String, Option<Span>)],
     context: &EvaluationContext,
@@ -886,15 +894,23 @@ fn eval_skip_conditions(
         let jinja = context.to_jinja();
 
         // Evaluate the skip condition as a boolean expression
-        let value = jinja.eval(condition).map_err(|err| {
-            ParseError::jinja_error(
-                format!("failed to evaluate skip condition '{}': {}", condition, err),
-                span.unwrap_or_else(Span::new_blank),
-            )
-        })?;
-
-        if value.is_true() {
-            return Ok(true);
+        match jinja.eval(condition) {
+            Ok(value) => {
+                if value.is_true() {
+                    return Ok(true);
+                }
+            }
+            Err(err) if err.kind() == minijinja::ErrorKind::SyntaxError => {
+                return Err(ParseError::jinja_error(
+                    format!("invalid skip condition '{}': {}", condition, err),
+                    span.unwrap_or_else(Span::new_blank),
+                ));
+            }
+            Err(_) => {
+                // Evaluation failed for a reason that a missing variant value can explain
+                // (undefined variables, operations on them). Keep the previous behaviour
+                // and continue to check the other conditions.
+            }
         }
     }
     Ok(false)
@@ -5970,6 +5986,32 @@ build:
             "unexpected error: {}",
             err
         );
+    }
+
+    #[test]
+    fn test_is_skipped_tolerates_undefined_variables() {
+        // Undefined variables must not become build failures: under strict undefined
+        // behaviour most operators error out when a variant key is missing, and skip
+        // conditions are evaluated against incomplete combinations during variant
+        // discovery. Only genuinely broken expressions are errors.
+        let ctx = EvaluationContext::for_platform(rattler_conda_types::Platform::Linux64);
+
+        for condition in [
+            "is_abi3",
+            "not is_abi3",
+            "python == \"3.12\"",
+            "unix and py < 310",
+            "undefined_thing | length",
+            "undefined_thing()",
+        ] {
+            let conditions = vec![condition.to_string()];
+            assert_eq!(
+                is_skipped(&conditions, &ctx).ok(),
+                Some(false),
+                "skip condition '{}' with undefined variables should not skip and should not error",
+                condition
+            );
+        }
     }
 
     #[test]

--- a/crates/rattler_build_recipe/src/stage0/parser/build.rs
+++ b/crates/rattler_build_recipe/src/stage0/parser/build.rs
@@ -607,6 +607,47 @@ fn parse_build_files(node: &Node) -> Result<IncludeExclude, ParseError> {
     ))
 }
 
+/// Validate that every concrete `skip` entry is a syntactically valid Jinja expression.
+///
+/// Unlike most recipe fields, `skip` entries are bare Jinja expressions
+/// (e.g. `win and python == "3.12"`) rather than `${{ ... }}` templates, so nothing
+/// parses them until they are evaluated against a variant. A typo such as an
+/// unbalanced bracket would otherwise pass unnoticed and silently evaluate to
+/// "not skipped", building outputs the recipe author meant to exclude.
+fn validate_skip_expressions(list: &ConditionalList<String>) -> Result<(), ParseError> {
+    fn validate_items(items: &[Item<String>]) -> Result<(), ParseError> {
+        for item in items {
+            match item {
+                Item::Value(value) => {
+                    // `${{ ... }}` templates are already validated when parsed, and their
+                    // expression is only known once rendered, so only check plain strings.
+                    let Some(expr) = value.as_concrete() else {
+                        continue;
+                    };
+                    if let Err(err) = JinjaExpression::new(expr.clone()) {
+                        return Err(ParseError::jinja_error(
+                            format!("invalid `skip` expression: {}", err),
+                            value
+                                .span()
+                                .copied()
+                                .unwrap_or_else(marked_yaml::Span::new_blank),
+                        ));
+                    }
+                }
+                Item::Conditional(conditional) => {
+                    validate_items(conditional.then.as_slice())?;
+                    if let Some(else_value) = &conditional.else_value {
+                        validate_items(else_value.as_slice())?;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    validate_items(list.as_slice())
+}
+
 /// Parse a Build section from YAML
 pub fn parse_build(node: &Node) -> Result<Build, ParseError> {
     let mapping = node.as_mapping().ok_or_else(|| {
@@ -653,7 +694,10 @@ fn parse_build_from_mapping(mapping: &MarkedMappingNode) -> Result<Build, ParseE
             }
             "skip" => {
                 // Skip accepts both a single value (e.g., "win") or a list
-                build.skip = parse_conditional_list_or_item(value_node)?.into();
+                let skip: ConditionalList<String> =
+                    parse_conditional_list_or_item(value_node)?.into();
+                validate_skip_expressions(&skip)?;
+                build.skip = skip;
             }
             "always_copy_files" => {
                 build.always_copy_files = parse_conditional_list(value_node)?;
@@ -1082,6 +1126,63 @@ mod tests {
         } else {
             panic!("Expected Some(number)");
         }
+    }
+
+    #[test]
+    fn test_parse_build_skip_with_unbalanced_bracket_errors() {
+        // Regression test for #2780: a mismatched bracket in a `skip` expression used to
+        // be silently ignored, so the output got built despite the intended skip.
+        let yaml = r#"
+skip: target_platform == "win-arm64" or cross_target_platform == "win-arm64") and target_platform != cross_target_platform
+"#;
+        let node = marked_yaml::parse_yaml(0, yaml).unwrap();
+        let err = parse_build(&node).expect_err("unbalanced bracket should be rejected");
+        assert!(
+            err.to_string().contains("skip"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_parse_build_skip_list_and_conditional_are_validated() {
+        // Inside a list
+        let yaml = r#"
+skip:
+  - win
+  - unix and (osx
+"#;
+        let node = marked_yaml::parse_yaml(0, yaml).unwrap();
+        assert!(
+            parse_build(&node).is_err(),
+            "unbalanced bracket in a skip list entry should be rejected"
+        );
+
+        // Inside the branch of an `if`/`then`/`else` entry
+        let yaml = r#"
+skip:
+  - if: unix
+    then: "python == \"3.12\""
+    else: "win and (arm64"
+"#;
+        let node = marked_yaml::parse_yaml(0, yaml).unwrap();
+        assert!(
+            parse_build(&node).is_err(),
+            "unbalanced bracket in a conditional skip branch should be rejected"
+        );
+    }
+
+    #[test]
+    fn test_parse_build_skip_accepts_valid_expressions() {
+        let yaml = r#"
+skip:
+  - (target_platform == "win-arm64" or cross_target_platform == "win-arm64") and target_platform != cross_target_platform
+  - match(python, ">=3.12")
+  - ${{ true }}
+"#;
+        let node = marked_yaml::parse_yaml(0, yaml).unwrap();
+        let build = parse_build(&node).expect("valid skip expressions should parse");
+        assert_eq!(build.skip.len(), 3);
     }
 
     #[test]

--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -720,7 +720,8 @@ build:
 
 Each entry is a Jinja expression (without the surrounding `${{ ... }}`). Entries
 that are not valid Jinja - an unbalanced bracket, for example - are reported as an
-error instead of being silently treated as "do not skip".
+error instead of being silently treated as "do not skip". An entry that references a
+variable which is not part of the variant still counts as "do not skip".
 
 ### Architecture-independent packages
 

--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -718,6 +718,10 @@ build:
     ...
 ```
 
+Each entry is a Jinja expression (without the surrounding `${{ ... }}`). Entries
+that are not valid Jinja - an unbalanced bracket, for example - are reported as an
+error instead of being silently treated as "do not skip".
+
 ### Architecture-independent packages
 
 Allows you to specify "no architecture" when building a package, thus making it

--- a/test-data/recipes/test-parsing/recipe_unbalanced_skip.yaml
+++ b/test-data/recipes/test-parsing/recipe_unbalanced_skip.yaml
@@ -1,0 +1,9 @@
+# Regression test for https://github.com/prefix-dev/rattler-build/issues/2780
+# The `skip` expression below is missing its opening bracket, which used to be
+# silently ignored (the output was built despite the intended skip).
+package:
+  name: unbalanced-skip
+  version: 0.1.0
+
+build:
+  skip: target_platform == "win-arm64" or cross_target_platform == "win-arm64") and target_platform != cross_target_platform

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -1771,6 +1771,20 @@ def test_missing_pin_subpackage(
     assert "missing output: test1" in stdout
 
 
+def test_unbalanced_bracket_in_skip(
+    rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
+):
+    # Issue #2780: a mismatched bracket in a `skip` expression used to be ignored,
+    # silently building an output the recipe meant to skip.
+    with pytest.raises(CalledProcessError) as e:
+        rattler_build.render(
+            recipes / "test-parsing" / "recipe_unbalanced_skip.yaml",
+            tmp_path,
+            stderr=STDOUT,
+        )
+    assert "skip" in e.value.output
+
+
 def test_cycle_detection(rattler_build: RattlerBuild, recipes: Path, tmp_path: Path):
     # make sure that tests are ran in the right order and that the packages are built correctly
     with pytest.raises(CalledProcessError) as e:


### PR DESCRIPTION
Fixes #2780

A `skip` entry with an unbalanced bracket was silently treated as "do not skip", so the output got built anyway. `is_skipped()` had `Err(_) => { /* continue */ }`, so an expression that failed to compile just contributed `false`.

`skip` was the only lenient path — `if:` conditions, `${{ }}` templates and variant-config conditionals all propagate Jinja errors. And unlike an `if:` condition, which becomes a `JinjaExpression` (validated at construction), `skip` entries are plain strings, so nothing parsed them until evaluation.

## Fix

**Parse time** — concrete `skip` entries go through `JinjaExpression::new`, a pure syntax check that resolves no variables. Recurses into `if`/`then`/`else`. Templates are left alone: already validated, and their expression is only known once rendered.

**Eval time** — `is_skipped` returns `Result<bool, ParseError>` and propagates *syntax errors*, with the span of the entry. Catches conditions that only exist after a template renders.

## Why only syntax errors are fatal

Propagating every evaluation failure was too aggressive. Under `UndefinedBehavior::Strict` a bare name is undefined (falsy), but almost any operator on it errors:

| Expression (empty variant) | Result |
|---|---|
| `is_abi3` | `Ok(undefined)` → falsy |
| `match(python, "<3.9")` | `Ok(true)` |
| `not is_abi3` | **Err** `UndefinedError` |
| `python == "3.12"` | **Err** `UndefinedError` |
| `undefined_thing \| length` | **Err** `InvalidOperation` |
| `target_platform == "win-arm64") and true` | **Err** `SyntaxError` |

So strict propagation would make `skip: python == "3.12"` a hard failure whenever `python` isn't in the variant, and would break variant discovery, which evaluates skips against incomplete combinations by design. `SyntaxError` is the one kind a missing variable can never produce. `InvalidOperation` is ambiguous (`cmp(...)` is a real bug, `undefined_thing | length` is undefined-driven), so it stays lenient.

`discover_new_variant_keys_from_evaluation` already used `.unwrap_or_default()` and keeps its leniency.

## Result

```
Error:   × Failed to parse recipe
  ╰─▶ Jinja template error: invalid `skip` expression: Failed to parse Jinja
      expression: syntax error: unexpected input after expression
   ╭─[recipe.yaml:9:9]
 8 │ build:
 9 │   skip: target_platform == "win-arm64" or cross_target_platform == "win-arm64") and …
   ·         ───────┬───────
   ╰────
```

Side effect: `test-data/recipes/test-parsing/recipe_bad_skip{,_multi}.yaml` (fixtures with `asd;asd;123`, orphaned from the old parser) now error as intended.

## Tests

Parser tests (single value, list entry, conditional branch, valid-expression control); eval tests for propagation plus `test_is_skipped_tolerates_undefined_variables` guarding the six shapes above; e2e `test_unbalanced_bracket_in_skip`; doc note.

`cargo test --workspace` green except pre-existing `test_system_tool` (no `patchelf` in the dev container).

## Not changed

An undefined variable in a skip condition stays silent (`skip: python == "3.12"` with no `python` quietly means "don't skip"). Same class of silent failure, but wider blast radius and not what was hit here. A `tracing::warn!` would be natural; `rattler_build_recipe` has no `tracing` dep, and the shared path would need to distinguish variant discovery from real evaluation to avoid spurious warnings. Happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Rj3CRpTRFpCtsnCVdaaQd