### PR TITLE
feat: expose exclude-newer policies for Python builds, tests, and debug sessions

### DIFF
--- a/crates/rattler_build_core/src/debug.rs
+++ b/crates/rattler_build_core/src/debug.rs
@@ -467,6 +467,7 @@ pub async fn add_packages_to_prefix(
     specs: &[String],
     channels: &[ChannelUrl],
     tool_config: &Configuration,
+    exclude_newer: Option<rattler_solve::ExcludeNewer>,
 ) -> miette::Result<()> {
     use miette::IntoDiagnostic;
 
@@ -518,7 +519,7 @@ pub async fn add_packages_to_prefix(
         tool_config,
         rattler_solve::ChannelPriority::Strict,
         rattler_solve::SolveStrategy::default(),
-        None,
+        exclude_newer,
     )
     .await?;
 

--- a/crates/rattler_build_core/src/package_test/run_test.rs
+++ b/crates/rattler_build_core/src/package_test/run_test.rs
@@ -30,7 +30,7 @@ use rattler_shell::{
     activation::ActivationError,
     shell::{Shell, ShellEnum},
 };
-use rattler_solve::{ChannelPriority, SolveStrategy};
+use rattler_solve::{ChannelPriority, ExcludeNewer, SolveStrategy};
 use std::collections::BTreeMap;
 use std::fmt::Write;
 use std::{
@@ -344,8 +344,8 @@ pub struct TestConfiguration {
     pub tool_configuration: tool_configuration::Configuration,
     /// The output directory to create the test prefixes in (will be `output_dir/test`)
     pub output_dir: PathBuf,
-    /// Exclude packages newer than this date from the solver
-    pub exclude_newer: Option<jiff::Timestamp>,
+    /// Exclude packages according to global, channel, and package cutoff dates.
+    pub exclude_newer: Option<ExcludeNewer>,
     /// The environment isolation mode for test scripts
     pub env_isolation: EnvironmentIsolation,
 }
@@ -595,13 +595,16 @@ pub async fn run_test(
         .map_err(|e| TestError::TestFailed(format!("failed to cache package: {e}")))?;
     let package_folder = cache_metadata.path().to_path_buf();
 
+    let test_channel = Channel::try_from_directory(tmp_repo.path())
+        .expect("could not create channel from directory")
+        .base_url;
+    let exclude_newer = config.exclude_newer.clone().map(|policy| {
+        // Only the artifacts explicitly copied into this temporary channel
+        // bypass the global cutoff. Package overrides retain precedence.
+        policy.with_channel_cutoff(test_channel.url().as_str(), jiff::Timestamp::MAX)
+    });
     let mut channels = config.channels.clone();
-    channels.insert(
-        0,
-        Channel::try_from_directory(tmp_repo.path())
-            .expect("could not create channel from directory")
-            .base_url,
-    );
+    channels.insert(0, test_channel);
 
     let host_platform = config.host_platform.clone().unwrap_or_else(|| {
         if target_platform == Platform::NoArch {
@@ -618,6 +621,7 @@ pub async fn run_test(
         target_platform: Some(target_platform),
         host_platform: Some(host_platform.clone()),
         channels,
+        exclude_newer,
         tool_configuration: tool_configuration::Configuration {
             package_cache: temp_package_cache,
             ..config.tool_configuration.clone()
@@ -662,7 +666,7 @@ pub async fn run_test(
             &config.tool_configuration,
             config.channel_priority,
             config.solve_strategy,
-            config.exclude_newer,
+            config.exclude_newer.clone(),
         )
         .await
         .wrap_err("failed to setup test environment")
@@ -882,7 +886,7 @@ async fn run_python_test_inner(
         &config.tool_configuration,
         config.channel_priority,
         config.solve_strategy,
-        config.exclude_newer,
+        config.exclude_newer.clone(),
     )
     .await
     .wrap_err("failed to setup test environment")
@@ -982,7 +986,7 @@ async fn run_perl_test(
         &config.tool_configuration,
         config.channel_priority,
         config.solve_strategy,
-        config.exclude_newer,
+        config.exclude_newer.clone(),
     )
     .await
     .wrap_err("failed to setup test environment")
@@ -1059,7 +1063,7 @@ async fn run_commands_test(
             &config.tool_configuration,
             config.channel_priority,
             config.solve_strategy,
-            config.exclude_newer,
+            config.exclude_newer.clone(),
         )
         .await
         .wrap_err("failed to setup test environment")
@@ -1090,7 +1094,7 @@ async fn run_commands_test(
         &config.tool_configuration,
         config.channel_priority,
         config.solve_strategy,
-        config.exclude_newer,
+        config.exclude_newer.clone(),
     )
     .await
     .wrap_err("failed to setup test environment")
@@ -1177,7 +1181,7 @@ async fn run_downstream_test(
         &config.tool_configuration,
         config.channel_priority,
         config.solve_strategy,
-        config.exclude_newer,
+        config.exclude_newer.clone(),
     )
     .await;
 
@@ -1271,7 +1275,7 @@ async fn run_r_test(
         &config.tool_configuration,
         config.channel_priority,
         config.solve_strategy,
-        config.exclude_newer,
+        config.exclude_newer.clone(),
     )
     .await
     .wrap_err("failed to setup test environment")
@@ -1347,7 +1351,7 @@ async fn run_ruby_test(
         &config.tool_configuration,
         config.channel_priority,
         config.solve_strategy,
-        config.exclude_newer,
+        config.exclude_newer.clone(),
     )
     .await
     .wrap_err("failed to setup test environment")
@@ -1394,6 +1398,72 @@ async fn run_ruby_test(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn exclude_newer_allows_the_test_artifact_and_preserves_package_overrides() {
+        let package = tempfile::tempdir().unwrap();
+        fs::create_dir_all(package.path().join("info/test")).unwrap();
+        fs::write(
+            package.path().join("info/index.json"),
+            serde_json::to_vec(&serde_json::json!({
+                "name": "cutoff-test-artifact",
+                "version": "1.0",
+                "build": "0",
+                "build_number": 0,
+                "subdir": Platform::current().to_string(),
+                "depends": [],
+                "timestamp": 1735689600000i64,
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        fs::write(
+            package.path().join("info/paths.json"),
+            r#"{"paths_version":1,"paths":[]}"#,
+        )
+        .unwrap();
+        fs::write(package.path().join("info/files"), "").unwrap();
+        fs::write(
+            package.path().join("info/test/test_time_dependencies.json"),
+            "[]",
+        )
+        .unwrap();
+
+        let test_dir = tempfile::tempdir().unwrap();
+        let cache_dir = tempfile::tempdir().unwrap();
+        let cutoff: jiff::Timestamp = "2020-01-01T00:00:00Z".parse().unwrap();
+        let mut config = TestConfiguration {
+            test_prefix: test_dir.path().join("test"),
+            target_platform: None,
+            host_platform: None,
+            current_platform: PlatformWithVirtualPackages {
+                platform: Platform::current(),
+                virtual_packages: Vec::new(),
+            },
+            keep_test_prefix: false,
+            test_index: None,
+            channels: Vec::new(),
+            channel_priority: ChannelPriority::Strict,
+            solve_strategy: SolveStrategy::Highest,
+            tool_configuration: tool_configuration::Configuration::builder()
+                .with_cache_dir(cache_dir.path().to_path_buf())
+                .finish(),
+            output_dir: test_dir.path().to_path_buf(),
+            exclude_newer: Some(cutoff.into()),
+            env_isolation: EnvironmentIsolation::default(),
+        };
+
+        run_test(package.path(), &config, None).await.unwrap();
+
+        config.exclude_newer = Some(
+            ExcludeNewer::from_datetime(cutoff)
+                .with_package_cutoff("cutoff-test-artifact".parse().unwrap(), cutoff),
+        );
+        assert!(matches!(
+            run_test(package.path(), &config, None).await,
+            Err(TestError::TestEnvironmentSetup(_))
+        ));
+    }
 
     #[tokio::test]
     async fn legacy_tests_use_build_platform_scripts() {

--- a/crates/rattler_build_core/src/render/resolved_dependencies.rs
+++ b/crates/rattler_build_core/src/render/resolved_dependencies.rs
@@ -865,7 +865,9 @@ pub(crate) async fn resolve_dependencies(
             tool_configuration,
             output.build_configuration.channel_priority,
             output.build_configuration.solve_strategy,
-            output.build_configuration.exclude_newer,
+            output
+                .build_configuration
+                .exclude_newer_with_build_outputs(),
         )
         .await
         .map_err(|e| ResolveError::DependencyResolutionError(e.into()))?;
@@ -954,7 +956,9 @@ pub(crate) async fn resolve_dependencies(
             tool_configuration,
             output.build_configuration.channel_priority,
             output.build_configuration.solve_strategy,
-            output.build_configuration.exclude_newer,
+            output
+                .build_configuration
+                .exclude_newer_with_build_outputs(),
         )
         .await
         .map_err(|e| ResolveError::DependencyResolutionError(e.into()))?;

--- a/crates/rattler_build_core/src/render/solver.rs
+++ b/crates/rattler_build_core/src/render/solver.rs
@@ -12,7 +12,9 @@ use rattler_conda_types::{
     Channel, ChannelNoticeLevel, ChannelUrl, MatchSpec, Platform, PrefixRecord, RepoDataRecord,
 };
 use rattler_repodata_gateway::ChannelNoticeResult;
-use rattler_solve::{ChannelPriority, SolveStrategy, SolverImpl, SolverTask, resolvo::Solver};
+use rattler_solve::{
+    ChannelPriority, ExcludeNewer, SolveStrategy, SolverImpl, SolverTask, resolvo::Solver,
+};
 
 use super::reporters::GatewayReporter;
 
@@ -63,7 +65,7 @@ pub async fn solve_environment(
     tool_configuration: &tool_configuration::Configuration,
     channel_priority: ChannelPriority,
     solve_strategy: SolveStrategy,
-    exclude_newer: Option<jiff::Timestamp>,
+    exclude_newer: Option<ExcludeNewer>,
 ) -> miette::Result<Vec<RepoDataRecord>> {
     let span_msg = format!("Resolving {name} environment");
     let span = tracing::info_span!("", message = %span_msg);
@@ -107,7 +109,7 @@ pub async fn solve_environment(
         specs: specs.to_vec(),
         channel_priority,
         strategy: solve_strategy,
-        exclude_newer: exclude_newer.map(Into::into),
+        exclude_newer,
         ..SolverTask::from_iter(&repo_data)
     };
 
@@ -135,7 +137,7 @@ pub async fn create_environment(
     tool_configuration: &tool_configuration::Configuration,
     channel_priority: ChannelPriority,
     solve_strategy: SolveStrategy,
-    exclude_newer: Option<jiff::Timestamp>,
+    exclude_newer: Option<ExcludeNewer>,
 ) -> miette::Result<Vec<RepoDataRecord>> {
     let required_packages = solve_environment(
         name,

--- a/crates/rattler_build_core/src/types/build_configuration.rs
+++ b/crates/rattler_build_core/src/types/build_configuration.rs
@@ -4,8 +4,8 @@ use std::collections::BTreeMap;
 use rattler_build_jinja::{JinjaConfig, Variable};
 use rattler_build_recipe::stage1::HashInfo;
 use rattler_build_types::NormalizedKey;
-use rattler_conda_types::{ChannelUrl, PackageName, Platform, RepodataRevision};
-use rattler_solve::{ChannelPriority, SolveStrategy};
+use rattler_conda_types::{Channel, ChannelUrl, PackageName, Platform, RepodataRevision};
+use rattler_solve::{ChannelPriority, ExcludeNewer, SolveStrategy};
 use serde::{Deserialize, Serialize};
 
 use crate::types::{
@@ -17,6 +17,15 @@ use rattler_build_script::{EnvironmentIsolation, SandboxConfiguration};
 /// Default value for store recipe for backwards compatibility
 fn default_true() -> bool {
     true
+}
+
+// Build metadata omits the cutoff, but older callers may supply a scalar when
+// deserializing a build configuration.
+fn deserialize_exclude_newer<'de, D>(deserializer: D) -> Result<Option<ExcludeNewer>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Option::<jiff::Timestamp>::deserialize(deserializer).map(|cutoff| cutoff.map(Into::into))
 }
 /// The configuration for a build of a package
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -67,15 +76,33 @@ pub struct BuildConfiguration {
     /// The configuration for the sandbox
     #[serde(skip_serializing, default)]
     pub sandbox_config: Option<SandboxConfiguration>,
-    /// Exclude packages newer than this date from the solver
-    #[serde(skip_serializing, default)]
-    pub exclude_newer: Option<jiff::Timestamp>,
+    /// Exclude packages according to global, channel, and package cutoff dates.
+    #[serde(
+        skip_serializing,
+        default,
+        deserialize_with = "deserialize_exclude_newer"
+    )]
+    pub exclude_newer: Option<ExcludeNewer>,
     /// Repodata revision to target when writing package metadata.
     #[serde(skip_serializing, default)]
     pub repodata_revision: RepodataRevision,
 }
 
 impl BuildConfiguration {
+    /// Apply the cutoff while allowing packages from this build's output channel.
+    /// Explicit package cutoffs still take precedence over the output channel.
+    pub fn exclude_newer_with_build_outputs(&self) -> Option<ExcludeNewer> {
+        self.exclude_newer.clone().map(|policy| {
+            match Channel::try_from_directory(&self.directories.output_dir) {
+                Ok(channel) => policy
+                    .with_channel_cutoff(channel.base_url.url().as_str(), jiff::Timestamp::MAX),
+                // Rendering can resolve dependencies before creating an output
+                // directory. No output channel is available in that case.
+                Err(_) => policy,
+            }
+        })
+    }
+
     /// true if the build is cross-compiling
     pub fn cross_compilation(&self) -> bool {
         self.target_platform != self.build_platform.platform
@@ -97,5 +124,87 @@ impl BuildConfiguration {
             undefined_behavior: rattler_build_jinja::UndefinedBehavior::Lenient,
             recipe_path: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rattler_conda_types::utils::TimestampMs;
+
+    use super::*;
+
+    fn build_configuration() -> BuildConfiguration {
+        let output: crate::metadata::Output = serde_yaml::from_str(include_str!(
+            "../../../../test-data/rendered_recipes/rich_recipe.yaml"
+        ))
+        .unwrap();
+        output.build_configuration
+    }
+
+    #[test]
+    fn exclude_newer_exempts_only_the_build_output_channel() {
+        let output_dir = tempfile::tempdir().unwrap();
+        let dependency_dir = tempfile::tempdir().unwrap();
+        let output_channel = Channel::try_from_directory(output_dir.path()).unwrap();
+        let dependency_channel = Channel::try_from_directory(dependency_dir.path()).unwrap();
+        let package: PackageName = "fresh-output".parse().unwrap();
+        let cutoff: jiff::Timestamp = "2020-01-01T00:00:00Z".parse().unwrap();
+        let timestamp =
+            TimestampMs::from("2025-01-01T00:00:00Z".parse::<jiff::Timestamp>().unwrap());
+        let mut config = build_configuration();
+        config.directories.output_dir = output_dir.path().to_path_buf();
+        config.exclude_newer = Some(cutoff.into());
+
+        let policy = config.exclude_newer_with_build_outputs().unwrap();
+        assert!(!policy.is_excluded(
+            &package,
+            Some(output_channel.base_url.url().as_str()),
+            Some(&timestamp),
+        ));
+        assert!(policy.is_excluded(
+            &package,
+            Some(dependency_channel.base_url.url().as_str()),
+            Some(&timestamp),
+        ));
+        assert!(policy.is_excluded(
+            &package,
+            Some("https://example.com/channel/"),
+            Some(&timestamp)
+        ));
+        assert!(policy.is_excluded(&package, Some(output_channel.base_url.url().as_str()), None));
+
+        config.exclude_newer = Some(
+            ExcludeNewer::from_datetime(cutoff)
+                .with_package_cutoff(package.clone(), cutoff)
+                .with_include_unknown_timestamp(true),
+        );
+        let policy = config.exclude_newer_with_build_outputs().unwrap();
+        assert!(policy.is_excluded(
+            &package,
+            Some(output_channel.base_url.url().as_str()),
+            Some(&timestamp),
+        ));
+        assert!(!policy.is_excluded(&package, Some(output_channel.base_url.url().as_str()), None));
+    }
+
+    #[test]
+    fn exclude_newer_is_omitted_from_metadata_and_accepts_legacy_scalar() {
+        let mut config = build_configuration();
+        let cutoff: jiff::Timestamp = "2020-01-01T00:00:00Z".parse().unwrap();
+        config.exclude_newer = Some(
+            ExcludeNewer::from_datetime(cutoff)
+                .with_channel_cutoff("https://example.com/channel/", jiff::Timestamp::MAX),
+        );
+        let mut serialized = serde_json::to_value(&config).unwrap();
+        assert!(serialized.get("exclude_newer").is_none());
+        let parsed: BuildConfiguration = serde_json::from_value(serialized.clone()).unwrap();
+        assert!(parsed.exclude_newer.is_none());
+
+        serialized["exclude_newer"] = serde_json::json!("2020-01-01T00:00:00Z");
+        let parsed: BuildConfiguration = serde_json::from_value(serialized).unwrap();
+        assert_eq!(
+            parsed.exclude_newer,
+            Some(ExcludeNewer::from_datetime(cutoff))
+        );
     }
 }

--- a/py-rattler-build/rust/Cargo.lock
+++ b/py-rattler-build/rust/Cargo.lock
@@ -4341,6 +4341,7 @@ dependencies = [
  "rattler_config",
  "rattler_networking",
  "rattler_package_streaming",
+ "rattler_redaction",
  "rattler_solve",
  "rattler_upload",
  "rattler_virtual_packages",

--- a/py-rattler-build/rust/Cargo.toml
+++ b/py-rattler-build/rust/Cargo.toml
@@ -38,6 +38,7 @@ tokio = { version = "1.53.1", features = [
 rattler_conda_types = "0.52"
 rattler_config = "0.7"
 rattler_networking = { version = "0.30" }
+rattler_redaction = { version = "0.2", default-features = false }
 rattler_solve = "9.0"
 rattler_virtual_packages = "6"
 clap = "4.6.6"

--- a/py-rattler-build/rust/src/build.rs
+++ b/py-rattler-build/rust/src/build.rs
@@ -19,7 +19,7 @@ use std::{
 };
 
 use crate::error::RattlerBuildError;
-use crate::exclude_newer::exclude_newer_policy;
+use crate::exclude_newer::PyExcludeNewer;
 use crate::render;
 use crate::repodata_revision::PyRepodataRevision;
 use crate::run_async_task;
@@ -250,7 +250,7 @@ use std::path::Path;
 /// directly without needing to write temporary files.
 #[pyfunction]
 #[allow(clippy::too_many_arguments)]
-#[pyo3(signature = (rendered_variant, tool_config, output_dir, channels, progress_callback=None, recipe_path=None, no_build_id=false, package_format=None, no_include_recipe=false, exclude_newer=None, env_isolation=PyEnvironmentIsolation::Strict, sibling_variants=Vec::new(), repodata_revision=None, *, exclude_newer_package=None, exclude_newer_channel=None, exclude_newer_include_unknown_timestamp=false))]
+#[pyo3(signature = (rendered_variant, tool_config, output_dir, channels, progress_callback=None, recipe_path=None, no_build_id=false, package_format=None, no_include_recipe=false, exclude_newer=None, env_isolation=PyEnvironmentIsolation::Strict, sibling_variants=Vec::new(), repodata_revision=None))]
 pub fn build_rendered_variant_py(
     py: Python<'_>,
     rendered_variant: render::PyRenderedVariant,
@@ -262,21 +262,13 @@ pub fn build_rendered_variant_py(
     no_build_id: bool,
     package_format: Option<String>,
     no_include_recipe: bool,
-    exclude_newer: Option<jiff::Timestamp>,
+    exclude_newer: Option<PyExcludeNewer>,
     env_isolation: PyEnvironmentIsolation,
     sibling_variants: Vec<render::PyRenderedVariant>,
     repodata_revision: Option<PyRepodataRevision>,
-    exclude_newer_package: Option<HashMap<String, Option<jiff::Timestamp>>>,
-    exclude_newer_channel: Option<HashMap<String, Option<jiff::Timestamp>>>,
-    exclude_newer_include_unknown_timestamp: bool,
 ) -> PyResult<BuildResultPy> {
     let tool_config = tool_config.inner;
-    let exclude_newer = exclude_newer_policy(
-        exclude_newer,
-        exclude_newer_package,
-        exclude_newer_channel,
-        exclude_newer_include_unknown_timestamp,
-    )?;
+    let exclude_newer = exclude_newer.and_then(|policy| policy.inner);
 
     let package_format = package_format
         .map(|p| PackageFormatAndCompression::from_str(&p))

--- a/py-rattler-build/rust/src/build.rs
+++ b/py-rattler-build/rust/src/build.rs
@@ -12,13 +12,14 @@ use rattler_build_script::EnvironmentIsolation;
 use rattler_build_types::NormalizedKey;
 use rattler_conda_types::{ChannelUrl, NamedChannelOrUrl, Platform};
 use rattler_config::config::build::PackageFormatAndCompression;
-use rattler_solve::SolveStrategy;
+use rattler_solve::{ExcludeNewer, SolveStrategy};
 use std::{
     collections::BTreeMap,
     sync::{Arc, Mutex},
 };
 
 use crate::error::RattlerBuildError;
+use crate::exclude_newer::exclude_newer_policy;
 use crate::render;
 use crate::repodata_revision::PyRepodataRevision;
 use crate::run_async_task;
@@ -120,7 +121,7 @@ pub(crate) fn output_from_rendered_variant(
     package_format: Option<&PackageFormatAndCompression>,
     no_include_recipe: bool,
     recipe_path: Option<&Path>,
-    exclude_newer: Option<jiff::Timestamp>,
+    exclude_newer: Option<ExcludeNewer>,
     env_isolation: EnvironmentIsolation,
     repodata_revision: PyRepodataRevision,
     extra_subpackages: BTreeMap<rattler_conda_types::PackageName, PackageIdentifier>,
@@ -249,7 +250,7 @@ use std::path::Path;
 /// directly without needing to write temporary files.
 #[pyfunction]
 #[allow(clippy::too_many_arguments)]
-#[pyo3(signature = (rendered_variant, tool_config, output_dir, channels, progress_callback=None, recipe_path=None, no_build_id=false, package_format=None, no_include_recipe=false, exclude_newer=None, env_isolation=PyEnvironmentIsolation::Strict, sibling_variants=Vec::new(), repodata_revision=None))]
+#[pyo3(signature = (rendered_variant, tool_config, output_dir, channels, progress_callback=None, recipe_path=None, no_build_id=false, package_format=None, no_include_recipe=false, exclude_newer=None, env_isolation=PyEnvironmentIsolation::Strict, sibling_variants=Vec::new(), repodata_revision=None, *, exclude_newer_package=None, exclude_newer_channel=None, exclude_newer_include_unknown_timestamp=false))]
 pub fn build_rendered_variant_py(
     py: Python<'_>,
     rendered_variant: render::PyRenderedVariant,
@@ -265,8 +266,17 @@ pub fn build_rendered_variant_py(
     env_isolation: PyEnvironmentIsolation,
     sibling_variants: Vec<render::PyRenderedVariant>,
     repodata_revision: Option<PyRepodataRevision>,
+    exclude_newer_package: Option<HashMap<String, Option<jiff::Timestamp>>>,
+    exclude_newer_channel: Option<HashMap<String, Option<jiff::Timestamp>>>,
+    exclude_newer_include_unknown_timestamp: bool,
 ) -> PyResult<BuildResultPy> {
     let tool_config = tool_config.inner;
+    let exclude_newer = exclude_newer_policy(
+        exclude_newer,
+        exclude_newer_package,
+        exclude_newer_channel,
+        exclude_newer_include_unknown_timestamp,
+    )?;
 
     let package_format = package_format
         .map(|p| PackageFormatAndCompression::from_str(&p))

--- a/py-rattler-build/rust/src/debug.rs
+++ b/py-rattler-build/rust/src/debug.rs
@@ -245,7 +245,7 @@ impl PyDebugSession {
 /// installs environments, creates build script) without running the build.
 #[pyfunction]
 #[allow(clippy::too_many_arguments)]
-#[pyo3(signature = (rendered_variant, tool_config=None, output_dir=None, channels=None, no_build_id=true, progress_callback=None, recipe_path=None, repodata_revision=None, *, exclude_newer=None, exclude_newer_package=None, exclude_newer_channel=None, exclude_newer_include_unknown_timestamp=false))]
+#[pyo3(signature = (rendered_variant, tool_config=None, output_dir=None, channels=None, no_build_id=true, progress_callback=None, recipe_path=None, repodata_revision=None, *, exclude_newer=None))]
 pub fn create_debug_session_py(
     py: Python<'_>,
     rendered_variant: PyRenderedVariant,
@@ -256,17 +256,9 @@ pub fn create_debug_session_py(
     progress_callback: Option<Py<PyAny>>,
     recipe_path: Option<PathBuf>,
     repodata_revision: Option<PyRepodataRevision>,
-    exclude_newer: Option<jiff::Timestamp>,
-    exclude_newer_package: Option<std::collections::HashMap<String, Option<jiff::Timestamp>>>,
-    exclude_newer_channel: Option<std::collections::HashMap<String, Option<jiff::Timestamp>>>,
-    exclude_newer_include_unknown_timestamp: bool,
+    exclude_newer: Option<crate::exclude_newer::PyExcludeNewer>,
 ) -> PyResult<PyDebugSession> {
-    let exclude_newer = crate::exclude_newer::exclude_newer_policy(
-        exclude_newer,
-        exclude_newer_package,
-        exclude_newer_channel,
-        exclude_newer_include_unknown_timestamp,
-    )?;
+    let exclude_newer = exclude_newer.and_then(|policy| policy.inner);
     let tool_config = tool_config
         .map(|tc| tc.inner)
         .unwrap_or_else(|| Configuration::builder().finish());

--- a/py-rattler-build/rust/src/debug.rs
+++ b/py-rattler-build/rust/src/debug.rs
@@ -169,6 +169,9 @@ impl PyDebugSession {
                 &specs,
                 &channels,
                 &self.tool_config,
+                self.output
+                    .build_configuration
+                    .exclude_newer_with_build_outputs(),
             )
             .await
         })?;
@@ -242,7 +245,7 @@ impl PyDebugSession {
 /// installs environments, creates build script) without running the build.
 #[pyfunction]
 #[allow(clippy::too_many_arguments)]
-#[pyo3(signature = (rendered_variant, tool_config=None, output_dir=None, channels=None, no_build_id=true, progress_callback=None, recipe_path=None, repodata_revision=None))]
+#[pyo3(signature = (rendered_variant, tool_config=None, output_dir=None, channels=None, no_build_id=true, progress_callback=None, recipe_path=None, repodata_revision=None, *, exclude_newer=None, exclude_newer_package=None, exclude_newer_channel=None, exclude_newer_include_unknown_timestamp=false))]
 pub fn create_debug_session_py(
     py: Python<'_>,
     rendered_variant: PyRenderedVariant,
@@ -253,7 +256,17 @@ pub fn create_debug_session_py(
     progress_callback: Option<Py<PyAny>>,
     recipe_path: Option<PathBuf>,
     repodata_revision: Option<PyRepodataRevision>,
+    exclude_newer: Option<jiff::Timestamp>,
+    exclude_newer_package: Option<std::collections::HashMap<String, Option<jiff::Timestamp>>>,
+    exclude_newer_channel: Option<std::collections::HashMap<String, Option<jiff::Timestamp>>>,
+    exclude_newer_include_unknown_timestamp: bool,
 ) -> PyResult<PyDebugSession> {
+    let exclude_newer = crate::exclude_newer::exclude_newer_policy(
+        exclude_newer,
+        exclude_newer_package,
+        exclude_newer_channel,
+        exclude_newer_include_unknown_timestamp,
+    )?;
     let tool_config = tool_config
         .map(|tc| tc.inner)
         .unwrap_or_else(|| Configuration::builder().finish());
@@ -290,7 +303,7 @@ pub fn create_debug_session_py(
         None,
         true, // no_include_recipe
         recipe_path.as_deref(),
-        None, // exclude_newer
+        exclude_newer,
         EnvironmentIsolation::default(),
         repodata_revision.unwrap_or_default(),
         BTreeMap::new(), // extra_subpackages

--- a/py-rattler-build/rust/src/exclude_newer.rs
+++ b/py-rattler-build/rust/src/exclude_newer.rs
@@ -1,0 +1,47 @@
+use std::{collections::HashMap, str::FromStr};
+
+use jiff::Timestamp;
+use pyo3::{PyResult, exceptions::PyValueError};
+use rattler_conda_types::{ChannelUrl, PackageName};
+use rattler_redaction::Redact;
+use rattler_solve::ExcludeNewer;
+
+/// Convert Python cutoff arguments without enabling filtering for an empty policy.
+pub(crate) fn exclude_newer_policy(
+    cutoff: Option<Timestamp>,
+    packages: Option<HashMap<String, Option<Timestamp>>>,
+    channels: Option<HashMap<String, Option<Timestamp>>>,
+    include_unknown_timestamp: bool,
+) -> PyResult<Option<ExcludeNewer>> {
+    let packages = packages.unwrap_or_default();
+    let channels = channels.unwrap_or_default();
+    if cutoff.is_none() && packages.is_empty() && channels.is_empty() {
+        return Ok(None);
+    }
+
+    let mut policy = ExcludeNewer::from_datetime(cutoff.unwrap_or(Timestamp::MAX))
+        .with_include_unknown_timestamp(include_unknown_timestamp);
+    for (name, cutoff) in packages {
+        let package = PackageName::from_str(&name).map_err(|err| {
+            PyValueError::new_err(format!(
+                "invalid exclude_newer_package name {name:?}: {err}"
+            ))
+        })?;
+        policy = policy.with_package_cutoff(package, cutoff.unwrap_or(Timestamp::MAX));
+    }
+    for (channel, cutoff) in channels {
+        let url = url::Url::parse(&channel).map_err(|err| {
+            PyValueError::new_err(format!("invalid exclude_newer_channel URL: {err}"))
+        })?;
+        if url.cannot_be_a_base() {
+            return Err(PyValueError::new_err(
+                "exclude_newer_channel keys must be absolute channel URLs",
+            ));
+        }
+        // Repodata records use the normalized base URL with credentials
+        // redacted. Match that key while leaving transport URLs untouched.
+        let channel = ChannelUrl::from(url).url().clone().redact().to_string();
+        policy = policy.with_channel_cutoff(channel, cutoff.unwrap_or(Timestamp::MAX));
+    }
+    Ok(Some(policy))
+}

--- a/py-rattler-build/rust/src/exclude_newer.rs
+++ b/py-rattler-build/rust/src/exclude_newer.rs
@@ -1,13 +1,36 @@
 use std::{collections::HashMap, str::FromStr};
 
 use jiff::Timestamp;
-use pyo3::{PyResult, exceptions::PyValueError};
+use pyo3::{exceptions::PyValueError, prelude::*};
 use rattler_conda_types::{ChannelUrl, PackageName};
 use rattler_redaction::Redact;
 use rattler_solve::ExcludeNewer;
 
+/// A validated cutoff policy shared by builds, tests, and debug sessions.
+#[pyclass(name = "ExcludeNewer", from_py_object)]
+#[derive(Clone)]
+pub struct PyExcludeNewer {
+    pub(crate) inner: Option<ExcludeNewer>,
+}
+
+#[pymethods]
+impl PyExcludeNewer {
+    #[new]
+    #[pyo3(signature = (cutoff=None, *, packages=None, channels=None, include_unknown_timestamp=false))]
+    fn new(
+        cutoff: Option<Timestamp>,
+        packages: Option<HashMap<String, Option<Timestamp>>>,
+        channels: Option<HashMap<String, Option<Timestamp>>>,
+        include_unknown_timestamp: bool,
+    ) -> PyResult<Self> {
+        Ok(Self {
+            inner: exclude_newer_policy(cutoff, packages, channels, include_unknown_timestamp)?,
+        })
+    }
+}
+
 /// Convert Python cutoff arguments without enabling filtering for an empty policy.
-pub(crate) fn exclude_newer_policy(
+fn exclude_newer_policy(
     cutoff: Option<Timestamp>,
     packages: Option<HashMap<String, Option<Timestamp>>>,
     channels: Option<HashMap<String, Option<Timestamp>>>,
@@ -23,19 +46,17 @@ pub(crate) fn exclude_newer_policy(
         .with_include_unknown_timestamp(include_unknown_timestamp);
     for (name, cutoff) in packages {
         let package = PackageName::from_str(&name).map_err(|err| {
-            PyValueError::new_err(format!(
-                "invalid exclude_newer_package name {name:?}: {err}"
-            ))
+            PyValueError::new_err(format!("invalid ExcludeNewer package name {name:?}: {err}"))
         })?;
         policy = policy.with_package_cutoff(package, cutoff.unwrap_or(Timestamp::MAX));
     }
     for (channel, cutoff) in channels {
         let url = url::Url::parse(&channel).map_err(|err| {
-            PyValueError::new_err(format!("invalid exclude_newer_channel URL: {err}"))
+            PyValueError::new_err(format!("invalid ExcludeNewer channel URL: {err}"))
         })?;
         if url.cannot_be_a_base() {
             return Err(PyValueError::new_err(
-                "exclude_newer_channel keys must be absolute channel URLs",
+                "ExcludeNewer channel keys must be absolute channel URLs",
             ));
         }
         // Repodata records use the normalized base URL with credentials

--- a/py-rattler-build/rust/src/lib.rs
+++ b/py-rattler-build/rust/src/lib.rs
@@ -7,6 +7,7 @@ mod build;
 mod cli_api;
 mod debug;
 mod error;
+mod exclude_newer;
 mod jinja_config;
 mod package;
 mod package_assembler;

--- a/py-rattler-build/rust/src/lib.rs
+++ b/py-rattler-build/rust/src/lib.rs
@@ -24,6 +24,7 @@ mod variant_config;
 
 use build::{BuildResultPy, PyEnvironmentIsolation};
 use error::RattlerBuildError;
+use exclude_newer::PyExcludeNewer;
 use jinja_config::PyJinjaConfig;
 use repodata_revision::PyRepodataRevision;
 
@@ -69,6 +70,7 @@ fn rattler_build<'py>(_py: Python<'py>, m: Bound<'py, PyModule>) -> PyResult<()>
     m.add_function(wrap_pyfunction!(upload::upload_package_to_cloudsmith_py, &m).unwrap())?;
     m.add_function(wrap_pyfunction!(upload::upload_packages_to_conda_forge_py, &m).unwrap())?;
     m.add_class::<PyJinjaConfig>()?;
+    m.add_class::<PyExcludeNewer>()?;
     m.add_class::<BuildResultPy>()?;
     m.add_class::<PyEnvironmentIsolation>()?;
     m.add_class::<PyRepodataRevision>()?;

--- a/py-rattler-build/rust/src/package.rs
+++ b/py-rattler-build/rust/src/package.rs
@@ -1,7 +1,6 @@
 // Python bindings for package inspection and testing
 
 use std::{
-    collections::HashMap,
     future::Future,
     path::PathBuf,
     str::FromStr,
@@ -268,7 +267,7 @@ impl PyPackage {
     }
 
     /// Run a specific test by index
-    #[pyo3(signature = (index, channel=None, channel_priority=None, auth_file=None, allow_insecure_host=None, compression_threads=None, use_bz2=true, use_zstd=true, use_sharded=true, progress_callback=None, *, exclude_newer=None, exclude_newer_package=None, exclude_newer_channel=None, exclude_newer_include_unknown_timestamp=false))]
+    #[pyo3(signature = (index, channel=None, channel_priority=None, auth_file=None, allow_insecure_host=None, compression_threads=None, use_bz2=true, use_zstd=true, use_sharded=true, progress_callback=None, *, exclude_newer=None))]
     #[allow(clippy::too_many_arguments)]
     fn run_test(
         &self,
@@ -282,10 +281,7 @@ impl PyPackage {
         use_zstd: bool,
         use_sharded: bool,
         progress_callback: Option<Py<PyAny>>,
-        exclude_newer: Option<jiff::Timestamp>,
-        exclude_newer_package: Option<HashMap<String, Option<jiff::Timestamp>>>,
-        exclude_newer_channel: Option<HashMap<String, Option<jiff::Timestamp>>>,
-        exclude_newer_include_unknown_timestamp: bool,
+        exclude_newer: Option<crate::exclude_newer::PyExcludeNewer>,
     ) -> PyResult<PyTestResult> {
         self.run_test_internal(
             Some(index),
@@ -298,18 +294,13 @@ impl PyPackage {
             use_zstd,
             use_sharded,
             progress_callback,
-            crate::exclude_newer::exclude_newer_policy(
-                exclude_newer,
-                exclude_newer_package,
-                exclude_newer_channel,
-                exclude_newer_include_unknown_timestamp,
-            )?,
+            exclude_newer.and_then(|policy| policy.inner),
         )
         .map(|results| results.into_iter().next().unwrap())
     }
 
     /// Run all tests in the package
-    #[pyo3(signature = (channel=None, channel_priority=None, auth_file=None, allow_insecure_host=None, compression_threads=None, use_bz2=true, use_zstd=true, use_sharded=true, progress_callback=None, *, exclude_newer=None, exclude_newer_package=None, exclude_newer_channel=None, exclude_newer_include_unknown_timestamp=false))]
+    #[pyo3(signature = (channel=None, channel_priority=None, auth_file=None, allow_insecure_host=None, compression_threads=None, use_bz2=true, use_zstd=true, use_sharded=true, progress_callback=None, *, exclude_newer=None))]
     #[allow(clippy::too_many_arguments)]
     fn run_tests(
         &self,
@@ -322,10 +313,7 @@ impl PyPackage {
         use_zstd: bool,
         use_sharded: bool,
         progress_callback: Option<Py<PyAny>>,
-        exclude_newer: Option<jiff::Timestamp>,
-        exclude_newer_package: Option<HashMap<String, Option<jiff::Timestamp>>>,
-        exclude_newer_channel: Option<HashMap<String, Option<jiff::Timestamp>>>,
-        exclude_newer_include_unknown_timestamp: bool,
+        exclude_newer: Option<crate::exclude_newer::PyExcludeNewer>,
     ) -> PyResult<Vec<PyTestResult>> {
         self.run_test_internal(
             None,
@@ -338,12 +326,7 @@ impl PyPackage {
             use_zstd,
             use_sharded,
             progress_callback,
-            crate::exclude_newer::exclude_newer_policy(
-                exclude_newer,
-                exclude_newer_package,
-                exclude_newer_channel,
-                exclude_newer_include_unknown_timestamp,
-            )?,
+            exclude_newer.and_then(|policy| policy.inner),
         )
     }
 

--- a/py-rattler-build/rust/src/package.rs
+++ b/py-rattler-build/rust/src/package.rs
@@ -1,6 +1,7 @@
 // Python bindings for package inspection and testing
 
 use std::{
+    collections::HashMap,
     future::Future,
     path::PathBuf,
     str::FromStr,
@@ -267,7 +268,7 @@ impl PyPackage {
     }
 
     /// Run a specific test by index
-    #[pyo3(signature = (index, channel=None, channel_priority=None, auth_file=None, allow_insecure_host=None, compression_threads=None, use_bz2=true, use_zstd=true, use_sharded=true, progress_callback=None))]
+    #[pyo3(signature = (index, channel=None, channel_priority=None, auth_file=None, allow_insecure_host=None, compression_threads=None, use_bz2=true, use_zstd=true, use_sharded=true, progress_callback=None, *, exclude_newer=None, exclude_newer_package=None, exclude_newer_channel=None, exclude_newer_include_unknown_timestamp=false))]
     #[allow(clippy::too_many_arguments)]
     fn run_test(
         &self,
@@ -281,6 +282,10 @@ impl PyPackage {
         use_zstd: bool,
         use_sharded: bool,
         progress_callback: Option<Py<PyAny>>,
+        exclude_newer: Option<jiff::Timestamp>,
+        exclude_newer_package: Option<HashMap<String, Option<jiff::Timestamp>>>,
+        exclude_newer_channel: Option<HashMap<String, Option<jiff::Timestamp>>>,
+        exclude_newer_include_unknown_timestamp: bool,
     ) -> PyResult<PyTestResult> {
         self.run_test_internal(
             Some(index),
@@ -293,12 +298,18 @@ impl PyPackage {
             use_zstd,
             use_sharded,
             progress_callback,
+            crate::exclude_newer::exclude_newer_policy(
+                exclude_newer,
+                exclude_newer_package,
+                exclude_newer_channel,
+                exclude_newer_include_unknown_timestamp,
+            )?,
         )
         .map(|results| results.into_iter().next().unwrap())
     }
 
     /// Run all tests in the package
-    #[pyo3(signature = (channel=None, channel_priority=None, auth_file=None, allow_insecure_host=None, compression_threads=None, use_bz2=true, use_zstd=true, use_sharded=true, progress_callback=None))]
+    #[pyo3(signature = (channel=None, channel_priority=None, auth_file=None, allow_insecure_host=None, compression_threads=None, use_bz2=true, use_zstd=true, use_sharded=true, progress_callback=None, *, exclude_newer=None, exclude_newer_package=None, exclude_newer_channel=None, exclude_newer_include_unknown_timestamp=false))]
     #[allow(clippy::too_many_arguments)]
     fn run_tests(
         &self,
@@ -311,6 +322,10 @@ impl PyPackage {
         use_zstd: bool,
         use_sharded: bool,
         progress_callback: Option<Py<PyAny>>,
+        exclude_newer: Option<jiff::Timestamp>,
+        exclude_newer_package: Option<HashMap<String, Option<jiff::Timestamp>>>,
+        exclude_newer_channel: Option<HashMap<String, Option<jiff::Timestamp>>>,
+        exclude_newer_include_unknown_timestamp: bool,
     ) -> PyResult<Vec<PyTestResult>> {
         self.run_test_internal(
             None,
@@ -323,6 +338,12 @@ impl PyPackage {
             use_zstd,
             use_sharded,
             progress_callback,
+            crate::exclude_newer::exclude_newer_policy(
+                exclude_newer,
+                exclude_newer_package,
+                exclude_newer_channel,
+                exclude_newer_include_unknown_timestamp,
+            )?,
         )
     }
 
@@ -492,6 +513,7 @@ impl PyPackage {
         use_zstd: bool,
         use_sharded: bool,
         progress_callback: Option<Py<PyAny>>,
+        exclude_newer: Option<rattler_solve::ExcludeNewer>,
     ) -> PyResult<Vec<PyTestResult>> {
         use ::rattler_build::{
             config::Config,
@@ -547,13 +569,14 @@ impl PyPackage {
             .into());
         }
 
-        let test_data = TestData::new(
+        let mut test_data = TestData::new(
             self.path.clone(),
             channel,
             compression_threads,
             test_index,
             common,
         );
+        test_data.exclude_newer = exclude_newer;
 
         // Run the test(s) with log capture and optional streaming callback
         let (result, log_buffer) = tracing_subscriber::with_log_capture(progress_callback, || {

--- a/py-rattler-build/src/rattler_build/__init__.py
+++ b/py-rattler-build/src/rattler_build/__init__.py
@@ -22,6 +22,7 @@ from rattler_build.cli_api import (
     test_package,
 )
 from rattler_build.debug import DebugPaths, DebugSession, ScriptResult
+from rattler_build.exclude_newer import ExcludeNewer
 from rattler_build.jinja_config import JinjaConfig
 from rattler_build.package import (
     CommandsTest,
@@ -80,6 +81,7 @@ __all__ = [
     "DownstreamTest",
     # Build configuration
     "EnvironmentIsolation",
+    "ExcludeNewer",
     "FileChecks",
     "FileEntry",
     "IoError",

--- a/py-rattler-build/src/rattler_build/debug.py
+++ b/py-rattler-build/src/rattler_build/debug.py
@@ -9,12 +9,11 @@ re-run the build script, inspecting output each time.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from rattler_build._rattler_build import debug as _debug
-from rattler_build.exclude_newer import ExcludeNewer, _to_native
+from rattler_build.exclude_newer import ExcludeNewer
 
 if TYPE_CHECKING:
     from rattler_build.progress import ProgressCallback
@@ -100,7 +99,7 @@ class DebugSession:
         channels: list[str] | None = None,
         no_build_id: bool = True,
         progress_callback: ProgressCallback | None = None,
-        exclude_newer: datetime | ExcludeNewer | None = None,
+        exclude_newer: ExcludeNewer | None = None,
     ) -> DebugSession:
         """Create a debug session from a rendered variant.
 
@@ -124,7 +123,7 @@ class DebugSession:
         progress_callback:
             Optional callback for progress events during setup.
         exclude_newer:
-            Dependency cutoff policy, or a datetime for a global cutoff.
+            Dependency cutoff policy.
 
         Returns
         -------
@@ -142,7 +141,7 @@ class DebugSession:
             progress_callback=progress_callback,
             recipe_path=variant._recipe_path,
             repodata_revision=variant._repodata_revision,
-            exclude_newer=_to_native(exclude_newer),
+            exclude_newer=exclude_newer._inner if exclude_newer is not None else None,
         )
         return cls(inner)
 

--- a/py-rattler-build/src/rattler_build/debug.py
+++ b/py-rattler-build/src/rattler_build/debug.py
@@ -9,6 +9,7 @@ re-run the build script, inspecting output each time.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -98,6 +99,10 @@ class DebugSession:
         channels: list[str] | None = None,
         no_build_id: bool = True,
         progress_callback: ProgressCallback | None = None,
+        exclude_newer: datetime | None = None,
+        exclude_newer_package: dict[str, datetime | None] | None = None,
+        exclude_newer_channel: dict[str, datetime | None] | None = None,
+        exclude_newer_include_unknown_timestamp: bool = False,
     ) -> DebugSession:
         """Create a debug session from a rendered variant.
 
@@ -120,6 +125,14 @@ class DebugSession:
             giving stable paths across iterations.
         progress_callback:
             Optional callback for progress events during setup.
+        exclude_newer:
+            Exclude packages newer than this timestamp.
+        exclude_newer_package:
+            Package-specific cutoffs. ``None`` values exempt a package.
+        exclude_newer_channel:
+            Cutoffs keyed by exact channel URL. ``None`` values exempt a channel.
+        exclude_newer_include_unknown_timestamp:
+            Include packages without a timestamp when filtering.
 
         Returns
         -------
@@ -137,6 +150,10 @@ class DebugSession:
             progress_callback=progress_callback,
             recipe_path=variant._recipe_path,
             repodata_revision=variant._repodata_revision,
+            exclude_newer=exclude_newer,
+            exclude_newer_package=exclude_newer_package,
+            exclude_newer_channel=exclude_newer_channel,
+            exclude_newer_include_unknown_timestamp=exclude_newer_include_unknown_timestamp,
         )
         return cls(inner)
 

--- a/py-rattler-build/src/rattler_build/debug.py
+++ b/py-rattler-build/src/rattler_build/debug.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from rattler_build._rattler_build import debug as _debug
+from rattler_build.exclude_newer import ExcludeNewer, _to_native
 
 if TYPE_CHECKING:
     from rattler_build.progress import ProgressCallback
@@ -99,10 +100,7 @@ class DebugSession:
         channels: list[str] | None = None,
         no_build_id: bool = True,
         progress_callback: ProgressCallback | None = None,
-        exclude_newer: datetime | None = None,
-        exclude_newer_package: dict[str, datetime | None] | None = None,
-        exclude_newer_channel: dict[str, datetime | None] | None = None,
-        exclude_newer_include_unknown_timestamp: bool = False,
+        exclude_newer: datetime | ExcludeNewer | None = None,
     ) -> DebugSession:
         """Create a debug session from a rendered variant.
 
@@ -126,13 +124,7 @@ class DebugSession:
         progress_callback:
             Optional callback for progress events during setup.
         exclude_newer:
-            Exclude packages newer than this timestamp.
-        exclude_newer_package:
-            Package-specific cutoffs. ``None`` values exempt a package.
-        exclude_newer_channel:
-            Cutoffs keyed by exact channel URL. ``None`` values exempt a channel.
-        exclude_newer_include_unknown_timestamp:
-            Include packages without a timestamp when filtering.
+            Dependency cutoff policy, or a datetime for a global cutoff.
 
         Returns
         -------
@@ -150,10 +142,7 @@ class DebugSession:
             progress_callback=progress_callback,
             recipe_path=variant._recipe_path,
             repodata_revision=variant._repodata_revision,
-            exclude_newer=exclude_newer,
-            exclude_newer_package=exclude_newer_package,
-            exclude_newer_channel=exclude_newer_channel,
-            exclude_newer_include_unknown_timestamp=exclude_newer_include_unknown_timestamp,
+            exclude_newer=_to_native(exclude_newer),
         )
         return cls(inner)
 

--- a/py-rattler-build/src/rattler_build/exclude_newer.py
+++ b/py-rattler-build/src/rattler_build/exclude_newer.py
@@ -1,0 +1,58 @@
+"""Dependency cutoff policies for builds, package tests, and debug sessions."""
+
+from datetime import datetime
+
+from rattler_build._rattler_build import ExcludeNewer as _ExcludeNewer
+
+
+class ExcludeNewer:
+    """Exclude dependencies newer than global, package, or channel cutoffs.
+
+    Args:
+        cutoff: Global cutoff. If omitted, only package and channel cutoffs apply.
+        packages: Cutoffs keyed by package name. ``None`` values exempt a package.
+            Package cutoffs take precedence over channel and global cutoffs.
+        channels: Cutoffs keyed by exact, absolute channel URL. ``None`` values
+            exempt a channel. Channel cutoffs take precedence over the global cutoff.
+        include_unknown_timestamp: Include packages without a timestamp when filtering.
+
+    A policy without a cutoff or overrides does not enable filtering. Packages
+    produced by the current build are exempt unless a package cutoff applies.
+
+    Example:
+        ```python
+        from datetime import datetime, timezone
+        from rattler_build import ExcludeNewer
+
+        policy = ExcludeNewer(
+            datetime(2024, 1, 1, tzinfo=timezone.utc),
+            packages={"python": None},
+            channels={"https://conda.anaconda.org/conda-forge/": None},
+        )
+        result = variant.run_build(exclude_newer=policy)
+        ```
+    """
+
+    def __init__(
+        self,
+        cutoff: datetime | None = None,
+        *,
+        packages: dict[str, datetime | None] | None = None,
+        channels: dict[str, datetime | None] | None = None,
+        include_unknown_timestamp: bool = False,
+    ):
+        self._inner = _ExcludeNewer(
+            cutoff,
+            packages=packages,
+            channels=channels,
+            include_unknown_timestamp=include_unknown_timestamp,
+        )
+
+
+def _to_native(exclude_newer: datetime | ExcludeNewer | None) -> _ExcludeNewer | None:
+    """Preserve the datetime shorthand accepted by existing build methods."""
+    if exclude_newer is None:
+        return None
+    if isinstance(exclude_newer, ExcludeNewer):
+        return exclude_newer._inner
+    return _ExcludeNewer(exclude_newer)

--- a/py-rattler-build/src/rattler_build/exclude_newer.py
+++ b/py-rattler-build/src/rattler_build/exclude_newer.py
@@ -47,12 +47,3 @@ class ExcludeNewer:
             channels=channels,
             include_unknown_timestamp=include_unknown_timestamp,
         )
-
-
-def _to_native(exclude_newer: datetime | ExcludeNewer | None) -> _ExcludeNewer | None:
-    """Preserve the datetime shorthand accepted by existing build methods."""
-    if exclude_newer is None:
-        return None
-    if isinstance(exclude_newer, ExcludeNewer):
-        return exclude_newer._inner
-    return _ExcludeNewer(exclude_newer)

--- a/py-rattler-build/src/rattler_build/package.py
+++ b/py-rattler-build/src/rattler_build/package.py
@@ -36,6 +36,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Union
 
 from rattler_build._rattler_build import _package
+from rattler_build.exclude_newer import ExcludeNewer, _to_native
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -232,10 +233,7 @@ class Package:
         use_zstd: bool = True,
         use_sharded: bool = True,
         progress_callback: "ProgressCallback | None" = None,
-        exclude_newer: datetime | None = None,
-        exclude_newer_package: dict[str, datetime | None] | None = None,
-        exclude_newer_channel: dict[str, datetime | None] | None = None,
-        exclude_newer_include_unknown_timestamp: bool = False,
+        exclude_newer: datetime | ExcludeNewer | None = None,
     ) -> "TestResult":
         """Run a specific test by index.
 
@@ -250,10 +248,7 @@ class Package:
             use_zstd: Enable zstd repodata
             use_sharded: Enable sharded repodata
             progress_callback: Optional callback for streaming log output in real-time
-            exclude_newer: Exclude packages newer than this timestamp.
-            exclude_newer_package: Package-specific cutoffs. ``None`` values exempt a package.
-            exclude_newer_channel: Cutoffs keyed by exact channel URL. ``None`` values exempt a channel.
-            exclude_newer_include_unknown_timestamp: Include packages without a timestamp when filtering.
+            exclude_newer: Dependency cutoff policy, or a datetime for a global cutoff.
 
         Returns:
             TestResult with success status and output
@@ -280,10 +275,7 @@ class Package:
                 use_zstd=use_zstd,
                 use_sharded=use_sharded,
                 progress_callback=progress_callback,
-                exclude_newer=exclude_newer,
-                exclude_newer_package=exclude_newer_package,
-                exclude_newer_channel=exclude_newer_channel,
-                exclude_newer_include_unknown_timestamp=exclude_newer_include_unknown_timestamp,
+                exclude_newer=_to_native(exclude_newer),
             )
         )
 
@@ -299,10 +291,7 @@ class Package:
         use_zstd: bool = True,
         use_sharded: bool = True,
         progress_callback: "ProgressCallback | None" = None,
-        exclude_newer: datetime | None = None,
-        exclude_newer_package: dict[str, datetime | None] | None = None,
-        exclude_newer_channel: dict[str, datetime | None] | None = None,
-        exclude_newer_include_unknown_timestamp: bool = False,
+        exclude_newer: datetime | ExcludeNewer | None = None,
     ) -> list["TestResult"]:
         """Run all tests in the package.
 
@@ -316,10 +305,7 @@ class Package:
             use_zstd: Enable zstd repodata
             use_sharded: Enable sharded repodata
             progress_callback: Optional callback for streaming log output in real-time
-            exclude_newer: Exclude packages newer than this timestamp.
-            exclude_newer_package: Package-specific cutoffs. ``None`` values exempt a package.
-            exclude_newer_channel: Cutoffs keyed by exact channel URL. ``None`` values exempt a channel.
-            exclude_newer_include_unknown_timestamp: Include packages without a timestamp when filtering.
+            exclude_newer: Dependency cutoff policy, or a datetime for a global cutoff.
 
         Returns:
             List of TestResult objects, one per test
@@ -351,10 +337,7 @@ class Package:
                 use_zstd=use_zstd,
                 use_sharded=use_sharded,
                 progress_callback=progress_callback,
-                exclude_newer=exclude_newer,
-                exclude_newer_package=exclude_newer_package,
-                exclude_newer_channel=exclude_newer_channel,
-                exclude_newer_include_unknown_timestamp=exclude_newer_include_unknown_timestamp,
+                exclude_newer=_to_native(exclude_newer),
             )
         ]
 

--- a/py-rattler-build/src/rattler_build/package.py
+++ b/py-rattler-build/src/rattler_build/package.py
@@ -232,6 +232,10 @@ class Package:
         use_zstd: bool = True,
         use_sharded: bool = True,
         progress_callback: "ProgressCallback | None" = None,
+        exclude_newer: datetime | None = None,
+        exclude_newer_package: dict[str, datetime | None] | None = None,
+        exclude_newer_channel: dict[str, datetime | None] | None = None,
+        exclude_newer_include_unknown_timestamp: bool = False,
     ) -> "TestResult":
         """Run a specific test by index.
 
@@ -246,6 +250,10 @@ class Package:
             use_zstd: Enable zstd repodata
             use_sharded: Enable sharded repodata
             progress_callback: Optional callback for streaming log output in real-time
+            exclude_newer: Exclude packages newer than this timestamp.
+            exclude_newer_package: Package-specific cutoffs. ``None`` values exempt a package.
+            exclude_newer_channel: Cutoffs keyed by exact channel URL. ``None`` values exempt a channel.
+            exclude_newer_include_unknown_timestamp: Include packages without a timestamp when filtering.
 
         Returns:
             TestResult with success status and output
@@ -272,6 +280,10 @@ class Package:
                 use_zstd=use_zstd,
                 use_sharded=use_sharded,
                 progress_callback=progress_callback,
+                exclude_newer=exclude_newer,
+                exclude_newer_package=exclude_newer_package,
+                exclude_newer_channel=exclude_newer_channel,
+                exclude_newer_include_unknown_timestamp=exclude_newer_include_unknown_timestamp,
             )
         )
 
@@ -287,6 +299,10 @@ class Package:
         use_zstd: bool = True,
         use_sharded: bool = True,
         progress_callback: "ProgressCallback | None" = None,
+        exclude_newer: datetime | None = None,
+        exclude_newer_package: dict[str, datetime | None] | None = None,
+        exclude_newer_channel: dict[str, datetime | None] | None = None,
+        exclude_newer_include_unknown_timestamp: bool = False,
     ) -> list["TestResult"]:
         """Run all tests in the package.
 
@@ -300,6 +316,10 @@ class Package:
             use_zstd: Enable zstd repodata
             use_sharded: Enable sharded repodata
             progress_callback: Optional callback for streaming log output in real-time
+            exclude_newer: Exclude packages newer than this timestamp.
+            exclude_newer_package: Package-specific cutoffs. ``None`` values exempt a package.
+            exclude_newer_channel: Cutoffs keyed by exact channel URL. ``None`` values exempt a channel.
+            exclude_newer_include_unknown_timestamp: Include packages without a timestamp when filtering.
 
         Returns:
             List of TestResult objects, one per test
@@ -331,6 +351,10 @@ class Package:
                 use_zstd=use_zstd,
                 use_sharded=use_sharded,
                 progress_callback=progress_callback,
+                exclude_newer=exclude_newer,
+                exclude_newer_package=exclude_newer_package,
+                exclude_newer_channel=exclude_newer_channel,
+                exclude_newer_include_unknown_timestamp=exclude_newer_include_unknown_timestamp,
             )
         ]
 

--- a/py-rattler-build/src/rattler_build/package.py
+++ b/py-rattler-build/src/rattler_build/package.py
@@ -36,7 +36,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Union
 
 from rattler_build._rattler_build import _package
-from rattler_build.exclude_newer import ExcludeNewer, _to_native
+from rattler_build.exclude_newer import ExcludeNewer
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -233,7 +233,7 @@ class Package:
         use_zstd: bool = True,
         use_sharded: bool = True,
         progress_callback: "ProgressCallback | None" = None,
-        exclude_newer: datetime | ExcludeNewer | None = None,
+        exclude_newer: ExcludeNewer | None = None,
     ) -> "TestResult":
         """Run a specific test by index.
 
@@ -248,7 +248,7 @@ class Package:
             use_zstd: Enable zstd repodata
             use_sharded: Enable sharded repodata
             progress_callback: Optional callback for streaming log output in real-time
-            exclude_newer: Dependency cutoff policy, or a datetime for a global cutoff.
+            exclude_newer: Dependency cutoff policy.
 
         Returns:
             TestResult with success status and output
@@ -275,7 +275,7 @@ class Package:
                 use_zstd=use_zstd,
                 use_sharded=use_sharded,
                 progress_callback=progress_callback,
-                exclude_newer=_to_native(exclude_newer),
+                exclude_newer=exclude_newer._inner if exclude_newer is not None else None,
             )
         )
 
@@ -291,7 +291,7 @@ class Package:
         use_zstd: bool = True,
         use_sharded: bool = True,
         progress_callback: "ProgressCallback | None" = None,
-        exclude_newer: datetime | ExcludeNewer | None = None,
+        exclude_newer: ExcludeNewer | None = None,
     ) -> list["TestResult"]:
         """Run all tests in the package.
 
@@ -305,7 +305,7 @@ class Package:
             use_zstd: Enable zstd repodata
             use_sharded: Enable sharded repodata
             progress_callback: Optional callback for streaming log output in real-time
-            exclude_newer: Dependency cutoff policy, or a datetime for a global cutoff.
+            exclude_newer: Dependency cutoff policy.
 
         Returns:
             List of TestResult objects, one per test
@@ -337,7 +337,7 @@ class Package:
                 use_zstd=use_zstd,
                 use_sharded=use_sharded,
                 progress_callback=progress_callback,
-                exclude_newer=_to_native(exclude_newer),
+                exclude_newer=exclude_newer._inner if exclude_newer is not None else None,
             )
         ]
 

--- a/py-rattler-build/src/rattler_build/render.py
+++ b/py-rattler-build/src/rattler_build/render.py
@@ -19,6 +19,7 @@ from rattler_build._rattler_build import (
 )
 from rattler_build._rattler_build import render as _render
 from rattler_build.build_result import BuildResult
+from rattler_build.exclude_newer import ExcludeNewer, _to_native
 from rattler_build.tool_config import PlatformConfig, ToolConfiguration
 
 if TYPE_CHECKING:
@@ -354,12 +355,8 @@ class RenderedVariant:
         no_build_id: bool = False,
         package_format: str | None = None,
         no_include_recipe: bool = False,
-        exclude_newer: datetime | None = None,
+        exclude_newer: datetime | ExcludeNewer | None = None,
         env_isolation: EnvironmentIsolation = EnvironmentIsolation.STRICT,
-        *,
-        exclude_newer_package: dict[str, datetime | None] | None = None,
-        exclude_newer_channel: dict[str, datetime | None] | None = None,
-        exclude_newer_include_unknown_timestamp: bool = False,
     ) -> BuildResult:
         """Build this rendered variant.
 
@@ -380,11 +377,8 @@ class RenderedVariant:
             no_build_id: Don't include build ID in output directory.
             package_format: Package format ("conda" or "tar.bz2").
             no_include_recipe: Don't include recipe in the output package.
-            exclude_newer: Exclude packages newer than this timestamp.
+            exclude_newer: Dependency cutoff policy, or a datetime for a global cutoff.
             env_isolation: Environment isolation mode. Defaults to ``EnvironmentIsolation.STRICT``.
-            exclude_newer_package: Package-specific cutoffs. ``None`` values exempt a package.
-            exclude_newer_channel: Cutoffs keyed by exact channel URL. ``None`` values exempt a channel.
-            exclude_newer_include_unknown_timestamp: Include packages without a timestamp when filtering.
 
         Returns:
             BuildResult: Information about the built package including paths, metadata, and timing.
@@ -427,13 +421,10 @@ class RenderedVariant:
             no_build_id=no_build_id,
             package_format=package_format,
             no_include_recipe=no_include_recipe,
-            exclude_newer=exclude_newer,
+            exclude_newer=_to_native(exclude_newer),
             env_isolation=env_isolation,
             sibling_variants=rust_siblings,
             repodata_revision=self._repodata_revision,
-            exclude_newer_package=exclude_newer_package,
-            exclude_newer_channel=exclude_newer_channel,
-            exclude_newer_include_unknown_timestamp=exclude_newer_include_unknown_timestamp,
         )
 
         # Convert Rust BuildResult to Python BuildResult
@@ -453,11 +444,8 @@ def build_rendered_variants(
     no_build_id: bool = False,
     package_format: str | None = None,
     no_include_recipe: bool = False,
-    exclude_newer: datetime | None = None,
+    exclude_newer: datetime | ExcludeNewer | None = None,
     env_isolation: EnvironmentIsolation = EnvironmentIsolation.STRICT,
-    exclude_newer_package: dict[str, datetime | None] | None = None,
-    exclude_newer_channel: dict[str, datetime | None] | None = None,
-    exclude_newer_include_unknown_timestamp: bool = False,
 ) -> list[BuildResult]:
     """Build multiple rendered variants.
 
@@ -476,11 +464,8 @@ def build_rendered_variants(
         no_build_id: Don't include build ID in output directory.
         package_format: Package format ("conda" or "tar.bz2").
         no_include_recipe: Don't include recipe in the output package.
-        exclude_newer: Exclude packages newer than this timestamp.
+        exclude_newer: Dependency cutoff policy, or a datetime for a global cutoff.
         env_isolation: Environment isolation mode. Defaults to ``EnvironmentIsolation.STRICT``.
-        exclude_newer_package: Package-specific cutoffs. ``None`` values exempt a package.
-        exclude_newer_channel: Cutoffs keyed by exact channel URL. ``None`` values exempt a channel.
-        exclude_newer_include_unknown_timestamp: Include packages without a timestamp when filtering.
 
     Returns:
         list[BuildResult]: List of build results, one per variant built.
@@ -521,9 +506,6 @@ def build_rendered_variants(
             no_include_recipe=no_include_recipe,
             exclude_newer=exclude_newer,
             env_isolation=env_isolation,
-            exclude_newer_package=exclude_newer_package,
-            exclude_newer_channel=exclude_newer_channel,
-            exclude_newer_include_unknown_timestamp=exclude_newer_include_unknown_timestamp,
         )
         results.append(result)
 

--- a/py-rattler-build/src/rattler_build/render.py
+++ b/py-rattler-build/src/rattler_build/render.py
@@ -356,6 +356,10 @@ class RenderedVariant:
         no_include_recipe: bool = False,
         exclude_newer: datetime | None = None,
         env_isolation: EnvironmentIsolation = EnvironmentIsolation.STRICT,
+        *,
+        exclude_newer_package: dict[str, datetime | None] | None = None,
+        exclude_newer_channel: dict[str, datetime | None] | None = None,
+        exclude_newer_include_unknown_timestamp: bool = False,
     ) -> BuildResult:
         """Build this rendered variant.
 
@@ -378,6 +382,9 @@ class RenderedVariant:
             no_include_recipe: Don't include recipe in the output package.
             exclude_newer: Exclude packages newer than this timestamp.
             env_isolation: Environment isolation mode. Defaults to ``EnvironmentIsolation.STRICT``.
+            exclude_newer_package: Package-specific cutoffs. ``None`` values exempt a package.
+            exclude_newer_channel: Cutoffs keyed by exact channel URL. ``None`` values exempt a channel.
+            exclude_newer_include_unknown_timestamp: Include packages without a timestamp when filtering.
 
         Returns:
             BuildResult: Information about the built package including paths, metadata, and timing.
@@ -424,6 +431,9 @@ class RenderedVariant:
             env_isolation=env_isolation,
             sibling_variants=rust_siblings,
             repodata_revision=self._repodata_revision,
+            exclude_newer_package=exclude_newer_package,
+            exclude_newer_channel=exclude_newer_channel,
+            exclude_newer_include_unknown_timestamp=exclude_newer_include_unknown_timestamp,
         )
 
         # Convert Rust BuildResult to Python BuildResult
@@ -445,6 +455,9 @@ def build_rendered_variants(
     no_include_recipe: bool = False,
     exclude_newer: datetime | None = None,
     env_isolation: EnvironmentIsolation = EnvironmentIsolation.STRICT,
+    exclude_newer_package: dict[str, datetime | None] | None = None,
+    exclude_newer_channel: dict[str, datetime | None] | None = None,
+    exclude_newer_include_unknown_timestamp: bool = False,
 ) -> list[BuildResult]:
     """Build multiple rendered variants.
 
@@ -465,6 +478,9 @@ def build_rendered_variants(
         no_include_recipe: Don't include recipe in the output package.
         exclude_newer: Exclude packages newer than this timestamp.
         env_isolation: Environment isolation mode. Defaults to ``EnvironmentIsolation.STRICT``.
+        exclude_newer_package: Package-specific cutoffs. ``None`` values exempt a package.
+        exclude_newer_channel: Cutoffs keyed by exact channel URL. ``None`` values exempt a channel.
+        exclude_newer_include_unknown_timestamp: Include packages without a timestamp when filtering.
 
     Returns:
         list[BuildResult]: List of build results, one per variant built.
@@ -505,6 +521,9 @@ def build_rendered_variants(
             no_include_recipe=no_include_recipe,
             exclude_newer=exclude_newer,
             env_isolation=env_isolation,
+            exclude_newer_package=exclude_newer_package,
+            exclude_newer_channel=exclude_newer_channel,
+            exclude_newer_include_unknown_timestamp=exclude_newer_include_unknown_timestamp,
         )
         results.append(result)
 

--- a/py-rattler-build/src/rattler_build/render.py
+++ b/py-rattler-build/src/rattler_build/render.py
@@ -19,7 +19,7 @@ from rattler_build._rattler_build import (
 )
 from rattler_build._rattler_build import render as _render
 from rattler_build.build_result import BuildResult
-from rattler_build.exclude_newer import ExcludeNewer, _to_native
+from rattler_build.exclude_newer import ExcludeNewer
 from rattler_build.tool_config import PlatformConfig, ToolConfiguration
 
 if TYPE_CHECKING:
@@ -410,6 +410,9 @@ class RenderedVariant:
 
         rust_siblings = [v._inner for v in self._siblings]
 
+        if isinstance(exclude_newer, datetime):
+            exclude_newer = ExcludeNewer(exclude_newer)
+
         # Build this single variant
         rust_result = build_rendered_variant_py(
             rendered_variant=self._inner,
@@ -421,7 +424,7 @@ class RenderedVariant:
             no_build_id=no_build_id,
             package_format=package_format,
             no_include_recipe=no_include_recipe,
-            exclude_newer=_to_native(exclude_newer),
+            exclude_newer=exclude_newer._inner if exclude_newer is not None else None,
             env_isolation=env_isolation,
             sibling_variants=rust_siblings,
             repodata_revision=self._repodata_revision,

--- a/py-rattler-build/src/rattler_build/stage0.py
+++ b/py-rattler-build/src/rattler_build/stage0.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any
 from rattler_build._rattler_build import EnvironmentIsolation, RepodataRevision
 from rattler_build._rattler_build import render as _render
 from rattler_build._rattler_build import stage0 as _stage0
+from rattler_build.exclude_newer import ExcludeNewer
 from rattler_build.render import RenderConfig, RenderedVariant
 from rattler_build.tool_config import ToolConfiguration
 from rattler_build.variant_config import VariantConfig
@@ -300,13 +301,9 @@ class Stage0Recipe(ABC):
         no_build_id: bool = False,
         package_format: str | None = None,
         no_include_recipe: bool = False,
-        exclude_newer: datetime | None = None,
+        exclude_newer: datetime | ExcludeNewer | None = None,
         env_isolation: EnvironmentIsolation = EnvironmentIsolation.STRICT,
         render_config: RenderConfig | None = None,
-        *,
-        exclude_newer_package: dict[str, datetime | None] | None = None,
-        exclude_newer_channel: dict[str, datetime | None] | None = None,
-        exclude_newer_include_unknown_timestamp: bool = False,
     ) -> list[BuildResult]:
         """Build this recipe.
 
@@ -324,12 +321,9 @@ class Stage0Recipe(ABC):
             no_build_id: Don't include build ID in output directory.
             package_format: Package format ("conda" or "tar.bz2").
             no_include_recipe: Don't include recipe in the output package.
-            exclude_newer: Exclude packages newer than this timestamp.
+            exclude_newer: Dependency cutoff policy, or a datetime for a global cutoff.
             env_isolation: Environment isolation mode. Defaults to ``EnvironmentIsolation.STRICT``.
             render_config: Optional RenderConfig to use when rendering before building.
-            exclude_newer_package: Package-specific cutoffs. ``None`` values exempt a package.
-            exclude_newer_channel: Cutoffs keyed by exact channel URL. ``None`` values exempt a channel.
-            exclude_newer_include_unknown_timestamp: Include packages without a timestamp when filtering.
 
         Returns:
             list[BuildResult]: List of build results, one per variant built.
@@ -366,9 +360,6 @@ class Stage0Recipe(ABC):
                 no_include_recipe=no_include_recipe,
                 exclude_newer=exclude_newer,
                 env_isolation=env_isolation,
-                exclude_newer_package=exclude_newer_package,
-                exclude_newer_channel=exclude_newer_channel,
-                exclude_newer_include_unknown_timestamp=exclude_newer_include_unknown_timestamp,
             )
             results.append(result)
 

--- a/py-rattler-build/src/rattler_build/stage0.py
+++ b/py-rattler-build/src/rattler_build/stage0.py
@@ -303,6 +303,10 @@ class Stage0Recipe(ABC):
         exclude_newer: datetime | None = None,
         env_isolation: EnvironmentIsolation = EnvironmentIsolation.STRICT,
         render_config: RenderConfig | None = None,
+        *,
+        exclude_newer_package: dict[str, datetime | None] | None = None,
+        exclude_newer_channel: dict[str, datetime | None] | None = None,
+        exclude_newer_include_unknown_timestamp: bool = False,
     ) -> list[BuildResult]:
         """Build this recipe.
 
@@ -323,6 +327,9 @@ class Stage0Recipe(ABC):
             exclude_newer: Exclude packages newer than this timestamp.
             env_isolation: Environment isolation mode. Defaults to ``EnvironmentIsolation.STRICT``.
             render_config: Optional RenderConfig to use when rendering before building.
+            exclude_newer_package: Package-specific cutoffs. ``None`` values exempt a package.
+            exclude_newer_channel: Cutoffs keyed by exact channel URL. ``None`` values exempt a channel.
+            exclude_newer_include_unknown_timestamp: Include packages without a timestamp when filtering.
 
         Returns:
             list[BuildResult]: List of build results, one per variant built.
@@ -359,6 +366,9 @@ class Stage0Recipe(ABC):
                 no_include_recipe=no_include_recipe,
                 exclude_newer=exclude_newer,
                 env_isolation=env_isolation,
+                exclude_newer_package=exclude_newer_package,
+                exclude_newer_channel=exclude_newer_channel,
+                exclude_newer_include_unknown_timestamp=exclude_newer_include_unknown_timestamp,
             )
             results.append(result)
 

--- a/py-rattler-build/tests/unit/test_exclude_newer.py
+++ b/py-rattler-build/tests/unit/test_exclude_newer.py
@@ -188,7 +188,7 @@ def test_build_and_test_cutoff(cutoff_channel: str, tmp_path: Path, entrypoint: 
         options["exclude_newer"] = ExcludeNewer(packages={"cutoff-dependency": CUTOFF, "cutoff-other": CUTOFF})
         result = recipe.run_build(**options)[0]
     elif entrypoint == "variant":
-        options["exclude_newer"] = CUTOFF
+        options["exclude_newer"] = ExcludeNewer(CUTOFF)
         result = recipe.render()[0].run_build(**options)
     else:
         options["exclude_newer"] = ExcludeNewer(channels={cutoff_channel: CUTOFF})
@@ -196,7 +196,7 @@ def test_build_and_test_cutoff(cutoff_channel: str, tmp_path: Path, entrypoint: 
 
     package = Package.from_file(result.packages[0])
     assert package.timestamp is not None and package.timestamp > CUTOFF
-    tests = package.run_tests(channel=[cutoff_channel], exclude_newer=CUTOFF)
+    tests = package.run_tests(channel=[cutoff_channel], exclude_newer=ExcludeNewer(CUTOFF))
     assert len(tests) == 1 and tests[0].success
     assert package.run_test(
         0,

--- a/py-rattler-build/tests/unit/test_exclude_newer.py
+++ b/py-rattler-build/tests/unit/test_exclude_newer.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import hashlib
 import io
 import json
-import subprocess
+import os
+import re
+import shutil
 import sys
 import tarfile
-from base64 import b64encode
 from collections.abc import Iterator
 from datetime import datetime, timezone
 from pathlib import Path
@@ -17,6 +18,8 @@ from urllib.parse import urlsplit
 from urllib.request import url2pathname
 
 import pytest
+from xprocess import ProcessStarter
+from xprocess.xprocess import XProcess
 
 from rattler_build import Package, Stage0Recipe, ToolConfiguration
 from rattler_build.debug import DebugSession
@@ -106,46 +109,27 @@ def cutoff_channel(tmp_path: Path) -> str:
 
 
 @pytest.fixture
-def cutoff_http_channel(cutoff_channel: str, tmp_path: Path) -> Iterator[tuple[str, Path]]:
+def cutoff_http_channel(cutoff_channel: str, tmp_path: Path, xprocess: XProcess) -> Iterator[str]:
     """Serve the tiny channel independently of the native binding's Python GIL."""
-    requests_path = tmp_path / "requests.jsonl"
-    requests_path.touch()
-    server_code = """
-import json
-import sys
-from functools import partial
-from http.server import HTTPServer, SimpleHTTPRequestHandler
+    shutil.copytree(
+        url2pathname(urlsplit(cutoff_channel).path),
+        tmp_path / "t" / "cutoff-test-token" / "channel",
+    )
 
-class Handler(SimpleHTTPRequestHandler):
-    def do_GET(self):
-        with open(sys.argv[2], "a") as requests:
-            requests.write(json.dumps({
-                "path": self.path,
-                "authorization": self.headers.get("Authorization"),
-            }) + "\\n")
-        if self.path.startswith("/t/cutoff-test-token/"):
-            self.path = self.path.removeprefix("/t/cutoff-test-token")
-        super().do_GET()
+    class Starter(ProcessStarter):
+        pattern = r"Serving HTTP on 127\.0\.0\.1 port (\d+)"
+        timeout = 10
+        terminate_on_interrupt = True
+        args = (sys.executable, "-u", "-m", "http.server", "0", "--bind", "127.0.0.1", "--directory", str(tmp_path))
 
-    def log_message(self, *args):
-        pass
-
-with HTTPServer(("127.0.0.1", 0), partial(Handler, directory=sys.argv[1])) as server:
-    print(server.server_address[1], flush=True)
-    server.serve_forever()
-"""
-    with subprocess.Popen(
-        [sys.executable, "-u", "-c", server_code, url2pathname(urlsplit(cutoff_channel).path), str(requests_path)],
-        stdout=subprocess.PIPE,
-        text=True,
-    ) as server:
-        assert server.stdout is not None
-        port = int(server.stdout.readline())
-        try:
-            yield f"http://127.0.0.1:{port}", requests_path
-        finally:
-            server.terminate()
-            server.wait(timeout=5)
+    name = f"cutoff-http-{os.getpid()}"
+    try:
+        _, logfile = xprocess.ensure(name, Starter, persist_logs=False)
+        match = re.search(Starter.pattern, logfile.read())
+        assert match is not None
+        yield f"http://127.0.0.1:{match[1]}"
+    finally:
+        xprocess.getinfo(name).terminate()
 
 
 def dependency_recipe() -> Stage0Recipe:
@@ -315,16 +299,16 @@ def test_invalid_package_override(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize("authentication", ["none", "basic", "token"])
-def test_authenticated_channel_cutoff(
-    cutoff_http_channel: tuple[str, Path], tmp_path: Path, authentication: str
+def test_channel_cutoff_matches_authenticated_urls(
+    cutoff_http_channel: str, tmp_path: Path, authentication: str
 ) -> None:
-    base_url, requests_path = cutoff_http_channel
+    base_url = cutoff_http_channel
     if authentication == "basic":
-        channel = base_url.replace("http://", "http://cutoff-user:cutoff-password@")
+        channel = base_url.replace("http://", "http://cutoff-user:cutoff-password@") + "/channel"
     elif authentication == "token":
-        channel = base_url + "/t/cutoff-test-token"
+        channel = base_url + "/t/cutoff-test-token/channel"
     else:
-        channel = base_url
+        channel = base_url + "/channel"
     session = DebugSession.create(
         dependency_recipe().render()[0],
         output_dir=tmp_path / "debug",
@@ -334,15 +318,6 @@ def test_authenticated_channel_cutoff(
     )
     assert (session.build_prefix / "share/cutoff-dependency.txt").read_text().strip() == "1"
     assert (session.host_prefix / "share/cutoff-other.txt").read_text().strip() == "1"
-    requests = [json.loads(line) for line in requests_path.read_text().splitlines()]
-    assert any(request["path"].endswith("/noarch/repodata.json") for request in requests)
-    if authentication == "basic":
-        expected_auth = "Basic " + b64encode(b"cutoff-user:cutoff-password").decode()
-        assert all(request["authorization"] == expected_auth for request in requests)
-    elif authentication == "token":
-        assert all(request["path"].startswith("/t/cutoff-test-token/") for request in requests)
-    else:
-        assert all(request["authorization"] is None for request in requests)
 
 
 @pytest.mark.parametrize("channel", ["conda-forge", "relative/channel", "mailto:channel@example.com"])

--- a/py-rattler-build/tests/unit/test_exclude_newer.py
+++ b/py-rattler-build/tests/unit/test_exclude_newer.py
@@ -1,0 +1,355 @@
+"""Cutoff policies resolve real packages from an offline channel."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import subprocess
+import sys
+import tarfile
+from base64 import b64encode
+from collections.abc import Iterator
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal
+from urllib.parse import urlsplit
+from urllib.request import url2pathname
+
+import pytest
+
+from rattler_build import Package, Stage0Recipe, ToolConfiguration
+from rattler_build.debug import DebugSession
+from rattler_build.render import build_rendered_variants
+
+CUTOFF = datetime(2024, 1, 1, tzinfo=timezone.utc)
+OLD = datetime(2020, 1, 1, tzinfo=timezone.utc)
+NEW = datetime(2030, 1, 1, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def cutoff_channel(tmp_path: Path) -> str:
+    channel = tmp_path / "channel"
+    records = {}
+    for name in ("cutoff-dependency", "cutoff-other", "cutoff-unknown"):
+        for version, timestamp in (("1", OLD), ("2", NEW)):
+            if name == "cutoff-unknown" and version == "2":
+                continue
+            index: dict[str, Any] = {
+                "name": name,
+                "version": version,
+                "build": "0",
+                "build_number": 0,
+                "subdir": "noarch",
+                "noarch": "generic",
+                "depends": [],
+            }
+            if name != "cutoff-unknown":
+                index["timestamp"] = int(timestamp.timestamp() * 1000)
+            marker = f"share/{name}.txt"
+            content = f"{version}\n".encode()
+            paths = {
+                "paths_version": 1,
+                "paths": [
+                    {
+                        "_path": marker,
+                        "path_type": "hardlink",
+                        "sha256": hashlib.sha256(content).hexdigest(),
+                        "size_in_bytes": len(content),
+                    }
+                ],
+            }
+            package_path = channel / "noarch" / f"{name}-{version}-0.tar.bz2"
+            package_path.parent.mkdir(parents=True, exist_ok=True)
+            with tarfile.open(package_path, "w:bz2") as archive:
+                for filename, data in {
+                    "info/index.json": json.dumps(index).encode(),
+                    "info/paths.json": json.dumps(paths).encode(),
+                    "info/files": f"{marker}\n".encode(),
+                    marker: content,
+                }.items():
+                    entry = tarfile.TarInfo(filename)
+                    entry.size = len(data)
+                    entry.mode = 0o644
+                    archive.addfile(entry, io.BytesIO(data))
+            records[package_path.name] = {
+                **index,
+                "sha256": hashlib.sha256(package_path.read_bytes()).hexdigest(),
+                "size": package_path.stat().st_size,
+            }
+    for subdir in (
+        "noarch",
+        "linux-64",
+        "linux-aarch64",
+        "linux-ppc64le",
+        "linux-s390x",
+        "linux-armv7l",
+        "linux-riscv64",
+        "osx-64",
+        "osx-arm64",
+        "win-64",
+        "win-arm64",
+    ):
+        destination = channel / subdir
+        destination.mkdir(exist_ok=True)
+        (destination / "repodata.json").write_text(
+            json.dumps(
+                {
+                    "info": {"subdir": subdir},
+                    "repodata_version": 1,
+                    "packages": records if subdir == "noarch" else {},
+                    "packages.conda": {},
+                }
+            )
+        )
+    return channel.as_uri() + "/"
+
+
+@pytest.fixture
+def cutoff_http_channel(cutoff_channel: str, tmp_path: Path) -> Iterator[tuple[str, Path]]:
+    """Serve the tiny channel independently of the native binding's Python GIL."""
+    requests_path = tmp_path / "requests.jsonl"
+    requests_path.touch()
+    server_code = """
+import json
+import sys
+from functools import partial
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+
+class Handler(SimpleHTTPRequestHandler):
+    def do_GET(self):
+        with open(sys.argv[2], "a") as requests:
+            requests.write(json.dumps({
+                "path": self.path,
+                "authorization": self.headers.get("Authorization"),
+            }) + "\\n")
+        if self.path.startswith("/t/cutoff-test-token/"):
+            self.path = self.path.removeprefix("/t/cutoff-test-token")
+        super().do_GET()
+
+    def log_message(self, *args):
+        pass
+
+with HTTPServer(("127.0.0.1", 0), partial(Handler, directory=sys.argv[1])) as server:
+    print(server.server_address[1], flush=True)
+    server.serve_forever()
+"""
+    with subprocess.Popen(
+        [sys.executable, "-u", "-c", server_code, url2pathname(urlsplit(cutoff_channel).path), str(requests_path)],
+        stdout=subprocess.PIPE,
+        text=True,
+    ) as server:
+        assert server.stdout is not None
+        port = int(server.stdout.readline())
+        try:
+            yield f"http://127.0.0.1:{port}", requests_path
+        finally:
+            server.terminate()
+            server.wait(timeout=5)
+
+
+def dependency_recipe() -> Stage0Recipe:
+    """Assert selected dependencies in both build prefixes and native tests."""
+    return Stage0Recipe.from_yaml(
+        """
+package:
+  name: cutoff-result
+  version: "1"
+build:
+  noarch: generic
+  script:
+    - if: unix
+      then:
+        - test "$(cat "$BUILD_PREFIX/share/cutoff-dependency.txt")" = "1"
+        - test "$(cat "$PREFIX/share/cutoff-other.txt")" = "1"
+        - echo built > "$PREFIX/cutoff-result.txt"
+      else:
+        - findstr /x "1" "%BUILD_PREFIX%\\share\\cutoff-dependency.txt"
+        - findstr /x "1" "%PREFIX%\\share\\cutoff-other.txt"
+        - echo built > "%PREFIX%\\cutoff-result.txt"
+requirements:
+  build:
+    - cutoff-dependency
+  host:
+    - cutoff-other
+  run:
+    - cutoff-other
+tests:
+  - requirements:
+      run:
+        - cutoff-dependency
+    script:
+      - if: unix
+        then:
+          - test "$(cat "$PREFIX/share/cutoff-dependency.txt")" = "1"
+          - test "$(cat "$PREFIX/share/cutoff-other.txt")" = "1"
+          - test -f "$PREFIX/cutoff-result.txt"
+        else:
+          - findstr /x "1" "%PREFIX%\\share\\cutoff-dependency.txt"
+          - findstr /x "1" "%PREFIX%\\share\\cutoff-other.txt"
+          - if not exist "%PREFIX%\\cutoff-result.txt" exit 1
+"""
+    )
+
+
+@pytest.mark.parametrize("entrypoint", ["recipe", "variant", "variants"])
+def test_build_and_test_cutoff(cutoff_channel: str, tmp_path: Path, entrypoint: str) -> None:
+    recipe = dependency_recipe()
+    options: dict[str, Any] = {
+        "output_dir": tmp_path / "output",
+        "channels": [cutoff_channel],
+        "tool_config": ToolConfiguration(test_strategy="native"),
+    }
+    if entrypoint == "recipe":
+        options["exclude_newer_package"] = {"cutoff-dependency": CUTOFF, "cutoff-other": CUTOFF}
+        result = recipe.run_build(**options)[0]
+    elif entrypoint == "variant":
+        options["exclude_newer"] = CUTOFF
+        result = recipe.render()[0].run_build(**options)
+    else:
+        options["exclude_newer_channel"] = {cutoff_channel: CUTOFF}
+        result = build_rendered_variants(recipe.render(), **options)[0]
+
+    package = Package.from_file(result.packages[0])
+    assert package.timestamp is not None and package.timestamp > CUTOFF
+    tests = package.run_tests(channel=[cutoff_channel], exclude_newer=CUTOFF)
+    assert len(tests) == 1 and tests[0].success
+    assert package.run_test(
+        0,
+        channel=[cutoff_channel],
+        exclude_newer_package={"cutoff-dependency": CUTOFF, "cutoff-other": CUTOFF},
+    ).success
+    if entrypoint == "variant":
+        # Explicit package cutoffs take precedence over the test channel exemption.
+        blocked = package.run_tests(
+            channel=[cutoff_channel],
+            exclude_newer=CUTOFF,
+            exclude_newer_package={"cutoff-result": CUTOFF},
+        )
+        assert len(blocked) == 1 and not blocked[0].success
+
+
+@pytest.mark.parametrize(
+    ("global_cutoff", "package_cutoffs", "channel_cutoff", "expected"),
+    [
+        (CUTOFF, None, "unset", ("1", "1")),
+        (None, {"cutoff-dependency": CUTOFF}, "unset", ("1", "2")),
+        (CUTOFF, {"cutoff-dependency": None}, "unset", ("2", "1")),
+        (None, None, CUTOFF, ("1", "1")),
+        (CUTOFF, None, None, ("2", "2")),
+        (CUTOFF, {"cutoff-dependency": CUTOFF}, None, ("1", "2")),
+        (CUTOFF, {"cutoff-dependency": None}, CUTOFF, ("2", "1")),
+    ],
+)
+def test_debug_cutoff_overrides(
+    cutoff_channel: str,
+    tmp_path: Path,
+    global_cutoff: datetime | None,
+    package_cutoffs: dict[str, datetime | None] | None,
+    channel_cutoff: datetime | None | Literal["unset"],
+    expected: tuple[str, str],
+) -> None:
+    session = DebugSession.create(
+        dependency_recipe().render()[0],
+        output_dir=tmp_path / "debug",
+        channels=[cutoff_channel],
+        exclude_newer=global_cutoff,
+        exclude_newer_package=package_cutoffs,
+        exclude_newer_channel=None if channel_cutoff == "unset" else {cutoff_channel: channel_cutoff},
+    )
+    assert (session.build_prefix / "share/cutoff-dependency.txt").read_text().strip() == expected[0]
+    assert (session.host_prefix / "share/cutoff-other.txt").read_text().strip() == expected[1]
+    session.add_packages(["cutoff-dependency"])
+    assert (session.host_prefix / "share/cutoff-dependency.txt").read_text().strip() == expected[0]
+
+
+@pytest.mark.parametrize(
+    ("cutoff", "include_unknown", "succeeds"),
+    [(CUTOFF, False, False), (CUTOFF, True, True), (None, False, True), (None, True, True)],
+)
+def test_unknown_timestamps(
+    cutoff_channel: str,
+    tmp_path: Path,
+    cutoff: datetime | None,
+    include_unknown: bool,
+    succeeds: bool,
+) -> None:
+    recipe = Stage0Recipe.from_yaml(
+        """
+package:
+  name: unknown-timestamp-result
+  version: "1"
+requirements:
+  host:
+    - cutoff-unknown
+"""
+    )
+
+    def create_session() -> DebugSession:
+        return DebugSession.create(
+            recipe.render()[0],
+            output_dir=tmp_path / "debug",
+            channels=[cutoff_channel],
+            exclude_newer=cutoff,
+            exclude_newer_package={},
+            exclude_newer_channel={},
+            exclude_newer_include_unknown_timestamp=include_unknown,
+        )
+
+    if succeeds:
+        assert (create_session().host_prefix / "share/cutoff-unknown.txt").is_file()
+    else:
+        from rattler_build import BuildError
+
+        with pytest.raises(BuildError):
+            create_session()
+
+
+def test_invalid_package_override(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="invalid exclude_newer_package name"):
+        dependency_recipe().render()[0].run_build(
+            output_dir=tmp_path / "output",
+            channels=[],
+            exclude_newer_package={"invalid package name": CUTOFF},
+        )
+
+
+@pytest.mark.parametrize("authentication", ["none", "basic", "token"])
+def test_authenticated_channel_cutoff(
+    cutoff_http_channel: tuple[str, Path], tmp_path: Path, authentication: str
+) -> None:
+    base_url, requests_path = cutoff_http_channel
+    if authentication == "basic":
+        channel = base_url.replace("http://", "http://cutoff-user:cutoff-password@")
+    elif authentication == "token":
+        channel = base_url + "/t/cutoff-test-token"
+    else:
+        channel = base_url
+    session = DebugSession.create(
+        dependency_recipe().render()[0],
+        output_dir=tmp_path / "debug",
+        channels=[channel],
+        exclude_newer_channel={channel: CUTOFF},
+        tool_config=ToolConfiguration(use_bz2=False, use_zstd=False, use_sharded=False),
+    )
+    assert (session.build_prefix / "share/cutoff-dependency.txt").read_text().strip() == "1"
+    assert (session.host_prefix / "share/cutoff-other.txt").read_text().strip() == "1"
+    requests = [json.loads(line) for line in requests_path.read_text().splitlines()]
+    assert any(request["path"].endswith("/noarch/repodata.json") for request in requests)
+    if authentication == "basic":
+        expected_auth = "Basic " + b64encode(b"cutoff-user:cutoff-password").decode()
+        assert all(request["authorization"] == expected_auth for request in requests)
+    elif authentication == "token":
+        assert all(request["path"].startswith("/t/cutoff-test-token/") for request in requests)
+    else:
+        assert all(request["authorization"] is None for request in requests)
+
+
+@pytest.mark.parametrize("channel", ["conda-forge", "relative/channel", "mailto:channel@example.com"])
+def test_invalid_channel_override(tmp_path: Path, channel: str) -> None:
+    with pytest.raises(ValueError, match="exclude_newer_channel"):
+        dependency_recipe().render()[0].run_build(
+            output_dir=tmp_path / "output",
+            channels=[],
+            exclude_newer_channel={channel: CUTOFF},
+        )

--- a/py-rattler-build/tests/unit/test_exclude_newer.py
+++ b/py-rattler-build/tests/unit/test_exclude_newer.py
@@ -21,7 +21,7 @@ import pytest
 from xprocess import ProcessStarter
 from xprocess.xprocess import XProcess
 
-from rattler_build import Package, Stage0Recipe, ToolConfiguration
+from rattler_build import ExcludeNewer, Package, Stage0Recipe, ToolConfiguration
 from rattler_build.debug import DebugSession
 from rattler_build.render import build_rendered_variants
 
@@ -185,13 +185,13 @@ def test_build_and_test_cutoff(cutoff_channel: str, tmp_path: Path, entrypoint: 
         "tool_config": ToolConfiguration(test_strategy="native"),
     }
     if entrypoint == "recipe":
-        options["exclude_newer_package"] = {"cutoff-dependency": CUTOFF, "cutoff-other": CUTOFF}
+        options["exclude_newer"] = ExcludeNewer(packages={"cutoff-dependency": CUTOFF, "cutoff-other": CUTOFF})
         result = recipe.run_build(**options)[0]
     elif entrypoint == "variant":
         options["exclude_newer"] = CUTOFF
         result = recipe.render()[0].run_build(**options)
     else:
-        options["exclude_newer_channel"] = {cutoff_channel: CUTOFF}
+        options["exclude_newer"] = ExcludeNewer(channels={cutoff_channel: CUTOFF})
         result = build_rendered_variants(recipe.render(), **options)[0]
 
     package = Package.from_file(result.packages[0])
@@ -201,14 +201,13 @@ def test_build_and_test_cutoff(cutoff_channel: str, tmp_path: Path, entrypoint: 
     assert package.run_test(
         0,
         channel=[cutoff_channel],
-        exclude_newer_package={"cutoff-dependency": CUTOFF, "cutoff-other": CUTOFF},
+        exclude_newer=options["exclude_newer"],
     ).success
     if entrypoint == "variant":
         # Explicit package cutoffs take precedence over the test channel exemption.
         blocked = package.run_tests(
             channel=[cutoff_channel],
-            exclude_newer=CUTOFF,
-            exclude_newer_package={"cutoff-result": CUTOFF},
+            exclude_newer=ExcludeNewer(CUTOFF, packages={"cutoff-result": CUTOFF}),
         )
         assert len(blocked) == 1 and not blocked[0].success
 
@@ -237,9 +236,11 @@ def test_debug_cutoff_overrides(
         dependency_recipe().render()[0],
         output_dir=tmp_path / "debug",
         channels=[cutoff_channel],
-        exclude_newer=global_cutoff,
-        exclude_newer_package=package_cutoffs,
-        exclude_newer_channel=None if channel_cutoff == "unset" else {cutoff_channel: channel_cutoff},
+        exclude_newer=ExcludeNewer(
+            global_cutoff,
+            packages=package_cutoffs,
+            channels=None if channel_cutoff == "unset" else {cutoff_channel: channel_cutoff},
+        ),
     )
     assert (session.build_prefix / "share/cutoff-dependency.txt").read_text().strip() == expected[0]
     assert (session.host_prefix / "share/cutoff-other.txt").read_text().strip() == expected[1]
@@ -274,10 +275,7 @@ requirements:
             recipe.render()[0],
             output_dir=tmp_path / "debug",
             channels=[cutoff_channel],
-            exclude_newer=cutoff,
-            exclude_newer_package={},
-            exclude_newer_channel={},
-            exclude_newer_include_unknown_timestamp=include_unknown,
+            exclude_newer=ExcludeNewer(cutoff, packages={}, channels={}, include_unknown_timestamp=include_unknown),
         )
 
     if succeeds:
@@ -289,13 +287,9 @@ requirements:
             create_session()
 
 
-def test_invalid_package_override(tmp_path: Path) -> None:
-    with pytest.raises(ValueError, match="invalid exclude_newer_package name"):
-        dependency_recipe().render()[0].run_build(
-            output_dir=tmp_path / "output",
-            channels=[],
-            exclude_newer_package={"invalid package name": CUTOFF},
-        )
+def test_invalid_package_override() -> None:
+    with pytest.raises(ValueError, match="invalid ExcludeNewer package name"):
+        ExcludeNewer(packages={"invalid package name": CUTOFF})
 
 
 @pytest.mark.parametrize("authentication", ["none", "basic", "token"])
@@ -313,7 +307,7 @@ def test_channel_cutoff_matches_authenticated_urls(
         dependency_recipe().render()[0],
         output_dir=tmp_path / "debug",
         channels=[channel],
-        exclude_newer_channel={channel: CUTOFF},
+        exclude_newer=ExcludeNewer(channels={channel: CUTOFF}),
         tool_config=ToolConfiguration(use_bz2=False, use_zstd=False, use_sharded=False),
     )
     assert (session.build_prefix / "share/cutoff-dependency.txt").read_text().strip() == "1"
@@ -321,10 +315,6 @@ def test_channel_cutoff_matches_authenticated_urls(
 
 
 @pytest.mark.parametrize("channel", ["conda-forge", "relative/channel", "mailto:channel@example.com"])
-def test_invalid_channel_override(tmp_path: Path, channel: str) -> None:
-    with pytest.raises(ValueError, match="exclude_newer_channel"):
-        dependency_recipe().render()[0].run_build(
-            output_dir=tmp_path / "output",
-            channels=[],
-            exclude_newer_channel={channel: CUTOFF},
-        )
+def test_invalid_channel_override(channel: str) -> None:
+    with pytest.raises(ValueError, match="ExcludeNewer channel"):
+        ExcludeNewer(channels={channel: CUTOFF})

--- a/py-rattler-build/tests/unit/test_render.py
+++ b/py-rattler-build/tests/unit/test_render.py
@@ -307,8 +307,9 @@ python:
     assert python_versions == {"3.9", "3.10"}
 
 
-def test_run_build_exclude_newer_datetime_conversion(tmp_path: Path) -> None:
-    """Test that Python datetime converts correctly to Rust chrono::DateTime<Utc>."""
+@pytest.mark.parametrize("entrypoint", ["recipe", "variant", "variants"])
+def test_run_build_exclude_newer_datetime_conversion(tmp_path: Path, entrypoint: str) -> None:
+    """Existing build APIs still accept a datetime for the global cutoff."""
     from datetime import datetime, timezone
 
     recipe_yaml = """
@@ -325,10 +326,16 @@ build:
     variant_config = VariantConfig()
     rendered = recipe.render(variant_config)
 
-    # Create a timezone-aware datetime (required for chrono::DateTime<Utc>)
     exclude_newer = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
 
-    result = rendered[0].run_build(output_dir=tmp_path, exclude_newer=exclude_newer)
+    if entrypoint == "recipe":
+        result = recipe.run_build(output_dir=tmp_path, exclude_newer=exclude_newer)[0]
+    elif entrypoint == "variant":
+        result = rendered[0].run_build(output_dir=tmp_path, exclude_newer=exclude_newer)
+    else:
+        from rattler_build.render import build_rendered_variants
+
+        result = build_rendered_variants(rendered, output_dir=tmp_path, exclude_newer=exclude_newer)[0]
     assert result.name == "datetime-test"
 
 

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -210,6 +210,7 @@ pub async fn debug_env_add(
         &opts.specs,
         &channels,
         &tool_config,
+        None,
     )
     .await
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -609,7 +609,7 @@ pub async fn get_build_output(
                 experimental: build_data.common.experimental,
                 env_isolation: build_data.env_isolation,
                 sandbox_config: build_data.sandbox_configuration.clone(),
-                exclude_newer: build_data.exclude_newer,
+                exclude_newer: build_data.exclude_newer.map(Into::into),
                 repodata_revision: repodata_revision_from_v3_flag(build_data.common.v3),
             },
             finalized_dependencies: None,
@@ -662,7 +662,9 @@ async fn run_queued_tests(
                 tool_configuration: tool_configuration.clone(),
                 test_index: None,
                 output_dir: output.build_configuration.directories.output_dir.clone(),
-                exclude_newer: output.build_configuration.exclude_newer,
+                exclude_newer: output
+                    .build_configuration
+                    .exclude_newer_with_build_outputs(),
                 env_isolation: output.build_configuration.env_isolation,
             },
             None,
@@ -933,7 +935,7 @@ pub async fn run_test(
         solve_strategy: SolveStrategy::Highest,
         tool_configuration: tool_config,
         output_dir: test_data.common.output_dir,
-        exclude_newer: None,
+        exclude_newer: test_data.exclude_newer,
         env_isolation: rattler_build_script::EnvironmentIsolation::default(),
     };
 

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -1154,6 +1154,7 @@ pub struct TestData {
     pub compression_threads: Option<u32>,
     pub common: CommonData,
     pub test_index: Option<usize>,
+    pub exclude_newer: Option<rattler_solve::ExcludeNewer>,
 }
 
 impl TestData {
@@ -1183,6 +1184,7 @@ impl TestData {
             compression_threads,
             test_index,
             common,
+            exclude_newer: None,
         }
     }
 }


### PR DESCRIPTION
Add a reusable `ExcludeNewer` Python object carrying global, package, and channel cutoffs plus unknown-timestamp handling. Pass it through the existing `exclude_newer` argument on build, standalone package test, and debug APIs. Existing build datetime arguments and positional calls remain compatible, and debug sessions retain the policy when adding packages.

Historical cutoffs currently exclude the newly built package from its own test environment. Exempt the build output channel and temporary test artifact channel while preserving explicit package override precedence. External channels still obey the policy, including authenticated channel URLs.

This supplies the upstream API support for conda/conda-build#6124, which adds `--exclude-newer` for `recipe.yaml` recipes as part of conda/conda#15759. The conda-build integration needs a release containing these bindings.
