### PR TITLE
fix: `files: []` packages nothing instead of everything

### DIFF
--- a/crates/rattler_build_core/src/packaging.rs
+++ b/crates/rattler_build_core/src/packaging.rs
@@ -1031,13 +1031,13 @@ impl Output {
                     host_prefix,
                     paths,
                     &self.recipe.build().always_include_files,
-                    &self.recipe.build().files,
+                    self.recipe.build().files.as_ref(),
                 )?
             }
             None => Files::from_prefix(
                 host_prefix,
                 &self.recipe.build().always_include_files,
-                &self.recipe.build().files,
+                self.recipe.build().files.as_ref(),
                 post_install_files,
             )?,
         };

--- a/crates/rattler_build_core/src/packaging/file_finder.rs
+++ b/crates/rattler_build_core/src/packaging/file_finder.rs
@@ -205,9 +205,8 @@ impl Files {
     /// `files` glob filters the explicit list down, and `always_include`
     /// scans the prefix to force-include matching files.
     ///
-    /// `files` is `None` when the recipe has no `files` key, in which case no
-    /// filtering happens. `Some` filters by the globs, so an empty [`GlobVec`]
-    /// selects nothing.
+    /// `files` is `None` when the recipe has no `files` key (no filtering); an
+    /// empty [`GlobVec`] selects nothing.
     pub fn from_paths(
         prefix: &Path,
         paths: impl IntoIterator<Item = PathBuf>,
@@ -263,9 +262,8 @@ impl Files {
     /// of the conda environment). If always_include is Some, then all files matching the glob pattern will be included
     /// in the new_files set.
     ///
-    /// `files` is `None` when the recipe has no `files` key, in which case every new
-    /// file is packaged. `Some` filters by the globs, so an empty [`GlobVec`] packages
-    /// nothing.
+    /// `files` is `None` when the recipe has no `files` key (no filtering); an
+    /// empty [`GlobVec`] packages nothing.
     pub fn from_prefix(
         prefix: &Path,
         always_include: &GlobVec,

--- a/crates/rattler_build_core/src/packaging/file_finder.rs
+++ b/crates/rattler_build_core/src/packaging/file_finder.rs
@@ -204,11 +204,15 @@ impl Files {
     /// explicit list, mirroring the behaviour of [`Files::from_prefix`]: the
     /// `files` glob filters the explicit list down, and `always_include`
     /// scans the prefix to force-include matching files.
+    ///
+    /// `files` is `None` when the recipe has no `files` key, in which case no
+    /// filtering happens. `Some` filters by the globs, so an empty [`GlobVec`]
+    /// selects nothing.
     pub fn from_paths(
         prefix: &Path,
         paths: impl IntoIterator<Item = PathBuf>,
         always_include: &GlobVec,
-        files: &GlobVec,
+        files: Option<&GlobVec>,
     ) -> Result<Self, PackagingError> {
         let old_files = collect_previous_files(prefix)?;
 
@@ -231,7 +235,7 @@ impl Files {
             new_files.insert(resolved);
         }
 
-        if !files.is_empty() {
+        if let Some(files) = files {
             new_files.retain(|f| {
                 files.is_match(f.strip_prefix(prefix).expect("File should be in prefix"))
             });
@@ -258,10 +262,14 @@ impl Files {
     /// Find all files in the given (host) prefix and remove all previously installed files (based on the PrefixRecord
     /// of the conda environment). If always_include is Some, then all files matching the glob pattern will be included
     /// in the new_files set.
+    ///
+    /// `files` is `None` when the recipe has no `files` key, in which case every new
+    /// file is packaged. `Some` filters by the globs, so an empty [`GlobVec`] packages
+    /// nothing.
     pub fn from_prefix(
         prefix: &Path,
         always_include: &GlobVec,
-        files: &GlobVec,
+        files: Option<&GlobVec>,
         post_install_files: Option<&HashSet<PathBuf>>,
     ) -> Result<Self, io::Error> {
         if !prefix.exists() {
@@ -293,8 +301,8 @@ impl Files {
             fs_is_case_sensitive,
         );
 
-        // Filter by files glob if specified
-        if !files.is_empty() {
+        // Filter by files glob if the recipe specified one
+        if let Some(files) = files {
             difference.retain(|f| {
                 files.is_match(f.strip_prefix(prefix).expect("File should be in prefix"))
             });
@@ -479,8 +487,7 @@ mod test {
 
         let inputs = vec![PathBuf::from("bin/foo"), prefix.join("bin/bar")];
 
-        let files =
-            Files::from_paths(prefix, inputs, &Default::default(), &Default::default()).unwrap();
+        let files = Files::from_paths(prefix, inputs, &Default::default(), None).unwrap();
         let new_files: HashSet<PathBuf> = files.new_files.iter().cloned().collect();
 
         assert_eq!(new_files.len(), 2);
@@ -498,13 +505,8 @@ mod test {
         let outside_file = outside.path().join("escape.txt");
         fs_err::write(&outside_file, b"nope").unwrap();
 
-        let err = Files::from_paths(
-            prefix,
-            vec![outside_file],
-            &Default::default(),
-            &Default::default(),
-        )
-        .unwrap_err();
+        let err =
+            Files::from_paths(prefix, vec![outside_file], &Default::default(), None).unwrap_err();
         assert!(matches!(
             err,
             crate::packaging::PackagingError::PackageFileOutsidePrefix(_)
@@ -520,7 +522,7 @@ mod test {
             prefix,
             vec![PathBuf::from("bin/missing")],
             &Default::default(),
-            &Default::default(),
+            None,
         )
         .unwrap_err();
         assert!(matches!(
@@ -545,12 +547,68 @@ mod test {
             prefix,
             vec![PathBuf::from("bin/foo"), PathBuf::from("bin/bar")],
             &Default::default(),
-            &only_foo,
+            Some(&only_foo),
         )
         .unwrap();
 
         assert_eq!(files.new_files.len(), 1);
         assert!(files.new_files.contains(&prefix.join("bin/foo")));
+    }
+
+    #[test]
+    fn test_files_from_paths_empty_files_glob_selects_nothing() {
+        use rattler_build_recipe::stage1::GlobVec;
+
+        // Issue #2753: `files: []` means "package nothing", not "no filter".
+        let tempdir = tempfile::TempDir::new().unwrap();
+        let prefix = tempdir.path();
+        fs_err::create_dir_all(prefix.join("bin")).unwrap();
+        fs_err::write(prefix.join("bin/foo"), b"foo").unwrap();
+
+        let empty = GlobVec::default();
+        let files = Files::from_paths(
+            prefix,
+            vec![PathBuf::from("bin/foo")],
+            &Default::default(),
+            Some(&empty),
+        )
+        .unwrap();
+        assert!(
+            files.new_files.is_empty(),
+            "an explicit empty `files` glob should select no files, got {:?}",
+            files.new_files
+        );
+
+        // Whereas an absent `files` key keeps everything.
+        let files = Files::from_paths(
+            prefix,
+            vec![PathBuf::from("bin/foo")],
+            &Default::default(),
+            None,
+        )
+        .unwrap();
+        assert_eq!(files.new_files.len(), 1);
+    }
+
+    #[test]
+    fn test_files_from_prefix_empty_files_glob_selects_nothing() {
+        use rattler_build_recipe::stage1::GlobVec;
+
+        let tempdir = tempfile::TempDir::new().unwrap();
+        let prefix = tempdir.path();
+        fs_err::create_dir_all(prefix.join("bin")).unwrap();
+        fs_err::write(prefix.join("bin/foo"), b"foo").unwrap();
+
+        let empty = GlobVec::default();
+        let files = Files::from_prefix(prefix, &Default::default(), Some(&empty), None).unwrap();
+        assert!(
+            files.new_files.is_empty(),
+            "an explicit empty `files` glob should select no files, got {:?}",
+            files.new_files
+        );
+
+        let files = Files::from_prefix(prefix, &Default::default(), None, None).unwrap();
+        assert!(!files.new_files.is_empty());
     }
 
     #[test]
@@ -565,13 +623,8 @@ mod test {
 
         let always: GlobVec = serde_yaml::from_str("- bin/extra").unwrap();
 
-        let files = Files::from_paths(
-            prefix,
-            vec![PathBuf::from("bin/foo")],
-            &always,
-            &Default::default(),
-        )
-        .unwrap();
+        let files =
+            Files::from_paths(prefix, vec![PathBuf::from("bin/foo")], &always, None).unwrap();
 
         assert_eq!(files.new_files.len(), 2);
         assert!(files.new_files.contains(&prefix.join("bin/foo")));

--- a/crates/rattler_build_core/src/render/solver.rs
+++ b/crates/rattler_build_core/src/render/solver.rs
@@ -281,13 +281,8 @@ pub async fn install_packages(
 
     if !installed_packages.is_empty() && name.starts_with("host") {
         // we have to clean up extra files in the prefix
-        let extra_files = Files::from_prefix(
-            target_prefix,
-            &Default::default(),
-            &Default::default(),
-            None,
-        )
-        .into_diagnostic()?;
+        let extra_files =
+            Files::from_prefix(target_prefix, &Default::default(), None, None).into_diagnostic()?;
 
         tracing::info!(
             "Cleaning up {} files in the prefix from a previous build.",

--- a/crates/rattler_build_core/src/staging.rs
+++ b/crates/rattler_build_core/src/staging.rs
@@ -351,7 +351,7 @@ impl Output {
         let new_files = Files::from_prefix(
             self.prefix(),
             &staging.build.always_include_files,
-            &staging.build.files,
+            staging.build.files.as_ref(),
             None,
         )
         .into_diagnostic()?;

--- a/crates/rattler_build_recipe/src/stage0/build.rs
+++ b/crates/rattler_build_recipe/src/stage0/build.rs
@@ -209,8 +209,12 @@ pub struct Build {
     pub merge_build_and_host_envs: Value<bool>,
 
     /// Files to include/exclude in the package (glob patterns or include/exclude mapping)
-    #[serde(default)]
-    pub files: IncludeExclude,
+    ///
+    /// `None` means the `files` key was absent from the recipe, which packages every
+    /// new file in the prefix. `Some` means it was given, and the globs decide - an
+    /// explicitly empty list therefore packages nothing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub files: Option<IncludeExclude>,
 
     /// Dynamic linking configuration
     #[serde(default)]
@@ -242,7 +246,7 @@ impl Default for Build {
             always_copy_files: ConditionalList::default(),
             always_include_files: ConditionalList::default(),
             merge_build_and_host_envs: Value::new_concrete(false, None),
-            files: IncludeExclude::default(),
+            files: None,
             dynamic_linking: DynamicLinking::default(),
             variant: VariantKeyUsage::default(),
             prefix_detection: PrefixDetection::default(),
@@ -491,7 +495,9 @@ impl Build {
         vars.extend(always_copy_files.used_variables());
         vars.extend(always_include_files.used_variables());
         vars.extend(merge_build_and_host_envs.used_variables());
-        vars.extend(files.used_variables());
+        if let Some(files) = files {
+            vars.extend(files.used_variables());
+        }
 
         // Dynamic linking
         let DynamicLinking {

--- a/crates/rattler_build_recipe/src/stage0/build.rs
+++ b/crates/rattler_build_recipe/src/stage0/build.rs
@@ -210,9 +210,8 @@ pub struct Build {
 
     /// Files to include/exclude in the package (glob patterns or include/exclude mapping)
     ///
-    /// `None` means the `files` key was absent from the recipe, which packages every
-    /// new file in the prefix. `Some` means it was given, and the globs decide - an
-    /// explicitly empty list therefore packages nothing.
+    /// `None` means the key was absent (packages everything); `Some` lets the globs
+    /// decide, so an empty list packages nothing.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub files: Option<IncludeExclude>,
 

--- a/crates/rattler_build_recipe/src/stage0/evaluate.rs
+++ b/crates/rattler_build_recipe/src/stage0/evaluate.rs
@@ -2213,9 +2213,8 @@ impl Evaluate for Stage0Build {
         let always_copy_files = evaluate_glob_vec_simple(&self.always_copy_files, context)?;
         let always_include_files = evaluate_glob_vec_simple(&self.always_include_files, context)?;
 
-        // Evaluate files (handle both list and include/exclude variants).
-        // Keep `None` (key absent) distinct from `Some(empty)` (`files: []`): the
-        // former packages everything, the latter packages nothing.
+        // Keep `None` (key absent, packages everything) distinct from `Some(empty)`
+        // (`files: []`, packages nothing).
         let files = self
             .files
             .as_ref()
@@ -3112,9 +3111,8 @@ fn merge_stage1_build(
     let merge_build_and_host_envs =
         output.merge_build_and_host_envs || toplevel.merge_build_and_host_envs;
 
-    // Files: use output if the key was given, otherwise inherit from top-level.
-    // An explicit `files: []` on the output is an override, not an absence, so it
-    // must not fall back to the top-level globs.
+    // Files: an explicit `files: []` is an override, not an absence, so only a
+    // missing key falls back to the top-level globs.
     let files = output.files.or(toplevel.files);
 
     // Dynamic linking: use output if not default, otherwise inherit from top-level
@@ -5077,8 +5075,7 @@ outputs:
         use crate::stage0::parser::parse_recipe_or_multi_from_source;
 
         // Regression test for https://github.com/prefix-dev/rattler-build/issues/2753
-        // `files: []` means "package nothing" and must not be confused with an absent
-        // `files` key, which packages everything and inherits the top-level globs.
+        // `files: []` means "package nothing"; an absent key inherits the top-level globs.
         let recipe_yaml = r#"
 schema_version: 1
 
@@ -5119,8 +5116,7 @@ outputs:
         let recipes = multi.evaluate(&ctx).unwrap();
         assert_eq!(recipes.len(), 3);
 
-        // `files: []` is an override, not an absence: it must stay `Some(empty)` so
-        // packaging selects nothing, instead of inheriting the top-level `lib/**`.
+        // An override, not an absence: must stay `Some(empty)`, not inherit `lib/**`.
         let cleared = recipes[0].build.files.as_ref();
         assert!(
             cleared.is_some_and(|files| files.is_empty()),
@@ -5136,8 +5132,7 @@ outputs:
             .expect("`files` should be inherited from top-level");
         assert!(!inherited.is_empty());
 
-        // A conditional list where no branch matches is still an explicit `files` key,
-        // so it selects nothing rather than falling back to packaging everything.
+        // No branch matches, but the key is still present, so it selects nothing.
         let conditional = recipes[2].build.files.as_ref();
         assert!(
             conditional.is_some_and(|files| files.is_empty()),

--- a/crates/rattler_build_recipe/src/stage0/evaluate.rs
+++ b/crates/rattler_build_recipe/src/stage0/evaluate.rs
@@ -2213,8 +2213,14 @@ impl Evaluate for Stage0Build {
         let always_copy_files = evaluate_glob_vec_simple(&self.always_copy_files, context)?;
         let always_include_files = evaluate_glob_vec_simple(&self.always_include_files, context)?;
 
-        // Evaluate files (handle both list and include/exclude variants)
-        let files = evaluate_glob_vec(&self.files, context)?;
+        // Evaluate files (handle both list and include/exclude variants).
+        // Keep `None` (key absent) distinct from `Some(empty)` (`files: []`): the
+        // former packages everything, the latter packages nothing.
+        let files = self
+            .files
+            .as_ref()
+            .map(|files| evaluate_glob_vec(files, context))
+            .transpose()?;
 
         // Evaluate dynamic linking
         let dynamic_linking = self.dynamic_linking.evaluate(context)?;
@@ -3106,12 +3112,10 @@ fn merge_stage1_build(
     let merge_build_and_host_envs =
         output.merge_build_and_host_envs || toplevel.merge_build_and_host_envs;
 
-    // Files: use output if not empty, otherwise inherit from top-level
-    let files = if output.files.is_empty() {
-        toplevel.files
-    } else {
-        output.files
-    };
+    // Files: use output if the key was given, otherwise inherit from top-level.
+    // An explicit `files: []` on the output is an override, not an absence, so it
+    // must not fall back to the top-level globs.
+    let files = output.files.or(toplevel.files);
 
     // Dynamic linking: use output if not default, otherwise inherit from top-level
     let dynamic_linking = if output.dynamic_linking.is_default() {
@@ -5066,6 +5070,80 @@ outputs:
             }
             _ => panic!("Expected MultiOutputRecipe"),
         }
+    }
+
+    #[test]
+    fn test_output_can_override_files_with_empty_list() {
+        use crate::stage0::parser::parse_recipe_or_multi_from_source;
+
+        // Regression test for https://github.com/prefix-dev/rattler-build/issues/2753
+        // `files: []` means "package nothing" and must not be confused with an absent
+        // `files` key, which packages everything and inherits the top-level globs.
+        let recipe_yaml = r#"
+schema_version: 1
+
+recipe:
+  name: myproject
+  version: 1.0.0
+
+build:
+  files:
+    - lib/**
+
+outputs:
+  - package:
+      name: output-packages-nothing
+      version: 1.0.0
+    build:
+      files: []
+
+  - package:
+      name: output-inherits-files
+      version: 1.0.0
+
+  - package:
+      name: output-conditional-misses
+      version: 1.0.0
+    build:
+      files:
+        - if: win
+          then: lib/only-on-windows.dll
+"#;
+
+        let parsed = parse_recipe_or_multi_from_source(recipe_yaml).unwrap();
+        let stage0::Recipe::MultiOutput(multi) = parsed else {
+            panic!("Expected MultiOutputRecipe");
+        };
+
+        let ctx = EvaluationContext::for_platform(rattler_conda_types::Platform::Linux64);
+        let recipes = multi.evaluate(&ctx).unwrap();
+        assert_eq!(recipes.len(), 3);
+
+        // `files: []` is an override, not an absence: it must stay `Some(empty)` so
+        // packaging selects nothing, instead of inheriting the top-level `lib/**`.
+        let cleared = recipes[0].build.files.as_ref();
+        assert!(
+            cleared.is_some_and(|files| files.is_empty()),
+            "explicit empty `files` should be preserved as Some(empty), got {:?}",
+            cleared
+        );
+
+        // No `files` key at all: inherit the top-level globs.
+        let inherited = recipes[1]
+            .build
+            .files
+            .as_ref()
+            .expect("`files` should be inherited from top-level");
+        assert!(!inherited.is_empty());
+
+        // A conditional list where no branch matches is still an explicit `files` key,
+        // so it selects nothing rather than falling back to packaging everything.
+        let conditional = recipes[2].build.files.as_ref();
+        assert!(
+            conditional.is_some_and(|files| files.is_empty()),
+            "`files` with no matching branch should be Some(empty), got {:?}",
+            conditional
+        );
     }
 
     #[test]

--- a/crates/rattler_build_recipe/src/stage0/parser/build.rs
+++ b/crates/rattler_build_recipe/src/stage0/parser/build.rs
@@ -666,7 +666,7 @@ fn parse_build_from_mapping(mapping: &MarkedMappingNode) -> Result<Build, ParseE
                     parse_bool_value(value_node, "merge_build_and_host_envs")?;
             }
             "files" => {
-                build.files = parse_build_files(value_node)?;
+                build.files = Some(parse_build_files(value_node)?);
             }
             "dynamic_linking" => {
                 build.dynamic_linking = parse_dynamic_linking(value_node)?;

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__complex_recipe_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__complex_recipe_snapshot.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rattler_build_recipe/src/stage0/parser/snapshot_tests.rs
-assertion_line: 47
 expression: "serde_yaml::to_string(&recipe).unwrap()"
 ---
 package:
@@ -16,7 +15,6 @@ build:
   always_copy_files: []
   always_include_files: []
   merge_build_and_host_envs: false
-  files: []
   dynamic_linking:
     rpaths: []
     binary_relocation: true

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__conditionals_recipe_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__conditionals_recipe_snapshot.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rattler_build_recipe/src/stage0/parser/snapshot_tests.rs
-assertion_line: 40
 expression: "serde_yaml::to_string(&recipe).unwrap()"
 ---
 package:
@@ -16,7 +15,6 @@ build:
   always_copy_files: []
   always_include_files: []
   merge_build_and_host_envs: false
-  files: []
   dynamic_linking:
     rpaths: []
     binary_relocation: true

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__full_recipe_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__full_recipe_snapshot.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rattler_build_recipe/src/stage0/parser/snapshot_tests.rs
-assertion_line: 26
 expression: "serde_yaml::to_string(&recipe).unwrap()"
 ---
 package:
@@ -16,7 +15,6 @@ build:
   always_copy_files: []
   always_include_files: []
   merge_build_and_host_envs: false
-  files: []
   dynamic_linking:
     rpaths: []
     binary_relocation: true

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__license_files_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__license_files_snapshot.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rattler_build_recipe/src/stage0/parser/snapshot_tests.rs
-assertion_line: 92
 expression: "serde_yaml::to_string(&recipe).unwrap()"
 ---
 package:
@@ -16,7 +15,6 @@ build:
   always_copy_files: []
   always_include_files: []
   merge_build_and_host_envs: false
-  files: []
   dynamic_linking:
     rpaths: []
     binary_relocation: true

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__minimal_recipe_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__minimal_recipe_snapshot.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rattler_build_recipe/src/stage0/parser/snapshot_tests.rs
-assertion_line: 19
 expression: "serde_yaml::to_string(&recipe).unwrap()"
 ---
 package:
@@ -16,7 +15,6 @@ build:
   always_copy_files: []
   always_include_files: []
   merge_build_and_host_envs: false
-  files: []
   dynamic_linking:
     rpaths: []
     binary_relocation: true

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__multi_output_conditionals_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__multi_output_conditionals_snapshot.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rattler_build_recipe/src/stage0/parser/snapshot_tests.rs
-assertion_line: 128
 expression: "serde_yaml::to_string(&recipe).unwrap()"
 ---
 schema_version: 1
@@ -17,7 +16,6 @@ build:
   always_copy_files: []
   always_include_files: []
   merge_build_and_host_envs: false
-  files: []
   dynamic_linking:
     rpaths: []
     binary_relocation: true
@@ -81,7 +79,6 @@ outputs:
     always_copy_files: []
     always_include_files: []
     merge_build_and_host_envs: false
-    files: []
     dynamic_linking:
       rpaths: []
       binary_relocation: true

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__multi_output_full_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__multi_output_full_snapshot.snap
@@ -25,7 +25,6 @@ build:
   always_copy_files: []
   always_include_files: []
   merge_build_and_host_envs: false
-  files: []
   dynamic_linking:
     rpaths: []
     binary_relocation: true
@@ -102,7 +101,6 @@ outputs:
     always_copy_files: []
     always_include_files: []
     merge_build_and_host_envs: false
-    files: []
     dynamic_linking:
       rpaths: []
       binary_relocation: true
@@ -143,7 +141,6 @@ outputs:
     always_copy_files: []
     always_include_files: []
     merge_build_and_host_envs: false
-    files: []
     dynamic_linking:
       rpaths: []
       binary_relocation: true
@@ -187,7 +184,6 @@ outputs:
     always_copy_files: []
     always_include_files: []
     merge_build_and_host_envs: false
-    files: []
     dynamic_linking:
       rpaths: []
       binary_relocation: true

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__multi_output_minimal_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__multi_output_minimal_snapshot.snap
@@ -21,7 +21,6 @@ build:
   always_copy_files: []
   always_include_files: []
   merge_build_and_host_envs: false
-  files: []
   dynamic_linking:
     rpaths: []
     binary_relocation: true
@@ -75,7 +74,6 @@ outputs:
     always_copy_files: []
     always_include_files: []
     merge_build_and_host_envs: false
-    files: []
     dynamic_linking:
       rpaths: []
       binary_relocation: true

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__multi_output_templates_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__multi_output_templates_snapshot.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rattler_build_recipe/src/stage0/parser/snapshot_tests.rs
-assertion_line: 120
 expression: "serde_yaml::to_string(&recipe).unwrap()"
 ---
 schema_version: 1
@@ -23,7 +22,6 @@ build:
   always_copy_files: []
   always_include_files: []
   merge_build_and_host_envs: false
-  files: []
   dynamic_linking:
     rpaths: []
     binary_relocation: true
@@ -78,7 +76,6 @@ outputs:
     always_copy_files: []
     always_include_files: []
     merge_build_and_host_envs: false
-    files: []
     dynamic_linking:
       rpaths: []
       binary_relocation: true
@@ -115,7 +112,6 @@ outputs:
     always_copy_files: []
     always_include_files: []
     merge_build_and_host_envs: false
-    files: []
     dynamic_linking:
       rpaths: []
       binary_relocation: true

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__multi_output_top_level_inherit_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__multi_output_top_level_inherit_snapshot.snap
@@ -23,7 +23,6 @@ build:
   always_copy_files: []
   always_include_files: []
   merge_build_and_host_envs: false
-  files: []
   dynamic_linking:
     rpaths: []
     binary_relocation: true
@@ -61,7 +60,6 @@ outputs:
     always_copy_files: []
     always_include_files: []
     merge_build_and_host_envs: false
-    files: []
     dynamic_linking:
       rpaths: []
       binary_relocation: true
@@ -101,7 +99,6 @@ outputs:
     always_copy_files: []
     always_include_files: []
     merge_build_and_host_envs: false
-    files: []
     dynamic_linking:
       rpaths: []
       binary_relocation: true
@@ -143,7 +140,6 @@ outputs:
     always_copy_files: []
     always_include_files: []
     merge_build_and_host_envs: false
-    files: []
     dynamic_linking:
       rpaths: []
       binary_relocation: true

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__run_exports_recipe_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__run_exports_recipe_snapshot.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rattler_build_recipe/src/stage0/parser/snapshot_tests.rs
-assertion_line: 54
 expression: "serde_yaml::to_string(&recipe).unwrap()"
 ---
 package:
@@ -16,7 +15,6 @@ build:
   always_copy_files: []
   always_include_files: []
   merge_build_and_host_envs: false
-  files: []
   dynamic_linking:
     rpaths: []
     binary_relocation: true

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__script_parsing_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__script_parsing_snapshot.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rattler_build_recipe/src/stage0/parser/snapshot_tests.rs
-assertion_line: 85
 expression: "serde_yaml::to_string(&recipe).unwrap()"
 ---
 package:
@@ -16,7 +15,6 @@ build:
   always_copy_files: []
   always_include_files: []
   merge_build_and_host_envs: false
-  files: []
   dynamic_linking:
     rpaths: []
     binary_relocation: true

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__single_output_compatibility.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__single_output_compatibility.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rattler_build_recipe/src/stage0/parser/snapshot_tests.rs
-assertion_line: 170
 expression: "serde_yaml::to_string(&recipe).unwrap()"
 ---
 package:
@@ -16,7 +15,6 @@ build:
   always_copy_files: []
   always_include_files: []
   merge_build_and_host_envs: false
-  files: []
   dynamic_linking:
     rpaths: []
     binary_relocation: true

--- a/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__templates_recipe_snapshot.snap
+++ b/crates/rattler_build_recipe/src/stage0/parser/snapshots/rattler_build_recipe__stage0__parser__snapshot_tests__templates_recipe_snapshot.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rattler_build_recipe/src/stage0/parser/snapshot_tests.rs
-assertion_line: 33
 expression: "serde_yaml::to_string(&recipe).unwrap()"
 ---
 package:
@@ -16,7 +15,6 @@ build:
   always_copy_files: []
   always_include_files: []
   merge_build_and_host_envs: false
-  files: []
   dynamic_linking:
     rpaths: []
     binary_relocation: true

--- a/crates/rattler_build_recipe/src/stage0/snapshots/rattler_build_recipe__stage0__test__roundtrip.snap
+++ b/crates/rattler_build_recipe/src/stage0/snapshots/rattler_build_recipe__stage0__test__roundtrip.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rattler_build_recipe/src/stage0/mod.rs
-assertion_line: 57
 expression: roundtripped
 ---
 package:
@@ -16,7 +15,6 @@ build:
   always_copy_files: []
   always_include_files: []
   merge_build_and_host_envs: false
-  files: []
   dynamic_linking:
     rpaths: []
     binary_relocation: true

--- a/crates/rattler_build_recipe/src/stage1/build.rs
+++ b/crates/rattler_build_recipe/src/stage1/build.rs
@@ -472,8 +472,12 @@ pub struct Build {
     pub merge_build_and_host_envs: bool,
 
     /// Files to include in the package (validated glob patterns)
-    #[serde(default, skip_serializing_if = "GlobVec::is_empty")]
-    pub files: GlobVec,
+    ///
+    /// `None` means the recipe had no `files` key, in which case every new file in
+    /// the prefix is packaged. `Some` means the key was given and the globs select
+    /// what to package, so `files: []` packages nothing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub files: Option<GlobVec>,
 
     /// Dynamic linking configuration
     #[serde(default, skip_serializing_if = "DynamicLinking::is_default")]
@@ -545,7 +549,7 @@ struct BuildDeserialize {
     #[serde(default)]
     merge_build_and_host_envs: bool,
     #[serde(default)]
-    files: GlobVec,
+    files: Option<GlobVec>,
     #[serde(default)]
     dynamic_linking: DynamicLinking,
     #[serde(default)]
@@ -743,7 +747,7 @@ impl Build {
             && self.always_copy_files.is_empty()
             && self.always_include_files.is_empty()
             && !self.merge_build_and_host_envs
-            && self.files.is_empty()
+            && self.files.is_none()
             && self.dynamic_linking.is_default()
             && self.variant.is_default()
             && self.prefix_detection.is_default()

--- a/crates/rattler_build_recipe/src/stage1/build.rs
+++ b/crates/rattler_build_recipe/src/stage1/build.rs
@@ -473,9 +473,8 @@ pub struct Build {
 
     /// Files to include in the package (validated glob patterns)
     ///
-    /// `None` means the recipe had no `files` key, in which case every new file in
-    /// the prefix is packaged. `Some` means the key was given and the globs select
-    /// what to package, so `files: []` packages nothing.
+    /// `None` means the key was absent (packages every new file); `Some` lets the
+    /// globs decide, so `files: []` packages nothing.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub files: Option<GlobVec>,
 

--- a/crates/rattler_build_recipe/src/variant_render.rs
+++ b/crates/rattler_build_recipe/src/variant_render.rs
@@ -1808,7 +1808,11 @@ outputs:
         );
         // Other top-level build settings (e.g. `files`) must be inherited too.
         assert!(
-            !output.build.files.is_empty(),
+            output
+                .build
+                .files
+                .as_ref()
+                .is_some_and(|files| !files.is_empty()),
             "cache-inherited output should inherit the top-level build.files glob"
         );
     }

--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -798,6 +798,30 @@ build:
       - include/**/private.h
 ```
 
+Leaving the `files` key out entirely packages every new file. Giving the key
+hands the selection to the globs, so an empty list packages nothing:
+
+```yaml title="recipe.yaml"
+build:
+  # a metapackage: no files, whatever the build produced
+  files: []
+```
+
+The same applies when a conditional list has no matching branch - the key is
+still present, so nothing is selected on the platforms that match no branch:
+
+```yaml title="recipe.yaml"
+build:
+  files:
+    - if: linux
+      then: lib/libfoo.so
+    - if: osx
+      then: lib/libfoo.dylib
+    # on Windows no branch matches, so the package is empty
+```
+
+This matters most for outputs that `inherit` from a staging output, where the
+files restored from the staging cache all count as new.
 
 ### Python specific options
 

--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -798,17 +798,17 @@ build:
       - include/**/private.h
 ```
 
-Leaving the `files` key out entirely packages every new file. Giving the key
-hands the selection to the globs, so an empty list packages nothing:
+Omitting `files` packages every new file; giving it hands the selection to the
+globs, so an empty list packages nothing:
 
 ```yaml title="recipe.yaml"
 build:
-  # a metapackage: no files, whatever the build produced
+  # a metapackage, whatever the build produced
   files: []
 ```
 
-The same applies when a conditional list has no matching branch - the key is
-still present, so nothing is selected on the platforms that match no branch:
+A conditional list with no matching branch is still an explicit key, so it too
+packages nothing:
 
 ```yaml title="recipe.yaml"
 build:
@@ -820,8 +820,8 @@ build:
     # on Windows no branch matches, so the package is empty
 ```
 
-This matters most for outputs that `inherit` from a staging output, where the
-files restored from the staging cache all count as new.
+This matters most for outputs that `inherit` from a staging output, where every
+file restored from the cache counts as new.
 
 ### Python specific options
 

--- a/py-rattler-build/tests/unit/test_stage0_bindings.py
+++ b/py-rattler-build/tests/unit/test_stage0_bindings.py
@@ -97,7 +97,6 @@ def test_recipe_to_dict_snapshot() -> None:
                 "always_copy_files": [],
                 "always_include_files": [],
                 "merge_build_and_host_envs": False,
-                "files": [],
                 "dynamic_linking": {
                     "rpaths": [],
                     "binary_relocation": True,
@@ -158,7 +157,6 @@ def test_single_output_recipe_to_dict_snapshot() -> None:
                 "always_copy_files": [],
                 "always_include_files": [],
                 "merge_build_and_host_envs": False,
-                "files": [],
                 "dynamic_linking": {
                     "rpaths": [],
                     "binary_relocation": True,
@@ -220,7 +218,6 @@ def test_multi_output_recipe_to_dict_snapshot() -> None:
                 "always_copy_files": [],
                 "always_include_files": [],
                 "merge_build_and_host_envs": False,
-                "files": [],
                 "dynamic_linking": {
                     "rpaths": [],
                     "binary_relocation": True,
@@ -249,7 +246,6 @@ def test_multi_output_recipe_to_dict_snapshot() -> None:
                         "always_copy_files": [],
                         "always_include_files": [],
                         "merge_build_and_host_envs": False,
-                        "files": [],
                         "dynamic_linking": {
                             "rpaths": [],
                             "binary_relocation": True,
@@ -277,7 +273,6 @@ def test_multi_output_recipe_to_dict_snapshot() -> None:
                         "always_copy_files": [],
                         "always_include_files": [],
                         "merge_build_and_host_envs": False,
-                        "files": [],
                         "dynamic_linking": {
                             "rpaths": [],
                             "binary_relocation": True,
@@ -338,7 +333,6 @@ def test_build_to_dict_snapshot() -> None:
             "always_copy_files": [],
             "always_include_files": [],
             "merge_build_and_host_envs": False,
-            "files": [],
             "dynamic_linking": {
                 "rpaths": [],
                 "binary_relocation": True,
@@ -442,7 +436,6 @@ def test_multi_output_outputs_snapshot() -> None:
                     "always_copy_files": [],
                     "always_include_files": [],
                     "merge_build_and_host_envs": False,
-                    "files": [],
                     "dynamic_linking": {
                         "rpaths": [],
                         "binary_relocation": True,
@@ -470,7 +463,6 @@ def test_multi_output_outputs_snapshot() -> None:
                     "always_copy_files": [],
                     "always_include_files": [],
                     "merge_build_and_host_envs": False,
-                    "files": [],
                     "dynamic_linking": {
                         "rpaths": [],
                         "binary_relocation": True,

--- a/test-data/recipes/staging/staging-empty-files.yaml
+++ b/test-data/recipes/staging/staging-empty-files.yaml
@@ -1,0 +1,60 @@
+# Regression test for https://github.com/prefix-dev/rattler-build/issues/2753
+# An output that inherits from a staging cache must respect its `files` selection.
+# `files: []`, and a conditional `files` list where no branch matches, both mean
+# "package nothing" - not "package everything from the staging cache".
+
+schema_version: 1
+
+recipe:
+  name: staging-empty-files
+  version: 1.0.0
+
+outputs:
+  - staging:
+      name: stage
+    build:
+      script:
+        - if: unix
+          then: |
+            mkdir -p $PREFIX/lib $PREFIX/include
+            echo "libcore" > $PREFIX/lib/libcore.so
+            echo "core.h"  > $PREFIX/include/core.h
+        - if: win
+          then: |
+            if not exist "%PREFIX%\lib" mkdir "%PREFIX%\lib"
+            if not exist "%PREFIX%\include" mkdir "%PREFIX%\include"
+            echo libcore > "%PREFIX%\lib\libcore.dll"
+            echo core.h > "%PREFIX%\include\core.h"
+
+  # A pure metapackage: `files: []` selects nothing.
+  - package:
+      name: empty-files-metapackage
+      version: 1.0.0
+    inherit: stage
+    build:
+      files: []
+    about:
+      summary: Metapackage with no files
+      license: MIT
+
+  # No branch matches on any platform, so this also selects nothing.
+  - package:
+      name: unmatched-conditional-files
+      version: 1.0.0
+    inherit: stage
+    build:
+      files:
+        - if: target_platform == "some-unknown-platform"
+          then: lib/never-matches
+    about:
+      summary: Conditional file list that matches nothing
+      license: MIT
+
+  # Control: an output with no `files` key still gets the whole staging cache.
+  - package:
+      name: inherits-all-files
+      version: 1.0.0
+    inherit: stage
+    about:
+      summary: Inherits every staged file
+      license: MIT

--- a/test-data/recipes/staging/staging-empty-files.yaml
+++ b/test-data/recipes/staging/staging-empty-files.yaml
@@ -1,7 +1,6 @@
 # Regression test for https://github.com/prefix-dev/rattler-build/issues/2753
-# An output that inherits from a staging cache must respect its `files` selection.
-# `files: []`, and a conditional `files` list where no branch matches, both mean
-# "package nothing" - not "package everything from the staging cache".
+# `files: []`, and a conditional list where no branch matches, both package nothing -
+# not the whole staging cache.
 
 schema_version: 1
 
@@ -26,7 +25,7 @@ outputs:
             echo libcore > "%PREFIX%\lib\libcore.dll"
             echo core.h > "%PREFIX%\include\core.h"
 
-  # A pure metapackage: `files: []` selects nothing.
+  # A pure metapackage.
   - package:
       name: empty-files-metapackage
       version: 1.0.0
@@ -37,7 +36,7 @@ outputs:
       summary: Metapackage with no files
       license: MIT
 
-  # No branch matches on any platform, so this also selects nothing.
+  # No branch matches on any platform.
   - package:
       name: unmatched-conditional-files
       version: 1.0.0
@@ -50,7 +49,7 @@ outputs:
       summary: Conditional file list that matches nothing
       license: MIT
 
-  # Control: an output with no `files` key still gets the whole staging cache.
+  # Control: no `files` key still gets the whole staging cache.
   - package:
       name: inherits-all-files
       version: 1.0.0

--- a/test/end-to-end/test_staging.py
+++ b/test/end-to-end/test_staging.py
@@ -346,11 +346,7 @@ def test_multiple_staging_caches(
 def test_staging_empty_files_selection(
     rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
 ):
-    """Issue #2753: an inheriting output must respect its `files` selection.
-
-    `files: []` and a conditional `files` list with no matching branch both mean
-    "package nothing", rather than falling through to the whole staging cache.
-    """
+    """Issue #2753: `files: []` and an unmatched conditional list package nothing."""
     rattler_build.build(
         recipes / "staging/staging-empty-files.yaml",
         tmp_path,

--- a/test/end-to-end/test_staging.py
+++ b/test/end-to-end/test_staging.py
@@ -343,6 +343,36 @@ def test_multiple_staging_caches(
     assert about["license"] == "MIT"
 
 
+def test_staging_empty_files_selection(
+    rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
+):
+    """Issue #2753: an inheriting output must respect its `files` selection.
+
+    `files: []` and a conditional `files` list with no matching branch both mean
+    "package nothing", rather than falling through to the whole staging cache.
+    """
+    rattler_build.build(
+        recipes / "staging/staging-empty-files.yaml",
+        tmp_path,
+        extra_args=["--experimental"],
+    )
+
+    lib_name = "lib/libcore.dll" if platform.system() == "Windows" else "lib/libcore.so"
+
+    def packaged_files(package: str) -> list[str]:
+        pkg = get_extracted_package(tmp_path, package)
+        paths = json.loads((pkg / "info/paths.json").read_text())
+        return [p["_path"] for p in paths["paths"]]
+
+    assert packaged_files("empty-files-metapackage") == []
+    assert packaged_files("unmatched-conditional-files") == []
+
+    # An output without a `files` key keeps packaging the whole staging cache.
+    inherits_all = packaged_files("inherits-all-files")
+    assert any(lib_name in f for f in inherits_all)
+    assert any("include/core.h" in f for f in inherits_all)
+
+
 def test_staging_with_top_level_inherit(
     rattler_build: RattlerBuild, recipes: Path, tmp_path: Path, clean_path_on_win32
 ):


### PR DESCRIPTION
Fixes #2753

`build.files` was a plain `GlobVec`, so an explicitly empty list was indistinguishable from an absent key. Every consumer skipped the filter with `if !files.is_empty()`, so `files: []` packaged everything instead of nothing.

Same root cause, two more symptoms:
- A conditional `files` list with no matching branch evaluates to empty (the `libclang-cpp`-on-Windows case).
- The output/top-level merge used `if output.files.is_empty() { toplevel.files }`, so `files: []` on an output silently inherited the top-level globs.

Not staging-specific — a plain single-output recipe with `files: []` also packaged everything. Staging just makes it severe: nothing in a restored cache is in a `PrefixRecord`, so the whole tree counts as new.

## Fix

`files` becomes `Option<GlobVec>`, mirroring `about.license_file` (#2598). `None` (no key) packages everything, as before; `Some` lets the globs decide, and `GlobVec::is_match` already returns false for an empty vec. `Files::from_prefix`/`from_paths` take `Option<&GlobVec>`; the merge becomes `output.files.or(toplevel.files)`.

Deliberately does **not** change what an *absent* `files:` key does on an inheriting output — that's #2730, and flipping it would silently empty the common "package everything from staging" pattern.

## Verified

| output | before | after |
|---|---|---|
| `files: []`, inherits staging | `['include/core.h', 'lib/libcore.so']` | `[]` |
| conditional `files`, no branch matches | `['include/core.h', 'lib/libcore.so']` | `[]` |
| `files: []`, plain single output | `['lib/should-not-be-packaged.txt']` | `[]` |
| no `files:` key, inherits staging | `['include/core.h', 'lib/libcore.so']` | unchanged |
| `files: [include/**]` | `['include/core.h']` | unchanged |

Unit tests on `Files` and on the merge, plus e2e `test_staging_empty_files_selection` with a new fixture. Snapshot churn is 25 `files: []` lines disappearing from stage0 snapshots — that is the fix showing up.

`cargo test --workspace` green except pre-existing `test_system_tool` (no `patchelf` in the dev container). fmt and clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Rj3CRpTRFpCtsnCVdaaQd