### PR TITLE
feat: warn on overlapping output files and unused staging files

### DIFF
--- a/crates/rattler_build_core/src/lib.rs
+++ b/crates/rattler_build_core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod console_utils;
 pub mod debug;
 pub mod metadata;
 pub mod migrate_recipe;
+pub mod output_checks;
 pub mod package_test;
 pub mod packaging;
 pub mod render;

--- a/crates/rattler_build_core/src/output_checks.rs
+++ b/crates/rattler_build_core/src/output_checks.rs
@@ -1,0 +1,188 @@
+//! Cross-output consistency checks that run after all outputs of a build are packaged.
+
+use std::{
+    collections::{BTreeSet, HashMap, HashSet},
+    path::PathBuf,
+};
+
+use fs_err as fs;
+
+use crate::{packaging::file_mapper::filter_file, staging::StagingCacheMetadata, types::Output};
+
+/// How many offending files to list per finding before truncating.
+const MAX_LISTED_FILES: usize = 10;
+
+fn format_file_list(files: &BTreeSet<PathBuf>) -> String {
+    let listed = files
+        .iter()
+        .take(MAX_LISTED_FILES)
+        .map(|p| format!("  - {}", p.display()))
+        .collect::<Vec<_>>()
+        .join("\n");
+    if files.len() > MAX_LISTED_FILES {
+        format!(
+            "{}\n  … and {} more",
+            listed,
+            files.len() - MAX_LISTED_FILES
+        )
+    } else {
+        listed
+    }
+}
+
+fn report(findings: Vec<String>, error: bool, flag: &str) -> miette::Result<()> {
+    if findings.is_empty() {
+        return Ok(());
+    }
+    if error {
+        Err(miette::miette!("{}", findings.join("\n\n")))
+    } else {
+        for finding in &findings {
+            tracing::warn!("{}", finding);
+        }
+        tracing::warn!("Pass `{}` to turn this warning into an error.", flag);
+        Ok(())
+    }
+}
+
+/// Warn (or error) when two outputs of the same recipe package the same file.
+///
+/// Installing both packages into one environment would clobber the file, and with
+/// staging caches this usually means an output forgot to narrow its `files` selection.
+/// Compared on prefix-relative paths as selected for packaging (before noarch path
+/// remapping), so a noarch and an arch output that ship the same file are caught too.
+/// Outputs with the same package name are never compared: they cannot be co-installed.
+pub fn check_overlapping_files(outputs: &[Output], error: bool) -> miette::Result<()> {
+    let mut by_recipe: HashMap<&std::path::Path, Vec<&Output>> = HashMap::new();
+    for output in outputs {
+        by_recipe
+            .entry(output.build_configuration.directories.recipe_path.as_path())
+            .or_default()
+            .push(output);
+    }
+
+    let mut findings = Vec::new();
+    for outputs in by_recipe.values() {
+        // Variants of the same pair would repeat the same finding, so keep one per name pair.
+        let mut seen_pairs = HashSet::new();
+        for (i, a) in outputs.iter().enumerate() {
+            let Some(files_a) = a.packaged_prefix_files() else {
+                continue;
+            };
+            for b in &outputs[i + 1..] {
+                if a.name() == b.name() {
+                    continue;
+                }
+                let Some(files_b) = b.packaged_prefix_files() else {
+                    continue;
+                };
+                let overlap: BTreeSet<PathBuf> = files_a.intersection(&files_b).cloned().collect();
+                if overlap.is_empty() || !seen_pairs.insert((a.name().clone(), b.name().clone())) {
+                    continue;
+                }
+                b.record_warning(&format!(
+                    "packages {} file(s) that are also packaged by output '{}'",
+                    overlap.len(),
+                    a.name().as_normalized(),
+                ));
+                findings.push(format!(
+                    "Outputs '{}' and '{}' both package {} file(s), which will clobber each other on installation:\n{}",
+                    a.name().as_normalized(),
+                    b.name().as_normalized(),
+                    overlap.len(),
+                    format_file_list(&overlap),
+                ));
+            }
+        }
+    }
+
+    report(findings, error, "--error-overlapping-files")
+}
+
+/// Warn (or error) when files in a staging cache were not packaged by any output
+/// that inherits from it.
+///
+/// Caches are compared per cache directory (one per staging output and variant
+/// selection). Pass every output of the run, before any skipping: a cache is only
+/// judged when all of its inheriting outputs were packaged, since a skipped or
+/// failed consumer leaves usage unknown.
+pub fn check_unused_staging_files(outputs: &[Output], error: bool) -> miette::Result<()> {
+    // cache dir -> outputs expected to consume it
+    let mut consumers: HashMap<PathBuf, Vec<&Output>> = HashMap::new();
+    for output in outputs {
+        let Some(cache_dir) = inherited_cache_dir(output) else {
+            continue;
+        };
+        consumers.entry(cache_dir).or_default().push(output);
+    }
+
+    let mut findings = Vec::new();
+    for (cache_dir, consumers) in consumers {
+        // Judge only caches whose consumers were all packaged in this run.
+        let files: Option<Vec<BTreeSet<PathBuf>>> = consumers
+            .iter()
+            .map(|o| o.packaged_prefix_files())
+            .collect();
+        let Some(files) = files else {
+            continue;
+        };
+
+        let Ok(metadata) = fs::read_to_string(cache_dir.join("metadata.json")) else {
+            continue;
+        };
+        let Ok(metadata) = serde_json::from_str::<StagingCacheMetadata>(&metadata) else {
+            continue;
+        };
+
+        let used: HashSet<&PathBuf> = files.iter().flatten().collect();
+        let unused: BTreeSet<PathBuf> = metadata
+            .prefix_files
+            .iter()
+            // files like CACHEDIR.TAG or .pyo are never packaged
+            .filter(|f| !filter_file(f) && !used.contains(f))
+            .cloned()
+            .collect();
+        if unused.is_empty() {
+            continue;
+        }
+
+        if let Some(first) = consumers.first() {
+            first.record_warning(&format!(
+                "{} file(s) from staging cache '{}' were not included in any output",
+                unused.len(),
+                metadata.name,
+            ));
+        }
+        findings.push(format!(
+            "{} file(s) from staging cache '{}' were not included in any of the outputs that inherit from it ({}):\n{}",
+            unused.len(),
+            metadata.name,
+            consumers
+                .iter()
+                .map(|o| o.name().as_normalized().to_string())
+                .collect::<Vec<_>>()
+                .join(", "),
+            format_file_list(&unused),
+        ));
+    }
+
+    report(findings, error, "--error-unused-staging-files")
+}
+
+/// The cache directory of the staging cache this output inherits from, if any.
+fn inherited_cache_dir(output: &Output) -> Option<PathBuf> {
+    let inherits = output.recipe.inherits_from.as_ref()?;
+    let staging = output
+        .recipe
+        .staging_caches
+        .iter()
+        .find(|s| s.name == inherits.cache_name)?;
+    let cache_key = output.staging_cache_key(staging).ok()?;
+    Some(
+        output
+            .build_configuration
+            .directories
+            .cache_dir
+            .join(format!("staging_{}", cache_key)),
+    )
+}

--- a/crates/rattler_build_core/src/output_checks.rs
+++ b/crates/rattler_build_core/src/output_checks.rs
@@ -1,4 +1,4 @@
-//! Cross-output consistency checks that run after all outputs of a build are packaged.
+//! Checks that compare packaged outputs.
 
 use std::{
     collections::{BTreeSet, HashMap, HashSet},
@@ -9,14 +9,13 @@ use fs_err as fs;
 
 use crate::{packaging::file_mapper::filter_file, staging::StagingCacheMetadata, types::Output};
 
-/// How many offending files to list per finding before truncating.
 const MAX_LISTED_FILES: usize = 10;
 
 fn format_file_list(files: &BTreeSet<PathBuf>) -> String {
     let listed = files
         .iter()
         .take(MAX_LISTED_FILES)
-        .map(|p| format!("  - {}", p.display()))
+        .map(|p| format!("  - {}", p.to_string_lossy().replace('\\', "/")))
         .collect::<Vec<_>>()
         .join("\n");
     if files.len() > MAX_LISTED_FILES {
@@ -45,13 +44,7 @@ fn report(findings: Vec<String>, error: bool, flag: &str) -> miette::Result<()> 
     }
 }
 
-/// Warn (or error) when two outputs of the same recipe package the same file.
-///
-/// Installing both packages into one environment would clobber the file, and with
-/// staging caches this usually means an output forgot to narrow its `files` selection.
-/// Compared on prefix-relative paths as selected for packaging (before noarch path
-/// remapping), so a noarch and an arch output that ship the same file are caught too.
-/// Outputs with the same package name are never compared: they cannot be co-installed.
+/// Report files packaged by two co-installable outputs of the same recipe.
 pub fn check_overlapping_files(outputs: &[Output], error: bool) -> miette::Result<()> {
     let mut by_recipe: HashMap<&std::path::Path, Vec<&Output>> = HashMap::new();
     for output in outputs {
@@ -63,14 +56,20 @@ pub fn check_overlapping_files(outputs: &[Output], error: bool) -> miette::Resul
 
     let mut findings = Vec::new();
     for outputs in by_recipe.values() {
-        // Variants of the same pair would repeat the same finding, so keep one per name pair.
+        // Report each package pair once across variants.
         let mut seen_pairs = HashSet::new();
         for (i, a) in outputs.iter().enumerate() {
             let Some(files_a) = a.packaged_prefix_files() else {
                 continue;
             };
             for b in &outputs[i + 1..] {
-                if a.name() == b.name() {
+                let a_platform = a.build_configuration.target_platform;
+                let b_platform = b.build_configuration.target_platform;
+                if a.name() == b.name()
+                    || (a_platform != rattler_conda_types::Platform::NoArch
+                        && b_platform != rattler_conda_types::Platform::NoArch
+                        && a_platform != b_platform)
+                {
                     continue;
                 }
                 let Some(files_b) = b.packaged_prefix_files() else {
@@ -99,15 +98,8 @@ pub fn check_overlapping_files(outputs: &[Output], error: bool) -> miette::Resul
     report(findings, error, "--error-overlapping-files")
 }
 
-/// Warn (or error) when files in a staging cache were not packaged by any output
-/// that inherits from it.
-///
-/// Caches are compared per cache directory (one per staging output and variant
-/// selection). Pass every output of the run, before any skipping: a cache is only
-/// judged when all of its inheriting outputs were packaged, since a skipped or
-/// failed consumer leaves usage unknown.
+/// Report staged files unused by any inheriting output.
 pub fn check_unused_staging_files(outputs: &[Output], error: bool) -> miette::Result<()> {
-    // cache dir -> outputs expected to consume it
     let mut consumers: HashMap<PathBuf, Vec<&Output>> = HashMap::new();
     for output in outputs {
         let Some(cache_dir) = inherited_cache_dir(output) else {
@@ -118,7 +110,7 @@ pub fn check_unused_staging_files(outputs: &[Output], error: bool) -> miette::Re
 
     let mut findings = Vec::new();
     for (cache_dir, consumers) in consumers {
-        // Judge only caches whose consumers were all packaged in this run.
+        // None means a consumer did not finish packaging.
         let files: Option<Vec<BTreeSet<PathBuf>>> = consumers
             .iter()
             .map(|o| o.packaged_prefix_files())
@@ -138,7 +130,7 @@ pub fn check_unused_staging_files(outputs: &[Output], error: bool) -> miette::Re
         let unused: BTreeSet<PathBuf> = metadata
             .prefix_files
             .iter()
-            // files like CACHEDIR.TAG or .pyo are never packaged
+            // Ignore files packaging always drops.
             .filter(|f| !filter_file(f) && !used.contains(f))
             .cloned()
             .collect();
@@ -169,7 +161,6 @@ pub fn check_unused_staging_files(outputs: &[Output], error: bool) -> miette::Re
     report(findings, error, "--error-unused-staging-files")
 }
 
-/// The cache directory of the staging cache this output inherits from, if any.
 fn inherited_cache_dir(output: &Output) -> Option<PathBuf> {
     let inherits = output.recipe.inherits_from.as_ref()?;
     let staging = output

--- a/crates/rattler_build_core/src/packaging.rs
+++ b/crates/rattler_build_core/src/packaging.rs
@@ -1,7 +1,7 @@
 //! This module contains the functions to package a conda package from a given
 //! output.
 use std::{
-    collections::{BTreeSet, HashMap, HashSet},
+    collections::{HashMap, HashSet},
     io::Write,
     path::{Component, Path, PathBuf},
 };
@@ -989,6 +989,8 @@ pub fn package_conda(
     tracing::info!("Archive written to '{}'", final_name.display());
 
     let paths_json = PathsJson::from_path(info_folder.join("paths.json"))?;
+    // Only successful packaging marks a consumer's file usage as known.
+    output.record_packaged_prefix_files(tmp.packaged_prefix_files);
     Ok((final_name, paths_json))
 }
 
@@ -1049,13 +1051,6 @@ impl Output {
                 post_install_files,
             )?,
         };
-
-        let relative_new_files: BTreeSet<PathBuf> = files_after
-            .new_files
-            .iter()
-            .filter_map(|f| f.strip_prefix(host_prefix).ok().map(Path::to_path_buf))
-            .collect();
-        self.record_packaged_prefix_files(relative_new_files);
 
         package_conda(self, tool_configuration, &files_after)
     }

--- a/crates/rattler_build_core/src/packaging.rs
+++ b/crates/rattler_build_core/src/packaging.rs
@@ -1,7 +1,7 @@
 //! This module contains the functions to package a conda package from a given
 //! output.
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeSet, HashMap, HashSet},
     io::Write,
     path::{Component, Path, PathBuf},
 };
@@ -20,7 +20,7 @@ use rattler_package_streaming::write::{write_conda_package, write_tar_bz2_packag
 use unicode_normalization::UnicodeNormalization;
 
 mod file_finder;
-mod file_mapper;
+pub(crate) mod file_mapper;
 mod metadata;
 pub use file_finder::{Files, TempFiles, content_type, read_package_files_list, record_files};
 pub use metadata::{contains_prefix_binary, contains_prefix_text, create_prefix_placeholder};
@@ -1049,6 +1049,13 @@ impl Output {
                 post_install_files,
             )?,
         };
+
+        let relative_new_files: BTreeSet<PathBuf> = files_after
+            .new_files
+            .iter()
+            .filter_map(|f| f.strip_prefix(host_prefix).ok().map(Path::to_path_buf))
+            .collect();
+        self.record_packaged_prefix_files(relative_new_files);
 
         package_conda(self, tool_configuration, &files_after)
     }

--- a/crates/rattler_build_core/src/packaging/file_finder.rs
+++ b/crates/rattler_build_core/src/packaging/file_finder.rs
@@ -2,7 +2,7 @@ use content_inspector::ContentType;
 use fs_err as fs;
 use rattler_conda_types::PrefixRecord;
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeSet, HashMap, HashSet},
     io::{self, Read},
     path::{Path, PathBuf},
 };
@@ -95,6 +95,8 @@ pub struct Files {
 pub struct TempFiles {
     /// The files that are copied to the temporary directory
     pub files: HashSet<PathBuf>,
+    /// Accepted source paths relative to the prefix, before noarch remapping.
+    pub packaged_prefix_files: BTreeSet<PathBuf>,
     /// The temporary directory where the files are copied to
     pub temp_dir: tempfile::TempDir,
     /// The prefix which is encoded in the files (the long placeholder for the actual prefix, e.g. /home/user/bld_placeholder...)
@@ -329,6 +331,7 @@ impl Files {
     pub fn to_temp_folder(&self, output: &Output) -> Result<TempFiles, PackagingError> {
         let temp_dir = TempDir::with_prefix(output.name().as_normalized())?;
         let mut files = HashSet::new();
+        let mut packaged_prefix_files = BTreeSet::new();
         let mut content_type_map = HashMap::new();
         for f in &self.new_files {
             // temporary measure to remove pyc files that are not supposed to be there
@@ -339,11 +342,13 @@ impl Files {
             if let Some(dest_file) = output.write_to_dest(f, &self.prefix, temp_dir.path())? {
                 content_type_map.insert(dest_file.clone(), content_type(f)?);
                 files.insert(dest_file);
+                packaged_prefix_files.insert(f.strip_prefix(&self.prefix)?.to_path_buf());
             }
         }
 
         Ok(TempFiles {
             files,
+            packaged_prefix_files,
             temp_dir,
             encoded_prefix: self.prefix.clone(),
             content_type_map,

--- a/crates/rattler_build_core/src/tool_configuration.rs
+++ b/crates/rattler_build_core/src/tool_configuration.rs
@@ -149,6 +149,13 @@ pub struct Configuration {
     /// Whether to error if the host prefix is detected in binary files
     pub error_prefix_in_binary: bool,
 
+    /// Whether outputs of one recipe packaging the same file is an error (defaults to a warning)
+    pub error_overlapping_files: bool,
+
+    /// Whether staging cache files not packaged by any inheriting output are an error
+    /// (defaults to a warning)
+    pub error_unused_staging_files: bool,
+
     /// Whether to allow symlinks in packages on Windows (defaults to false)
     pub allow_symlinks_on_windows: bool,
 
@@ -216,6 +223,8 @@ pub struct ConfigurationBuilder {
     allow_insecure_host: Option<Vec<String>>,
     continue_on_failure: ContinueOnFailure,
     error_prefix_in_binary: bool,
+    error_overlapping_files: bool,
+    error_unused_staging_files: bool,
     allow_symlinks_on_windows: bool,
     allow_absolute_license_paths: bool,
     environments_externally_managed: bool,
@@ -251,6 +260,8 @@ impl ConfigurationBuilder {
             allow_insecure_host: None,
             continue_on_failure: ContinueOnFailure::No,
             error_prefix_in_binary: false,
+            error_overlapping_files: false,
+            error_unused_staging_files: false,
             allow_symlinks_on_windows: false,
             allow_absolute_license_paths: false,
             environments_externally_managed: false,
@@ -278,6 +289,22 @@ impl ConfigurationBuilder {
     pub fn with_error_prefix_in_binary(self, error_prefix_in_binary: bool) -> Self {
         Self {
             error_prefix_in_binary,
+            ..self
+        }
+    }
+
+    /// Whether outputs of one recipe packaging the same file is an error
+    pub fn with_error_overlapping_files(self, error_overlapping_files: bool) -> Self {
+        Self {
+            error_overlapping_files,
+            ..self
+        }
+    }
+
+    /// Whether staging cache files not packaged by any inheriting output are an error
+    pub fn with_error_unused_staging_files(self, error_unused_staging_files: bool) -> Self {
+        Self {
+            error_unused_staging_files,
             ..self
         }
     }
@@ -507,6 +534,8 @@ impl ConfigurationBuilder {
             allow_insecure_host: self.allow_insecure_host,
             continue_on_failure: self.continue_on_failure,
             error_prefix_in_binary: self.error_prefix_in_binary,
+            error_overlapping_files: self.error_overlapping_files,
+            error_unused_staging_files: self.error_unused_staging_files,
             allow_symlinks_on_windows: self.allow_symlinks_on_windows,
             allow_absolute_license_paths: self.allow_absolute_license_paths,
             environments_externally_managed: self.environments_externally_managed,

--- a/crates/rattler_build_core/src/types/build_output.rs
+++ b/crates/rattler_build_core/src/types/build_output.rs
@@ -11,10 +11,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{
     borrow::Cow,
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     fmt::{self, Display, Formatter},
     io::Write,
-    path::Path,
+    path::{Path, PathBuf},
     sync::{Arc, Mutex},
 };
 
@@ -114,6 +114,21 @@ impl BuildOutput {
         let mut summary = self.build_summary.lock().unwrap();
         summary.artifact = Some(artifact.to_path_buf());
         summary.paths = Some(paths.clone());
+    }
+
+    /// Record the prefix-relative files that were selected for packaging
+    pub fn record_packaged_prefix_files(&self, files: BTreeSet<PathBuf>) {
+        self.build_summary.lock().unwrap().packaged_prefix_files = Some(files);
+    }
+
+    /// The prefix-relative files that were selected for packaging, if this
+    /// output has been packaged
+    pub fn packaged_prefix_files(&self) -> Option<BTreeSet<PathBuf>> {
+        self.build_summary
+            .lock()
+            .unwrap()
+            .packaged_prefix_files
+            .clone()
     }
 
     /// Record the end of the build

--- a/crates/rattler_build_core/src/types/build_output.rs
+++ b/crates/rattler_build_core/src/types/build_output.rs
@@ -116,13 +116,12 @@ impl BuildOutput {
         summary.paths = Some(paths.clone());
     }
 
-    /// Record the prefix-relative files that were selected for packaging
+    /// Record the prefix-relative files selected for packaging.
     pub fn record_packaged_prefix_files(&self, files: BTreeSet<PathBuf>) {
         self.build_summary.lock().unwrap().packaged_prefix_files = Some(files);
     }
 
-    /// The prefix-relative files that were selected for packaging, if this
-    /// output has been packaged
+    /// Return the selected prefix-relative files after packaging.
     pub fn packaged_prefix_files(&self) -> Option<BTreeSet<PathBuf>> {
         self.build_summary
             .lock()

--- a/crates/rattler_build_core/src/types/mod.rs
+++ b/crates/rattler_build_core/src/types/mod.rs
@@ -1,6 +1,6 @@
 //! Common types used throughout Rattler-Build
 //! All the metadata that makes up a recipe file
-use std::{iter, path::PathBuf, str::FromStr};
+use std::{collections::BTreeSet, iter, path::PathBuf, str::FromStr};
 
 use jiff::Timestamp;
 use rattler_conda_types::{
@@ -139,6 +139,9 @@ pub struct BuildSummary {
     pub warnings: Vec<String>,
     /// The paths that are packaged in the artifact
     pub paths: Option<PathsJson>,
+    /// The prefix-relative files that were selected for packaging (before any
+    /// noarch path remapping)
+    pub packaged_prefix_files: Option<BTreeSet<PathBuf>>,
     ///  Whether the build was successful or not
     pub failed: bool,
 }

--- a/docs/multiple_output_cache.md
+++ b/docs/multiple_output_cache.md
@@ -243,6 +243,18 @@ package that additionally depends on `python` expands the matrix further (one
 package per `libfoo` × `python` combination), but the staging cache is reused
 across `python` variants.
 
+### Consistency checks
+
+After all outputs are built, rattler-build warns when
+
+- two outputs of the same recipe package the same file (installing both would
+  clobber it), or
+- files from a staging cache were not included in any output that inherits
+  from it.
+
+`--error-overlapping-files` and `--error-unused-staging-files` turn these
+warnings into hard errors.
+
 ### How caching works
 
 The staging cache is keyed by a SHA256 hash over:

--- a/docs/reference/cli/rattler-build/build.md
+++ b/docs/reference/cli/rattler-build/build.md
@@ -101,6 +101,10 @@ e.g. `tar-bz2:<number>` (from 1 to 9) or `conda:<number>` (from -7 to
 :  Error if the host prefix is detected in any binary files
 - <a id="arg---allow-symlinks-on-windows" href="#arg---allow-symlinks-on-windows">`--allow-symlinks-on-windows`</a>
 :  Allow symlinks in packages on Windows (defaults to false - symlinks are forbidden on Windows)
+- <a id="arg---error-overlapping-files" href="#arg---error-overlapping-files">`--error-overlapping-files`</a>
+:  Error instead of warn when outputs of one recipe package the same file
+- <a id="arg---error-unused-staging-files" href="#arg---error-unused-staging-files">`--error-unused-staging-files`</a>
+:  Error instead of warn when files from a staging cache are not included in any output that inherits from it
 - <a id="arg---exclude-newer" href="#arg---exclude-newer">`--exclude-newer <EXCLUDE_NEWER>`</a>
 :  Exclude packages newer than this date from the solver, in RFC3339 format (e.g. 2024-03-15T12:00:00Z)
 

--- a/docs/reference/cli/rattler-build/publish.md
+++ b/docs/reference/cli/rattler-build/publish.md
@@ -103,6 +103,10 @@ e.g. `tar-bz2:<number>` (from 1 to 9) or `conda:<number>` (from -7 to
 :  Error if the host prefix is detected in any binary files
 - <a id="arg---allow-symlinks-on-windows" href="#arg---allow-symlinks-on-windows">`--allow-symlinks-on-windows`</a>
 :  Allow symlinks in packages on Windows (defaults to false - symlinks are forbidden on Windows)
+- <a id="arg---error-overlapping-files" href="#arg---error-overlapping-files">`--error-overlapping-files`</a>
+:  Error instead of warn when outputs of one recipe package the same file
+- <a id="arg---error-unused-staging-files" href="#arg---error-unused-staging-files">`--error-unused-staging-files`</a>
+:  Error instead of warn when files from a staging cache are not included in any output that inherits from it
 - <a id="arg---exclude-newer" href="#arg---exclude-newer">`--exclude-newer <EXCLUDE_NEWER>`</a>
 :  Exclude packages newer than this date from the solver, in RFC3339 format (e.g. 2024-03-15T12:00:00Z)
 

--- a/py-rattler-build/rust/src/cli_api.rs
+++ b/py-rattler-build/rust/src/cli_api.rs
@@ -145,6 +145,8 @@ pub fn build_recipes_py(
         ContinueOnFailure::from(continue_on_failure),
         error_prefix_in_binary,
         allow_symlinks_on_windows,
+        false, // error_overlapping_files
+        false, // error_unused_staging_files
         allow_absolute_license_paths,
         exclude_newer,
         build_num,

--- a/py-rattler-build/rust/src/cli_api.rs
+++ b/py-rattler-build/rust/src/cli_api.rs
@@ -22,7 +22,7 @@ use crate::repodata_revision::PyRepodataRevision;
 use crate::run_async_task;
 
 #[pyfunction]
-#[pyo3(signature = (recipes, up_to, build_platform, target_platform, host_platform, channel, variant_config, variant_overrides=None, ignore_recipe_variants=false, render_only=false, with_solve=false, keep_build=false, no_build_id=false, package_format=None, compression_threads=None, io_concurrency_limit=None, no_include_recipe=false, test=None, output_dir=None, auth_file=None, channel_priority=None, skip_existing=None, noarch_build_platform=None, allow_insecure_host=None, continue_on_failure=false, error_prefix_in_binary=false, allow_symlinks_on_windows=false, allow_absolute_license_paths=false, exclude_newer=None, build_num=None, build_string_prefix=None, use_bz2=true, use_zstd=true, use_sharded=true, repodata_revision=None))]
+#[pyo3(signature = (recipes, up_to, build_platform, target_platform, host_platform, channel, variant_config, variant_overrides=None, ignore_recipe_variants=false, render_only=false, with_solve=false, keep_build=false, no_build_id=false, package_format=None, compression_threads=None, io_concurrency_limit=None, no_include_recipe=false, test=None, output_dir=None, auth_file=None, channel_priority=None, skip_existing=None, noarch_build_platform=None, allow_insecure_host=None, continue_on_failure=false, error_prefix_in_binary=false, allow_symlinks_on_windows=false, allow_absolute_license_paths=false, exclude_newer=None, build_num=None, build_string_prefix=None, use_bz2=true, use_zstd=true, use_sharded=true, repodata_revision=None, error_overlapping_files=false, error_unused_staging_files=false))]
 #[allow(clippy::too_many_arguments)]
 pub fn build_recipes_py(
     recipes: Vec<PathBuf>,
@@ -60,6 +60,8 @@ pub fn build_recipes_py(
     use_zstd: bool,
     use_sharded: bool,
     repodata_revision: Option<PyRepodataRevision>,
+    error_overlapping_files: bool,
+    error_unused_staging_files: bool,
 ) -> PyResult<()> {
     let channel_priority = channel_priority
         .map(|c| ChannelPriorityWrapper::from_str(&c).map(|c| c.value))
@@ -145,8 +147,8 @@ pub fn build_recipes_py(
         ContinueOnFailure::from(continue_on_failure),
         error_prefix_in_binary,
         allow_symlinks_on_windows,
-        false, // error_overlapping_files
-        false, // error_unused_staging_files
+        error_overlapping_files,
+        error_unused_staging_files,
         allow_absolute_license_paths,
         exclude_newer,
         build_num,

--- a/py-rattler-build/src/rattler_build/cli_api.py
+++ b/py-rattler-build/src/rattler_build/cli_api.py
@@ -37,6 +37,8 @@ def build_recipes(
     allow_insecure_host: list[str] | None = None,
     continue_on_failure: bool = False,
     error_prefix_in_binary: bool = False,
+    error_overlapping_files: bool = False,
+    error_unused_staging_files: bool = False,
     allow_symlinks_on_windows: bool = False,
     allow_absolute_license_paths: bool = False,
     exclude_newer: datetime | None = None,
@@ -80,6 +82,8 @@ def build_recipes(
         allow_insecure_host: Allow insecure hosts for the build.
         continue_on_failure: Continue building other recipes even if one fails. (default: False)
         error_prefix_in_binary: Do not allow the $PREFIX to appear in binary files. (default: False)
+        error_overlapping_files: Error if outputs package overlapping files. (default: False)
+        error_unused_staging_files: Error if staged files are not packaged by any inheriting output. (default: False)
         allow_symlinks_on_windows: Allow symlinks on Windows and `noarch` packages. (default: False)
         allow_absolute_license_paths: Allow absolute paths in license files. (default: False)
         exclude_newer: Exclude any packages that were released after the specified date when solving the build, host and test environments. (default: None)
@@ -135,6 +139,8 @@ def build_recipes(
         use_zstd,
         use_sharded,
         repodata_revision,
+        error_overlapping_files,
+        error_unused_staging_files,
     )
 
 

--- a/py-rattler-build/tests/unit/test_cli_api.py
+++ b/py-rattler-build/tests/unit/test_cli_api.py
@@ -1,6 +1,7 @@
 import shutil
 import warnings
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 import tomli as tomllib
@@ -20,6 +21,15 @@ def test_version_match_local_cargo() -> None:
     assert rattler_build.rattler_build_version() == local_version
 
 
+@pytest.mark.parametrize("strict", [False, True])
+def test_build_recipes_output_check_flags(strict: bool) -> None:
+    options = {"error_overlapping_files": True, "error_unused_staging_files": True} if strict else {}
+    with patch("rattler_build.cli_api.build_recipes_py") as build:
+        with pytest.warns(DeprecationWarning):
+            rattler_build.build_recipes([], **options)
+    assert build.call_args.args[-2:] == (strict, strict)
+
+
 def test_test_package_deprecation_warning(tmp_path: Path, recipes_dir: Path) -> None:
     recipe_name = "recipe.yaml"
     recipe_path = tmp_path.joinpath(recipe_name)
@@ -28,7 +38,13 @@ def test_test_package_deprecation_warning(tmp_path: Path, recipes_dir: Path) -> 
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
-        rattler_build.build_recipes([recipe_path], output_dir=output_dir, test="skip")
+        rattler_build.build_recipes(
+            [recipe_path],
+            output_dir=output_dir,
+            test="skip",
+            error_overlapping_files=True,
+            error_unused_staging_files=True,
+        )
 
     for conda_file in output_dir.glob("**/*.conda"):
         with pytest.warns(DeprecationWarning, match="test_package is deprecated"):

--- a/py-rattler-build/tests/unit/test_cli_api.py
+++ b/py-rattler-build/tests/unit/test_cli_api.py
@@ -24,9 +24,8 @@ def test_version_match_local_cargo() -> None:
 @pytest.mark.parametrize("strict", [False, True])
 def test_build_recipes_output_check_flags(strict: bool) -> None:
     options = {"error_overlapping_files": True, "error_unused_staging_files": True} if strict else {}
-    with patch("rattler_build.cli_api.build_recipes_py") as build:
-        with pytest.warns(DeprecationWarning):
-            rattler_build.build_recipes([], **options)
+    with patch("rattler_build.cli_api.build_recipes_py") as build, pytest.warns(DeprecationWarning):
+        rattler_build.build_recipes([], **options)
     assert build.call_args.args[-2:] == (strict, strict)
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub use rattler_build_core::debug;
 pub use rattler_build_core::env_vars;
 pub use rattler_build_core::metadata;
 pub use rattler_build_core::migrate_recipe;
+pub use rattler_build_core::output_checks;
 pub use rattler_build_core::package_test;
 pub use rattler_build_core::packaging;
 pub use rattler_build_core::publish;
@@ -249,6 +250,8 @@ pub fn get_tool_config(
         .with_allow_insecure_host(build_data.common.allow_insecure_host.clone())
         .with_error_prefix_in_binary(build_data.error_prefix_in_binary)
         .with_allow_symlinks_on_windows(build_data.allow_symlinks_on_windows)
+        .with_error_overlapping_files(build_data.error_overlapping_files)
+        .with_error_unused_staging_files(build_data.error_unused_staging_files)
         .with_allow_absolute_license_paths(build_data.allow_absolute_license_paths)
         .with_io_concurrency_limit(Some(build_data.io_concurrency_limit))
         .with_zstd_repodata_enabled(build_data.common.use_zstd)
@@ -713,6 +716,9 @@ pub async fn run_build_from_args(
 ) -> miette::Result<()> {
     let mut outputs = Vec::new();
     let mut test_queue = Vec::new();
+    // Keep the unfiltered list: the staging check below must see skipped outputs to
+    // know when a cache's usage cannot be judged.
+    let all_outputs = build_output.clone();
     let outputs_to_build = skip_existing(build_output, &tool_configuration).await?;
     let mut build_queue = OutputBuildQueue::new(outputs_to_build);
 
@@ -798,9 +804,21 @@ pub async fn run_build_from_args(
     // let the package solver report any dependency that is still unavailable.
     run_queued_tests(&test_queue, &tool_configuration).await?;
 
+    // Cross-output consistency checks: overlapping files between outputs, and
+    // staging cache files that no inheriting output packaged. Warnings by default;
+    // recorded first so they show up in the summaries below even in error mode.
+    let checks_result = output_checks::check_overlapping_files(
+        &outputs,
+        tool_configuration.error_overlapping_files,
+    )
+    .and(output_checks::check_unused_staging_files(
+        &all_outputs,
+        tool_configuration.error_unused_staging_files,
+    ));
+
     let span = tracing::info_span!("Build summary");
     let _enter = span.enter();
-    for output in outputs {
+    for output in &outputs {
         // print summaries for each output
         let _ = output.log_build_summary().map_err(|e| {
             tracing::error!("Error writing build summary: {}", e);
@@ -816,7 +834,7 @@ pub async fn run_build_from_args(
         }
     }
 
-    Ok(())
+    checks_result
 }
 
 /// Check if the noarch builds should be skipped because the noarch platform has
@@ -1579,6 +1597,8 @@ pub async fn debug_recipe(
         continue_on_failure: ContinueOnFailure::No,
         error_prefix_in_binary: false,
         allow_symlinks_on_windows: false,
+        error_overlapping_files: false,
+        error_unused_staging_files: false,
         allow_absolute_license_paths: false,
         exclude_newer: None,
         build_num_override: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -708,6 +708,18 @@ async fn run_queued_tests(
     Ok(())
 }
 
+fn check_outputs(
+    built_outputs: &[Output],
+    all_outputs: &[Output],
+    configuration: &Configuration,
+) -> miette::Result<()> {
+    output_checks::check_overlapping_files(built_outputs, configuration.error_overlapping_files)
+        .and(output_checks::check_unused_staging_files(
+            all_outputs,
+            configuration.error_unused_staging_files,
+        ))
+}
+
 /// Runs build.
 pub async fn run_build_from_args(
     build_output: Vec<Output>,
@@ -716,8 +728,7 @@ pub async fn run_build_from_args(
 ) -> miette::Result<()> {
     let mut outputs = Vec::new();
     let mut test_queue = Vec::new();
-    // Keep the unfiltered list: the staging check below must see skipped outputs to
-    // know when a cache's usage cannot be judged.
+    // Missing consumers suppress the unused-cache check.
     let all_outputs = build_output.clone();
     let outputs_to_build = skip_existing(build_output, &tool_configuration).await?;
     let mut build_queue = OutputBuildQueue::new(outputs_to_build);
@@ -804,17 +815,7 @@ pub async fn run_build_from_args(
     // let the package solver report any dependency that is still unavailable.
     run_queued_tests(&test_queue, &tool_configuration).await?;
 
-    // Cross-output consistency checks: overlapping files between outputs, and
-    // staging cache files that no inheriting output packaged. Warnings by default;
-    // recorded first so they show up in the summaries below even in error mode.
-    let checks_result = output_checks::check_overlapping_files(
-        &outputs,
-        tool_configuration.error_overlapping_files,
-    )
-    .and(output_checks::check_unused_staging_files(
-        &all_outputs,
-        tool_configuration.error_unused_staging_files,
-    ));
+    let checks_result = check_outputs(&outputs, &all_outputs, &tool_configuration);
 
     let span = tracing::info_span!("Build summary");
     let _enter = span.enter();
@@ -1311,6 +1312,9 @@ async fn build_and_collect_packages(
     tool_configuration: &Configuration,
 ) -> miette::Result<Vec<PathBuf>> {
     let mut package_paths = Vec::new();
+    let mut built_outputs = Vec::new();
+    // Missing consumers suppress the unused-cache check.
+    let all_outputs = build_output.clone();
     let outputs_to_build = skip_existing(build_output, tool_configuration).await?;
     let mut build_queue = OutputBuildQueue::new(outputs_to_build);
 
@@ -1337,9 +1341,12 @@ async fn build_and_collect_packages(
             }
         };
 
-        build_queue.record_processed(output);
+        build_queue.record_processed(output.clone());
         package_paths.push(archive);
+        built_outputs.push(output);
     }
+
+    check_outputs(&built_outputs, &all_outputs, tool_configuration)?;
 
     Ok(package_paths)
 }

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -723,6 +723,15 @@ pub struct BuildOpts {
     #[arg(long, help_heading = "Modifying result")]
     pub allow_symlinks_on_windows: bool,
 
+    /// Error instead of warn when outputs of one recipe package the same file
+    #[arg(long, help_heading = "Modifying result")]
+    pub error_overlapping_files: bool,
+
+    /// Error instead of warn when files from a staging cache are not included in any
+    /// output that inherits from it
+    #[arg(long, help_heading = "Modifying result")]
+    pub error_unused_staging_files: bool,
+
     /// Allow absolute paths in license_file entries (defaults to false)
     #[arg(long, hide = true, help_heading = "Modifying result")]
     pub allow_absolute_license_paths: bool,
@@ -921,6 +930,8 @@ pub struct BuildData {
     pub continue_on_failure: ContinueOnFailure,
     pub error_prefix_in_binary: bool,
     pub allow_symlinks_on_windows: bool,
+    pub error_overlapping_files: bool,
+    pub error_unused_staging_files: bool,
     pub allow_absolute_license_paths: bool,
     pub exclude_newer: Option<jiff::Timestamp>,
     pub build_num_override: Option<u64>,
@@ -958,6 +969,8 @@ impl BuildData {
         continue_on_failure: ContinueOnFailure,
         error_prefix_in_binary: bool,
         allow_symlinks_on_windows: bool,
+        error_overlapping_files: bool,
+        error_unused_staging_files: bool,
         allow_absolute_license_paths: bool,
         exclude_newer: Option<jiff::Timestamp>,
         build_num_override: Option<u64>,
@@ -1000,6 +1013,8 @@ impl BuildData {
             continue_on_failure,
             error_prefix_in_binary,
             allow_symlinks_on_windows,
+            error_overlapping_files,
+            error_unused_staging_files,
             allow_absolute_license_paths,
             exclude_newer,
             build_num_override,
@@ -1053,6 +1068,8 @@ impl BuildData {
             opts.continue_on_failure.into(),
             opts.error_prefix_in_binary,
             opts.allow_symlinks_on_windows,
+            opts.error_overlapping_files,
+            opts.error_unused_staging_files,
             opts.allow_absolute_license_paths,
             opts.exclude_newer,
             None, // build_num_override — set by caller (BuildOnlyOpts or PublishOpts)

--- a/test-data/recipes/staging/staging-checks.yaml
+++ b/test-data/recipes/staging/staging-checks.yaml
@@ -1,6 +1,4 @@
-# Fixtures for the cross-output consistency checks (issues #2730 / #2753):
-# `liba` and `libb` both package lib/libcore.so, and include/unused.h is not
-# packaged by any output.
+# Both outputs package libcore.so; neither packages unused.h.
 
 schema_version: 1
 

--- a/test-data/recipes/staging/staging-checks.yaml
+++ b/test-data/recipes/staging/staging-checks.yaml
@@ -1,0 +1,42 @@
+# Fixtures for the cross-output consistency checks (issues #2730 / #2753):
+# `liba` and `libb` both package lib/libcore.so, and include/unused.h is not
+# packaged by any output.
+
+schema_version: 1
+
+recipe:
+  name: staging-checks
+  version: 1.0.0
+
+outputs:
+  - staging:
+      name: stage
+    build:
+      script:
+        - if: unix
+          then: |
+            mkdir -p $PREFIX/lib $PREFIX/include
+            echo "libcore" > $PREFIX/lib/libcore.so
+            echo "unused"  > $PREFIX/include/unused.h
+        - if: win
+          then: |
+            if not exist "%PREFIX%\lib" mkdir "%PREFIX%\lib"
+            if not exist "%PREFIX%\include" mkdir "%PREFIX%\include"
+            echo libcore > "%PREFIX%\lib\libcore.so"
+            echo unused > "%PREFIX%\include\unused.h"
+
+  - package:
+      name: liba
+      version: 1.0.0
+    inherit: stage
+    build:
+      files:
+        - lib/**
+
+  - package:
+      name: libb
+      version: 1.0.0
+    inherit: stage
+    build:
+      files:
+        - lib/libcore.so

--- a/test-data/recipes/staging/staging-checks.yaml
+++ b/test-data/recipes/staging/staging-checks.yaml
@@ -1,4 +1,4 @@
-# Both outputs package libcore.so; neither packages unused.h.
+# Both outputs select libcore.so and a filtered .la file; neither packages unused.h.
 
 schema_version: 1
 
@@ -15,12 +15,14 @@ outputs:
           then: |
             mkdir -p $PREFIX/lib $PREFIX/include
             echo "libcore" > $PREFIX/lib/libcore.so
+            echo "filtered" > $PREFIX/lib/libcore.la
             echo "unused"  > $PREFIX/include/unused.h
         - if: win
           then: |
             if not exist "%PREFIX%\lib" mkdir "%PREFIX%\lib"
             if not exist "%PREFIX%\include" mkdir "%PREFIX%\include"
             echo libcore > "%PREFIX%\lib\libcore.so"
+            echo filtered > "%PREFIX%\lib\libcore.la"
             echo unused > "%PREFIX%\include\unused.h"
 
   - package:
@@ -38,3 +40,4 @@ outputs:
     build:
       files:
         - lib/libcore.so
+        - lib/libcore.la

--- a/test/end-to-end/test_staging.py
+++ b/test/end-to-end/test_staging.py
@@ -4,7 +4,7 @@ import json
 import os
 import platform
 from pathlib import Path
-from subprocess import CalledProcessError
+from subprocess import STDOUT, CalledProcessError
 
 import pytest
 import yaml
@@ -367,6 +367,48 @@ def test_staging_empty_files_selection(
     inherits_all = packaged_files("inherits-all-files")
     assert any(lib_name in f for f in inherits_all)
     assert any("include/core.h" in f for f in inherits_all)
+
+
+def test_staging_consistency_checks(
+    rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
+):
+    """Issues #2730/#2753: warn on overlapping output files and unused staging files."""
+    args = rattler_build.build_args(
+        recipes / "staging/staging-checks.yaml",
+        tmp_path / "warn",
+        extra_args=["--experimental"],
+    )
+    output = rattler_build(*args, stderr=STDOUT)
+    assert "Outputs 'liba' and 'libb' both package 1 file(s)" in output
+    assert "lib/libcore.so" in output
+    assert "1 file(s) from staging cache 'stage' were not included" in output
+    assert "include/unused.h" in output
+
+    # With the flags, the warnings become hard errors.
+    for flag in ["--error-overlapping-files", "--error-unused-staging-files"]:
+        args = rattler_build.build_args(
+            recipes / "staging/staging-checks.yaml",
+            tmp_path / flag.strip("-"),
+            extra_args=["--experimental", flag],
+        )
+        with pytest.raises(CalledProcessError):
+            rattler_build(*args, stderr=STDOUT)
+
+
+def test_staging_checks_quiet_when_all_files_used(
+    rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
+):
+    """Outputs that together use every staged file and share nothing raise no errors."""
+    args = rattler_build.build_args(
+        recipes / "staging/staging-empty-files.yaml",
+        tmp_path,
+        extra_args=[
+            "--experimental",
+            "--error-overlapping-files",
+            "--error-unused-staging-files",
+        ],
+    )
+    rattler_build(*args, stderr=STDOUT)
 
 
 def test_staging_with_top_level_inherit(

--- a/test/end-to-end/test_staging.py
+++ b/test/end-to-end/test_staging.py
@@ -395,6 +395,49 @@ def test_staging_consistency_checks(
             rattler_build(*args, stderr=STDOUT)
 
 
+def test_staging_filtered_files_do_not_overlap(
+    rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
+):
+    recipe = yaml.safe_load((recipes / "staging/staging-checks.yaml").read_text())
+    recipe["outputs"][2]["build"]["files"] = ["lib/libcore.la"]
+    recipe_path = tmp_path / "recipe.yaml"
+    recipe_path.write_text(yaml.safe_dump(recipe))
+    args = rattler_build.build_args(
+        recipe_path,
+        tmp_path / "output",
+        extra_args=["--experimental", "--error-overlapping-files"],
+    )
+    output = rattler_build(*args, stderr=STDOUT)
+    assert "both package" not in output
+    pkg = get_extracted_package(tmp_path / "output", "libb")
+    assert json.loads((pkg / "info/paths.json").read_text())["paths"] == []
+
+
+def test_staging_checks_skip_failed_packaging_consumer(
+    rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
+):
+    recipe = yaml.safe_load((recipes / "staging/staging-checks.yaml").read_text())
+    # Fail inside package_conda, after files have been selected and copied.
+    recipe["outputs"][2]["about"] = {"license_file": "missing-license.txt"}
+    recipe_path = tmp_path / "recipe.yaml"
+    recipe_path.write_text(yaml.safe_dump(recipe))
+    args = rattler_build.build_args(
+        recipe_path,
+        tmp_path / "output",
+        extra_args=[
+            "--experimental",
+            "--continue-on-failure",
+            "--error-unused-staging-files",
+        ],
+    )
+    output = rattler_build(*args, stderr=STDOUT)
+    assert "Build failed for libb" in output
+    assert "No license files were copied" in output
+    assert "were not included" not in output
+    assert list((tmp_path / "output").glob("*/liba-*.tar.bz2"))
+    assert not list((tmp_path / "output").glob("*/libb-*.tar.bz2"))
+
+
 def test_staging_checks_quiet_when_all_files_used(
     rattler_build: RattlerBuild, recipes: Path, tmp_path: Path
 ):


### PR DESCRIPTION
Ref #2730 (see also #2753)

Adds two cross-output consistency checks that run after all outputs are built:

- **Overlapping files** — two outputs of the same recipe package the same file, so installing both clobbers it. With staging caches this usually means an output forgot to narrow its `files` selection.
- **Unused staging files** — files from a staging cache were not included in any output that inherits from it (the "silently dropped or silently duplicated" ambiguity from #2730).

Both are warnings by default; `--error-overlapping-files` and `--error-unused-staging-files` turn them into hard errors. Warnings are also recorded on the involved outputs so they appear in build/markdown summaries.

```
⚠ Outputs 'liba' and 'libb' both package 1 file(s), which will clobber each other on installation:
    - lib/libcore.so
⚠ 1 file(s) from staging cache 'stage' were not included in any of the outputs that inherit from it (liba, libb):
    - include/unused.h
```

## How

`create_package` now records the prefix-relative files each output selected for packaging (before noarch path remapping) in the build summary. The checks in the new `output_checks` module compare those sets:

- Overlap: pairwise within one recipe, on prefix-relative paths — so a noarch and an arch output shipping the same prefix file are caught even though their packaged paths differ. Same-name outputs are never compared (they can't be co-installed); variant repeats of a pair are deduped.
- Unused: per cache directory (one per staging output + variant selection), against `prefix_files` from the cache's `metadata.json`, minus files packaging always drops (`CACHEDIR.TAG`, `.pyo`, …). A cache is only judged when **all** of its inheriting outputs were packaged in the run — a consumer skipped by `--skip-existing`/`--noarch-build-platform` or failed under `--continue-on-failure` leaves usage unknown, so no false errors (verified manually with `--skip-existing=local --error-unused-staging-files`).

## Notes

- `test-data/recipes/staging/multiple-staging-caches.yaml` now (correctly) warns: `libcore` and `core-headers` genuinely both package `include/core.h`.
- Flag plumbing follows `--error-prefix-in-binary`; py-rattler-build passes the defaults (can be exposed as kwargs later).
- CLI docs regenerated with `rattler_build_docs`; prose section added to `docs/multiple_output_cache.md`.

## Tests

- e2e `test_staging_consistency_checks`: both warnings fire on a new fixture, and each flag makes the build fail.
- e2e `test_staging_checks_quiet_when_all_files_used`: a recipe whose outputs cover the cache and share nothing builds clean under both strict flags.
- Full workspace tests green except pre-existing `test_system_tool` (no `patchelf` in the dev container); all 23 staging e2e tests pass; fmt and clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Rj3CRpTRFpCtsnCVdaaQd

---
_Generated by [Claude Code](https://claude.ai/code/session_016Rj3CRpTRFpCtsnCVdaaQd)_