### PR TITLE
docs: use JSON Pointer (RFC 6901) syntax

### DIFF
--- a/docs/reference/recipe_file.md
+++ b/docs/reference/recipe_file.md
@@ -1235,7 +1235,7 @@ requirements:
 ```
 
 In the built package, optional groups are written into
-`index.json::extra_depends`.
+`index.json#/extra_depends`.
 
 ### Run exports
 

--- a/docs/v3.md
+++ b/docs/v3.md
@@ -121,7 +121,7 @@ requirements:
 ```
 
 In the built package, optional groups land in
-`index.json::extra_depends`.
+`index.json#/extra_depends`.
 
 ### Richer `MatchSpec` syntax
 


### PR DESCRIPTION
to refer to keys inside JSON files instead of an ad-hoc Rust-like idiosyncrasy