### PR TITLE
fix: run link checks when relocation is disabled

### DIFF
--- a/crates/rattler_build_core/src/post_process/relink.rs
+++ b/crates/rattler_build_core/src/post_process/relink.rs
@@ -156,7 +156,6 @@ pub fn relink(temp_files: &TempFiles, output: &Output) -> Result<(), RelinkError
         // skip linking checks for wasm
         || target_platform.arch() == Some(Arch::Wasm32)
         || target_platform.arch() == Some(Arch::Wasm64)
-        || relocation_config.is_none()
     {
         return Ok(());
     }
@@ -187,13 +186,10 @@ pub fn relink(temp_files: &TempFiles, output: &Output) -> Result<(), RelinkError
             }
 
             let rel_path = p.strip_prefix(tmp_prefix)?;
-            if !relocation_config.is_match(rel_path) {
-                return Ok(None);
-            }
 
             match get_relinker(target_platform, p) {
                 Ok(relinker) => {
-                    if !target_platform.is_windows() {
+                    if !target_platform.is_windows() && relocation_config.is_match(rel_path) {
                         relinker.relink(
                             tmp_prefix,
                             encoded_prefix,

--- a/test-data/recipes/link-check-no-relocation-declared/recipe.yaml
+++ b/test-data/recipes/link-check-no-relocation-declared/recipe.yaml
@@ -1,0 +1,31 @@
+context:
+  version: "0.1.0"
+
+package:
+  name: link-check-no-relocation-declared
+  version: ${{ version }}
+
+source:
+  path: ../../../examples/linking/zlink/
+
+build:
+  script:
+    - cmake -S . -B build -GNinja -DCMAKE_INSTALL_PREFIX=$PREFIX -DZLIB_ROOT=$PREFIX
+    - cmake --build build
+    - cmake --install build
+    - mkdir -p $PREFIX/share/link-check-no-relocation
+    - sha256sum $PREFIX/bin/zlink | cut -d ' ' -f 1 > $PREFIX/share/link-check-no-relocation/zlink.sha256
+  dynamic_linking:
+    binary_relocation: false
+    overdepending_behavior: ignore
+    overlinking_behavior: error
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ninja
+    - cmake
+  host:
+    - zlib
+  run:
+    - zlib

--- a/test-data/recipes/link-check-no-relocation-undeclared/recipe.yaml
+++ b/test-data/recipes/link-check-no-relocation-undeclared/recipe.yaml
@@ -1,0 +1,37 @@
+context:
+  version: "0.1.0"
+
+package:
+  name: link-check-no-relocation-undeclared
+  version: ${{ version }}
+
+source:
+  path: ../../../examples/linking/zlink/
+
+build:
+  script:
+    - if: unix
+      then:
+        - cmake -S . -B build -GNinja -DCMAKE_INSTALL_PREFIX=$PREFIX -DZLIB_ROOT=$PREFIX
+        - cmake --build build
+        - cmake --install build
+    - if: win
+      then:
+        - cmake -S . -B build -GNinja -DCMAKE_INSTALL_PREFIX=%PREFIX% -DZLIB_ROOT=%PREFIX%\Library
+        - cmake --build build
+        - cmake --install build
+  dynamic_linking:
+    binary_relocation: false
+    overdepending_behavior: ignore
+    overlinking_behavior: error
+
+requirements:
+  ignore_run_exports:
+    from_package:
+      - zlib
+  build:
+    - ${{ compiler('c') }}
+    - ninja
+    - cmake
+  host:
+    - zlib

--- a/test/end-to-end/conftest.py
+++ b/test/end-to-end/conftest.py
@@ -14,7 +14,8 @@ def clean_path_on_win32():
     if sys.platform == "win32":
         original_path = os.environ.get("PATH", "")
         try:
-            os.environ["PATH"] = ""
+            system_root = os.environ.get("SystemRoot", r"C:\Windows")
+            os.environ["PATH"] = str(Path(system_root) / "System32")
             yield
         finally:
             os.environ["PATH"] = original_path

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -3165,6 +3165,43 @@ def test_overlinking_check(rattler_build: RattlerBuild, recipes: Path, tmp_path:
         assert "linking check error: Overlinking against" in e.output
 
 
+@pytest.mark.skipif(
+    platform.system() not in ("Linux", "Windows"),
+    reason="Link checking fixture supports Linux and Windows",
+)
+def test_overlinking_check_without_binary_relocation(
+    rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
+):
+    target_platform = "win-64" if platform.system() == "Windows" else "linux-64"
+    args = rattler_build.build_args(
+        recipes / "link-check-no-relocation-undeclared",
+        tmp_path,
+        extra_args=["--target-platform", target_platform],
+    )
+    with pytest.raises(CalledProcessError) as exc_info:
+        rattler_build(*args, stderr=STDOUT)
+
+    assert "linking check error: Overlinking against" in exc_info.value.output
+
+
+@pytest.mark.skipif(platform.system() != "Linux", reason="Linux-only hash fixture")
+def test_declared_link_without_binary_relocation_is_not_modified(
+    rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
+):
+    rattler_build.build(
+        recipes / "link-check-no-relocation-declared",
+        tmp_path,
+        extra_args=["--target-platform", "linux-64"],
+    )
+    package = get_extracted_package(tmp_path, "link-check-no-relocation-declared")
+    binary = package / "bin/zlink"
+    expected_hash = (
+        (package / "share/link-check-no-relocation/zlink.sha256").read_text().strip()
+    )
+
+    assert hashlib.sha256(binary.read_bytes()).hexdigest() == expected_hash
+
+
 @pytest.mark.skipif(platform.system() != "Linux", reason="Linux-only test")
 def test_overdepending_check(
     rattler_build: RattlerBuild, recipes: Path, tmp_path: Path

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -3170,7 +3170,10 @@ def test_overlinking_check(rattler_build: RattlerBuild, recipes: Path, tmp_path:
     reason="Link checking fixture supports Linux and Windows",
 )
 def test_overlinking_check_without_binary_relocation(
-    rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
+    rattler_build: RattlerBuild,
+    recipes: Path,
+    tmp_path: Path,
+    clean_path_on_win32,
 ):
     target_platform = "win-64" if platform.system() == "Windows" else "linux-64"
     args = rattler_build.build_args(


### PR DESCRIPTION
`binary_relocation: false` currently returns from post-processing before dynamic binaries are discovered, so it also disables requested overlinking and overdepending checks. The same coupling prevents those checks from running on Windows, where relocation itself is intentionally skipped.

This change discovers every supported binary independently of the relocation selection. Relinking still happens only for paths selected by `binary_relocation`, and never on Windows; the complete discovered set is then passed to the existing linking checks. NoArch and WASM exclusions are unchanged.

Regression coverage exercises an undeclared zlib link with relocation disabled on Linux and Windows, plus a declared-dependency Linux build that records the pre-processing binary hash and verifies the packaged binary is byte-identical.

Verified locally with:
- `pixi run test-end-to-end-ci` (220 passed, 18 skipped)
- `pixi run cargo test --workspace --all-targets --features=recipe-generation -- --nocapture`
- `pixi run -e pre-commit lint`
- `pixi run cargo fmt --all -- --check`
- `pixi run cargo clippy --workspace --all-targets --features=recipe-generation -- -D warnings`

Closes #2771
