### PR TITLE
fix: document `ignore_keys` and propagate top-level `use_keys`

### DIFF
--- a/crates/rattler_build_recipe/src/stage0/evaluate.rs
+++ b/crates/rattler_build_recipe/src/stage0/evaluate.rs
@@ -3129,11 +3129,17 @@ fn merge_stage1_build(
         output.dynamic_linking
     };
 
-    // Variant: use output if not default, otherwise inherit from top-level
+    // Variant: use output if not default, but always inherit top-level use_keys.
     let variant = if output.variant.is_default() {
         toplevel.variant
     } else {
-        output.variant
+        let mut variant = output.variant;
+        for key in toplevel.variant.use_keys {
+            if !variant.use_keys.contains(&key) {
+                variant.use_keys.push(key);
+            }
+        }
+        variant
     };
 
     // Prefix detection: use output if not default, otherwise inherit from top-level
@@ -3498,6 +3504,9 @@ impl Evaluate for crate::stage0::MultiOutputRecipe {
             .cloned()
             .collect();
 
+        // Top-level use_keys apply to every build unit, including staging builds.
+        let top_level_use_keys = self.build.variant.evaluate(&context_with_vars)?.use_keys;
+
         // First pass: Evaluate all staging outputs and collect them
         let mut staging_caches = IndexMap::new();
         for output in &self.outputs {
@@ -3533,7 +3542,7 @@ impl Evaluate for crate::stage0::MultiOutputRecipe {
                     &["target_platform", "channel_targets", "channel_sources"];
 
                 let os_env_var_keys = context_with_vars.os_env_var_keys();
-                let actual_variant: BTreeMap<NormalizedKey, Variable> = context_with_vars
+                let mut actual_variant: BTreeMap<NormalizedKey, Variable> = context_with_vars
                     .variables()
                     .iter()
                     .filter(|(k, _)| {
@@ -3553,6 +3562,13 @@ impl Evaluate for crate::stage0::MultiOutputRecipe {
                     })
                     .map(|(k, v)| (NormalizedKey::from(k.as_str()), v.clone()))
                     .collect();
+
+                for key in &top_level_use_keys {
+                    let key = NormalizedKey::from(key.as_str());
+                    if let Some(value) = context_with_vars.variables().get(&key.0) {
+                        actual_variant.insert(key, value.clone());
+                    }
+                }
 
                 let staging_cache = StagingCache::new(
                     staging_name.clone(),

--- a/crates/rattler_build_recipe/src/stage0/evaluate.rs
+++ b/crates/rattler_build_recipe/src/stage0/evaluate.rs
@@ -3129,7 +3129,7 @@ fn merge_stage1_build(
         output.dynamic_linking
     };
 
-    // Variant: use output if not default, but always inherit top-level use_keys.
+    // Variant: use output if not default, but always inherit top-level use_keys and ignore_keys.
     let variant = if output.variant.is_default() {
         toplevel.variant
     } else {
@@ -3137,6 +3137,11 @@ fn merge_stage1_build(
         for key in toplevel.variant.use_keys {
             if !variant.use_keys.contains(&key) {
                 variant.use_keys.push(key);
+            }
+        }
+        for key in toplevel.variant.ignore_keys {
+            if !variant.ignore_keys.contains(&key) {
+                variant.ignore_keys.push(key);
             }
         }
         variant
@@ -3504,8 +3509,8 @@ impl Evaluate for crate::stage0::MultiOutputRecipe {
             .cloned()
             .collect();
 
-        // Top-level use_keys apply to every build unit, including staging builds.
-        let top_level_use_keys = self.build.variant.evaluate(&context_with_vars)?.use_keys;
+        // Top-level use_keys and ignore_keys apply to every build unit, including staging builds.
+        let top_level_variant = self.build.variant.evaluate(&context_with_vars)?;
 
         // First pass: Evaluate all staging outputs and collect them
         let mut staging_caches = IndexMap::new();
@@ -3563,11 +3568,16 @@ impl Evaluate for crate::stage0::MultiOutputRecipe {
                     .map(|(k, v)| (NormalizedKey::from(k.as_str()), v.clone()))
                     .collect();
 
-                for key in &top_level_use_keys {
+                for key in &top_level_variant.use_keys {
                     let key = NormalizedKey::from(key.as_str());
                     if let Some(value) = context_with_vars.variables().get(&key.0) {
                         actual_variant.insert(key, value.clone());
                     }
+                }
+
+                // Ignore wins over both detected and explicitly included keys.
+                for key in &top_level_variant.ignore_keys {
+                    actual_variant.remove(&NormalizedKey::from(key.as_str()));
                 }
 
                 let staging_cache = StagingCache::new(

--- a/crates/rattler_build_recipe/src/variant_render.rs
+++ b/crates/rattler_build_recipe/src/variant_render.rs
@@ -1504,6 +1504,82 @@ python:
     }
 
     #[test]
+    fn test_top_level_use_keys_apply_to_package_and_staging_outputs() {
+        let recipe_yaml = r#"
+schema_version: 1
+
+recipe:
+  name: test-project
+  version: "1.0.0"
+
+build:
+  variant:
+    use_keys:
+      - parent_key
+
+outputs:
+  - staging:
+      name: build-cache
+    build:
+      script: echo $parent_key
+
+  - package:
+      name: staged
+    inherit: build-cache
+    build:
+      variant:
+        ignore_keys:
+          - ignored_key
+
+  - package:
+      name: direct
+    inherit: null
+    build:
+      script: echo $parent_key
+      variant:
+        use_keys:
+          - output_key
+"#;
+
+        let variant_config = VariantConfig::from_yaml_str(
+            "parent_key: [parent]\noutput_key: [output]\nignored_key: [ignored]\n",
+        )
+        .unwrap();
+        let recipe = stage0::parse_recipe_or_multi_from_source(recipe_yaml).unwrap();
+        let rendered =
+            render_recipe_with_variant_config(&recipe, &variant_config, RenderConfig::new())
+                .unwrap();
+
+        assert_eq!(rendered.len(), 2);
+        for output in &rendered {
+            assert_eq!(
+                output.variant.get(&"parent_key".into()),
+                Some(&Variable::from_string("parent"))
+            );
+        }
+
+        let staged = rendered
+            .iter()
+            .find(|output| output.recipe.package.name.as_normalized() == "staged")
+            .unwrap();
+        assert_eq!(
+            staged.recipe.staging_caches[0]
+                .used_variant
+                .get(&"parent_key".into()),
+            Some(&Variable::from_string("parent"))
+        );
+
+        let direct = rendered
+            .iter()
+            .find(|output| output.recipe.package.name.as_normalized() == "direct")
+            .unwrap();
+        assert_eq!(
+            direct.variant.get(&"output_key".into()),
+            Some(&Variable::from_string("output"))
+        );
+    }
+
+    #[test]
     fn test_build_steps_if_participates_in_variant_matrix() {
         let recipe_yaml = r#"
 package:

--- a/crates/rattler_build_recipe/src/variant_render.rs
+++ b/crates/rattler_build_recipe/src/variant_render.rs
@@ -1504,7 +1504,7 @@ python:
     }
 
     #[test]
-    fn test_top_level_use_keys_apply_to_package_and_staging_outputs() {
+    fn test_top_level_variant_keys_apply_to_package_and_staging_outputs() {
         let recipe_yaml = r#"
 schema_version: 1
 
@@ -1516,33 +1516,40 @@ build:
   variant:
     use_keys:
       - parent_key
+      - ignored_key
+    ignore_keys:
+      - ignored_key
 
 outputs:
   - staging:
       name: build-cache
     build:
-      script: echo $parent_key
+      script: echo $parent_key ${{ ignored_key }}
 
   - package:
       name: staged
     inherit: build-cache
     build:
       variant:
+        use_keys:
+          - output_ignored_key
         ignore_keys:
+          - output_ignored_key
           - ignored_key
 
   - package:
       name: direct
     inherit: null
     build:
-      script: echo $parent_key
+      script: echo $parent_key ${{ ignored_key }}
       variant:
         use_keys:
           - output_key
+          - ignored_key
 "#;
 
         let variant_config = VariantConfig::from_yaml_str(
-            "parent_key: [parent]\noutput_key: [output]\nignored_key: [ignored]\n",
+            "parent_key: [parent]\noutput_key: [output]\nignored_key: [ignored]\noutput_ignored_key: [ignored]\n",
         )
         .unwrap();
         let recipe = stage0::parse_recipe_or_multi_from_source(recipe_yaml).unwrap();
@@ -1556,6 +1563,7 @@ outputs:
                 output.variant.get(&"parent_key".into()),
                 Some(&Variable::from_string("parent"))
             );
+            assert!(!output.variant.contains_key(&"ignored_key".into()));
         }
 
         let staged = rendered
@@ -1567,6 +1575,17 @@ outputs:
                 .used_variant
                 .get(&"parent_key".into()),
             Some(&Variable::from_string("parent"))
+        );
+
+        assert!(
+            !staged.recipe.staging_caches[0]
+                .used_variant
+                .contains_key(&"ignored_key".into())
+        );
+        assert!(!staged.variant.contains_key(&"output_ignored_key".into()));
+        assert_eq!(
+            staged.recipe.build.variant.ignore_keys,
+            ["output_ignored_key", "ignored_key"]
         );
 
         let direct = rendered

--- a/docs/variants.md
+++ b/docs/variants.md
@@ -123,6 +123,29 @@ This JSON string is then hashed with the MD5 hash algorithm, and produces the ha
 For certain packages (such as Python packages) special rules exists, and the `py<Major.Minor>` version is prepended to the hash, so that the final hash
 would look something like `py38h123123`.
 
+### Including and ignoring variant keys
+
+Rattler-Build normally includes variant keys that are used by the recipe, such as
+unconstrained dependencies and variables used in expressions. A recipe can override
+this detection with `build.variant.use_keys` and `build.variant.ignore_keys`:
+
+```yaml title="recipe.yaml"
+build:
+  variant:
+    # Include this key even when the recipe does not otherwise use it.
+    use_keys:
+      - cuda
+    # Exclude this key even when the recipe uses it.
+    ignore_keys:
+      - python
+```
+
+An ignored key does not contribute to the package's variant or hash, so its configured
+values do not produce distinct packages. These options belong in `recipe.yaml`, not in
+the variant configuration file. In multi-output recipes, top-level `use_keys` apply to
+package and staging outputs, and are available to their build scripts as environment
+variables.
+
 ### Zip keys
 
 Zip keys modify how variants are combined. Usually, each variant key that has multiple

--- a/docs/variants.md
+++ b/docs/variants.md
@@ -142,9 +142,11 @@ build:
 
 An ignored key does not contribute to the package's variant or hash, so its configured
 values do not produce distinct packages. These options belong in `recipe.yaml`, not in
-the variant configuration file. In multi-output recipes, top-level `use_keys` apply to
-package and staging outputs, and are available to their build scripts as environment
-variables.
+the variant configuration file. In multi-output recipes, top-level `use_keys` and
+`ignore_keys` apply to both package and staging outputs. Package outputs extend these
+lists with their own entries rather than replacing them. If a key appears in both
+lists, `ignore_keys` takes precedence. Included keys are available to build scripts
+as environment variables.
 
 ### Zip keys
 


### PR DESCRIPTION
Closes #2799.

Documents `build.variant.ignore_keys` alongside `use_keys` in the variants guide. Also ensures top-level `use_keys` are retained by package outputs with their own variant settings and passed to staging builds, making those values available to build scripts as environment variables.

Adds a regression test covering direct and staging outputs.