### PR TITLE
docs: recommend brush for cross-platform scripts

### DIFF
--- a/docs/windows_quirks.md
+++ b/docs/windows_quirks.md
@@ -83,6 +83,34 @@ if %ERRORLEVEL% neq 0 exit 1
 
 To find more examples of this pattern, [try this Github search query](https://github.com/search?q=org%3Aconda-forge+bash+language%3ABatchfile+&type=code).
 
+### Using `brush` on Windows
+
+[`brush`](https://github.com/reubeno/brush) runs Bash-compatible scripts on
+Windows, macOS and Linux. It avoids a separate `build.bat` wrapper when the
+same shell script can build on every platform. Select it explicitly and add it
+to the build requirements:
+
+```yaml title="recipe.yaml"
+build:
+  script:
+    interpreter: brush
+    content:
+      - cmake -S . -B build ${CMAKE_ARGS}
+      - cmake --build build --config Release
+      - cmake --install build --config Release
+
+requirements:
+  build:
+    - brush
+    - cmake
+```
+
+Rattler-Build only resolves `brush` from the build environment, not the system
+or host environment. See [Using `brush`](build_script.md#using-brush) for the
+full interpreter behavior and
+[conda-forge recipes using it](https://github.com/search?q=org%3Aconda-forge+%22interpreter%3A+brush%22&type=code)
+for more examples.
+
 ## Installing the correct MSVC compilers
 
 In order to install the correct MSVC compilers, you should get the Community [Visual Studio Installer](https://visualstudio.microsoft.com/downloads/).

--- a/docs/windows_quirks.md
+++ b/docs/windows_quirks.md
@@ -88,14 +88,22 @@ To find more examples of this pattern, [try this Github search query](https://gi
 [`brush`](https://github.com/reubeno/brush) runs Bash-compatible scripts on
 Windows, macOS and Linux. It avoids a separate `build.bat` wrapper when the
 same shell script can build on every platform. Select it explicitly and add it
-to the build requirements:
+to the build requirements.
+
+`brush` uses Unix-style variable expansion on every platform, including
+Windows. `$PREFIX` is the root of the host environment. `$LIBRARY_PREFIX` is
+set for Windows targets and points to `$PREFIX/Library`, where non-Python
+libraries and executables usually belong. Use `$PREFIX` for Python and other
+root-level contents. For a script that installs a Unix-style layout on every
+platform, `${LIBRARY_PREFIX:-$PREFIX}` selects `$LIBRARY_PREFIX` when it exists
+and falls back to `$PREFIX` elsewhere:
 
 ```yaml title="recipe.yaml"
 build:
   script:
     interpreter: brush
     content:
-      - cmake -S . -B build ${CMAKE_ARGS}
+      - cmake -S . -B build ${CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX="${LIBRARY_PREFIX:-$PREFIX}"
       - cmake --build build --config Release
       - cmake --install build --config Release
 


### PR DESCRIPTION
Document `brush` as a Bash-compatible option for recipes that also build on Windows. Add a complete recipe example, explain where the interpreter must be installed, and link to both the full interpreter reference and conda-forge examples.

Tested with `zensical build --strict`.