### PR TITLE
fix: preserve inherited variant priority and staging cache inputs

### DIFF
--- a/crates/rattler_build_core/src/staging.rs
+++ b/crates/rattler_build_core/src/staging.rs
@@ -88,7 +88,7 @@ impl Output {
     ///
     /// The cache key is based on:
     /// - The staging cache configuration (requirements, sources)
-    /// - The relevant variant variables (those used in the requirements)
+    /// - The staging build's used variants, including top-level use_keys
     /// - The build and host platforms
     pub fn staging_cache_key(&self, staging: &StagingCache) -> Result<String, StagingError> {
         // Collect variant variable names that are used in the staging requirements
@@ -134,8 +134,15 @@ impl Output {
                 .into(),
         );
 
-        // Create the cache key from staging config + selected variant + prefix
-        let cache_key = (&staging, &selected_variant, self.prefix());
+        // used_variant is skipped by StagingCache serialization, so include it
+        // explicitly: forced keys can affect script environment without changing
+        // the rendered script or requirements.
+        let cache_key = (
+            &staging,
+            &staging.used_variant,
+            &selected_variant,
+            self.prefix(),
+        );
 
         // Serialize to JSON and hash
         let json = serde_json::to_vec(&cache_key)?;
@@ -582,6 +589,26 @@ mod tests {
     };
     use rattler_build_script::EnvironmentIsolation;
     use rattler_conda_types::Platform;
+
+    #[test]
+    fn staging_cache_key_tracks_forced_variant_values() {
+        let output: Output = serde_yaml::from_str(include_str!(
+            "../../../test-data/rendered_recipes/rich_recipe.yaml"
+        ))
+        .unwrap();
+        let mut staging = StagingCache::new(
+            "compile".to_string(),
+            Build::default(),
+            Requirements::default(),
+            Vec::new(),
+            [("forced_key".into(), "first".into())].into(),
+        );
+        let first = output.staging_cache_key(&staging).unwrap();
+        staging
+            .used_variant
+            .insert("forced_key".into(), "second".into());
+        assert_ne!(first, output.staging_cache_key(&staging).unwrap());
+    }
 
     #[test]
     fn staging_build_steps_prepare_as_sections() {

--- a/crates/rattler_build_recipe/src/stage0/evaluate.rs
+++ b/crates/rattler_build_recipe/src/stage0/evaluate.rs
@@ -3165,6 +3165,9 @@ fn merge_stage1_build(
         toplevel.variant
     } else {
         let mut variant = output.variant;
+        variant.down_prioritize_variant = variant
+            .down_prioritize_variant
+            .or(toplevel.variant.down_prioritize_variant);
         for key in toplevel.variant.use_keys {
             if !variant.use_keys.contains(&key) {
                 variant.use_keys.push(key);

--- a/crates/rattler_build_recipe/src/variant_render.rs
+++ b/crates/rattler_build_recipe/src/variant_render.rs
@@ -1699,6 +1699,7 @@ recipe:
 
 build:
   variant:
+    down_prioritize_variant: 3
     use_keys:
       - parent_key
       - ignored_key
@@ -1728,13 +1729,14 @@ outputs:
     build:
       script: echo $parent_key ${{ ignored_key }}
       variant:
+        down_prioritize_variant: 0
         use_keys:
           - output_key
           - ignored_key
 "#;
 
         let variant_config = VariantConfig::from_yaml_str(
-            "parent_key: [parent]\noutput_key: [output]\nignored_key: [ignored]\noutput_ignored_key: [ignored]\n",
+            "parent_key: [parent]\noutput_key: [output]\nignored_key: [ignored_a, ignored_b]\noutput_ignored_key: [ignored_a, ignored_b]\n",
         )
         .unwrap();
         let recipe = stage0::parse_recipe_or_multi_from_source(recipe_yaml).unwrap();
@@ -1742,7 +1744,19 @@ outputs:
             render_recipe_with_variant_config(&recipe, &variant_config, RenderConfig::new())
                 .unwrap();
 
-        assert_eq!(rendered.len(), 2);
+        // Rendering retains combinations for expression evaluation and sibling
+        // pin matching. The CLI deduplicates the resulting package identities.
+        assert_eq!(rendered.len(), 8);
+        let identities: HashSet<_> = rendered
+            .iter()
+            .map(|output| {
+                (
+                    output.recipe.package.name.clone(),
+                    output.recipe.build.string.as_resolved().unwrap(),
+                )
+            })
+            .collect();
+        assert_eq!(identities.len(), 2);
         for output in &rendered {
             assert_eq!(
                 output.variant.get(&"parent_key".into()),
@@ -1768,6 +1782,7 @@ outputs:
                 .contains_key(&"ignored_key".into())
         );
         assert!(!staged.variant.contains_key(&"output_ignored_key".into()));
+        assert_eq!(staged.recipe.build.variant.down_prioritize_variant, Some(3));
         assert_eq!(
             staged.recipe.build.variant.ignore_keys,
             ["output_ignored_key", "ignored_key"]
@@ -1777,6 +1792,7 @@ outputs:
             .iter()
             .find(|output| output.recipe.package.name.as_normalized() == "direct")
             .unwrap();
+        assert_eq!(direct.recipe.build.variant.down_prioritize_variant, Some(0));
         assert_eq!(
             direct.variant.get(&"output_key".into()),
             Some(&Variable::from_string("output"))

--- a/docs/multiple_output_cache.md
+++ b/docs/multiple_output_cache.md
@@ -166,6 +166,13 @@ outputs:
         - share/**
 ```
 
+Package outputs always inherit top-level build settings and `about` metadata,
+even with `inherit: cache-name`. The exceptions are the top-level build plan and
+tests: these are inherited only with `inherit: null` (or an omitted `inherit`).
+Staging builds themselves inherit top-level sources, context, and variant key
+lists, not the other top-level build settings. Staging inheritance passes build
+artifacts and dependency information, not an arbitrary recipe configuration.
+
 ### Multiple staging caches
 
 A recipe can define multiple independent staging outputs. Each staging output is
@@ -229,8 +236,11 @@ outputs:
 ### Variants and staging
 
 Staging caches interact with [variant configuration](variants.md). The cache
-key includes only the variant variables that are referenced in the staging
-output's requirements. This means:
+key includes the staging build's used variant values, including variables used
+in expressions, unconstrained dependencies, and top-level `build.variant.use_keys`.
+Top-level `build.variant.ignore_keys` removes keys from that used-variant map;
+ignored values can still change the cache key if they change the rendered build
+plan, sources, or requirements. This means:
 
 - Different variants produce different staging caches
 - The staging build is only rerun when its relevant variant keys change
@@ -247,9 +257,11 @@ across `python` variants.
 
 The staging cache is keyed by a SHA256 hash over:
 
-- The staging output's resolved requirements (build and host dependencies)
-- Relevant variant variables (only those referenced in the staging requirements)
+- The staging output's rendered configuration (build plan, sources, and requirements)
+- The staging build's used variant values, including top-level `use_keys`
+- Unconstrained staging dependency variant values from the package output
 - `host_platform` and `build_platform` (always included)
+- The destination prefix
 
 Staging caches are stored under `output/build_cache/staging_<hash>/`. Each
 cache directory contains:

--- a/docs/variants.md
+++ b/docs/variants.md
@@ -148,6 +148,12 @@ lists with their own entries rather than replacing them. If a key appears in bot
 lists, `ignore_keys` takes precedence. Included keys are available to build scripts
 as environment variables.
 
+Ignored keys remain available to recipe expressions during rendering. Combinations
+that produce the same package identity are deduplicated before building; do not
+rely on an ignored key to distinguish package contents. The top-level
+`down_prioritize_variant` is inherited independently of these lists; an output
+can override it explicitly, including with `0`.
+
 ### Zip keys
 
 Zip keys modify how variants are combined. Usually, each variant key that has multiple


### PR DESCRIPTION
Follow-up to #2802.

## Changes
- Inherit top-level `down_prioritize_variant` independently of output `use_keys` / `ignore_keys`, preserving explicit overrides including zero.
- Include staging `used_variant` in the cache key. This field is skipped by serialization, so previously a forced key could change the staging script environment without invalidating its cache.
- Document top-level versus staging inheritance, the actual cache inputs, and ignored-key behavior.
- Expand regression coverage for priority inheritance, explicit zero, multiple ignored values, and forced-key cache invalidation.

## Correction to the initial review
Multiple rendered combinations are not duplicate builds: the CLI already deduplicates `DiscoveredOutput` identities. Keep ignored values available during rendering for expressions and sibling pin matching rather than removing them before matrix expansion. The expanded test verifies that eight combinations yield only two distinct package identities; no renderer deduplication change is needed.

## Validation
- `cargo test -p rattler_build_recipe --lib` — 347 passed
- `cargo test -p rattler_build_core --lib` — 218 passed
- `cargo fmt --all --check`
- `git diff --check`

The cache-key change invalidates existing staging caches once; they rebuild normally.