### PR TITLE
feat: compile reusable build actions before solving

### DIFF
--- a/crates/rattler_build_core/src/script.rs
+++ b/crates/rattler_build_core/src/script.rs
@@ -10,7 +10,7 @@ use std::{
 
 use indexmap::IndexMap;
 use minijinja::Value;
-use rattler_build_jinja::{Jinja, JinjaConfig, Variable};
+use rattler_build_jinja::{Jinja, JinjaConfig, UndefinedBehavior, Variable};
 
 // Re-export from rattler_build_script
 pub use rattler_build_script::{
@@ -24,7 +24,7 @@ pub use rattler_build_script::{
 };
 
 use crate::{env_vars, metadata::Output};
-use rattler_build_recipe::stage1::build::{BuildPlan, Step};
+use rattler_build_recipe::stage1::build::BuildPlan;
 
 /// Prepare execution arguments for a stage1 build plan.
 ///
@@ -73,16 +73,25 @@ pub(crate) fn prepare_build_plan_execution_args(
     }
 
     let scripts: Vec<_> = match plan {
-        BuildPlan::Steps(steps) => steps.iter().enumerate().map(|(index, step)| {
-            (step.to_script(), Some(step.name.clone().unwrap_or_else(|| format!("step {index}"))), step.action_context.as_ref())
-        }).collect(),
+        BuildPlan::Steps(steps) => steps
+            .iter()
+            .enumerate()
+            .map(|(index, step)| {
+                (
+                    step.to_script(),
+                    Some(step.name.clone().unwrap_or_else(|| format!("step {index}"))),
+                    step.action_context.as_ref(),
+                )
+            })
+            .collect(),
         BuildPlan::Script(script) => vec![(script.clone(), None, None)],
     };
 
     let mut secrets = IndexMap::new();
     let mut sections = Vec::with_capacity(scripts.len());
     for (script, step_label, action_context) in scripts {
-        let mut section_jinja = execution_jinja(selector_config.clone(), recipe_context, action_context);
+        let mut section_jinja =
+            execution_jinja(selector_config.clone(), recipe_context, action_context);
         for (key, value) in env_vars.iter().chain(script.env()) {
             if action_context.is_some_and(|bindings| bindings.contains_key(key)) {
                 continue;
@@ -138,23 +147,18 @@ pub(crate) fn prepare_build_plan_execution_args(
     })
 }
 
-fn execution_jinja(
-    config: JinjaConfig,
+pub(crate) fn execution_jinja(
+    mut config: JinjaConfig,
     recipe_context: &IndexMap<String, Variable>,
     action_context: Option<&IndexMap<String, Variable>>,
 ) -> Jinja {
+    if action_context.is_some() {
+        config.undefined_behavior = UndefinedBehavior::Strict;
+    }
     Jinja::new(config).with_context(action_context.unwrap_or(recipe_context))
 }
 
 impl Output {
-    /// Runtime renderer for a flat executable, respecting action-local scope.
-    pub(crate) fn step_jinja(&self, step: &Step) -> Jinja {
-        execution_jinja(
-            self.build_configuration.selector_config(),
-            &self.recipe.context,
-            step.action_context.as_ref(),
-        )
-    }
     /// Helper function to get a jinja renderer for the output's recipe context.
     pub(crate) fn jinja_renderer(&self) -> impl Fn(&str) -> Result<String, String> {
         let selector_config = self.build_configuration.selector_config();
@@ -282,4 +286,3 @@ impl Output {
         rattler_build_script::create_build_script(exec_args).await
     }
 }
-

--- a/crates/rattler_build_core/src/script.rs
+++ b/crates/rattler_build_core/src/script.rs
@@ -24,7 +24,7 @@ pub use rattler_build_script::{
 };
 
 use crate::{env_vars, metadata::Output};
-use rattler_build_recipe::stage1::build::BuildPlan;
+use rattler_build_recipe::stage1::build::{BuildPlan, Step};
 
 /// Prepare execution arguments for a stage1 build plan.
 ///
@@ -73,22 +73,20 @@ pub(crate) fn prepare_build_plan_execution_args(
     }
 
     let scripts: Vec<_> = match plan {
-        BuildPlan::Steps(steps) => steps
-            .iter()
-            .enumerate()
-            .map(|(index, step)| {
-                let label = step.name.clone().unwrap_or_else(|| format!("step {index}"));
-                (step.to_script(), Some(label))
-            })
-            .collect(),
-        BuildPlan::Script(script) => vec![(script.clone(), None)],
+        BuildPlan::Steps(steps) => steps.iter().enumerate().map(|(index, step)| {
+            (step.to_script(), Some(step.name.clone().unwrap_or_else(|| format!("step {index}"))), step.action_context.as_ref())
+        }).collect(),
+        BuildPlan::Script(script) => vec![(script.clone(), None, None)],
     };
 
     let mut secrets = IndexMap::new();
     let mut sections = Vec::with_capacity(scripts.len());
-    for (script, step_label) in scripts {
-        let mut section_jinja = Jinja::new(selector_config.clone()).with_context(recipe_context);
+    for (script, step_label, action_context) in scripts {
+        let mut section_jinja = execution_jinja(selector_config.clone(), recipe_context, action_context);
         for (key, value) in env_vars.iter().chain(script.env()) {
+            if action_context.is_some_and(|bindings| bindings.contains_key(key)) {
+                continue;
+            }
             section_jinja
                 .context_mut()
                 .insert(key.clone(), Value::from_safe_string(value.clone()));
@@ -140,7 +138,23 @@ pub(crate) fn prepare_build_plan_execution_args(
     })
 }
 
+fn execution_jinja(
+    config: JinjaConfig,
+    recipe_context: &IndexMap<String, Variable>,
+    action_context: Option<&IndexMap<String, Variable>>,
+) -> Jinja {
+    Jinja::new(config).with_context(action_context.unwrap_or(recipe_context))
+}
+
 impl Output {
+    /// Runtime renderer for a flat executable, respecting action-local scope.
+    pub(crate) fn step_jinja(&self, step: &Step) -> Jinja {
+        execution_jinja(
+            self.build_configuration.selector_config(),
+            &self.recipe.context,
+            step.action_context.as_ref(),
+        )
+    }
     /// Helper function to get a jinja renderer for the output's recipe context.
     pub(crate) fn jinja_renderer(&self) -> impl Fn(&str) -> Result<String, String> {
         let selector_config = self.build_configuration.selector_config();
@@ -268,3 +282,4 @@ impl Output {
         rattler_build_script::create_build_script(exec_args).await
     }
 }
+

--- a/crates/rattler_build_recipe/src/actions.rs
+++ b/crates/rattler_build_recipe/src/actions.rs
@@ -1,0 +1,549 @@
+//! Render-time action sources shared by local and packaged action compilation.
+use std::{collections::HashMap, path::PathBuf, sync::{Arc, Mutex}};
+use serde::{Deserialize, Serialize};
+use crate::{ParseError, Span, stage0::types::{JinjaTemplate, Value}};
+use rattler_build_jinja::Variable;
+
+/// Native source input, retaining individual templates inside lists.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ActionValue {
+    List(Vec<ActionValue>),
+    /// Retained until the invocation condition is known; declared inputs reject maps.
+    Mapping(indexmap::IndexMap<String, ActionValue>),
+    Scalar(Value<Variable>),
+}
+
+impl ActionValue {
+    pub(crate) fn used_variables(&self) -> Vec<String> {
+        match self {
+            Self::Scalar(value) => value.used_variables(),
+            Self::List(values) => values.iter().flat_map(Self::used_variables).collect(),
+            Self::Mapping(values) => values.values().flat_map(Self::used_variables).collect(),
+        }
+    }
+
+    pub(crate) fn parse(node: &marked_yaml::Node) -> Result<Self, ParseError> {
+        if let Some(sequence) = node.as_sequence() {
+            return sequence.iter().map(Self::parse).collect::<Result<Vec<_>, _>>().map(Self::List);
+        }
+        if let Some(mapping) = node.as_mapping() {
+            return mapping.iter().map(|(key, value)| Ok((key.as_str().to_owned(), Self::parse(value)?)))
+                .collect::<Result<indexmap::IndexMap<_, _>, ParseError>>().map(Self::Mapping);
+        }
+        let scalar = node.as_scalar().ok_or_else(|| ParseError::generic(
+            "action inputs must be scalars or homogeneous lists", Span::new_blank()))?;
+        let text = scalar.as_str();
+        if text.contains("${{") {
+            let template = JinjaTemplate::new(text.to_owned())
+                .map_err(|error| ParseError::jinja_error(error, *scalar.span()))?;
+            return Ok(Self::Scalar(Value::new_template(template, Some(*scalar.span()))));
+        }
+        let value = if scalar.may_coerce() {
+            let native: serde_yaml::Value = serde_yaml::from_str(text)
+                .map_err(|error| invalid(format!("invalid action scalar: {error}")))?;
+            Variable::from(minijinja::Value::from_serialize(native))
+        } else {
+            Variable::from(text.to_owned())
+        };
+        Ok(Self::Scalar(Value::new_concrete(value, Some(*scalar.span()))))
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct ActionEnvironment {
+    pub sources: ActionSources,
+    pub origin: Option<PathBuf>,
+    pub selected: Option<Vec<String>>,
+    pub variants: indexmap::IndexMap<String, Variable>,
+}
+
+/// Compilation result; requirements belong to the effective recipe, not a run.
+#[derive(Debug, Clone, Default)]
+pub struct CompiledSteps {
+    pub steps: Vec<crate::stage1::build::Step>,
+    pub requirements: crate::stage1::build::StepRequirements,
+    pub provenance: Vec<ActionProvenance>,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ScalarType { String, Boolean, Integer }
+
+#[derive(Debug, Clone)]
+struct InputDefinition {
+    scalar: ScalarType,
+    list: bool,
+    required: bool,
+    default: Option<ActionValue>,
+}
+
+#[derive(Debug, Clone)]
+struct ActionDocument {
+    inputs: indexmap::IndexMap<String, InputDefinition>,
+    requirements: crate::stage0::build::StepRequirements,
+    steps: Vec<crate::stage0::build::Step>,
+}
+
+fn invalid(message: impl Into<String>) -> ParseError {
+    ParseError::generic(message, Span::new_blank())
+}
+
+fn scalar_type(value: &str) -> Result<ScalarType, ParseError> {
+    match value {
+        "string" => Ok(ScalarType::String),
+        "boolean" => Ok(ScalarType::Boolean),
+        "integer" => Ok(ScalarType::Integer),
+        _ => Err(invalid(format!("invalid action input type '{value}'"))),
+    }
+}
+
+fn identifier(name: &str) -> bool {
+    let mut chars = name.chars();
+    chars.next().is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+fn text(node: &marked_yaml::Node) -> Result<&str, ParseError> {
+    let scalar = node.as_scalar().ok_or_else(|| invalid("expected a string"))?;
+    if scalar.may_coerce() && !serde_yaml::from_str::<serde_yaml::Value>(scalar.as_str())
+        .is_ok_and(|value| value.is_string()) {
+        return Err(invalid("expected a string"));
+    }
+    Ok(scalar.as_str())
+}
+
+fn parse_document(contents: &str) -> Result<ActionDocument, ParseError> {
+    use crate::stage0::parser::build::{parse_steps, parse_step_requirements};
+    let node = rattler_build_yaml_parser::parse_yaml(contents)
+        .map_err(|error| invalid(format!("invalid action YAML: {error}")))?;
+    let mapping = node.as_mapping().ok_or_else(|| invalid("action document must be a mapping"))?;
+    let mut inputs = indexmap::IndexMap::new();
+    let mut requirements = Default::default();
+    let mut steps = None;
+    for (key, value) in mapping.iter() {
+        match key.as_str() {
+            "schema_version" => {
+                if !value.as_scalar().is_some_and(|v| v.may_coerce() && v.as_i64() == Some(1)) {
+                    return Err(invalid("action schema_version must be integer 1"));
+                }
+            }
+            "action" => {
+                let metadata = value.as_mapping().ok_or_else(|| invalid("action metadata must be a mapping"))?;
+                for (key, value) in metadata.iter() {
+                    if !matches!(key.as_str(), "name" | "description") {
+                        return Err(invalid(format!("unknown action metadata field '{}'", key.as_str())));
+                    }
+                    text(value)?;
+                }
+            }
+            "inputs" => {
+                let declarations = value.as_mapping().ok_or_else(|| invalid("action inputs must be a mapping"))?;
+                for (name, definition) in declarations.iter() {
+                    if !identifier(name.as_str()) { return Err(invalid("input names must match [A-Za-z_][A-Za-z0-9_]*")); }
+                    let fields = definition.as_mapping().ok_or_else(|| invalid("input definition must be a mapping"))?;
+                    let mut kind = None;
+                    let mut items = None;
+                    let mut required = None;
+                    let mut default = None;
+                    for (key, value) in fields.iter() {
+                        match key.as_str() {
+                            "type" => kind = Some(text(value)?.to_owned()),
+                            "items" => items = Some(scalar_type(text(value)?)?),
+                            "description" => { text(value)?; }
+                            "required" => required = Some(value.as_scalar().filter(|v| v.may_coerce()).and_then(|v| v.as_bool()).ok_or_else(|| invalid("required must be a boolean"))?),
+                            "default" => {
+                                let parsed = ActionValue::parse(value)?;
+                                if !parsed.used_variables().is_empty() || contains_template(&parsed) { return Err(invalid("action defaults must be static, not Jinja")); }
+                                default = Some(parsed);
+                            }
+                            other => return Err(invalid(format!("unknown input field '{other}'"))),
+                        }
+                    }
+                    let kind = kind.ok_or_else(|| invalid("action input requires an explicit type"))?;
+                    let list = kind == "list";
+                    let scalar = if list { items.ok_or_else(|| invalid("list input requires scalar items type"))? } else {
+                        if items.is_some() { return Err(invalid("items is only valid for list inputs")); }
+                        scalar_type(&kind)?
+                    };
+                    if required == Some(true) && default.is_some() { return Err(invalid("required input cannot have a default")); }
+                    let definition = InputDefinition { scalar, list, required: required.unwrap_or(default.is_none()), default };
+                    if let Some(default) = &definition.default {
+                        let value = evaluate_input(default, &crate::stage1::EvaluationContext::new())?;
+                        validate_input(name.as_str(), &definition, &value)?;
+                    }
+                    inputs.insert(name.as_str().to_owned(), definition);
+                }
+            }
+            "requirements" => {
+                let fields = value.as_mapping().ok_or_else(|| invalid("action requirements must be a mapping"))?;
+                for (key, _) in fields.iter() {
+                    if !matches!(key.as_str(), "build" | "host") { return Err(invalid("actions can only own build and host requirements")); }
+                }
+                requirements = parse_step_requirements(value)?;
+            }
+            "steps" => steps = Some(parse_steps(value)?),
+            other => return Err(invalid(format!("unknown action document field '{other}'"))),
+        }
+    }
+    Ok(ActionDocument { inputs, requirements, steps: steps.ok_or_else(|| invalid("action document requires steps (which may be empty)"))? })
+}
+
+fn contains_template(value: &ActionValue) -> bool {
+    match value {
+        ActionValue::Scalar(value) => value.as_concrete().is_none(),
+        ActionValue::List(values) => values.iter().any(contains_template),
+        ActionValue::Mapping(values) => values.values().any(contains_template),
+    }
+}
+
+fn evaluate_input(value: &ActionValue, context: &crate::stage1::EvaluationContext) -> Result<Variable, ParseError> {
+    match value {
+        ActionValue::Scalar(value) => {
+            if let crate::stage0::types::ValueInner::Template(template) = value.inner() {
+                let source = template.source().trim();
+                let standalone = source.starts_with("${{") && source.ends_with("}}")
+                    && !source[3..source.len() - 2].contains("${{");
+                if !standalone {
+                    let jinja = context.to_jinja();
+                    let result = jinja.render_str(template.source())
+                        .map_err(|error| invalid(format!("invalid action input expression: {error}")))?;
+                    for key in jinja.accessed_variables_excluding_functions() { context.track_access(&key); }
+                    return Ok(Variable::from(result));
+                }
+            }
+            crate::stage0::evaluate::evaluate_value_to_variable(value, context)
+        }
+        ActionValue::List(values) => values.iter().map(|v| evaluate_input(v, context)).collect::<Result<Vec<_>, _>>().map(Variable::from),
+        ActionValue::Mapping(_) => Err(invalid("action inputs must be scalars or homogeneous lists")),
+    }
+}
+
+fn validate_input(name: &str, definition: &InputDefinition, value: &Variable) -> Result<(), ParseError> {
+    use minijinja::value::ValueKind;
+    let value = value.as_ref();
+    if value.is_none() {
+        return if definition.required { Err(invalid(format!("required action input '{name}' cannot be null"))) } else { Ok(()) };
+    }
+    let scalar_valid = |value: &minijinja::Value| match definition.scalar {
+        ScalarType::String => value.kind() == ValueKind::String,
+        ScalarType::Integer => value.kind() == ValueKind::Number && serde_json::to_value(value).is_ok_and(|value| value.is_i64()),
+        ScalarType::Boolean => value.kind() == ValueKind::Bool,
+    };
+    let valid = if definition.list {
+        value.kind() == ValueKind::Seq && value.try_iter().map(|mut items| items.all(|item| scalar_valid(&item))).unwrap_or(false)
+    } else { scalar_valid(value) };
+    if valid { Ok(()) } else { Err(invalid(format!("action input '{name}' does not match its declared type"))) }
+}
+
+/// An unresolved external reference and its compilation environment.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ActionRequest {
+    pub reference: String,
+    /// File containing the reference, not its parent directory.
+    pub origin: PathBuf,
+    pub channel_sources: Option<String>,
+}
+
+/// Exact provider identity retained in rendered recipes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ResolvedProvider {
+    pub name: String,
+    pub version: String,
+    pub build: String,
+    pub subdir: String,
+    pub channel: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sha256: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub md5: Option<String>,
+}
+
+/// Source identity without machine-specific source paths.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ActionProvenance {
+    pub reference: String,
+    pub provider: Option<ResolvedProvider>,
+    pub content_sha256: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fingerprint: Option<String>,
+}
+
+/// A source document supplied by a transport. Evaluation belongs to the compiler.
+#[derive(Debug, Clone)]
+pub struct ActionSource {
+    pub path: PathBuf,
+    pub contents: String,
+    pub fingerprint: Option<String>,
+    pub provenance: Option<ActionProvenance>,
+}
+
+#[derive(Debug, Default)]
+struct SourceRegistry {
+    sources: HashMap<ActionRequest, ActionSource>,
+    pending: Option<ActionRequest>,
+}
+
+/// Shared source registry and typed synchronous-to-asynchronous resolution bridge.
+#[derive(Debug, Clone, Default)]
+pub struct ActionSources(Arc<Mutex<SourceRegistry>>);
+
+impl ActionSources {
+    pub fn register(&self, request: ActionRequest, source: ActionSource) {
+        let mut registry = self.0.lock().unwrap_or_else(|poison| poison.into_inner());
+        if registry.pending.as_ref() == Some(&request) {
+            registry.pending = None;
+        }
+        registry.sources.insert(request, source);
+    }
+
+    pub fn take_pending(&self) -> Option<ActionRequest> {
+        self.0.lock().unwrap_or_else(|poison| poison.into_inner()).pending.take()
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.lock().unwrap_or_else(|poison| poison.into_inner()).sources.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub(crate) fn resolve(&self, request: ActionRequest) -> Option<ActionSource> {
+        let mut registry = self.0.lock().unwrap_or_else(|poison| poison.into_inner());
+        if let Some(source) = registry.sources.get(&request) {
+            return Some(source.clone());
+        }
+        registry.pending = Some(request);
+        None
+    }
+}
+
+/// Compile source invocations into an ordered executable plan.
+pub fn compile_steps(
+    steps: &[crate::stage0::build::Step],
+    context: &crate::stage1::EvaluationContext,
+) -> Result<CompiledSteps, ParseError> {
+    let origin = context.actions.origin.clone().unwrap_or_else(|| PathBuf::from("recipe.yaml"));
+    let mut compiler = Compiler { stack: Vec::new(), parsed: HashMap::new() };
+    let mut compiled = compiler.compile(steps, context, &origin, context.actions.selected.as_deref(), None, "")?;
+    if let Some(selected) = &context.actions.selected {
+        let mut policy = None;
+        for name in selected {
+            let step = steps.iter().find(|step| source_metadata(step).0 == Some(name.as_str()))
+                .ok_or_else(|| invalid(format!("unknown step '{name}'")))?;
+            let next = match step {
+                crate::stage0::build::Step::Run(step) => (step.requirements.inherit.build, step.requirements.inherit.host),
+                crate::stage0::build::Step::Uses(_) => (true, true),
+            };
+            if policy.is_some_and(|policy| policy != next) { return Err(invalid("selected steps have conflicting requirements inheritance")); }
+            policy = Some(next);
+        }
+        if let Some((build, host)) = policy {
+            compiled.requirements.inherit.build = build;
+            compiled.requirements.inherit.host = host;
+        }
+    }
+    Ok(compiled)
+}
+
+struct Compiler {
+    stack: Vec<PathBuf>,
+    parsed: HashMap<PathBuf, Arc<ActionDocument>>,
+}
+
+fn source_metadata(step: &crate::stage0::build::Step) -> (Option<&str>, bool, &[String]) {
+    match step {
+        crate::stage0::build::Step::Run(step) => (step.name.as_deref(), step.optional, &step.depends_on),
+        crate::stage0::build::Step::Uses(step) => (step.name.as_deref(), step.optional, &step.depends_on),
+    }
+}
+
+fn selected_order(steps: &[crate::stage0::build::Step], selected: Option<&[String]>) -> Result<Vec<usize>, ParseError> {
+    let mut names = HashMap::new();
+    for (index, step) in steps.iter().enumerate() {
+        if let Some(name) = source_metadata(step).0 {
+            if names.insert(name, index).is_some() { return Err(invalid(format!("duplicate step name '{name}'"))); }
+        }
+    }
+    fn visit(index: usize, steps: &[crate::stage0::build::Step], names: &HashMap<&str, usize>, state: &mut [u8], order: &mut Vec<usize>) -> Result<(), ParseError> {
+        if state[index] == 2 { return Ok(()); }
+        if state[index] == 1 { return Err(invalid("cycle in source step dependencies")); }
+        state[index] = 1;
+        for name in source_metadata(&steps[index]).2 {
+            let dependency = names.get(name.as_str()).ok_or_else(|| invalid(format!("unknown step dependency '{name}'")))?;
+            visit(*dependency, steps, names, state, order)?;
+        }
+        state[index] = 2;
+        order.push(index);
+        Ok(())
+    }
+    let roots = if let Some(selected) = selected {
+        selected.iter().map(|name| names.get(name.as_str()).copied().ok_or_else(|| invalid(format!("unknown step '{name}'")))).collect::<Result<Vec<_>, _>>()?
+    } else {
+        steps.iter().enumerate().filter_map(|(index, step)| (!source_metadata(step).1).then_some(index)).collect()
+    };
+    let mut state = vec![0; steps.len()];
+    let mut order = Vec::new();
+    for index in roots { visit(index, steps, &names, &mut state, &mut order)?; }
+    Ok(order)
+}
+
+impl Compiler {
+    fn compile(
+        &mut self,
+        steps: &[crate::stage0::build::Step],
+        context: &crate::stage1::EvaluationContext,
+        origin: &std::path::Path,
+        selected: Option<&[String]>,
+        provenance: Option<&ActionProvenance>,
+        prefix: &str,
+    ) -> Result<CompiledSteps, ParseError> {
+        use crate::stage0::{build::Step, evaluate::{evaluate_condition, evaluate_dependency_list, evaluate_run_steps, evaluate_string_value}};
+        let mut compiled = CompiledSteps::default();
+        for index in selected_order(steps, selected)? {
+            let step = &steps[index];
+            let local_name = source_metadata(step).0.map(str::to_owned).unwrap_or_else(|| format!("#{}", index + 1));
+            let qualified = if prefix.is_empty() { local_name } else { format!("{prefix}/{local_name}") };
+            match step {
+                Step::Run(_) => {
+                    for mut executable in evaluate_run_steps(std::slice::from_ref(step), context)? {
+                        if !self.stack.is_empty() {
+                            executable.action_context = Some(context.variables().clone());
+                            executable.name = Some(qualified.clone());
+                        }
+                        executable.optional = false;
+                        executable.depends_on.clear();
+                        compiled.requirements.build.extend(executable.requirements.build.iter().cloned());
+                        compiled.requirements.host.extend(executable.requirements.host.iter().cloned());
+                        compiled.steps.push(executable);
+                    }
+                }
+                Step::Uses(invocation) => {
+                    if let Some(condition) = &invocation.condition
+                        && !evaluate_condition(condition, context, invocation.condition_span.as_ref())? {
+                        continue;
+                    }
+                    let reference = evaluate_string_value(&invocation.uses, context)?;
+                    let local = reference.starts_with("./") || reference.starts_with("../") || reference.starts_with(".\\") || reference.starts_with("..\\");
+                    let mut source = if local {
+                        let path = std::path::Path::new(&reference);
+                        if !matches!(path.extension().and_then(|s| s.to_str()), Some("yaml" | "yml")) {
+                            return Err(invalid("local action references must name a .yaml or .yml document"));
+                        }
+                        let path = origin.parent().unwrap_or(std::path::Path::new(".")).join(path);
+                        let contents = std::fs::read_to_string(&path).map_err(|error| invalid(format!("cannot load action '{}': {error}", path.display())))?;
+                        ActionSource { path, contents, fingerprint: provenance.and_then(|p| p.fingerprint.clone()), provenance: provenance.cloned() }
+                    } else {
+                        if std::path::Path::new(&reference).is_absolute() || !reference.contains(':') {
+                            return Err(invalid("action references must be explicit relative YAML paths or packaged references"));
+                        }
+                        let request = ActionRequest {
+                            reference: reference.clone(), origin: origin.to_owned(),
+                            channel_sources: context.actions.variants.get("channel_sources").map(ToString::to_string),
+                        };
+                        context.actions.sources.resolve(request).ok_or_else(|| invalid(format!("external action '{reference}' needs source resolution")))?
+                    };
+                    source.provenance = Some(ActionProvenance {
+                        reference: reference.clone(),
+                        provider: source.provenance.as_ref().and_then(|p| p.provider.clone()),
+                        content_sha256: hex::encode(rattler_digest::compute_bytes_digest::<rattler_digest::Sha256>(source.contents.as_bytes())),
+                        fingerprint: source.fingerprint.clone(),
+                    });
+                    let identity = source.path.canonicalize().or_else(|_| std::path::absolute(&source.path))
+                        .map_err(|error| invalid(format!("cannot identify action '{}': {error}", source.path.display())))?;
+                    if self.stack.contains(&identity) {
+                        let chain = self.stack.iter().chain(std::iter::once(&identity)).map(|p| p.display().to_string()).collect::<Vec<_>>().join(" -> ");
+                        return Err(invalid(format!("action cycle: {chain}")));
+                    }
+                    if self.stack.len() >= 64 {
+                        let chain = self.stack.iter().chain(std::iter::once(&identity)).map(|p| p.display().to_string()).collect::<Vec<_>>().join(" -> ");
+                        return Err(invalid(format!("action nesting exceeds maximum depth 64: {chain}")));
+                    }
+                    let document = if let Some(document) = self.parsed.get(&identity) { document.clone() } else {
+                        let document = Arc::new(parse_document(&source.contents)?);
+                        self.parsed.insert(identity.clone(), document.clone());
+                        document
+                    };
+                    for key in invocation.inputs.keys() {
+                        if !document.inputs.contains_key(key) { return Err(invalid(format!("undeclared action input '{key}'"))); }
+                    }
+                    let mut bindings = indexmap::IndexMap::new();
+                    for (name, definition) in &document.inputs {
+                        let value = if let Some(value) = invocation.inputs.get(name).or(definition.default.as_ref()) {
+                            evaluate_input(value, context)?
+                        } else if definition.required {
+                            return Err(invalid(format!("missing required action input '{name}'")));
+                        } else { Variable::from(minijinja::Value::from(())) };
+                        validate_input(name, definition, &value)?;
+                        bindings.insert(name.clone(), value);
+                    }
+                    let mut variables = context.actions.variants.clone();
+                    variables.insert("inputs".to_owned(), Variable::from(minijinja::Value::from_serialize(&bindings)));
+                    let mut action_context = crate::stage1::EvaluationContext::with_variables_config_os_env_keys_and_repodata_revision(
+                        variables, context.jinja_config().clone(), context.os_env_var_keys().clone(), context.repodata_revision());
+                    action_context.actions = context.actions.clone();
+                    let build = evaluate_dependency_list(&document.requirements.build, &action_context)?;
+                    let host = evaluate_dependency_list(&document.requirements.host, &action_context)?;
+                    self.stack.push(identity);
+                    let nested = self.compile(&document.steps, &action_context, &source.path, None, source.provenance.as_ref(), &qualified);
+                    self.stack.pop();
+                    let nested = nested?;
+                    compiled.requirements.build.extend(build);
+                    compiled.requirements.host.extend(host);
+                    compiled.requirements.build.extend(nested.requirements.build);
+                    compiled.requirements.host.extend(nested.requirements.host);
+                    compiled.steps.extend(nested.steps);
+                    if let Some(provenance) = source.provenance { compiled.provenance.push(provenance); }
+                    compiled.provenance.extend(nested.provenance);
+                    for key in action_context.accessed_variables() {
+                        if key != "inputs" { context.track_access(&key); }
+                    }
+                }
+            }
+        }
+        Ok(compiled)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn input_defaults_obey_native_types_and_signed_integer_bounds() -> Result<(), ParseError> {
+        let document = parse_document(
+            "inputs:\n  text:\n    type: string\n    default: 'true'\n  count:\n    type: integer\n    default: -9223372036854775808\nsteps: []\n",
+        )?;
+        let context = crate::stage1::EvaluationContext::new();
+        let text = document.inputs.get("text").and_then(|input| input.default.as_ref())
+            .ok_or_else(|| invalid("missing text default"))?;
+        assert_eq!(evaluate_input(text, &context)?.as_ref().as_str(), Some("true"));
+        for value in ["9223372036854775808", "1.0", "'1'"] {
+            assert!(parse_document(&format!("inputs:\n  count:\n    type: integer\n    default: {value}\nsteps: []\n")).is_err());
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn list_defaults_reject_mixed_scalars_and_nested_lists() {
+        for value in ["[one, true]", "[[one]]", "{one: two}"] {
+            assert!(parse_document(&format!("inputs:\n  names:\n    type: list\n    items: string\n    default: {value}\nsteps: []\n")).is_err());
+        }
+    }
+
+    #[test]
+    fn action_schema_rejects_unknown_fields_and_dynamic_defaults() {
+        for source in [
+            "unknown: true\nsteps: []",
+            "requirements:\n  run: [python]\nsteps: []",
+            "inputs:\n  value:\n    type: string\n    required: true\n    default: x\nsteps: []",
+            "inputs:\n  value:\n    type: string\n    default: '${{ \"literal\" }}'\nsteps: []",
+            "inputs:\n  invalid-name:\n    type: string\nsteps: []",
+            "inputs:\n  value:\n    type: list\nsteps: []",
+        ] {
+            assert!(parse_document(source).is_err());
+        }
+    }
+}

--- a/crates/rattler_build_recipe/src/actions.rs
+++ b/crates/rattler_build_recipe/src/actions.rs
@@ -1,8 +1,16 @@
 //! Render-time action sources shared by local and packaged action compilation.
-use std::{collections::HashMap, path::PathBuf, sync::{Arc, Mutex}};
-use serde::{Deserialize, Serialize};
-use crate::{ParseError, Span, stage0::types::{JinjaTemplate, Value}};
+use crate::{
+    ParseError, Span,
+    stage0::{JinjaTemplate, Value, parse_step_requirements, parse_steps},
+};
 use rattler_build_jinja::Variable;
+use rattler_build_yaml_parser::ValueInner;
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::HashMap,
+    path::PathBuf,
+    sync::{Arc, Mutex},
+};
 
 /// Native source input, retaining individual templates inside lists.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -25,19 +33,33 @@ impl ActionValue {
 
     pub(crate) fn parse(node: &marked_yaml::Node) -> Result<Self, ParseError> {
         if let Some(sequence) = node.as_sequence() {
-            return sequence.iter().map(Self::parse).collect::<Result<Vec<_>, _>>().map(Self::List);
+            return sequence
+                .iter()
+                .map(Self::parse)
+                .collect::<Result<Vec<_>, _>>()
+                .map(Self::List);
         }
         if let Some(mapping) = node.as_mapping() {
-            return mapping.iter().map(|(key, value)| Ok((key.as_str().to_owned(), Self::parse(value)?)))
-                .collect::<Result<indexmap::IndexMap<_, _>, ParseError>>().map(Self::Mapping);
+            return mapping
+                .iter()
+                .map(|(key, value)| Ok((key.as_str().to_owned(), Self::parse(value)?)))
+                .collect::<Result<indexmap::IndexMap<_, _>, ParseError>>()
+                .map(Self::Mapping);
         }
-        let scalar = node.as_scalar().ok_or_else(|| ParseError::generic(
-            "action inputs must be scalars or homogeneous lists", Span::new_blank()))?;
+        let scalar = node.as_scalar().ok_or_else(|| {
+            ParseError::generic(
+                "action inputs must be scalars or homogeneous lists",
+                Span::new_blank(),
+            )
+        })?;
         let text = scalar.as_str();
         if text.contains("${{") {
             let template = JinjaTemplate::new(text.to_owned())
                 .map_err(|error| ParseError::jinja_error(error, *scalar.span()))?;
-            return Ok(Self::Scalar(Value::new_template(template, Some(*scalar.span()))));
+            return Ok(Self::Scalar(Value::new_template(
+                template,
+                Some(*scalar.span()),
+            )));
         }
         let value = if scalar.may_coerce() {
             let native: serde_yaml::Value = serde_yaml::from_str(text)
@@ -46,7 +68,10 @@ impl ActionValue {
         } else {
             Variable::from(text.to_owned())
         };
-        Ok(Self::Scalar(Value::new_concrete(value, Some(*scalar.span()))))
+        Ok(Self::Scalar(Value::new_concrete(
+            value,
+            Some(*scalar.span()),
+        )))
     }
 }
 
@@ -67,7 +92,11 @@ pub struct CompiledSteps {
 }
 
 #[derive(Debug, Clone, Copy)]
-enum ScalarType { String, Boolean, Integer }
+enum ScalarType {
+    String,
+    Boolean,
+    Integer,
+}
 
 #[derive(Debug, Clone)]
 struct InputDefinition {
@@ -99,48 +128,69 @@ fn scalar_type(value: &str) -> Result<ScalarType, ParseError> {
 
 fn identifier(name: &str) -> bool {
     let mut chars = name.chars();
-    chars.next().is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+    chars
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
         && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
 fn text(node: &marked_yaml::Node) -> Result<&str, ParseError> {
-    let scalar = node.as_scalar().ok_or_else(|| invalid("expected a string"))?;
-    if scalar.may_coerce() && !serde_yaml::from_str::<serde_yaml::Value>(scalar.as_str())
-        .is_ok_and(|value| value.is_string()) {
+    let scalar = node
+        .as_scalar()
+        .ok_or_else(|| invalid("expected a string"))?;
+    if scalar.may_coerce()
+        && !serde_yaml::from_str::<serde_yaml::Value>(scalar.as_str())
+            .is_ok_and(|value| value.is_string())
+    {
         return Err(invalid("expected a string"));
     }
     Ok(scalar.as_str())
 }
 
 fn parse_document(contents: &str) -> Result<ActionDocument, ParseError> {
-    use crate::stage0::parser::build::{parse_steps, parse_step_requirements};
     let node = rattler_build_yaml_parser::parse_yaml(contents)
         .map_err(|error| invalid(format!("invalid action YAML: {error}")))?;
-    let mapping = node.as_mapping().ok_or_else(|| invalid("action document must be a mapping"))?;
+    let mapping = node
+        .as_mapping()
+        .ok_or_else(|| invalid("action document must be a mapping"))?;
     let mut inputs = indexmap::IndexMap::new();
     let mut requirements = Default::default();
     let mut steps = None;
     for (key, value) in mapping.iter() {
         match key.as_str() {
             "schema_version" => {
-                if !value.as_scalar().is_some_and(|v| v.may_coerce() && v.as_i64() == Some(1)) {
+                if !value
+                    .as_scalar()
+                    .is_some_and(|v| v.may_coerce() && v.as_i64() == Some(1))
+                {
                     return Err(invalid("action schema_version must be integer 1"));
                 }
             }
             "action" => {
-                let metadata = value.as_mapping().ok_or_else(|| invalid("action metadata must be a mapping"))?;
+                let metadata = value
+                    .as_mapping()
+                    .ok_or_else(|| invalid("action metadata must be a mapping"))?;
                 for (key, value) in metadata.iter() {
                     if !matches!(key.as_str(), "name" | "description") {
-                        return Err(invalid(format!("unknown action metadata field '{}'", key.as_str())));
+                        return Err(invalid(format!(
+                            "unknown action metadata field '{}'",
+                            key.as_str()
+                        )));
                     }
                     text(value)?;
                 }
             }
             "inputs" => {
-                let declarations = value.as_mapping().ok_or_else(|| invalid("action inputs must be a mapping"))?;
+                let declarations = value
+                    .as_mapping()
+                    .ok_or_else(|| invalid("action inputs must be a mapping"))?;
                 for (name, definition) in declarations.iter() {
-                    if !identifier(name.as_str()) { return Err(invalid("input names must match [A-Za-z_][A-Za-z0-9_]*")); }
-                    let fields = definition.as_mapping().ok_or_else(|| invalid("input definition must be a mapping"))?;
+                    if !identifier(name.as_str()) {
+                        return Err(invalid("input names must match [A-Za-z_][A-Za-z0-9_]*"));
+                    }
+                    let fields = definition
+                        .as_mapping()
+                        .ok_or_else(|| invalid("input definition must be a mapping"))?;
                     let mut kind = None;
                     let mut items = None;
                     let mut required = None;
@@ -149,35 +199,67 @@ fn parse_document(contents: &str) -> Result<ActionDocument, ParseError> {
                         match key.as_str() {
                             "type" => kind = Some(text(value)?.to_owned()),
                             "items" => items = Some(scalar_type(text(value)?)?),
-                            "description" => { text(value)?; }
-                            "required" => required = Some(value.as_scalar().filter(|v| v.may_coerce()).and_then(|v| v.as_bool()).ok_or_else(|| invalid("required must be a boolean"))?),
+                            "description" => {
+                                text(value)?;
+                            }
+                            "required" => {
+                                required = Some(
+                                    value
+                                        .as_scalar()
+                                        .filter(|v| v.may_coerce())
+                                        .and_then(|v| v.as_bool())
+                                        .ok_or_else(|| invalid("required must be a boolean"))?,
+                                )
+                            }
                             "default" => {
                                 let parsed = ActionValue::parse(value)?;
-                                if !parsed.used_variables().is_empty() || contains_template(&parsed) { return Err(invalid("action defaults must be static, not Jinja")); }
+                                if !parsed.used_variables().is_empty() || contains_template(&parsed)
+                                {
+                                    return Err(invalid(
+                                        "action defaults must be static, not Jinja",
+                                    ));
+                                }
                                 default = Some(parsed);
                             }
                             other => return Err(invalid(format!("unknown input field '{other}'"))),
                         }
                     }
-                    let kind = kind.ok_or_else(|| invalid("action input requires an explicit type"))?;
+                    let kind =
+                        kind.ok_or_else(|| invalid("action input requires an explicit type"))?;
                     let list = kind == "list";
-                    let scalar = if list { items.ok_or_else(|| invalid("list input requires scalar items type"))? } else {
-                        if items.is_some() { return Err(invalid("items is only valid for list inputs")); }
+                    let scalar = if list {
+                        items.ok_or_else(|| invalid("list input requires scalar items type"))?
+                    } else {
+                        if items.is_some() {
+                            return Err(invalid("items is only valid for list inputs"));
+                        }
                         scalar_type(&kind)?
                     };
-                    if required == Some(true) && default.is_some() { return Err(invalid("required input cannot have a default")); }
-                    let definition = InputDefinition { scalar, list, required: required.unwrap_or(default.is_none()), default };
+                    if required == Some(true) && default.is_some() {
+                        return Err(invalid("required input cannot have a default"));
+                    }
+                    let definition = InputDefinition {
+                        scalar,
+                        list,
+                        required: required.unwrap_or(default.is_none()),
+                        default,
+                    };
                     if let Some(default) = &definition.default {
-                        let value = evaluate_input(default, &crate::stage1::EvaluationContext::new())?;
+                        let value =
+                            evaluate_input(default, &crate::stage1::EvaluationContext::new())?;
                         validate_input(name.as_str(), &definition, &value)?;
                     }
                     inputs.insert(name.as_str().to_owned(), definition);
                 }
             }
             "requirements" => {
-                let fields = value.as_mapping().ok_or_else(|| invalid("action requirements must be a mapping"))?;
+                let fields = value
+                    .as_mapping()
+                    .ok_or_else(|| invalid("action requirements must be a mapping"))?;
                 for (key, _) in fields.iter() {
-                    if !matches!(key.as_str(), "build" | "host") { return Err(invalid("actions can only own build and host requirements")); }
+                    if !matches!(key.as_str(), "build" | "host") {
+                        return Err(invalid("actions can only own build and host requirements"));
+                    }
                 }
                 requirements = parse_step_requirements(value)?;
             }
@@ -185,7 +267,12 @@ fn parse_document(contents: &str) -> Result<ActionDocument, ParseError> {
             other => return Err(invalid(format!("unknown action document field '{other}'"))),
         }
     }
-    Ok(ActionDocument { inputs, requirements, steps: steps.ok_or_else(|| invalid("action document requires steps (which may be empty)"))? })
+    Ok(ActionDocument {
+        inputs,
+        requirements,
+        steps: steps
+            .ok_or_else(|| invalid("action document requires steps (which may be empty)"))?,
+    })
 }
 
 fn contains_template(value: &ActionValue) -> bool {
@@ -196,43 +283,81 @@ fn contains_template(value: &ActionValue) -> bool {
     }
 }
 
-fn evaluate_input(value: &ActionValue, context: &crate::stage1::EvaluationContext) -> Result<Variable, ParseError> {
+fn evaluate_input(
+    value: &ActionValue,
+    context: &crate::stage1::EvaluationContext,
+) -> Result<Variable, ParseError> {
     match value {
         ActionValue::Scalar(value) => {
-            if let crate::stage0::types::ValueInner::Template(template) = value.inner() {
+            if let ValueInner::Template(template) = value.inner() {
                 let source = template.source().trim();
-                let standalone = source.starts_with("${{") && source.ends_with("}}")
+                let standalone = source.starts_with("${{")
+                    && source.ends_with("}}")
                     && !source[3..source.len() - 2].contains("${{");
                 if !standalone {
                     let jinja = context.to_jinja();
-                    let result = jinja.render_str(template.source())
-                        .map_err(|error| invalid(format!("invalid action input expression: {error}")))?;
-                    for key in jinja.accessed_variables_excluding_functions() { context.track_access(&key); }
+                    let result = jinja.render_str(template.source()).map_err(|error| {
+                        invalid(format!("invalid action input expression: {error}"))
+                    })?;
+                    for key in jinja.accessed_variables_excluding_functions() {
+                        context.track_access(&key);
+                    }
                     return Ok(Variable::from(result));
                 }
             }
             crate::stage0::evaluate::evaluate_value_to_variable(value, context)
         }
-        ActionValue::List(values) => values.iter().map(|v| evaluate_input(v, context)).collect::<Result<Vec<_>, _>>().map(Variable::from),
-        ActionValue::Mapping(_) => Err(invalid("action inputs must be scalars or homogeneous lists")),
+        ActionValue::List(values) => values
+            .iter()
+            .map(|v| evaluate_input(v, context))
+            .collect::<Result<Vec<_>, _>>()
+            .map(Variable::from),
+        ActionValue::Mapping(_) => Err(invalid(
+            "action inputs must be scalars or homogeneous lists",
+        )),
     }
 }
 
-fn validate_input(name: &str, definition: &InputDefinition, value: &Variable) -> Result<(), ParseError> {
+fn validate_input(
+    name: &str,
+    definition: &InputDefinition,
+    value: &Variable,
+) -> Result<(), ParseError> {
     use minijinja::value::ValueKind;
     let value = value.as_ref();
     if value.is_none() {
-        return if definition.required { Err(invalid(format!("required action input '{name}' cannot be null"))) } else { Ok(()) };
+        return if definition.required {
+            Err(invalid(format!(
+                "required action input '{name}' cannot be null"
+            )))
+        } else {
+            Ok(())
+        };
     }
     let scalar_valid = |value: &minijinja::Value| match definition.scalar {
         ScalarType::String => value.kind() == ValueKind::String,
-        ScalarType::Integer => value.kind() == ValueKind::Number && serde_json::to_value(value).is_ok_and(|value| value.is_i64()),
+        ScalarType::Integer => {
+            value.kind() == ValueKind::Number
+                && serde_json::to_value(value).is_ok_and(|value| value.is_i64())
+        }
         ScalarType::Boolean => value.kind() == ValueKind::Bool,
     };
     let valid = if definition.list {
-        value.kind() == ValueKind::Seq && value.try_iter().map(|mut items| items.all(|item| scalar_valid(&item))).unwrap_or(false)
-    } else { scalar_valid(value) };
-    if valid { Ok(()) } else { Err(invalid(format!("action input '{name}' does not match its declared type"))) }
+        value.kind() == ValueKind::Seq
+            && value
+                .try_iter()
+                .map(|mut items| items.all(|item| scalar_valid(&item)))
+                .unwrap_or(false)
+    } else {
+        scalar_valid(value)
+    };
+    if valid {
+        Ok(())
+    } else {
+        Err(invalid(format!(
+            "action input '{name}' does not match its declared type"
+        )))
+    }
 }
 
 /// An unresolved external reference and its compilation environment.
@@ -299,11 +424,19 @@ impl ActionSources {
     }
 
     pub fn take_pending(&self) -> Option<ActionRequest> {
-        self.0.lock().unwrap_or_else(|poison| poison.into_inner()).pending.take()
+        self.0
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .pending
+            .take()
     }
 
     pub fn len(&self) -> usize {
-        self.0.lock().unwrap_or_else(|poison| poison.into_inner()).sources.len()
+        self.0
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .sources
+            .len()
     }
 
     pub fn is_empty(&self) -> bool {
@@ -325,19 +458,42 @@ pub fn compile_steps(
     steps: &[crate::stage0::build::Step],
     context: &crate::stage1::EvaluationContext,
 ) -> Result<CompiledSteps, ParseError> {
-    let origin = context.actions.origin.clone().unwrap_or_else(|| PathBuf::from("recipe.yaml"));
-    let mut compiler = Compiler { stack: Vec::new(), parsed: HashMap::new() };
-    let mut compiled = compiler.compile(steps, context, &origin, context.actions.selected.as_deref(), None, "")?;
+    let origin = context
+        .actions
+        .origin
+        .clone()
+        .unwrap_or_else(|| PathBuf::from("recipe.yaml"));
+    let mut compiler = Compiler {
+        stack: Vec::new(),
+        parsed: HashMap::new(),
+    };
+    let mut compiled = compiler.compile(
+        steps,
+        context,
+        &origin,
+        context.actions.selected.as_deref(),
+        None,
+        "",
+    )?;
     if let Some(selected) = &context.actions.selected {
         let mut policy = None;
         for name in selected {
-            let step = steps.iter().find(|step| source_metadata(step).0 == Some(name.as_str()))
+            let step = steps
+                .iter()
+                .find(|step| source_metadata(step).0 == Some(name.as_str()))
                 .ok_or_else(|| invalid(format!("unknown step '{name}'")))?;
             let next = match step {
-                crate::stage0::build::Step::Run(step) => (step.requirements.inherit.build, step.requirements.inherit.host),
+                crate::stage0::build::Step::Run(step) => (
+                    step.requirements.inherit.build,
+                    step.requirements.inherit.host,
+                ),
                 crate::stage0::build::Step::Uses(_) => (true, true),
             };
-            if policy.is_some_and(|policy| policy != next) { return Err(invalid("selected steps have conflicting requirements inheritance")); }
+            if policy.is_some_and(|policy| policy != next) {
+                return Err(invalid(
+                    "selected steps have conflicting requirements inheritance",
+                ));
+            }
             policy = Some(next);
         }
         if let Some((build, host)) = policy {
@@ -355,24 +511,45 @@ struct Compiler {
 
 fn source_metadata(step: &crate::stage0::build::Step) -> (Option<&str>, bool, &[String]) {
     match step {
-        crate::stage0::build::Step::Run(step) => (step.name.as_deref(), step.optional, &step.depends_on),
-        crate::stage0::build::Step::Uses(step) => (step.name.as_deref(), step.optional, &step.depends_on),
+        crate::stage0::build::Step::Run(step) => {
+            (step.name.as_deref(), step.optional, &step.depends_on)
+        }
+        crate::stage0::build::Step::Uses(step) => {
+            (step.name.as_deref(), step.optional, &step.depends_on)
+        }
     }
 }
 
-fn selected_order(steps: &[crate::stage0::build::Step], selected: Option<&[String]>) -> Result<Vec<usize>, ParseError> {
+fn selected_order(
+    steps: &[crate::stage0::build::Step],
+    selected: Option<&[String]>,
+) -> Result<Vec<usize>, ParseError> {
     let mut names = HashMap::new();
     for (index, step) in steps.iter().enumerate() {
         if let Some(name) = source_metadata(step).0 {
-            if names.insert(name, index).is_some() { return Err(invalid(format!("duplicate step name '{name}'"))); }
+            if names.insert(name, index).is_some() {
+                return Err(invalid(format!("duplicate step name '{name}'")));
+            }
         }
     }
-    fn visit(index: usize, steps: &[crate::stage0::build::Step], names: &HashMap<&str, usize>, state: &mut [u8], order: &mut Vec<usize>) -> Result<(), ParseError> {
-        if state[index] == 2 { return Ok(()); }
-        if state[index] == 1 { return Err(invalid("cycle in source step dependencies")); }
+    fn visit(
+        index: usize,
+        steps: &[crate::stage0::build::Step],
+        names: &HashMap<&str, usize>,
+        state: &mut [u8],
+        order: &mut Vec<usize>,
+    ) -> Result<(), ParseError> {
+        if state[index] == 2 {
+            return Ok(());
+        }
+        if state[index] == 1 {
+            return Err(invalid("cycle in source step dependencies"));
+        }
         state[index] = 1;
         for name in source_metadata(&steps[index]).2 {
-            let dependency = names.get(name.as_str()).ok_or_else(|| invalid(format!("unknown step dependency '{name}'")))?;
+            let dependency = names
+                .get(name.as_str())
+                .ok_or_else(|| invalid(format!("unknown step dependency '{name}'")))?;
             visit(*dependency, steps, names, state, order)?;
         }
         state[index] = 2;
@@ -380,13 +557,27 @@ fn selected_order(steps: &[crate::stage0::build::Step], selected: Option<&[Strin
         Ok(())
     }
     let roots = if let Some(selected) = selected {
-        selected.iter().map(|name| names.get(name.as_str()).copied().ok_or_else(|| invalid(format!("unknown step '{name}'")))).collect::<Result<Vec<_>, _>>()?
+        selected
+            .iter()
+            .map(|name| {
+                names
+                    .get(name.as_str())
+                    .copied()
+                    .ok_or_else(|| invalid(format!("unknown step '{name}'")))
+            })
+            .collect::<Result<Vec<_>, _>>()?
     } else {
-        steps.iter().enumerate().filter_map(|(index, step)| (!source_metadata(step).1).then_some(index)).collect()
+        steps
+            .iter()
+            .enumerate()
+            .filter_map(|(index, step)| (!source_metadata(step).1).then_some(index))
+            .collect()
     };
     let mut state = vec![0; steps.len()];
     let mut order = Vec::new();
-    for index in roots { visit(index, steps, &names, &mut state, &mut order)?; }
+    for index in roots {
+        visit(index, steps, &names, &mut state, &mut order)?;
+    }
     Ok(order)
 }
 
@@ -400,12 +591,25 @@ impl Compiler {
         provenance: Option<&ActionProvenance>,
         prefix: &str,
     ) -> Result<CompiledSteps, ParseError> {
-        use crate::stage0::{build::Step, evaluate::{evaluate_condition, evaluate_dependency_list, evaluate_run_steps, evaluate_string_value}};
+        use crate::stage0::{
+            build::Step,
+            evaluate::{
+                evaluate_condition, evaluate_dependency_list, evaluate_run_steps,
+                evaluate_string_value,
+            },
+        };
         let mut compiled = CompiledSteps::default();
         for index in selected_order(steps, selected)? {
             let step = &steps[index];
-            let local_name = source_metadata(step).0.map(str::to_owned).unwrap_or_else(|| format!("#{}", index + 1));
-            let qualified = if prefix.is_empty() { local_name } else { format!("{prefix}/{local_name}") };
+            let local_name = source_metadata(step)
+                .0
+                .map(str::to_owned)
+                .unwrap_or_else(|| format!("#{}", index + 1));
+            let qualified = if prefix.is_empty() {
+                local_name
+            } else {
+                format!("{prefix}/{local_name}")
+            };
             match step {
                 Step::Run(_) => {
                     for mut executable in evaluate_run_steps(std::slice::from_ref(step), context)? {
@@ -415,90 +619,185 @@ impl Compiler {
                         }
                         executable.optional = false;
                         executable.depends_on.clear();
-                        compiled.requirements.build.extend(executable.requirements.build.iter().cloned());
-                        compiled.requirements.host.extend(executable.requirements.host.iter().cloned());
+                        compiled
+                            .requirements
+                            .build
+                            .extend(executable.requirements.build.iter().cloned());
+                        compiled
+                            .requirements
+                            .host
+                            .extend(executable.requirements.host.iter().cloned());
                         compiled.steps.push(executable);
                     }
                 }
                 Step::Uses(invocation) => {
                     if let Some(condition) = &invocation.condition
-                        && !evaluate_condition(condition, context, invocation.condition_span.as_ref())? {
+                        && !evaluate_condition(
+                            condition,
+                            context,
+                            invocation.condition_span.as_ref(),
+                        )?
+                    {
                         continue;
                     }
                     let reference = evaluate_string_value(&invocation.uses, context)?;
-                    let local = reference.starts_with("./") || reference.starts_with("../") || reference.starts_with(".\\") || reference.starts_with("..\\");
+                    let local = reference.starts_with("./")
+                        || reference.starts_with("../")
+                        || reference.starts_with(".\\")
+                        || reference.starts_with("..\\");
                     let mut source = if local {
                         let path = std::path::Path::new(&reference);
-                        if !matches!(path.extension().and_then(|s| s.to_str()), Some("yaml" | "yml")) {
-                            return Err(invalid("local action references must name a .yaml or .yml document"));
+                        if !matches!(
+                            path.extension().and_then(|s| s.to_str()),
+                            Some("yaml" | "yml")
+                        ) {
+                            return Err(invalid(
+                                "local action references must name a .yaml or .yml document",
+                            ));
                         }
-                        let path = origin.parent().unwrap_or(std::path::Path::new(".")).join(path);
-                        let contents = std::fs::read_to_string(&path).map_err(|error| invalid(format!("cannot load action '{}': {error}", path.display())))?;
-                        ActionSource { path, contents, fingerprint: provenance.and_then(|p| p.fingerprint.clone()), provenance: provenance.cloned() }
+                        let path = origin
+                            .parent()
+                            .unwrap_or(std::path::Path::new("."))
+                            .join(path);
+                        let contents = std::fs::read_to_string(&path).map_err(|error| {
+                            invalid(format!("cannot load action '{}': {error}", path.display()))
+                        })?;
+                        ActionSource {
+                            path,
+                            contents,
+                            fingerprint: provenance.and_then(|p| p.fingerprint.clone()),
+                            provenance: provenance.cloned(),
+                        }
                     } else {
-                        if std::path::Path::new(&reference).is_absolute() || !reference.contains(':') {
-                            return Err(invalid("action references must be explicit relative YAML paths or packaged references"));
+                        if std::path::Path::new(&reference).is_absolute()
+                            || !reference.contains(':')
+                        {
+                            return Err(invalid(
+                                "action references must be explicit relative YAML paths or packaged references",
+                            ));
                         }
                         let request = ActionRequest {
-                            reference: reference.clone(), origin: origin.to_owned(),
-                            channel_sources: context.actions.variants.get("channel_sources").map(ToString::to_string),
+                            reference: reference.clone(),
+                            origin: origin.to_owned(),
+                            channel_sources: context
+                                .actions
+                                .variants
+                                .get("channel_sources")
+                                .map(ToString::to_string),
                         };
-                        context.actions.sources.resolve(request).ok_or_else(|| invalid(format!("external action '{reference}' needs source resolution")))?
+                        context.actions.sources.resolve(request).ok_or_else(|| {
+                            invalid(format!(
+                                "external action '{reference}' needs source resolution"
+                            ))
+                        })?
                     };
                     source.provenance = Some(ActionProvenance {
                         reference: reference.clone(),
                         provider: source.provenance.as_ref().and_then(|p| p.provider.clone()),
-                        content_sha256: hex::encode(rattler_digest::compute_bytes_digest::<rattler_digest::Sha256>(source.contents.as_bytes())),
+                        content_sha256: hex::encode(rattler_digest::compute_bytes_digest::<
+                            rattler_digest::Sha256,
+                        >(
+                            source.contents.as_bytes()
+                        )),
                         fingerprint: source.fingerprint.clone(),
                     });
-                    let identity = source.path.canonicalize().or_else(|_| std::path::absolute(&source.path))
-                        .map_err(|error| invalid(format!("cannot identify action '{}': {error}", source.path.display())))?;
+                    let identity = source
+                        .path
+                        .canonicalize()
+                        .or_else(|_| std::path::absolute(&source.path))
+                        .map_err(|error| {
+                            invalid(format!(
+                                "cannot identify action '{}': {error}",
+                                source.path.display()
+                            ))
+                        })?;
                     if self.stack.contains(&identity) {
-                        let chain = self.stack.iter().chain(std::iter::once(&identity)).map(|p| p.display().to_string()).collect::<Vec<_>>().join(" -> ");
+                        let chain = self
+                            .stack
+                            .iter()
+                            .chain(std::iter::once(&identity))
+                            .map(|p| p.display().to_string())
+                            .collect::<Vec<_>>()
+                            .join(" -> ");
                         return Err(invalid(format!("action cycle: {chain}")));
                     }
                     if self.stack.len() >= 64 {
-                        let chain = self.stack.iter().chain(std::iter::once(&identity)).map(|p| p.display().to_string()).collect::<Vec<_>>().join(" -> ");
-                        return Err(invalid(format!("action nesting exceeds maximum depth 64: {chain}")));
+                        let chain = self
+                            .stack
+                            .iter()
+                            .chain(std::iter::once(&identity))
+                            .map(|p| p.display().to_string())
+                            .collect::<Vec<_>>()
+                            .join(" -> ");
+                        return Err(invalid(format!(
+                            "action nesting exceeds maximum depth 64: {chain}"
+                        )));
                     }
-                    let document = if let Some(document) = self.parsed.get(&identity) { document.clone() } else {
+                    let document = if let Some(document) = self.parsed.get(&identity) {
+                        document.clone()
+                    } else {
                         let document = Arc::new(parse_document(&source.contents)?);
                         self.parsed.insert(identity.clone(), document.clone());
                         document
                     };
                     for key in invocation.inputs.keys() {
-                        if !document.inputs.contains_key(key) { return Err(invalid(format!("undeclared action input '{key}'"))); }
+                        if !document.inputs.contains_key(key) {
+                            return Err(invalid(format!("undeclared action input '{key}'")));
+                        }
                     }
                     let mut bindings = indexmap::IndexMap::new();
                     for (name, definition) in &document.inputs {
-                        let value = if let Some(value) = invocation.inputs.get(name).or(definition.default.as_ref()) {
+                        let value = if let Some(value) =
+                            invocation.inputs.get(name).or(definition.default.as_ref())
+                        {
                             evaluate_input(value, context)?
                         } else if definition.required {
                             return Err(invalid(format!("missing required action input '{name}'")));
-                        } else { Variable::from(minijinja::Value::from(())) };
+                        } else {
+                            Variable::from(minijinja::Value::from(()))
+                        };
                         validate_input(name, definition, &value)?;
                         bindings.insert(name.clone(), value);
                     }
                     let mut variables = context.actions.variants.clone();
-                    variables.insert("inputs".to_owned(), Variable::from(minijinja::Value::from_serialize(&bindings)));
+                    variables.insert(
+                        "inputs".to_owned(),
+                        Variable::from(minijinja::Value::from_serialize(&bindings)),
+                    );
                     let mut action_context = crate::stage1::EvaluationContext::with_variables_config_os_env_keys_and_repodata_revision(
                         variables, context.jinja_config().clone(), context.os_env_var_keys().clone(), context.repodata_revision());
                     action_context.actions = context.actions.clone();
-                    let build = evaluate_dependency_list(&document.requirements.build, &action_context)?;
-                    let host = evaluate_dependency_list(&document.requirements.host, &action_context)?;
+                    let build =
+                        evaluate_dependency_list(&document.requirements.build, &action_context)?;
+                    let host =
+                        evaluate_dependency_list(&document.requirements.host, &action_context)?;
                     self.stack.push(identity);
-                    let nested = self.compile(&document.steps, &action_context, &source.path, None, source.provenance.as_ref(), &qualified);
+                    let nested = self.compile(
+                        &document.steps,
+                        &action_context,
+                        &source.path,
+                        None,
+                        source.provenance.as_ref(),
+                        &qualified,
+                    );
                     self.stack.pop();
                     let nested = nested?;
                     compiled.requirements.build.extend(build);
                     compiled.requirements.host.extend(host);
-                    compiled.requirements.build.extend(nested.requirements.build);
+                    compiled
+                        .requirements
+                        .build
+                        .extend(nested.requirements.build);
                     compiled.requirements.host.extend(nested.requirements.host);
                     compiled.steps.extend(nested.steps);
-                    if let Some(provenance) = source.provenance { compiled.provenance.push(provenance); }
+                    if let Some(provenance) = source.provenance {
+                        compiled.provenance.push(provenance);
+                    }
                     compiled.provenance.extend(nested.provenance);
                     for key in action_context.accessed_variables() {
-                        if key != "inputs" { context.track_access(&key); }
+                        if key != "inputs" {
+                            context.track_access(&key);
+                        }
                     }
                 }
             }
@@ -517,11 +816,22 @@ mod tests {
             "inputs:\n  text:\n    type: string\n    default: 'true'\n  count:\n    type: integer\n    default: -9223372036854775808\nsteps: []\n",
         )?;
         let context = crate::stage1::EvaluationContext::new();
-        let text = document.inputs.get("text").and_then(|input| input.default.as_ref())
+        let text = document
+            .inputs
+            .get("text")
+            .and_then(|input| input.default.as_ref())
             .ok_or_else(|| invalid("missing text default"))?;
-        assert_eq!(evaluate_input(text, &context)?.as_ref().as_str(), Some("true"));
+        assert_eq!(
+            evaluate_input(text, &context)?.as_ref().as_str(),
+            Some("true")
+        );
         for value in ["9223372036854775808", "1.0", "'1'"] {
-            assert!(parse_document(&format!("inputs:\n  count:\n    type: integer\n    default: {value}\nsteps: []\n")).is_err());
+            assert!(
+                parse_document(&format!(
+                    "inputs:\n  count:\n    type: integer\n    default: {value}\nsteps: []\n"
+                ))
+                .is_err()
+            );
         }
         Ok(())
     }

--- a/crates/rattler_build_recipe/src/actions.rs
+++ b/crates/rattler_build_recipe/src/actions.rs
@@ -526,10 +526,10 @@ fn selected_order(
 ) -> Result<Vec<usize>, ParseError> {
     let mut names = HashMap::new();
     for (index, step) in steps.iter().enumerate() {
-        if let Some(name) = source_metadata(step).0 {
-            if names.insert(name, index).is_some() {
-                return Err(invalid(format!("duplicate step name '{name}'")));
-            }
+        if let Some(name) = source_metadata(step).0
+            && names.insert(name, index).is_some()
+        {
+            return Err(invalid(format!("duplicate step name '{name}'")));
         }
     }
     fn visit(
@@ -659,7 +659,7 @@ impl Compiler {
                             .parent()
                             .unwrap_or(std::path::Path::new("."))
                             .join(path);
-                        let contents = std::fs::read_to_string(&path).map_err(|error| {
+                        let contents = fs_err::read_to_string(&path).map_err(|error| {
                             invalid(format!("cannot load action '{}': {error}", path.display()))
                         })?;
                         ActionSource {

--- a/crates/rattler_build_recipe/src/lib.rs
+++ b/crates/rattler_build_recipe/src/lib.rs
@@ -1,6 +1,7 @@
 //! Recipe data model and parsing for rattler-build, including multi-stage evaluation
 //! and variant rendering.
 
+pub mod actions;
 pub mod error;
 pub mod source_code;
 pub mod stage0;

--- a/crates/rattler_build_recipe/src/stage0/build.rs
+++ b/crates/rattler_build_recipe/src/stage0/build.rs
@@ -150,7 +150,6 @@ impl StepRequirements {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
 #[serde(deny_unknown_fields)]
 pub struct RunStep {
-
     /// Optional unique name used by `rattler-build run` and dependency edges.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,

--- a/crates/rattler_build_recipe/src/stage0/build.rs
+++ b/crates/rattler_build_recipe/src/stage0/build.rs
@@ -29,15 +29,15 @@ pub struct VariantKeyUsage {
 
 /// A single build step.
 ///
-/// Steps are an ordered, GitHub-Actions-style alternative to a monolithic
-/// `build.script`. A step is an inline `run` script.
+/// Source steps are inline scripts or action invocations compiled into
+/// executable steps.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum Step {
     /// An inline script step.
-    Run(RunStep),
+    Run(Box<RunStep>),
     /// A render-time action invocation, never an executable step.
-    Uses(UsesStep),
+    Uses(Box<UsesStep>),
 }
 
 /// Source-only action invocation.

--- a/crates/rattler_build_recipe/src/stage0/build.rs
+++ b/crates/rattler_build_recipe/src/stage0/build.rs
@@ -36,6 +36,27 @@ pub struct VariantKeyUsage {
 pub enum Step {
     /// An inline script step.
     Run(RunStep),
+    /// A render-time action invocation, never an executable step.
+    Uses(UsesStep),
+}
+
+/// Source-only action invocation.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct UsesStep {
+    pub uses: Value<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub optional: bool,
+    #[serde(default)]
+    pub depends_on: Vec<String>,
+    #[serde(default, rename = "if", skip_serializing_if = "Option::is_none")]
+    pub condition: Option<JinjaExpression>,
+    #[serde(skip)]
+    pub condition_span: Option<Span>,
+    #[serde(default, rename = "with")]
+    pub inputs: indexmap::IndexMap<String, crate::actions::ActionValue>,
 }
 
 /// Dependencies added to the selected step solve group.
@@ -129,6 +150,7 @@ impl StepRequirements {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
 #[serde(deny_unknown_fields)]
 pub struct RunStep {
+
     /// Optional unique name used by `rattler-build run` and dependency edges.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
@@ -176,6 +198,16 @@ impl Step {
     pub fn used_variables(&self) -> Vec<String> {
         match self {
             Step::Run(run) => run.used_variables(),
+            Step::Uses(action) => {
+                let mut vars = action.uses.used_variables();
+                if let Some(condition) = &action.condition {
+                    vars.extend(condition.used_variables().iter().cloned());
+                }
+                for value in action.inputs.values() {
+                    vars.extend(value.used_variables());
+                }
+                vars
+            }
         }
     }
 }

--- a/crates/rattler_build_recipe/src/stage0/evaluate.rs
+++ b/crates/rattler_build_recipe/src/stage0/evaluate.rs
@@ -432,7 +432,7 @@ pub fn evaluate_license_files(
 }
 
 /// Evaluate a simple conditional expression
-fn evaluate_condition(
+pub(crate) fn evaluate_condition(
     expr: &JinjaExpression,
     context: &EvaluationContext,
     span: Option<&Span>,
@@ -1392,7 +1392,7 @@ pub fn evaluate_script(
 /// Each step's `if` condition is evaluated here, where the target platform and
 /// selectors are known, and excluded steps are dropped. `run` content keeps its
 /// templates so they render at build time, exactly like `build.script`.
-pub fn evaluate_steps(
+pub(crate) fn evaluate_run_steps(
     steps: &[Stage0Step],
     context: &EvaluationContext,
 ) -> Result<Vec<Stage1Step>, ParseError> {
@@ -1444,16 +1444,26 @@ pub fn evaluate_steps(
                 step.requirements.inherit.host = run.requirements.inherit.host;
                 scripts.push(step);
             }
+            Stage0Step::Uses(_) => {
+                return Err(ParseError::generic("action invocation requires action compilation", Span::new_blank()));
+            }
         }
     }
 
     Ok(scripts)
 }
 
+pub fn evaluate_steps(
+    steps: &[Stage0Step],
+    context: &EvaluationContext,
+) -> Result<Vec<Stage1Step>, ParseError> {
+    Ok(crate::actions::compile_steps(steps, context)?.steps)
+}
+
 fn evaluate_build_plan(
     plan: &Stage0BuildPlan,
     context: &EvaluationContext,
-) -> Result<Stage1BuildPlan, ParseError> {
+) -> Result<(Stage1BuildPlan, crate::actions::CompiledSteps), ParseError> {
     match plan {
         Stage0BuildPlan::Steps(steps) => {
             if !context.jinja_config().experimental {
@@ -1463,10 +1473,12 @@ fn evaluate_build_plan(
                     Span::new_blank(),
                 ));
             }
-            Ok(Stage1BuildPlan::Steps(evaluate_steps(steps, context)?))
+            let mut compiled = crate::actions::compile_steps(steps, context)?;
+            let plan = Stage1BuildPlan::Steps(std::mem::take(&mut compiled.steps));
+            Ok((plan, compiled))
         }
         Stage0BuildPlan::Script(script) => {
-            Ok(Stage1BuildPlan::Script(evaluate_script(script, context)?))
+            Ok((Stage1BuildPlan::Script(evaluate_script(script, context)?), Default::default()))
         }
     }
 }
@@ -2229,7 +2241,7 @@ impl Evaluate for Stage0Build {
         // (enforced during parsing). Steps mode is preserved even if the list is
         // empty or all steps filter out, so outputs don't accidentally inherit a
         // top-level script.
-        let plan = evaluate_build_plan(&self.plan, context)?;
+        let (plan, actions) = evaluate_build_plan(&self.plan, context)?;
 
         // Evaluate noarch
         //
@@ -2337,6 +2349,8 @@ impl Evaluate for Stage0Build {
         )?;
 
         Ok(Stage1Build {
+            action_provenance: actions.provenance,
+            action_requirements: actions.requirements,
             number,
             string,
             plan,
@@ -2360,8 +2374,13 @@ impl Evaluate for stage0::StagingBuild {
     type Output = Stage1Build;
 
     fn evaluate(&self, context: &EvaluationContext) -> Result<Self::Output, ParseError> {
+        let mut staging_context = context.clone();
+        staging_context.actions.selected = None;
+        let (plan, actions) = evaluate_build_plan(&self.plan, &staging_context)?;
         Ok(Stage1Build {
-            plan: evaluate_build_plan(&self.plan, context)?,
+            plan,
+            action_provenance: actions.provenance,
+            action_requirements: actions.requirements,
             ..Stage1Build::default()
         })
     }
@@ -2955,9 +2974,10 @@ impl Evaluate for Stage0Recipe {
             .cloned()
             .collect();
         let package = self.package.evaluate(&context_with_vars)?;
-        let build = self.build.evaluate(&context_with_vars)?;
+        let mut build = self.build.evaluate(&context_with_vars)?;
         let about = self.about.evaluate(&context_with_vars)?;
-        let requirements = self.requirements.evaluate(&context_with_vars)?;
+        let mut requirements = self.requirements.evaluate(&context_with_vars)?;
+        merge_action_requirements(&mut build, &mut requirements);
         let extra = self.extra.evaluate(&context_with_vars)?;
 
         // Evaluate source list (conditionals expand to multiple sources)
@@ -3108,6 +3128,13 @@ fn build_plan_inherits_from_toplevel(toplevel: &Stage1BuildPlan, output: &Stage1
     )
 }
 
+fn merge_action_requirements(build: &mut Stage1Build, requirements: &mut Stage1Requirements) {
+    if !build.action_requirements.inherit.build { requirements.build.clear(); }
+    if !build.action_requirements.inherit.host { requirements.host.clear(); }
+    requirements.build.extend(std::mem::take(&mut build.action_requirements.build));
+    requirements.host.extend(std::mem::take(&mut build.action_requirements.host));
+}
+
 /// Merge two Stage1 Build configurations
 /// The output build takes precedence, but if output has default/empty values, use top-level
 fn merge_stage1_build(
@@ -3121,6 +3148,11 @@ fn merge_stage1_build(
     // when inheriting a top-level script, matching the historical multi-output
     // behavior. It does not inherit a top-level steps plan because there is no
     // whole-plan `cwd` to apply to steps without silently dropping it.
+    let (action_requirements, action_provenance) = if build_plan_inherits_from_toplevel(&toplevel.plan, &output.plan) {
+        (toplevel.action_requirements, toplevel.action_provenance)
+    } else {
+        (output.action_requirements, output.action_provenance)
+    };
     let plan = if build_plan_inherits_from_toplevel(&toplevel.plan, &output.plan) {
         toplevel.plan
     } else {
@@ -3221,6 +3253,8 @@ fn merge_stage1_build(
     };
 
     stage1::Build {
+        action_requirements,
+        action_provenance,
         plan,
         number,
         string,
@@ -3345,7 +3379,11 @@ fn evaluate_package_output_to_recipe(
     //   (the cache has its own plan, and the output doesn't need one for filtering files)
     let build = if inherits_from_toplevel {
         // Full merge including the build plan
-        let toplevel_build = recipe.build.evaluate(context)?;
+        let mut toplevel_source = recipe.build.clone();
+        if !output.build.plan.is_default() {
+            toplevel_source.plan = Stage0BuildPlan::default();
+        }
+        let toplevel_build = toplevel_source.evaluate(context)?;
         let output_build = output.build.evaluate(context)?;
         merge_stage1_build(toplevel_build, output_build)
     } else {
@@ -3353,7 +3391,9 @@ fn evaluate_package_output_to_recipe(
         // output does not set itself, EXCEPT the build plan (the cache has its
         // own plan; a cache-inheriting output packages the restored files and
         // does not need to re-run the top-level plan).
-        let toplevel_build = recipe.build.evaluate(context)?;
+        let mut toplevel_source = recipe.build.clone();
+        toplevel_source.plan = Stage0BuildPlan::default();
+        let toplevel_build = toplevel_source.evaluate(context)?;
         let output_build = output.build.evaluate(context)?;
         let output_plan = output_build.plan.clone();
         let mut merged = merge_stage1_build(toplevel_build, output_build);
@@ -3393,7 +3433,8 @@ fn evaluate_package_output_to_recipe(
     };
 
     // Evaluate requirements
-    let requirements = output.requirements.evaluate(context)?;
+    let mut requirements = output.requirements.evaluate(context)?;
+    merge_action_requirements(&mut build, &mut requirements);
 
     // Use recipe-level extra (outputs don't have their own extra)
     let extra = recipe.extra.evaluate(context)?;
@@ -3586,16 +3627,7 @@ impl Evaluate for crate::stage0::MultiOutputRecipe {
                 // Evaluate staging output components
                 let mut build = staging_output.build.evaluate(&context_with_vars)?;
                 let mut requirements = staging_output.requirements.evaluate(&context_with_vars)?;
-                if build.plan.steps().is_some() {
-                    let selected = build.plan.select_steps(None).map_err(|error| {
-                        ParseError::invalid_value("staging build.steps", error, Span::new_blank())
-                    })?;
-                    for step in &selected {
-                        requirements.build.extend(step.requirements.build.clone());
-                        requirements.host.extend(step.requirements.host.clone());
-                    }
-                    build.plan = Stage1BuildPlan::Steps(selected);
-                }
+                merge_action_requirements(&mut build, &mut requirements);
 
                 // Staging outputs inherit top-level sources (prepend), then add their own
                 // (conditionals expand to multiple sources)
@@ -6699,6 +6731,7 @@ package:
             Stage1StepRun::Commands(vec!["echo b".to_string()])
         );
     }
+
 
     #[test]
     fn test_build_evaluate_preserves_steps_mode_when_all_steps_filter_out() {

--- a/crates/rattler_build_recipe/src/stage0/evaluate.rs
+++ b/crates/rattler_build_recipe/src/stage0/evaluate.rs
@@ -20,6 +20,7 @@
 //! 5. Call `Build::render_build_string_with_hash()` to finalize the build string
 
 use std::{
+    borrow::Cow,
     collections::{BTreeMap, HashSet},
     path::PathBuf,
     str::FromStr,
@@ -1483,6 +1484,23 @@ fn evaluate_build_plan(
         Stage0BuildPlan::Script(script) => Ok((
             Stage1BuildPlan::Script(evaluate_script(script, context)?),
             Default::default(),
+        )),
+    }
+}
+
+fn validate_selected_plan(
+    build: &Stage1Build,
+    context: &EvaluationContext,
+) -> Result<(), ParseError> {
+    if build.skip || context.actions.selected.is_none() {
+        return Ok(());
+    }
+    match &build.plan {
+        Stage1BuildPlan::Steps(_) => Ok(()),
+        Stage1BuildPlan::Script(_) => Err(ParseError::invalid_value(
+            "build.steps",
+            "named step execution requires a build.steps plan",
+            Span::new_blank(),
         )),
     }
 }
@@ -2979,6 +2997,7 @@ impl Evaluate for Stage0Recipe {
             .collect();
         let package = self.package.evaluate(&context_with_vars)?;
         let mut build = self.build.evaluate(&context_with_vars)?;
+        validate_selected_plan(&build, &context_with_vars)?;
         let about = self.about.evaluate(&context_with_vars)?;
         let mut requirements = self.requirements.evaluate(&context_with_vars)?;
         merge_action_requirements(&mut build, &mut requirements);
@@ -3393,12 +3412,16 @@ fn evaluate_package_output_to_recipe(
     let build = if inherits_from_toplevel {
         // Full merge including the build plan
         let mut toplevel_source = recipe.build.clone();
+        let mut toplevel_context = Cow::Borrowed(context);
         if !output.build.plan.is_default()
             && let Stage0BuildPlan::Steps(steps) = &mut toplevel_source.plan
         {
             steps.clear();
+            if context.actions.selected.is_some() {
+                toplevel_context.to_mut().actions.selected = None;
+            }
         }
-        let toplevel_build = toplevel_source.evaluate(context)?;
+        let toplevel_build = toplevel_source.evaluate(&toplevel_context)?;
         let output_build = output.build.evaluate(context)?;
         merge_stage1_build(toplevel_build, output_build)
     } else {
@@ -3415,6 +3438,7 @@ fn evaluate_package_output_to_recipe(
         merged.plan = output_plan;
         merged
     };
+    validate_selected_plan(&build, context)?;
 
     // Multi-output recipes do not auto-discover `build.sh`/`build.bat`: a single
     // shared build script is almost never what each output wants (e.g. noarch

--- a/crates/rattler_build_recipe/src/stage0/evaluate.rs
+++ b/crates/rattler_build_recipe/src/stage0/evaluate.rs
@@ -2263,7 +2263,12 @@ impl Evaluate for Stage0Build {
         // (enforced during parsing). Steps mode is preserved even if the list is
         // empty or all steps filter out, so outputs don't accidentally inherit a
         // top-level script.
-        let (plan, actions) = evaluate_build_plan(&self.plan, context)?;
+        let skip = evaluate_skip_list(&self.skip, context)?;
+        let (plan, actions) = if skip {
+            (Stage1BuildPlan::Steps(Vec::new()), Default::default())
+        } else {
+            evaluate_build_plan(&self.plan, context)?
+        };
 
         // Evaluate noarch
         //
@@ -2292,10 +2297,6 @@ impl Evaluate for Stage0Build {
                 }
             }
         };
-
-        // Evaluate skip conditions as Jinja boolean expressions
-        // This tracks accessed variables for proper variant hash computation
-        let skip = evaluate_skip_list(&self.skip, context)?;
 
         // Evaluate V3 package flags.
         let flags = evaluate_flag_list(&self.flags, context)?;

--- a/crates/rattler_build_recipe/src/stage0/evaluate.rs
+++ b/crates/rattler_build_recipe/src/stage0/evaluate.rs
@@ -1445,7 +1445,10 @@ pub(crate) fn evaluate_run_steps(
                 scripts.push(step);
             }
             Stage0Step::Uses(_) => {
-                return Err(ParseError::generic("action invocation requires action compilation", Span::new_blank()));
+                return Err(ParseError::generic(
+                    "action invocation requires action compilation",
+                    Span::new_blank(),
+                ));
             }
         }
     }
@@ -1477,9 +1480,10 @@ fn evaluate_build_plan(
             let plan = Stage1BuildPlan::Steps(std::mem::take(&mut compiled.steps));
             Ok((plan, compiled))
         }
-        Stage0BuildPlan::Script(script) => {
-            Ok((Stage1BuildPlan::Script(evaluate_script(script, context)?), Default::default()))
-        }
+        Stage0BuildPlan::Script(script) => Ok((
+            Stage1BuildPlan::Script(evaluate_script(script, context)?),
+            Default::default(),
+        )),
     }
 }
 
@@ -3129,10 +3133,18 @@ fn build_plan_inherits_from_toplevel(toplevel: &Stage1BuildPlan, output: &Stage1
 }
 
 fn merge_action_requirements(build: &mut Stage1Build, requirements: &mut Stage1Requirements) {
-    if !build.action_requirements.inherit.build { requirements.build.clear(); }
-    if !build.action_requirements.inherit.host { requirements.host.clear(); }
-    requirements.build.extend(std::mem::take(&mut build.action_requirements.build));
-    requirements.host.extend(std::mem::take(&mut build.action_requirements.host));
+    if !build.action_requirements.inherit.build {
+        requirements.build.clear();
+    }
+    if !build.action_requirements.inherit.host {
+        requirements.host.clear();
+    }
+    requirements
+        .build
+        .extend(std::mem::take(&mut build.action_requirements.build));
+    requirements
+        .host
+        .extend(std::mem::take(&mut build.action_requirements.host));
 }
 
 /// Merge two Stage1 Build configurations
@@ -3148,11 +3160,12 @@ fn merge_stage1_build(
     // when inheriting a top-level script, matching the historical multi-output
     // behavior. It does not inherit a top-level steps plan because there is no
     // whole-plan `cwd` to apply to steps without silently dropping it.
-    let (action_requirements, action_provenance) = if build_plan_inherits_from_toplevel(&toplevel.plan, &output.plan) {
-        (toplevel.action_requirements, toplevel.action_provenance)
-    } else {
-        (output.action_requirements, output.action_provenance)
-    };
+    let (action_requirements, action_provenance) =
+        if build_plan_inherits_from_toplevel(&toplevel.plan, &output.plan) {
+            (toplevel.action_requirements, toplevel.action_provenance)
+        } else {
+            (output.action_requirements, output.action_provenance)
+        };
     let plan = if build_plan_inherits_from_toplevel(&toplevel.plan, &output.plan) {
         toplevel.plan
     } else {
@@ -3380,8 +3393,10 @@ fn evaluate_package_output_to_recipe(
     let build = if inherits_from_toplevel {
         // Full merge including the build plan
         let mut toplevel_source = recipe.build.clone();
-        if !output.build.plan.is_default() {
-            toplevel_source.plan = Stage0BuildPlan::default();
+        if !output.build.plan.is_default()
+            && let Stage0BuildPlan::Steps(steps) = &mut toplevel_source.plan
+        {
+            steps.clear();
         }
         let toplevel_build = toplevel_source.evaluate(context)?;
         let output_build = output.build.evaluate(context)?;
@@ -6731,7 +6746,6 @@ package:
             Stage1StepRun::Commands(vec!["echo b".to_string()])
         );
     }
-
 
     #[test]
     fn test_build_evaluate_preserves_steps_mode_when_all_steps_filter_out() {

--- a/crates/rattler_build_recipe/src/stage0/evaluate.rs
+++ b/crates/rattler_build_recipe/src/stage0/evaluate.rs
@@ -6470,13 +6470,13 @@ package:
     }
 
     fn run_step(cmd: &str) -> Stage0Step {
-        Stage0Step::Run(Stage0RunStep {
+        Stage0Step::Run(Box::new(Stage0RunStep {
             run: ConditionalList::new(vec![Item::Value(Value::new_concrete(
                 cmd.to_string(),
                 None,
             ))]),
             ..Default::default()
-        })
+        }))
     }
 
     fn step_condition(expr: &str) -> JinjaExpression {
@@ -6503,14 +6503,14 @@ package:
 
     #[test]
     fn test_evaluate_steps_if_filters_step() {
-        let win_step = Stage0Step::Run(Stage0RunStep {
+        let win_step = Stage0Step::Run(Box::new(Stage0RunStep {
             run: ConditionalList::new(vec![Item::Value(Value::new_concrete(
                 "echo windows".to_string(),
                 None,
             ))]),
             condition: Some(step_condition("win")),
             ..Default::default()
-        });
+        }));
         let steps = vec![run_step("echo always"), win_step];
 
         let mut ctx = EvaluationContext::new();
@@ -6528,14 +6528,14 @@ package:
 
     #[test]
     fn test_evaluate_steps_if_tracks_accessed_variables() {
-        let gated_step = Stage0Step::Run(Stage0RunStep {
+        let gated_step = Stage0Step::Run(Box::new(Stage0RunStep {
             run: ConditionalList::new(vec![Item::Value(Value::new_concrete(
                 "echo enabled".to_string(),
                 None,
             ))]),
             condition: Some(step_condition("enable_feature")),
             ..Default::default()
-        });
+        }));
         let mut ctx = EvaluationContext::new();
         ctx.insert("enable_feature".to_string(), Variable::from(true));
 
@@ -6550,14 +6550,14 @@ package:
 
     #[test]
     fn test_evaluate_steps_if_undefined_variable_errors() {
-        let undefined_step = Stage0Step::Run(Stage0RunStep {
+        let undefined_step = Stage0Step::Run(Box::new(Stage0RunStep {
             run: ConditionalList::new(vec![Item::Value(Value::new_concrete(
                 "echo undefined".to_string(),
                 None,
             ))]),
             condition: Some(step_condition("undefined_feature")),
             ..Default::default()
-        });
+        }));
         let ctx = EvaluationContext::new();
 
         let err = evaluate_steps(&[undefined_step], &ctx).unwrap_err();
@@ -6570,14 +6570,14 @@ package:
 
     #[test]
     fn test_evaluate_steps_tracks_filtered_out_step_variables() {
-        let step = Stage0Step::Run(Stage0RunStep {
+        let step = Stage0Step::Run(Box::new(Stage0RunStep {
             run: ConditionalList::new(vec![Item::Value(Value::new_template(
                 JinjaTemplate::new("echo ${{ flavor }}".to_string()).unwrap(),
                 None,
             ))]),
             condition: Some(step_condition("win")),
             ..Default::default()
-        });
+        }));
         let mut ctx = EvaluationContext::new();
         ctx.insert("win".to_string(), Variable::from(false));
         ctx.insert("flavor".to_string(), Variable::from("vanilla"));
@@ -6590,14 +6590,14 @@ package:
 
     #[test]
     fn test_evaluate_steps_if_expression_compares_target_platform() {
-        let step = Stage0Step::Run(Stage0RunStep {
+        let step = Stage0Step::Run(Box::new(Stage0RunStep {
             run: ConditionalList::new(vec![Item::Value(Value::new_concrete(
                 "echo gated".to_string(),
                 None,
             ))]),
             condition: Some(step_condition("target_platform == 'win-64'")),
             ..Default::default()
-        });
+        }));
         let mut linux_ctx = EvaluationContext::new();
         linux_ctx.insert("target_platform".to_string(), Variable::from("linux-64"));
 
@@ -6617,7 +6617,7 @@ package:
 
     /// A run step that sets an explicit interpreter and step-local env.
     fn run_step_with(cmd: &str, interpreter: &str, env: &[(&str, &str)]) -> Stage0Step {
-        Stage0Step::Run(Stage0RunStep {
+        Stage0Step::Run(Box::new(Stage0RunStep {
             run: ConditionalList::new(vec![Item::Value(Value::new_concrete(
                 cmd.to_string(),
                 None,
@@ -6628,7 +6628,7 @@ package:
                 .map(|(k, v)| (k.to_string(), Value::new_concrete(v.to_string(), None)))
                 .collect(),
             ..Default::default()
-        })
+        }))
     }
 
     #[test]
@@ -6695,14 +6695,14 @@ package:
 
     #[test]
     fn test_evaluate_steps_carries_cwd() {
-        let step = Stage0Step::Run(Stage0RunStep {
+        let step = Stage0Step::Run(Box::new(Stage0RunStep {
             run: ConditionalList::new(vec![Item::Value(Value::new_concrete(
                 "make install".to_string(),
                 None,
             ))]),
             cwd: Some(Value::new_concrete("subdir".to_string(), None)),
             ..Default::default()
-        });
+        }));
         let ctx = EvaluationContext::new();
 
         let scripts = evaluate_steps(&[step], &ctx).unwrap();
@@ -6773,14 +6773,14 @@ package:
 
     #[test]
     fn test_build_evaluate_preserves_steps_mode_when_all_steps_filter_out() {
-        let false_step = Stage0Step::Run(Stage0RunStep {
+        let false_step = Stage0Step::Run(Box::new(Stage0RunStep {
             run: ConditionalList::new(vec![Item::Value(Value::new_concrete(
                 "echo filtered".to_string(),
                 None,
             ))]),
             condition: Some(step_condition("win")),
             ..Default::default()
-        });
+        }));
         let build = Stage0Build {
             plan: Stage0BuildPlan::Steps(vec![false_step]),
             ..Default::default()

--- a/crates/rattler_build_recipe/src/stage0/mod.rs
+++ b/crates/rattler_build_recipe/src/stage0/mod.rs
@@ -4,7 +4,7 @@
 use rattler_conda_types::RepodataRevision;
 
 mod about;
-mod build;
+pub mod build;
 pub mod evaluate;
 mod extra;
 mod match_spec;
@@ -17,7 +17,7 @@ mod tests;
 mod types;
 
 pub use about::{About, License};
-pub use build::{BinaryRelocation, Build, BuildPlan, PythonBuild, RunStep, Step};
+pub use build::{BinaryRelocation, Build, BuildPlan, PythonBuild, RunStep, Step, UsesStep};
 pub use extra::Extra;
 pub use match_spec::SerializableMatchSpec;
 pub use output::{

--- a/crates/rattler_build_recipe/src/stage0/mod.rs
+++ b/crates/rattler_build_recipe/src/stage0/mod.rs
@@ -25,6 +25,7 @@ pub use output::{
     SingleOutputRecipe, StagingBuild, StagingMetadata, StagingOutput,
 };
 pub use package::{Package, PackageMetadata};
+pub(crate) use parser::build::{parse_step_requirements, parse_steps};
 pub use parser::{
     ParseConfig, parse_recipe, parse_recipe_from_source, parse_recipe_from_source_with_config,
     parse_recipe_or_multi, parse_recipe_or_multi_from_source,

--- a/crates/rattler_build_recipe/src/stage0/output.rs
+++ b/crates/rattler_build_recipe/src/stage0/output.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 
 use crate::stage0::{
     about::About,
-    build::{Build, BuildPlan},
+    build::{Build, BuildPlan, Step},
     package::{Package, PackageMetadata},
     requirements::Requirements,
     source::Source,
@@ -22,10 +22,14 @@ fn recipe_free_specs(
 ) -> Vec<rattler_conda_types::PackageName> {
     Requirements::free_specs_from_lists(
         [&requirements.build, &requirements.host].into_iter().chain(
-            plan.steps().into_iter().flatten().flat_map(|step| {
-                let super::build::Step::Run(step) = step;
-                [&step.requirements.build, &step.requirements.host]
-            }),
+            plan.steps()
+                .into_iter()
+                .flatten()
+                .filter_map(|step| match step {
+                    Step::Run(run) => Some(&run.requirements),
+                    Step::Uses(_) => None,
+                })
+                .flat_map(|requirements| [&requirements.build, &requirements.host]),
         ),
     )
 }

--- a/crates/rattler_build_recipe/src/stage0/parser/build.rs
+++ b/crates/rattler_build_recipe/src/stage0/parser/build.rs
@@ -389,7 +389,7 @@ pub(crate) fn parse_steps(node: &Node) -> Result<Vec<Step>, ParseError> {
     Ok(steps)
 }
 
-fn parse_step_requirements(node: &Node) -> Result<StepRequirements, ParseError> {
+pub(crate) fn parse_step_requirements(node: &Node) -> Result<StepRequirements, ParseError> {
     // Keep the first prototype's list form as a host-only shorthand.
     if node.as_sequence().is_some() {
         return Ok(StepRequirements {
@@ -462,11 +462,22 @@ fn parse_step_requirements(node: &Node) -> Result<StepRequirements, ParseError> 
 }
 
 /// Parse a single build step mapping into a [`Step`].
-fn parse_step(node: &Node) -> Result<Step, ParseError> {
+pub(crate) fn parse_step(node: &Node) -> Result<Step, ParseError> {
     let mapping = node.as_mapping().ok_or_else(|| {
         ParseError::expected_type("mapping", "non-mapping", get_span(node))
             .with_message("Expected each step to be a mapping")
     })?;
+    let is_uses = mapping.iter().any(|(key, _)| key.as_str() == "uses");
+    for (key, _) in mapping.iter() {
+        let allowed = if is_uses {
+            &["uses", "with", "name", "optional", "depends_on", "if"][..]
+        } else {
+            &["run", "name", "optional", "depends_on", "if", "requirements", "interpreter", "cwd", "env"][..]
+        };
+        if !allowed.contains(&key.as_str()) {
+            return Err(ParseError::invalid_value("steps", format!("field '{}' is not allowed on this step kind", key.as_str()), *key.span()));
+        }
+    }
 
     let mut run = None;
     let mut name = None;
@@ -478,11 +489,22 @@ fn parse_step(node: &Node) -> Result<Step, ParseError> {
     let mut interpreter = None;
     let mut cwd = None;
     let mut env = indexmap::IndexMap::new();
+    let mut inputs = indexmap::IndexMap::new();
 
     for (key_node, value_node) in mapping.iter() {
         let key = key_node.as_str();
 
         match key {
+            "with" => {
+                let values = value_node.as_mapping().ok_or_else(|| ParseError::expected_type(
+                    "mapping", "non-mapping", get_span(value_node)))?;
+                for (key, value) in values.iter() {
+                    inputs.insert(key.as_str().to_owned(), crate::actions::ActionValue::parse(value)?);
+                }
+            }
+            "uses" => {
+                uses = Some(parse_field!("steps.uses", value_node));
+            }
             "name" => {
                 name = Some(
                     value_node
@@ -556,10 +578,19 @@ fn parse_step(node: &Node) -> Result<Step, ParseError> {
         }
     }
 
-    let run = run.ok_or_else(|| {
-        ParseError::invalid_value("steps", "a step must contain 'run'", get_span(node))
-            .with_suggestion("Add a 'run:' script")
-    })?;
+    if run.is_some() == uses.is_some() {
+        return Err(ParseError::invalid_value(
+            "steps",
+            "a step must contain exactly one of 'run' or 'uses'",
+            get_span(node),
+        )
+        .with_suggestion("Add either a 'run:' script or a 'uses:' reference"));
+    }
+    if let Some(uses) = uses {
+        return Ok(Step::Uses(crate::stage0::build::UsesStep {
+            uses, name, optional, depends_on, condition, condition_span, inputs,
+        }));
+    }
 
     Ok(Step::Run(RunStep {
         name,
@@ -1344,18 +1375,17 @@ steps:
         let steps = build.plan.steps().expect("steps mode");
         assert_eq!(steps.len(), 2);
 
-        match &steps[0] {
-            Step::Run(first) => {
+        assert!(matches!(&steps[0], Step::Run(_)));
+        if let Step::Run(first) = &steps[0] {
                 assert_eq!(first.name.as_deref(), Some("configure"));
                 assert_eq!(first.run.len(), 1);
                 assert!(first.condition.is_none());
                 assert!(first.interpreter.is_none());
                 assert!(first.env.is_empty());
-            }
         }
 
-        match &steps[1] {
-            Step::Run(second) => {
+        assert!(matches!(&steps[1], Step::Run(_)));
+        if let Step::Run(second) = &steps[1] {
                 assert_eq!(second.name.as_deref(), Some("test"));
                 assert!(second.optional);
                 assert_eq!(second.depends_on, ["configure"]);
@@ -1367,8 +1397,29 @@ steps:
                 assert!(second.interpreter.is_some());
                 assert!(second.cwd.is_some());
                 assert!(second.env.contains_key("FOO"));
-            }
         }
+    }
+
+    #[test]
+    fn test_parse_reusable_step_reference() {
+        let yaml = r#"
+steps:
+  - name: build
+    uses: cargo:build
+"#;
+        let node = marked_yaml::parse_yaml(0, yaml).unwrap();
+        let build = parse_build(&node).unwrap();
+        assert!(matches!(&build.plan.steps().unwrap()[0], Step::Uses(_)));
+        if let Step::Uses(step) = &build.plan.steps().unwrap()[0] {
+            assert_eq!(step.uses.as_concrete(), Some(&"cargo:build".to_string()));
+        }
+    }
+
+    #[test]
+    fn test_parse_step_rejects_run_and_uses() {
+        let yaml = "steps:\n  - uses: cargo:build\n    run: cargo build\n";
+        let node = marked_yaml::parse_yaml(0, yaml).unwrap();
+        assert!(parse_build(&node).is_err());
     }
 
     #[test]
@@ -1383,9 +1434,11 @@ steps:
 "#;
         let node = marked_yaml::parse_yaml(0, yaml).unwrap();
         let build = parse_build(&node).unwrap();
-        let Step::Run(step) = &build.plan.steps().unwrap()[0];
-        assert!(!step.requirements.inherit.build);
-        assert!(!step.requirements.inherit.host);
+        assert!(matches!(&build.plan.steps().unwrap()[0], Step::Run(_)));
+        if let Step::Run(step) = &build.plan.steps().unwrap()[0] {
+            assert!(!step.requirements.inherit.build);
+            assert!(!step.requirements.inherit.host);
+        }
     }
 
     #[test]

--- a/crates/rattler_build_recipe/src/stage0/parser/build.rs
+++ b/crates/rattler_build_recipe/src/stage0/parser/build.rs
@@ -606,7 +606,7 @@ pub(crate) fn parse_step(node: &Node) -> Result<Step, ParseError> {
         .with_suggestion("Add either a 'run:' script or a 'uses:' reference"));
     }
     if let Some(uses) = uses {
-        return Ok(Step::Uses(crate::stage0::build::UsesStep {
+        return Ok(Step::Uses(Box::new(crate::stage0::build::UsesStep {
             uses,
             name,
             optional,
@@ -614,10 +614,10 @@ pub(crate) fn parse_step(node: &Node) -> Result<Step, ParseError> {
             condition,
             condition_span,
             inputs,
-        }));
+        })));
     }
 
-    Ok(Step::Run(RunStep {
+    Ok(Step::Run(Box::new(RunStep {
         name,
         optional,
         depends_on,
@@ -630,7 +630,7 @@ pub(crate) fn parse_step(node: &Node) -> Result<Step, ParseError> {
         interpreter,
         cwd,
         env,
-    }))
+    })))
 }
 
 /// Parse a step `if` condition as a verbatim Jinja expression.

--- a/crates/rattler_build_recipe/src/stage0/parser/build.rs
+++ b/crates/rattler_build_recipe/src/stage0/parser/build.rs
@@ -472,14 +472,29 @@ pub(crate) fn parse_step(node: &Node) -> Result<Step, ParseError> {
         let allowed = if is_uses {
             &["uses", "with", "name", "optional", "depends_on", "if"][..]
         } else {
-            &["run", "name", "optional", "depends_on", "if", "requirements", "interpreter", "cwd", "env"][..]
+            &[
+                "run",
+                "name",
+                "optional",
+                "depends_on",
+                "if",
+                "requirements",
+                "interpreter",
+                "cwd",
+                "env",
+            ][..]
         };
         if !allowed.contains(&key.as_str()) {
-            return Err(ParseError::invalid_value("steps", format!("field '{}' is not allowed on this step kind", key.as_str()), *key.span()));
+            return Err(ParseError::invalid_value(
+                "steps",
+                format!("field '{}' is not allowed on this step kind", key.as_str()),
+                *key.span(),
+            ));
         }
     }
 
     let mut run = None;
+    let mut uses = None;
     let mut name = None;
     let mut optional = false;
     let mut depends_on = Vec::new();
@@ -496,10 +511,14 @@ pub(crate) fn parse_step(node: &Node) -> Result<Step, ParseError> {
 
         match key {
             "with" => {
-                let values = value_node.as_mapping().ok_or_else(|| ParseError::expected_type(
-                    "mapping", "non-mapping", get_span(value_node)))?;
+                let values = value_node.as_mapping().ok_or_else(|| {
+                    ParseError::expected_type("mapping", "non-mapping", get_span(value_node))
+                })?;
                 for (key, value) in values.iter() {
-                    inputs.insert(key.as_str().to_owned(), crate::actions::ActionValue::parse(value)?);
+                    inputs.insert(
+                        key.as_str().to_owned(),
+                        crate::actions::ActionValue::parse(value)?,
+                    );
                 }
             }
             "uses" => {
@@ -588,7 +607,13 @@ pub(crate) fn parse_step(node: &Node) -> Result<Step, ParseError> {
     }
     if let Some(uses) = uses {
         return Ok(Step::Uses(crate::stage0::build::UsesStep {
-            uses, name, optional, depends_on, condition, condition_span, inputs,
+            uses,
+            name,
+            optional,
+            depends_on,
+            condition,
+            condition_span,
+            inputs,
         }));
     }
 
@@ -597,7 +622,9 @@ pub(crate) fn parse_step(node: &Node) -> Result<Step, ParseError> {
         optional,
         depends_on,
         requirements,
-        run,
+        run: run.ok_or_else(|| {
+            ParseError::invalid_value("steps", "a run step must contain 'run'", get_span(node))
+        })?,
         condition,
         condition_span,
         interpreter,
@@ -1377,26 +1404,26 @@ steps:
 
         assert!(matches!(&steps[0], Step::Run(_)));
         if let Step::Run(first) = &steps[0] {
-                assert_eq!(first.name.as_deref(), Some("configure"));
-                assert_eq!(first.run.len(), 1);
-                assert!(first.condition.is_none());
-                assert!(first.interpreter.is_none());
-                assert!(first.env.is_empty());
+            assert_eq!(first.name.as_deref(), Some("configure"));
+            assert_eq!(first.run.len(), 1);
+            assert!(first.condition.is_none());
+            assert!(first.interpreter.is_none());
+            assert!(first.env.is_empty());
         }
 
         assert!(matches!(&steps[1], Step::Run(_)));
         if let Step::Run(second) = &steps[1] {
-                assert_eq!(second.name.as_deref(), Some("test"));
-                assert!(second.optional);
-                assert_eq!(second.depends_on, ["configure"]);
-                assert_eq!(second.requirements.build.len(), 1);
-                assert_eq!(second.requirements.host.len(), 1);
-                assert!(!second.requirements.inherit.build);
-                assert!(!second.requirements.inherit.host);
-                assert!(second.condition.is_some());
-                assert!(second.interpreter.is_some());
-                assert!(second.cwd.is_some());
-                assert!(second.env.contains_key("FOO"));
+            assert_eq!(second.name.as_deref(), Some("test"));
+            assert!(second.optional);
+            assert_eq!(second.depends_on, ["configure"]);
+            assert_eq!(second.requirements.build.len(), 1);
+            assert_eq!(second.requirements.host.len(), 1);
+            assert!(!second.requirements.inherit.build);
+            assert!(!second.requirements.inherit.host);
+            assert!(second.condition.is_some());
+            assert!(second.interpreter.is_some());
+            assert!(second.cwd.is_some());
+            assert!(second.env.contains_key("FOO"));
         }
     }
 

--- a/crates/rattler_build_recipe/src/stage0/parser/mod.rs
+++ b/crates/rattler_build_recipe/src/stage0/parser/mod.rs
@@ -5,7 +5,7 @@
 //! error messages.
 
 mod about;
-mod build;
+pub(crate) mod build;
 mod extra;
 mod helpers;
 mod output_parser;

--- a/crates/rattler_build_recipe/src/stage1/build.rs
+++ b/crates/rattler_build_recipe/src/stage1/build.rs
@@ -293,7 +293,6 @@ impl StepRequirements {
     }
 }
 
-
 /// A stage1 build step with evaluated metadata and script content.
 ///
 /// This is deliberately separate from [`Script`]: rendered recipes use

--- a/crates/rattler_build_recipe/src/stage1/build.rs
+++ b/crates/rattler_build_recipe/src/stage1/build.rs
@@ -293,6 +293,7 @@ impl StepRequirements {
     }
 }
 
+
 /// A stage1 build step with evaluated metadata and script content.
 ///
 /// This is deliberately separate from [`Script`]: rendered recipes use
@@ -300,6 +301,9 @@ impl StepRequirements {
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Step {
+    /// Native isolated bindings for an action-owned executable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub action_context: Option<IndexMap<String, rattler_build_jinja::Variable>>,
     /// Optional unique name used by the step DAG and CLI.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
@@ -330,6 +334,7 @@ impl Step {
     /// Create a step from an evaluated script payload.
     pub fn new(script: Script) -> Self {
         Self {
+            action_context: None,
             name: None,
             optional: false,
             depends_on: Vec::new(),
@@ -637,6 +642,12 @@ impl<'de> serde::Deserialize<'de> for PostProcess {
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(try_from = "BuildDeserialize")]
 pub struct Build {
+    /// Source identities contributing to this executable plan, including empty actions.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub action_provenance: Vec<crate::actions::ActionProvenance>,
+    /// Intermediate requirements consumed by effective recipe construction.
+    #[serde(skip)]
+    pub action_requirements: StepRequirements,
     /// Build number (increments with each rebuild)
     /// None means inherit from top-level, Some(n) means use n (even if n is 0)
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -736,6 +747,8 @@ where
 #[serde(deny_unknown_fields)]
 struct BuildDeserialize {
     #[serde(default)]
+    action_provenance: Vec<crate::actions::ActionProvenance>,
+    #[serde(default)]
     number: Option<u64>,
     #[serde(default)]
     string: BuildString,
@@ -785,6 +798,8 @@ impl TryFrom<BuildDeserialize> for Build {
         };
 
         Ok(Self {
+            action_provenance: raw.action_provenance,
+            action_requirements: StepRequirements::default(),
             number: raw.number,
             string: raw.string,
             plan,

--- a/crates/rattler_build_recipe/src/stage1/mod.rs
+++ b/crates/rattler_build_recipe/src/stage1/mod.rs
@@ -48,6 +48,8 @@ pub use rattler_build_types::{
 /// Evaluation context containing variables for template rendering and conditional evaluation
 #[derive(Debug, Clone)]
 pub struct EvaluationContext {
+    /// Render session, preserved when recipe-private context is added.
+    pub(crate) actions: crate::actions::ActionEnvironment,
     /// Variables available during evaluation (e.g., "name", "version", "py", "target_platform")
     variables: IndexMap<String, Variable>,
     /// Configuration for Jinja functions (compiler, cdt, etc.)
@@ -64,6 +66,7 @@ pub struct EvaluationContext {
 impl Default for EvaluationContext {
     fn default() -> Self {
         Self {
+            actions: Default::default(),
             variables: IndexMap::new(),
             jinja_config: JinjaConfig::default(),
             accessed_variables: Arc::new(Mutex::new(HashSet::new())),
@@ -74,6 +77,18 @@ impl Default for EvaluationContext {
 }
 
 impl EvaluationContext {
+    /// Configure action compilation before adding recipe-private variables.
+    pub fn with_actions(
+        mut self,
+        sources: crate::actions::ActionSources,
+        origin: Option<std::path::PathBuf>,
+        selected: Option<Vec<String>>,
+    ) -> Self {
+        self.actions = crate::actions::ActionEnvironment {
+            sources, origin, selected, variants: self.variables.clone(),
+        };
+        self
+    }
     /// Create a new empty evaluation context
     pub fn new() -> Self {
         Self::default()
@@ -100,6 +115,7 @@ impl EvaluationContext {
     #[cfg(test)]
     pub fn from_map(variables: IndexMap<String, String>) -> Self {
         Self {
+            actions: Default::default(),
             variables: variables
                 .into_iter()
                 .map(|(k, v)| (k, Variable::from(v)))
@@ -114,6 +130,7 @@ impl EvaluationContext {
     /// Create an evaluation context from a map of Variable values
     pub fn from_variables(variables: IndexMap<String, Variable>) -> Self {
         Self {
+            actions: Default::default(),
             variables,
             jinja_config: JinjaConfig::default(),
             accessed_variables: Arc::new(Mutex::new(HashSet::new())),
@@ -129,6 +146,7 @@ impl EvaluationContext {
         jinja_config: JinjaConfig,
     ) -> Self {
         Self {
+            actions: Default::default(),
             variables,
             jinja_config,
             accessed_variables: Arc::new(Mutex::new(HashSet::new())),
@@ -159,6 +177,7 @@ impl EvaluationContext {
         repodata_revision: RepodataRevision,
     ) -> Self {
         Self {
+            actions: Default::default(),
             variables,
             jinja_config,
             accessed_variables: Arc::new(Mutex::new(HashSet::new())),
@@ -170,6 +189,7 @@ impl EvaluationContext {
     /// Create an evaluation context with variables and Jinja config
     pub fn with_config(variables: IndexMap<String, String>, jinja_config: JinjaConfig) -> Self {
         Self {
+            actions: Default::default(),
             variables: variables
                 .into_iter()
                 .map(|(k, v)| (k, Variable::from(v)))

--- a/crates/rattler_build_recipe/src/stage1/mod.rs
+++ b/crates/rattler_build_recipe/src/stage1/mod.rs
@@ -85,7 +85,10 @@ impl EvaluationContext {
         selected: Option<Vec<String>>,
     ) -> Self {
         self.actions = crate::actions::ActionEnvironment {
-            sources, origin, selected, variants: self.variables.clone(),
+            sources,
+            origin,
+            selected,
+            variants: self.variables.clone(),
         };
         self
     }

--- a/crates/rattler_build_recipe/src/variant_render.rs
+++ b/crates/rattler_build_recipe/src/variant_render.rs
@@ -958,6 +958,10 @@ fn discover_new_variant_keys_from_evaluation(
             } else {
                 (context.clone(), IndexMap::new())
             };
+            if crate::stage0::evaluate::evaluate_skip_list(&recipe.build.skip, &context_with_vars)?
+            {
+                return Ok(HashSet::new());
+            }
             let mut evaluated = recipe.requirements.evaluate(&context_with_vars)?;
             let build = recipe.build.evaluate(&context_with_vars)?;
             evaluated.build.extend(build.action_requirements.build);

--- a/crates/rattler_build_recipe/src/variant_render.rs
+++ b/crates/rattler_build_recipe/src/variant_render.rs
@@ -88,6 +88,12 @@ pub struct PinSubpackageInfo {
 /// Configuration for rendering recipes with variants
 #[derive(Debug, Clone)]
 pub struct RenderConfig {
+    /// Shared render-time action source registry.
+    pub action_sources: crate::actions::ActionSources,
+    /// Literal source invocation names selected before action expansion.
+    pub selected_steps: Option<Vec<String>>,
+    /// Constraints on fully expanded combinations, used by metadata rerendering.
+    pub variant_constraints: BTreeMap<NormalizedKey, Variable>,
     /// Additional context variables to provide (beyond variant values)
     /// These can be strings, booleans, numbers, etc. using the Variable type
     pub extra_context: IndexMap<String, Variable>,
@@ -119,6 +125,9 @@ pub struct RenderConfig {
 impl Default for RenderConfig {
     fn default() -> Self {
         Self {
+            action_sources: crate::actions::ActionSources::default(),
+            selected_steps: None,
+            variant_constraints: BTreeMap::new(),
             extra_context: IndexMap::new(),
             experimental: false,
             repodata_revision: RepodataRevision::Legacy,
@@ -926,7 +935,12 @@ fn discover_new_variant_keys_from_evaluation(
     variant_config: &VariantConfig,
     config: &RenderConfig,
 ) -> Result<HashSet<NormalizedKey>, ParseError> {
-    let context = build_evaluation_context(combination, config)?;
+    let mut context = build_evaluation_context(combination, config)?;
+    for (key, values) in &variant_config.variants {
+        if let Some(value) = values.first() {
+            context.actions.variants.entry(key.to_string()).or_insert_with(|| value.clone());
+        }
+    }
 
     // Get requirements and evaluate them
     // NOTE: We need to merge the recipe's context variables into the evaluation context
@@ -940,13 +954,11 @@ fn discover_new_variant_keys_from_evaluation(
             } else {
                 (context.clone(), IndexMap::new())
             };
-            let evaluated = recipe.requirements.evaluate(&context_with_vars)?;
-            let mut free_specs = evaluated.free_specs();
-            free_specs.extend(evaluated_step_free_specs(
-                &recipe.build.plan,
-                &context_with_vars,
-            )?);
-            free_specs
+            let mut evaluated = recipe.requirements.evaluate(&context_with_vars)?;
+            let build = recipe.build.evaluate(&context_with_vars)?;
+            evaluated.build.extend(build.action_requirements.build);
+            evaluated.host.extend(build.action_requirements.host);
+            evaluated.free_specs()
         }
         Stage0Recipe::MultiOutput(recipe) => {
             // Merge recipe context variables into evaluation context
@@ -990,6 +1002,22 @@ fn discover_new_variant_keys_from_evaluation(
                         all_free_specs.extend(specs);
                     }
                 }
+                if !should_skip {
+                    let build = match output {
+                        stage0::Output::Staging(staging) => staging.build.evaluate(&context_with_vars)?,
+                        stage0::Output::Package(pkg) => {
+                            if pkg.build.plan.is_default() {
+                                recipe.build.evaluate(&context_with_vars)?
+                            } else {
+                                pkg.build.evaluate(&context_with_vars)?
+                            }
+                        }
+                    };
+                    let mut action_requirements = crate::stage1::Requirements::default();
+                    action_requirements.build = build.action_requirements.build;
+                    action_requirements.host = build.action_requirements.host;
+                    all_free_specs.extend(action_requirements.free_specs());
+                }
             }
             all_free_specs
         }
@@ -997,6 +1025,12 @@ fn discover_new_variant_keys_from_evaluation(
 
     // Find free specs that are variant keys but not in current combination
     let mut new_keys = HashSet::new();
+    for key in context.accessed_variables() {
+        let key = NormalizedKey::from(key);
+        if variant_config.get(&key).is_some() && !combination.contains_key(&key) {
+            new_keys.insert(key);
+        }
+    }
     for spec in free_specs {
         let key = NormalizedKey::from(spec.as_normalized());
         if variant_config.get(&key).is_some() && !combination.contains_key(&key) {
@@ -1012,40 +1046,12 @@ fn expand_combination_with_keys(
     base: &BTreeMap<NormalizedKey, Variable>,
     new_keys: &HashSet<NormalizedKey>,
     variant_config: &VariantConfig,
-) -> Vec<BTreeMap<NormalizedKey, Variable>> {
-    if new_keys.is_empty() {
-        return vec![base.clone()];
-    }
-
-    // Get values for each new key
-    let key_values: Vec<(NormalizedKey, Vec<Variable>)> = new_keys
-        .iter()
-        .filter_map(|key| {
-            variant_config
-                .get(key)
-                .map(|values| (key.clone(), values.clone()))
-        })
-        .collect();
-
-    if key_values.is_empty() {
-        return vec![base.clone()];
-    }
-
-    // Create cross-product of all new key values
-    let mut results = vec![base.clone()];
-    for (key, values) in key_values {
-        let mut new_results = Vec::new();
-        for combo in &results {
-            for value in &values {
-                let mut new_combo = combo.clone();
-                new_combo.insert(key.clone(), value.clone());
-                new_results.push(new_combo);
-            }
-        }
-        results = new_results;
-    }
-
-    results
+) -> Result<Vec<BTreeMap<NormalizedKey, Variable>>, ParseError> {
+    let keys = base.keys().cloned().chain(new_keys.iter().cloned()).collect();
+    let mut combinations = variant_config.combinations(&keys)
+        .map_err(|error| ParseError::generic(error.to_string(), marked_yaml::Span::new_blank()))?;
+    combinations.retain(|combination| base.iter().all(|(key, value)| combination.get(key) == Some(value)));
+    Ok(combinations)
 }
 
 /// Recursively expand variant combinations by discovering new variant keys from evaluation
@@ -1060,12 +1066,8 @@ fn expand_variants_tree(
     let mut final_combinations = Vec::new();
     let mut to_process = initial_combinations;
 
-    // Limit iterations to prevent infinite loops
-    const MAX_ITERATIONS: usize = 10;
-    let mut iteration = 0;
-
-    while !to_process.is_empty() && iteration < MAX_ITERATIONS {
-        iteration += 1;
+    // Each expansion adds a configured key, so the finite key set bounds progress.
+    while !to_process.is_empty() {
         let mut next_round = Vec::new();
 
         for combination in to_process {
@@ -1083,7 +1085,7 @@ fn expand_variants_tree(
             } else {
                 // Expand with new keys and process in next round
                 let expanded =
-                    expand_combination_with_keys(&combination, &new_keys, variant_config);
+                    expand_combination_with_keys(&combination, &new_keys, variant_config)?;
                 next_round.extend(expanded);
             }
         }
@@ -1091,8 +1093,6 @@ fn expand_variants_tree(
         to_process = next_round;
     }
 
-    // Add any remaining combinations (in case we hit iteration limit)
-    final_combinations.extend(to_process);
 
     // Deduplicate combinations
     let mut seen = HashSet::new();
@@ -1132,7 +1132,7 @@ fn build_evaluation_context(
             jinja_config,
             config.os_env_var_keys.clone(),
             config.repodata_revision,
-        ),
+        ).with_actions(config.action_sources.clone(), config.recipe_path.clone(), config.selected_steps.clone()),
     )
 }
 
@@ -1158,7 +1158,8 @@ fn render_with_empty_combinations(
     let jinja_config = create_jinja_config(config, &empty_variant);
     let context =
         EvaluationContext::with_variables_and_config(config.extra_context.clone(), jinja_config)
-            .with_repodata_revision(config.repodata_revision);
+            .with_repodata_revision(config.repodata_revision)
+            .with_actions(config.action_sources.clone(), config.recipe_path.clone(), config.selected_steps.clone());
 
     // Evaluate the recipe
     let outputs = evaluate_recipe(stage0_recipe, &context)?;
@@ -1241,6 +1242,14 @@ fn finalize_build_string_single(
 ) -> Result<(), RenderError> {
     let build_string_prefix = config.build_string_prefix.as_deref();
     let noarch = result.recipe.build.noarch.unwrap_or(NoArchType::none());
+    let action_provenance = result.recipe.staging_caches.iter()
+        .flat_map(|cache| cache.build.action_provenance.iter())
+        .chain(result.recipe.build.action_provenance.iter()).collect::<Vec<_>>();
+    if !action_provenance.is_empty() {
+        let identity = Variable::from(minijinja::Value::from_serialize(&action_provenance));
+        result.variant.insert(NormalizedKey::from("__actions"), identity.clone());
+        result.recipe.used_variant.insert(NormalizedKey::from("__actions"), identity);
+    }
 
     // Compute hash from the variant (which now includes pin_subpackage information)
     let mut hash_info = HashInfo::from_variant(&result.variant, &noarch);
@@ -1608,6 +1617,9 @@ fn render_with_variants(
     let mut results = Vec::with_capacity(combinations.len());
 
     for combination in combinations {
+        if !config.variant_constraints.iter().all(|(key, value)| combination.get(key).is_none_or(|actual| actual == value)) {
+            continue;
+        }
         let context = build_evaluation_context(&combination, &config)?;
         let outputs = evaluate_recipe(stage0_recipe, &context)?;
 

--- a/crates/rattler_build_recipe/src/variant_render.rs
+++ b/crates/rattler_build_recipe/src/variant_render.rs
@@ -938,7 +938,11 @@ fn discover_new_variant_keys_from_evaluation(
     let mut context = build_evaluation_context(combination, config)?;
     for (key, values) in &variant_config.variants {
         if let Some(value) = values.first() {
-            context.actions.variants.entry(key.to_string()).or_insert_with(|| value.clone());
+            context
+                .actions
+                .variants
+                .entry(key.normalize())
+                .or_insert_with(|| value.clone());
         }
     }
 
@@ -1004,7 +1008,9 @@ fn discover_new_variant_keys_from_evaluation(
                 }
                 if !should_skip {
                     let build = match output {
-                        stage0::Output::Staging(staging) => staging.build.evaluate(&context_with_vars)?,
+                        stage0::Output::Staging(staging) => {
+                            staging.build.evaluate(&context_with_vars)?
+                        }
                         stage0::Output::Package(pkg) => {
                             if pkg.build.plan.is_default() {
                                 recipe.build.evaluate(&context_with_vars)?
@@ -1047,10 +1053,18 @@ fn expand_combination_with_keys(
     new_keys: &HashSet<NormalizedKey>,
     variant_config: &VariantConfig,
 ) -> Result<Vec<BTreeMap<NormalizedKey, Variable>>, ParseError> {
-    let keys = base.keys().cloned().chain(new_keys.iter().cloned()).collect();
-    let mut combinations = variant_config.combinations(&keys)
+    let keys = base
+        .keys()
+        .cloned()
+        .chain(new_keys.iter().cloned())
+        .collect();
+    let mut combinations = variant_config
+        .combinations(&keys)
         .map_err(|error| ParseError::generic(error.to_string(), marked_yaml::Span::new_blank()))?;
-    combinations.retain(|combination| base.iter().all(|(key, value)| combination.get(key) == Some(value)));
+    combinations.retain(|combination| {
+        base.iter()
+            .all(|(key, value)| combination.get(key) == Some(value))
+    });
     Ok(combinations)
 }
 
@@ -1093,7 +1107,6 @@ fn expand_variants_tree(
         to_process = next_round;
     }
 
-
     // Deduplicate combinations
     let mut seen = HashSet::new();
     final_combinations.retain(|combo| {
@@ -1132,7 +1145,12 @@ fn build_evaluation_context(
             jinja_config,
             config.os_env_var_keys.clone(),
             config.repodata_revision,
-        ).with_actions(config.action_sources.clone(), config.recipe_path.clone(), config.selected_steps.clone()),
+        )
+        .with_actions(
+            config.action_sources.clone(),
+            config.recipe_path.clone(),
+            config.selected_steps.clone(),
+        ),
     )
 }
 
@@ -1159,7 +1177,11 @@ fn render_with_empty_combinations(
     let context =
         EvaluationContext::with_variables_and_config(config.extra_context.clone(), jinja_config)
             .with_repodata_revision(config.repodata_revision)
-            .with_actions(config.action_sources.clone(), config.recipe_path.clone(), config.selected_steps.clone());
+            .with_actions(
+                config.action_sources.clone(),
+                config.recipe_path.clone(),
+                config.selected_steps.clone(),
+            );
 
     // Evaluate the recipe
     let outputs = evaluate_recipe(stage0_recipe, &context)?;
@@ -1242,13 +1264,22 @@ fn finalize_build_string_single(
 ) -> Result<(), RenderError> {
     let build_string_prefix = config.build_string_prefix.as_deref();
     let noarch = result.recipe.build.noarch.unwrap_or(NoArchType::none());
-    let action_provenance = result.recipe.staging_caches.iter()
+    let action_provenance = result
+        .recipe
+        .staging_caches
+        .iter()
         .flat_map(|cache| cache.build.action_provenance.iter())
-        .chain(result.recipe.build.action_provenance.iter()).collect::<Vec<_>>();
+        .chain(result.recipe.build.action_provenance.iter())
+        .collect::<Vec<_>>();
     if !action_provenance.is_empty() {
         let identity = Variable::from(minijinja::Value::from_serialize(&action_provenance));
-        result.variant.insert(NormalizedKey::from("__actions"), identity.clone());
-        result.recipe.used_variant.insert(NormalizedKey::from("__actions"), identity);
+        result
+            .variant
+            .insert(NormalizedKey::from("__actions"), identity.clone());
+        result
+            .recipe
+            .used_variant
+            .insert(NormalizedKey::from("__actions"), identity);
     }
 
     // Compute hash from the variant (which now includes pin_subpackage information)
@@ -1617,7 +1648,11 @@ fn render_with_variants(
     let mut results = Vec::with_capacity(combinations.len());
 
     for combination in combinations {
-        if !config.variant_constraints.iter().all(|(key, value)| combination.get(key).is_none_or(|actual| actual == value)) {
+        if !config
+            .variant_constraints
+            .iter()
+            .all(|(key, value)| combination.get(key).is_none_or(|actual| actual == value))
+        {
             continue;
         }
         let context = build_evaluation_context(&combination, &config)?;
@@ -1894,8 +1929,6 @@ numpy: ["1.26.*", "2.0.*"]
             .iter()
             .map(|output| {
                 assert!(!output.variant.contains_key(&"numpy".into()));
-                assert!(output.recipe.requirements.build.is_empty());
-                assert!(output.recipe.requirements.host.is_empty());
                 (
                     output
                         .variant

--- a/crates/rattler_build_recipe/src/variant_render.rs
+++ b/crates/rattler_build_recipe/src/variant_render.rs
@@ -1011,13 +1011,16 @@ fn discover_new_variant_keys_from_evaluation(
                         stage0::Output::Staging(staging) => {
                             staging.build.evaluate(&context_with_vars)?
                         }
-                        stage0::Output::Package(pkg) => {
-                            if pkg.build.plan.is_default() {
+                        stage0::Output::Package(pkg) => match &pkg.inherit {
+                            stage0::Inherit::TopLevel if pkg.build.plan.is_default() => {
                                 recipe.build.evaluate(&context_with_vars)?
-                            } else {
+                            }
+                            stage0::Inherit::TopLevel
+                            | stage0::Inherit::CacheName(_)
+                            | stage0::Inherit::CacheWithOptions(_) => {
                                 pkg.build.evaluate(&context_with_vars)?
                             }
-                        }
+                        },
                     };
                     let mut action_requirements = crate::stage1::Requirements::default();
                     action_requirements.build = build.action_requirements.build;

--- a/docs/build_script.md
+++ b/docs/build_script.md
@@ -45,7 +45,7 @@ build:
 ## Experimental build steps
 
 !!! warning "Experimental"
-    Named inline build steps may change or be removed. They require
+    Named and reusable build steps may change or be removed. They require
     `--experimental`.
 
 `build.steps` is an experimental alternative to `build.script`. `script` and

--- a/docs/build_script.md
+++ b/docs/build_script.md
@@ -125,6 +125,68 @@ recipe for an independent lint step and an optional C++ test step.
 or creating build environments. Dependency solving is disabled unless
 `--with-solve` is explicitly supplied, as with `build --render-only`.
 
+### Reusable steps
+
+An action is a strict YAML document compiled during recipe rendering:
+
+```yaml title="recipe.yaml"
+build:
+  steps:
+    - name: lint
+      uses: ./steps/lint.yaml
+      with:
+        paths: [src, tests]
+```
+
+```yaml title="steps/lint.yaml"
+schema_version: 1
+action:
+  name: Python lint checks
+inputs:
+  paths:
+    type: list
+    items: string
+    default: ["."]
+requirements:
+  build: [ruff]
+steps:
+  - name: check
+    run: ruff check ${{ inputs.paths | join(" ") }}
+    env:
+      RUFF_NO_CACHE: "1"
+  - name: format
+    depends_on: [check]
+    run: ruff format --check ${{ inputs.paths | join(" ") }}
+```
+
+Local references must start with `./` or `../` and end in `.yaml` or `.yml`.
+Top-level references are relative to the recipe; nested references are relative
+to their containing action document. Actions may call other actions. Cycles are
+errors, nesting is limited to 64 documents, and repeated invocations are legal.
+`steps: []` is valid and still contributes the action's build and host requirements.
+
+Inputs require an explicit `string`, `boolean`, `integer` (signed 64-bit), or
+`list` type. Lists declare a scalar `items` type. A static default makes an input
+optional; otherwise it is required unless `required: false` is set. Optional
+inputs without defaults receive null. Explicit null overrides a default but is
+invalid for required inputs. Values are never coerced: quoted strings remain
+strings, standalone Jinja expressions preserve native types, and list elements
+can contain templates. Unknown fields and undeclared inputs are errors.
+
+An invocation accepts only `uses`, `with`, `name`, `optional`, `depends_on`, and
+`if`. Its condition is evaluated before loading the document or validating its
+inputs. Run steps own `env`, `cwd`, `interpreter`, and inline requirements.
+Action requirements merge into the effective recipe before variant expansion
+and solving. Configured variants are available implicitly inside actions, while
+recipe-private context is not: pass private values explicitly through `with`.
+`python` and `inputs.python` are separate names.
+
+Name invocations explicitly to select their whole group with `rattler-build run`.
+Selection and dependencies are resolved before flattening, including empty
+groups. Rendered recipes contain only executable run steps and native execution
+bindings; rebuilding them does not load action source documents.
+
+
 !!! warning "Windows multiline steps"
     On Windows, a multiline `run: |` block is emitted as one command-list item.
     Rattler-Build inserts fail-fast guards between list items, not between the

--- a/py-rattler-build/rust/src/render.rs
+++ b/py-rattler-build/rust/src/render.rs
@@ -100,6 +100,7 @@ impl PyRenderConfig {
                 os_env_var_keys,
                 build_string_prefix,
                 build_number_override,
+                ..RustRenderConfig::default()
             },
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -421,6 +421,7 @@ pub async fn get_build_output(
         os_env_var_keys,
         build_number_override: build_data.build_num_override,
         build_string_prefix: build_data.build_string_prefix.clone(),
+        selected_steps: build_data.selected_steps.clone(),
         ..RenderConfig::default()
     };
 
@@ -476,67 +477,25 @@ pub async fn get_build_output(
 
     let timestamp = jiff::Timestamp::now();
 
-    for mut discovered_output in outputs_and_variants {
-        let mut inherit_parent_build = true;
-        let mut inherit_parent_host = true;
-        // Resolve the step DAG before solving so step-local host requirements
-        // participate in environment creation. A normal build selects all
-        // non-optional roots; `run` supplies explicit roots.
-        if discovered_output.recipe.build.plan.steps().is_some() {
-            let selected = discovered_output
-                .recipe
-                .build
-                .plan
-                .select_steps(build_data.selected_steps.as_deref())
-                .map_err(|error| miette::miette!("invalid build steps: {error}"))?;
-            if let Some(requested_steps) = build_data.selected_steps.as_deref() {
-                // The explicitly requested roots define the solve group. DAG
-                // prerequisites execute in that same environment; their own
-                // inheritance setting applies only when selected directly.
-                let mut root_inheritance = requested_steps.iter().map(|requested| {
-                    selected
-                        .iter()
-                        .find(|step| step.name.as_deref() == Some(requested.as_str()))
-                        .expect("selected root must be present after DAG resolution")
-                        .requirements
-                        .inherit
-                        .clone()
-                });
-                if let Some(first) = root_inheritance.next() {
-                    if root_inheritance.any(|inherit| inherit != first) {
-                        return Err(miette::miette!(
-                            "selected build steps use incompatible parent environment inheritance; run them separately"
-                        ));
-                    }
-                    inherit_parent_build = first.build;
-                    inherit_parent_host = first.host;
-                }
-                if !inherit_parent_build {
-                    discovered_output.recipe.requirements.build.clear();
-                }
-                if !inherit_parent_host {
-                    discovered_output.recipe.requirements.host.clear();
-                }
-            }
-            for step in &selected {
-                discovered_output
-                    .recipe
-                    .requirements
-                    .build
-                    .extend(step.requirements.build.clone());
-                discovered_output
-                    .recipe
-                    .requirements
-                    .host
-                    .extend(step.requirements.host.clone());
-            }
-            discovered_output.recipe.build.plan =
-                rattler_build_recipe::stage1::build::BuildPlan::Steps(selected);
-        } else if build_data.selected_steps.is_some() {
-            return Err(miette::miette!(
-                "named steps were requested, but this recipe uses build.script"
-            ));
-        }
+    for discovered_output in outputs_and_variants {
+        let root_inheritance = discovered_output
+            .recipe
+            .build
+            .plan
+            .steps()
+            .unwrap_or_default()
+            .iter()
+            .find(|step| {
+                step.name.as_ref().is_some_and(|name| {
+                    build_data
+                        .selected_steps
+                        .as_ref()
+                        .is_some_and(|selected| selected.contains(name))
+                })
+            })
+            .map(|step| &step.requirements.inherit);
+        let inherit_parent_build = root_inheritance.is_none_or(|inherit| inherit.build);
+        let inherit_parent_host = root_inheritance.is_none_or(|inherit| inherit.host);
 
         let recipe = &discovered_output.recipe;
 

--- a/test/end-to-end/test_actions.py
+++ b/test/end-to-end/test_actions.py
@@ -112,6 +112,29 @@ def test_empty_action_keeps_named_dependencies_and_requirements(
     assert (project / "result.txt").read_text().strip() == "prepared"
 
 
+@pytest.mark.parametrize("reference", ["./missing.yaml", "missing-provider:build@0"])
+def test_skipped_output_does_not_resolve_actions(
+    rattler_build: RattlerBuild, tmp_path: Path, reference: str
+):
+    project = action_project(
+        tmp_path, {"steps": []}, steps=[{"uses": reference}]
+    )
+    path = project / "recipe.yaml"
+    recipe = yaml.safe_load(path.read_text())
+    recipe["build"]["skip"] = True
+    path.write_text(yaml.safe_dump(recipe))
+    rendered = rattler_build.render(
+        project, tmp_path / "output", extra_args=["--experimental"]
+    )
+    assert rendered == []
+    recipe["build"]["skip"] = False
+    path.write_text(yaml.safe_dump(recipe))
+    with pytest.raises(CalledProcessError):
+        rattler_build.render(
+            project, tmp_path / "output", extra_args=["--experimental"]
+        )
+
+
 def test_false_invocation_skips_resolution_and_input_validation(
     rattler_build: RattlerBuild, tmp_path: Path
 ):

--- a/test/end-to-end/test_actions.py
+++ b/test/end-to-end/test_actions.py
@@ -116,9 +116,7 @@ def test_empty_action_keeps_named_dependencies_and_requirements(
 def test_skipped_output_does_not_resolve_actions(
     rattler_build: RattlerBuild, tmp_path: Path, reference: str
 ):
-    project = action_project(
-        tmp_path, {"steps": []}, steps=[{"uses": reference}]
-    )
+    project = action_project(tmp_path, {"steps": []}, steps=[{"uses": reference}])
     path = project / "recipe.yaml"
     recipe = yaml.safe_load(path.read_text())
     recipe["build"]["skip"] = True

--- a/test/end-to-end/test_actions.py
+++ b/test/end-to-end/test_actions.py
@@ -406,6 +406,7 @@ def test_staging_actions_share_package_compilation(
         yaml.safe_dump(
             {
                 "recipe": {"name": "action-staging", "version": "1.0"},
+                "build": {"steps": [{"uses": "./unused.yaml"}]},
                 "outputs": [
                     {
                         "staging": {"name": "prepared"},
@@ -414,20 +415,6 @@ def test_staging_actions_share_package_compilation(
                     {
                         "package": {"name": "action-staging"},
                         "inherit": "prepared",
-                        "build": {
-                            "steps": [
-                                {
-                                    "name": "verify",
-                                    "run": [
-                                        {
-                                            "if": "win",
-                                            "then": 'if not exist "%PREFIX%/staged.txt" exit /b 17',
-                                            "else": 'test -f "$PREFIX/staged.txt"',
-                                        },
-                                    ],
-                                }
-                            ]
-                        },
                     },
                 ],
             }
@@ -477,3 +464,48 @@ def test_excluded_action_does_not_consume_argument_variants(
     assert [
         item["build_configuration"]["variant"].get("python") for item in rendered
     ] == [None]
+
+
+def test_named_execution_rejects_script_mode(
+    rattler_build: RattlerBuild, tmp_path: Path
+):
+    (tmp_path / "recipe.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "package": {"name": "script-selection", "version": "1"},
+                "build": {"script": "echo unexpected > marker.txt"},
+            }
+        )
+    )
+    with pytest.raises(CalledProcessError):
+        run_action(rattler_build, tmp_path, tmp_path / "output", name="missing")
+    assert not (tmp_path / "marker.txt").exists()
+
+
+def test_output_selection_ignores_discarded_top_level_actions(
+    rattler_build: RattlerBuild, tmp_path: Path
+):
+    (tmp_path / "recipe.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": 1,
+                "recipe": {"name": "output-selection", "version": "1"},
+                "build": {"steps": [{"name": "unused", "uses": "./missing.yaml"}]},
+                "outputs": [
+                    {
+                        "package": {"name": "output-selection"},
+                        "build": {
+                            "steps": [
+                                {
+                                    "name": "check",
+                                    "run": "echo selected > marker.txt",
+                                }
+                            ]
+                        },
+                    }
+                ],
+            }
+        )
+    )
+    run_action(rattler_build, tmp_path, tmp_path / "output", name="check")
+    assert (tmp_path / "marker.txt").read_text().strip() == "selected"

--- a/test/end-to-end/test_actions.py
+++ b/test/end-to-end/test_actions.py
@@ -107,6 +107,7 @@ def test_empty_action_keeps_named_dependencies_and_requirements(
         "3.11",
         "3.12",
     }
+    (project / "variants.yaml").write_text('python: ["3.11"]\n')
     run_action(rattler_build, project, tmp_path / "output")
     assert (project / "result.txt").read_text().strip() == "prepared"
 

--- a/test/end-to-end/test_actions.py
+++ b/test/end-to-end/test_actions.py
@@ -1,0 +1,478 @@
+import shutil
+import tarfile
+from pathlib import Path
+from subprocess import CalledProcessError, STDOUT
+
+import pytest
+import yaml
+from helpers import RattlerBuild, get_extracted_package, get_package
+
+
+def action_project(tmp_path: Path, action, *, arguments=None, context=None, steps=None):
+    project = tmp_path / "project"
+    project.mkdir()
+    recipe = {
+        "schema_version": 1,
+        "package": {"name": "action-contract", "version": "1.0"},
+        "build": {
+            "steps": steps
+            if steps is not None
+            else [{"name": "test", "uses": "./action.yaml", "with": arguments or {}}]
+        },
+    }
+    if context is not None:
+        recipe["context"] = context
+    (project / "recipe.yaml").write_text(yaml.safe_dump(recipe))
+    (project / "action.yaml").write_text(yaml.safe_dump(action))
+    return project
+
+
+def run_action(rattler_build: RattlerBuild, project: Path, output: Path, name="test"):
+    return rattler_build(
+        "run",
+        name,
+        "--recipe",
+        str(project),
+        "--source-dir",
+        str(project),
+        "--output-dir",
+        str(output),
+        "--experimental",
+    )
+
+
+def test_nested_action_selection_and_relative_resolution(
+    rattler_build: RattlerBuild, tmp_path: Path
+):
+    project = action_project(
+        tmp_path,
+        {"steps": []},
+        steps=[
+            {"name": "prepare", "run": "echo prepare > order.txt"},
+            {"name": "test", "uses": "./nested/outer.yaml", "depends_on": ["prepare"]},
+            {"name": "unselected", "run": "echo wrong >> order.txt"},
+        ],
+    )
+    nested = project / "nested"
+    nested.mkdir()
+    (nested / "outer.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "steps": [
+                    {"uses": "./child.yml", "with": {"message": "first"}},
+                    {"uses": "./child.yml", "with": {"message": "second"}},
+                    {"run": "echo outer >> order.txt"},
+                ]
+            }
+        )
+    )
+    (nested / "child.yml").write_text(
+        yaml.safe_dump(
+            {
+                "inputs": {"message": {"type": "string"}},
+                "steps": [{"run": "echo ${{ inputs.message }} >> order.txt"}],
+            }
+        )
+    )
+    run_action(rattler_build, project, tmp_path / "output")
+    assert [
+        line.strip() for line in (project / "order.txt").read_text().splitlines()
+    ] == [
+        "prepare",
+        "first",
+        "second",
+        "outer",
+    ]
+
+
+def test_empty_action_keeps_named_dependencies_and_requirements(
+    rattler_build: RattlerBuild, tmp_path: Path
+):
+    project = action_project(
+        tmp_path,
+        {
+            "requirements": {"host": ["python"]},
+            "steps": [],
+        },
+        steps=[
+            {"name": "prepare", "run": "echo prepared > result.txt"},
+            {"name": "test", "uses": "./action.yaml", "depends_on": ["prepare"]},
+        ],
+    )
+    (project / "variants.yaml").write_text('python: ["3.11", "3.12"]\n')
+    rendered = rattler_build.render(
+        project, tmp_path / "render", extra_args=["--experimental"]
+    )
+    assert {item["build_configuration"]["variant"]["python"] for item in rendered} == {
+        "3.11",
+        "3.12",
+    }
+    run_action(rattler_build, project, tmp_path / "output")
+    assert (project / "result.txt").read_text().strip() == "prepared"
+
+
+def test_false_invocation_skips_resolution_and_input_validation(
+    rattler_build: RattlerBuild, tmp_path: Path
+):
+    project = action_project(
+        tmp_path,
+        {
+            "steps": [
+                {
+                    "uses": "./missing.yaml",
+                    "if": "false",
+                    "with": {"bad": "${{ missing_value }}"},
+                },
+                {"run": "echo included > result.txt"},
+            ]
+        },
+    )
+    run_action(rattler_build, project, tmp_path / "output")
+    assert (project / "result.txt").read_text().strip() == "included"
+
+
+@pytest.mark.parametrize("cycle", [True, False], ids=["cycle", "depth-limit"])
+def test_recursive_action_errors_before_execution(
+    rattler_build: RattlerBuild, tmp_path: Path, cycle
+):
+    project = action_project(
+        tmp_path,
+        {
+            "steps": [
+                {"run": "echo must-not-run > result.txt"},
+                {"uses": "./next-0.yaml"},
+            ]
+        },
+    )
+    count = 2 if cycle else 65
+    for index in range(count):
+        following = (
+            "./action.yaml"
+            if cycle and index == count - 1
+            else f"./next-{index + 1}.yaml"
+        )
+        steps = [{"uses": following}] if cycle or index < count - 1 else []
+        (project / f"next-{index}.yaml").write_text(yaml.safe_dump({"steps": steps}))
+    with pytest.raises(CalledProcessError):
+        run_action(rattler_build, project, tmp_path / "output")
+    assert not (project / "result.txt").exists()
+
+
+def test_action_inputs_preserve_native_types_and_punctuation(
+    rattler_build: RattlerBuild, tmp_path: Path
+):
+    project = action_project(
+        tmp_path,
+        {
+            "inputs": {
+                "text": {"type": "string"},
+                "numbers": {"type": "list", "items": "integer"},
+                "enabled": {"type": "boolean"},
+                "optional": {"type": "string", "default": "fallback"},
+            },
+            "steps": [
+                {
+                    "run": "echo ${{ inputs.text }}-${{ inputs.numbers[0] + inputs.numbers[1] }}-${{ 1 if inputs.enabled else 0 }}-${{ 'null' if inputs.optional is none else inputs.optional }} > result.txt"
+                }
+            ],
+        },
+        arguments={
+            "text": "status: ready",
+            "numbers": ["${{ count }}", 2],
+            "enabled": "${{ enabled }}",
+            "optional": None,
+        },
+        context={"count": 7, "enabled": False},
+    )
+    run_action(rattler_build, project, tmp_path / "output")
+    assert (project / "result.txt").read_text().strip() == "status: ready-9-0-null"
+
+
+def test_action_variants_and_inputs_have_separate_namespaces(
+    rattler_build: RattlerBuild, tmp_path: Path
+):
+    project = action_project(
+        tmp_path,
+        {
+            "inputs": {"python": {"type": "string"}},
+            "steps": [
+                {
+                    "run": "echo ${{ python }}-${{ inputs.python }}-${{ 'leaked' if private_value is defined else 'isolated' }} > result.txt"
+                }
+            ],
+        },
+        arguments={"python": "${{ private_value }}"},
+        context={"private_value": "argument", "python": "recipe-shadow"},
+    )
+    (project / "variants.yaml").write_text('python: ["3.11"]\n')
+    run_action(rattler_build, project, tmp_path / "output")
+    assert (project / "result.txt").read_text().strip() == "3.11-argument-isolated"
+
+
+def test_action_bare_requirements_expand_normal_recipe_variants(
+    rattler_build: RattlerBuild, tmp_path: Path
+):
+    project = action_project(
+        tmp_path,
+        {
+            "requirements": {"host": ["python"]},
+            "steps": [
+                {"run": "echo ${{ python }}"},
+            ],
+        },
+    )
+    (project / "variants.yaml").write_text('python: ["3.11", "3.12"]\n')
+    rendered = rattler_build.render(
+        project, tmp_path / "output", extra_args=["--experimental"]
+    )
+    assert {item["build_configuration"]["variant"]["python"] for item in rendered} == {
+        "3.11",
+        "3.12",
+    }
+    assert len({item["recipe"]["build"]["string"] for item in rendered}) == 2
+
+
+def test_nested_bindings_remain_isolated_with_late_bound_values(
+    rattler_build: RattlerBuild, tmp_path: Path
+):
+    project = action_project(
+        tmp_path,
+        {
+            "inputs": {"message": {"type": "string"}},
+            "steps": [
+                {"uses": "./child.yaml", "with": {"message": "child"}},
+                {"run": "echo ${{ inputs.message }} > parent.txt"},
+            ],
+        },
+        arguments={"message": "parent"},
+    )
+    (project / "child.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "inputs": {"message": {"type": "string"}},
+                "steps": [
+                    {"run": "echo ${{ inputs.message }} > child.txt"},
+                    {"run": "echo ${{ BUILD_DIR }} > spaced.txt"},
+                    {"run": "echo ${{BUILD_DIR}} > compact.txt"},
+                ],
+            }
+        )
+    )
+    run_action(rattler_build, project, tmp_path / "output")
+    assert (project / "parent.txt").read_text().strip() == "parent"
+    assert (project / "child.txt").read_text().strip() == "child"
+    spaced = (project / "spaced.txt").read_text().strip()
+    assert Path(spaced).is_dir()
+    assert (project / "compact.txt").read_text().strip() == spaced
+
+
+@pytest.mark.parametrize(
+    "declaration,value",
+    [
+        ({}, "value"),
+        ({"type": "string", "required": True, "default": "value"}, "value"),
+        ({"type": "integer"}, "7"),
+        ({"type": "integer"}, True),
+        ({"type": "list", "items": "integer"}, [1, "2"]),
+        ({"type": "list", "items": "integer"}, [None]),
+        ({"type": "list"}, []),
+        ({"type": "string", "items": "string"}, "value"),
+        ({"type": "string", "default": "${{ python }}"}, "value"),
+        ({"type": "string"}, None),
+    ],
+)
+def test_action_rejects_invalid_typed_arguments(
+    rattler_build: RattlerBuild, tmp_path: Path, declaration, value
+):
+    project = action_project(
+        tmp_path,
+        {
+            "inputs": {"value": declaration},
+            "steps": [{"run": "echo invalid > result.txt"}],
+        },
+        arguments={"value": value},
+    )
+    with pytest.raises(CalledProcessError):
+        run_action(rattler_build, project, tmp_path / "output")
+    assert not (project / "result.txt").exists()
+
+
+@pytest.mark.parametrize(
+    "action",
+    [
+        {"schema_version": 999, "steps": []},
+        {"unknown": True, "steps": []},
+        {"action": {"unknown": True}, "steps": []},
+        {"requirements": {"run": ["python"]}, "steps": []},
+        {"inputs": {"value": {"type": "string"}}, "steps": []},
+        {"inputs": {"bad-name": {"type": "string"}}, "steps": []},
+        {"schema_version": 1},
+    ],
+)
+def test_action_rejects_invalid_documents(
+    rattler_build: RattlerBuild, tmp_path: Path, action
+):
+    project = action_project(tmp_path, action)
+    with pytest.raises(CalledProcessError):
+        rattler_build.render(
+            project, tmp_path / "output", extra_args=["--experimental"]
+        )
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"env": {"A": "B"}},
+        {"cwd": "child"},
+        {"interpreter": "python"},
+        {"requirements": {"build": ["python"]}},
+    ],
+)
+def test_action_invocation_rejects_execution_overrides(
+    rattler_build: RattlerBuild, tmp_path: Path, override
+):
+    project = action_project(
+        tmp_path,
+        {"steps": []},
+        steps=[
+            {"uses": "./action.yaml", **override},
+        ],
+    )
+    with pytest.raises(CalledProcessError):
+        rattler_build.render(
+            project, tmp_path / "output", extra_args=["--experimental"]
+        )
+
+
+def test_compiled_action_rebuild_does_not_need_action_documents(
+    rattler_build: RattlerBuild, tmp_path: Path
+):
+    project = action_project(
+        tmp_path,
+        {
+            "inputs": {"message": {"type": "string"}},
+            "steps": [
+                {"run": 'echo ${{ inputs.message }}> "${{ PREFIX }}/marker.txt"'}
+            ],
+        },
+        arguments={"message": "compiled-action"},
+    )
+    original_output = tmp_path / "original"
+    rattler_build.build(project, original_output, extra_args=["--experimental"])
+    original_package = get_package(original_output, "action-contract")
+    assert (
+        get_extracted_package(original_output, "action-contract") / "marker.txt"
+    ).read_text().strip() == "compiled-action"
+    stripped = tmp_path / original_package.name
+    with tarfile.open(original_package, "r:bz2") as source:
+        with tarfile.open(stripped, "w:bz2") as target:
+            for member in source:
+                if (
+                    member.name.startswith("info/recipe/")
+                    and member.name != "info/recipe/rendered_recipe.yaml"
+                ):
+                    continue
+                target.addfile(
+                    member, source.extractfile(member) if member.isfile() else None
+                )
+    shutil.rmtree(project)
+    rebuilt_output = tmp_path / "rebuilt"
+    rattler_build(
+        "rebuild",
+        "--package-file",
+        str(stripped),
+        "--output-dir",
+        str(rebuilt_output),
+        "--experimental",
+        "--test=skip",
+        stderr=STDOUT,
+    )
+    assert (
+        get_extracted_package(rebuilt_output, "action-contract") / "marker.txt"
+    ).read_text().strip() == "compiled-action"
+
+
+def test_staging_actions_share_package_compilation(
+    rattler_build: RattlerBuild, tmp_path: Path
+):
+    project = action_project(
+        tmp_path,
+        {
+            "steps": [{"run": 'echo staged> "${{ PREFIX }}/staged.txt"'}],
+        },
+    )
+    (project / "recipe.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "recipe": {"name": "action-staging", "version": "1.0"},
+                "outputs": [
+                    {
+                        "staging": {"name": "prepared"},
+                        "build": {"steps": [{"uses": "./action.yaml"}]},
+                    },
+                    {
+                        "package": {"name": "action-staging"},
+                        "inherit": "prepared",
+                        "build": {
+                            "steps": [
+                                {
+                                    "name": "verify",
+                                    "run": [
+                                        {
+                                            "if": "win",
+                                            "then": 'if not exist "%PREFIX%/staged.txt" exit /b 17',
+                                            "else": 'test -f "$PREFIX/staged.txt"',
+                                        },
+                                    ],
+                                }
+                            ]
+                        },
+                    },
+                ],
+            }
+        )
+    )
+    output = tmp_path / "output"
+    rattler_build.build(project, output, extra_args=["--experimental"])
+    assert (
+        get_extracted_package(output, "action-staging") / "staged.txt"
+    ).read_text().strip() == "staged"
+
+
+def test_action_cannot_defer_private_recipe_context_to_execution(
+    rattler_build: RattlerBuild, tmp_path: Path
+):
+    project = action_project(
+        tmp_path,
+        {
+            "steps": [{"run": "echo ${{ private_value }} > result.txt"}],
+        },
+        context={"private_value": "secret"},
+    )
+    with pytest.raises(CalledProcessError):
+        run_action(rattler_build, project, tmp_path / "output")
+    assert not (project / "result.txt").exists()
+
+
+def test_excluded_action_does_not_consume_argument_variants(
+    rattler_build: RattlerBuild, tmp_path: Path
+):
+    project = action_project(
+        tmp_path,
+        {"steps": [{"run": "echo selected"}]},
+        steps=[
+            {
+                "if": "false",
+                "uses": "./missing.yaml",
+                "with": {"version": "${{ python }}"},
+            },
+            {"uses": "./action.yaml"},
+        ],
+    )
+    (project / "variants.yaml").write_text('python: ["3.11", "3.12"]\n')
+    rendered = rattler_build.render(
+        project, tmp_path / "output", extra_args=["--experimental"]
+    )
+    assert [
+        item["build_configuration"]["variant"].get("python") for item in rendered
+    ] == [None]

--- a/test/end-to-end/test_actions.py
+++ b/test/end-to-end/test_actions.py
@@ -1,7 +1,7 @@
 import shutil
 import tarfile
 from pathlib import Path
-from subprocess import CalledProcessError, STDOUT
+from subprocess import STDOUT, CalledProcessError
 
 import pytest
 import yaml
@@ -388,17 +388,19 @@ def test_compiled_action_rebuild_does_not_need_action_documents(
         get_extracted_package(original_output, "action-contract") / "marker.txt"
     ).read_text().strip() == "compiled-action"
     stripped = tmp_path / original_package.name
-    with tarfile.open(original_package, "r:bz2") as source:
-        with tarfile.open(stripped, "w:bz2") as target:
-            for member in source:
-                if (
-                    member.name.startswith("info/recipe/")
-                    and member.name != "info/recipe/rendered_recipe.yaml"
-                ):
-                    continue
-                target.addfile(
-                    member, source.extractfile(member) if member.isfile() else None
-                )
+    with (
+        tarfile.open(original_package, "r:bz2") as source,
+        tarfile.open(stripped, "w:bz2") as target,
+    ):
+        for member in source:
+            if (
+                member.name.startswith("info/recipe/")
+                and member.name != "info/recipe/rendered_recipe.yaml"
+            ):
+                continue
+            target.addfile(
+                member, source.extractfile(member) if member.isfile() else None
+            )
     shutil.rmtree(project)
     rebuilt_output = tmp_path / "rebuilt"
     rattler_build(

--- a/test/end-to-end/test_simple.py
+++ b/test/end-to-end/test_simple.py
@@ -136,32 +136,6 @@ def test_run_refuses_changed_sources_without_discarding_edits(
     assert (tmp_path / "second" / "runs.txt").is_file()
 
 
-def test_build_steps_reject_uses(rattler_build: RattlerBuild, tmp_path: Path):
-    recipe = tmp_path / "recipe.yaml"
-    recipe.write_text(
-        """package:
-  name: inline-steps-only
-  version: "1.0"
-build:
-  steps:
-    - name: check
-      uses: ./check.yaml
-"""
-    )
-
-    result = rattler_build(
-        "build",
-        "--recipe",
-        recipe,
-        "--render-only",
-        "--experimental",
-        capture_output=True,
-    )
-
-    assert result.returncode != 0
-    assert "uses" in result.stderr
-
-
 def test_run_render_only_is_read_only(rattler_build: RattlerBuild, tmp_path: Path):
     recipe = tmp_path / "recipe.yaml"
     output = tmp_path / "output"


### PR DESCRIPTION
Reusable actions need to contribute dependencies before variant expansion and solving. Interpreting `uses` again during execution makes that ordering difficult to enforce and leaves rebuilds dependent on the original action files.

This compiles recursive action documents during Stage0-to-Stage1 evaluation. Source `Run` and `Uses` are separate types; Stage1 contains a flat executable plan with native input bindings. Action documents use a strict, versioned schema with typed inputs and action-owned build/host requirements. Callers pass `with` values instead of overriding execution settings.

Configured variants are available inside actions, but recipe-private context must be passed explicitly. Invocation names remain literal CLI targets: selection and dependencies are resolved before flattening, including empty groups. False invocations skip source loading and input validation. Relative paths, recursion cycles, and the depth limit are handled by the same compiler.

The source registry also gives packaged actions and metadata-generated recipes a shared compilation path in the following PRs. Rebuild executes the stored plan without loading action documents.

On Windows, 347 recipe tests and 41 focused CLI/action/staging cases pass. Fresh-context review found three selection/inheritance defects; their reproducers failed before the fixes and now pass.

Part of PFX-1808. Native stack 2808, bottom to top: #2763 → #2807 → #2764 → #2765 → #2767.