### PR TITLE
feat: add force_use_keys variant keys

### DIFF
--- a/crates/rattler_build_recipe/src/variant_render.rs
+++ b/crates/rattler_build_recipe/src/variant_render.rs
@@ -1576,8 +1576,8 @@ fn render_with_variants(
         for mut recipe in outputs {
             let mut variant = recipe.used_variant.clone();
 
-            // force_use applies to every package and staging build.
-            for key in variant_config.force_use.iter().flatten() {
+            // force_use_keys applies to every package and staging build.
+            for key in variant_config.force_use_keys.iter().flatten() {
                 if let Some(value) = combination.get(key) {
                     variant.insert(key.clone(), value.clone());
                     recipe.used_variant.insert(key.clone(), value.clone());
@@ -3855,7 +3855,7 @@ build:
     }
 
     #[test]
-    fn test_force_use_applies_to_package_and_staging_builds() {
+    fn test_force_use_keys_applies_to_package_and_staging_builds() {
         let recipe_yaml = r#"
 recipe:
   name: force-use-test
@@ -3864,11 +3864,18 @@ outputs:
   - staging:
       name: build-stage
   - package:
-      name: force-use-test
+      name: uses-target
     inherit: build-stage
+  - package:
+      name: ignores-target
+    inherit: build-stage
+    build:
+      variant:
+        ignore_keys:
+          - target
 "#;
         let variant_yaml = r#"
-force_use:
+force_use_keys:
   - target
 target:
   - x86_64-conda-linux-gnu
@@ -3882,11 +3889,14 @@ unused:
             render_recipe_with_variant_config(&stage0_recipe, &variant_config, RenderConfig::new())
                 .unwrap();
 
-        assert_eq!(rendered.len(), 2);
+        assert_eq!(rendered.len(), 4);
         for output in rendered {
-            assert!(output.variant.contains_key(&"target".into()));
+            let ignores_target = output.recipe.package.name.as_normalized() == "ignores-target";
+            assert_eq!(
+                output.variant.contains_key(&"target".into()),
+                !ignores_target
+            );
             assert!(!output.variant.contains_key(&"unused".into()));
-            assert!(output.recipe.used_variant.contains_key(&"target".into()));
             assert!(
                 output.recipe.staging_caches[0]
                     .used_variant

--- a/crates/rattler_build_recipe/src/variant_render.rs
+++ b/crates/rattler_build_recipe/src/variant_render.rs
@@ -1573,8 +1573,19 @@ fn render_with_variants(
         let outputs = evaluate_recipe(stage0_recipe, &context)?;
 
         // Convert each output to a RenderedVariant
-        for recipe in outputs {
+        for mut recipe in outputs {
             let mut variant = recipe.used_variant.clone();
+
+            // force_use applies to every package and staging build.
+            for key in variant_config.force_use.iter().flatten() {
+                if let Some(value) = combination.get(key) {
+                    variant.insert(key.clone(), value.clone());
+                    recipe.used_variant.insert(key.clone(), value.clone());
+                    for cache in &mut recipe.staging_caches {
+                        cache.used_variant.insert(key.clone(), value.clone());
+                    }
+                }
+            }
 
             // Add use_keys to the variant (forces them to be included even if not referenced)
             // We need to get them from the combination since they were used to compute it
@@ -3841,6 +3852,47 @@ build:
             bs.ends_with("_42"),
             "build string should end with '_42', got '{bs}'"
         );
+    }
+
+    #[test]
+    fn test_force_use_applies_to_package_and_staging_builds() {
+        let recipe_yaml = r#"
+recipe:
+  name: force-use-test
+  version: "1.0"
+outputs:
+  - staging:
+      name: build-stage
+  - package:
+      name: force-use-test
+    inherit: build-stage
+"#;
+        let variant_yaml = r#"
+force_use:
+  - target
+target:
+  - x86_64-conda-linux-gnu
+  - aarch64-conda-linux-gnu
+unused:
+  - ignored
+"#;
+        let stage0_recipe = stage0::parse_recipe_or_multi_from_source(recipe_yaml).unwrap();
+        let variant_config = VariantConfig::from_yaml_str(variant_yaml).unwrap();
+        let rendered =
+            render_recipe_with_variant_config(&stage0_recipe, &variant_config, RenderConfig::new())
+                .unwrap();
+
+        assert_eq!(rendered.len(), 2);
+        for output in rendered {
+            assert!(output.variant.contains_key(&"target".into()));
+            assert!(!output.variant.contains_key(&"unused".into()));
+            assert!(output.recipe.used_variant.contains_key(&"target".into()));
+            assert!(
+                output.recipe.staging_caches[0]
+                    .used_variant
+                    .contains_key(&"target".into())
+            );
+        }
     }
 
     #[test]

--- a/crates/rattler_build_variant_config/src/config.rs
+++ b/crates/rattler_build_variant_config/src/config.rs
@@ -44,7 +44,7 @@ pub struct VariantConfig {
 
     /// Variant keys that should be included in every build, even when the recipe does not use them.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub force_use: Option<Vec<NormalizedKey>>,
+    pub force_use_keys: Option<Vec<NormalizedKey>>,
 
     /// The variant values - a mapping of keys to lists of possible values.
     /// Each key represents a variable in the build matrix.
@@ -214,8 +214,8 @@ impl VariantConfig {
         if other.zip_keys.is_some() {
             self.zip_keys = other.zip_keys;
         }
-        if other.force_use.is_some() {
-            self.force_use = other.force_use;
+        if other.force_use_keys.is_some() {
+            self.force_use_keys = other.force_use_keys;
         }
     }
 
@@ -243,7 +243,7 @@ impl VariantConfig {
         used_vars: &HashSet<NormalizedKey>,
     ) -> Result<Vec<BTreeMap<NormalizedKey, Variable>>, VariantExpandError> {
         let mut used_vars = used_vars.clone();
-        used_vars.extend(self.force_use.iter().flatten().cloned());
+        used_vars.extend(self.force_use_keys.iter().flatten().cloned());
         let zip_keys = self.zip_keys.as_deref().unwrap_or(&[]);
         compute_combinations(&self.variants, zip_keys, &used_vars)
     }
@@ -306,16 +306,16 @@ zip_keys:
     }
 
     #[test]
-    fn test_parse_force_use() {
+    fn test_parse_force_use_keys() {
         let config = VariantConfig::from_yaml_str(
-            "force_use: [target, emulator]\ntarget: [x86_64-linux-gnu]\nemulator: [qemu]",
+            "force_use_keys: [target, emulator]\ntarget: [x86_64-linux-gnu]\nemulator: [qemu]",
         )
         .unwrap();
         assert_eq!(
-            config.force_use,
+            config.force_use_keys,
             Some(vec!["target".into(), "emulator".into()])
         );
-        assert!(!config.variants.contains_key(&"force_use".into()));
+        assert!(!config.variants.contains_key(&"force_use_keys".into()));
         assert_eq!(config.combinations(&HashSet::new()).unwrap()[0].len(), 2);
     }
 
@@ -327,11 +327,11 @@ zip_keys:
         let mut config2 = VariantConfig::new();
         config2.insert("numpy", vec!["1.20".into(), "1.21".into()]);
         config2.insert("python", vec!["3.11".into()]); // Should override
-        config2.force_use = Some(vec!["numpy".into()]);
+        config2.force_use_keys = Some(vec!["numpy".into()]);
 
         config1.merge(config2);
 
-        assert_eq!(config1.force_use, Some(vec!["numpy".into()]));
+        assert_eq!(config1.force_use_keys, Some(vec!["numpy".into()]));
         assert_eq!(config1.variants.len(), 2);
         assert_eq!(config1.get(&"python".into()).unwrap().len(), 1); // Overridden
         assert_eq!(

--- a/crates/rattler_build_variant_config/src/config.rs
+++ b/crates/rattler_build_variant_config/src/config.rs
@@ -42,6 +42,10 @@ pub struct VariantConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub zip_keys: Option<Vec<Vec<NormalizedKey>>>,
 
+    /// Variant keys that should be included in every build, even when the recipe does not use them.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub force_use: Option<Vec<NormalizedKey>>,
+
     /// The variant values - a mapping of keys to lists of possible values.
     /// Each key represents a variable in the build matrix.
     #[serde(flatten)]
@@ -201,14 +205,17 @@ impl VariantConfig {
 
     /// Merge another variant configuration into this one
     ///
-    /// Variant values are replaced (not merged), and zip_keys from `other` take precedence.
+    /// Variant values are replaced (not merged), and special keys from `other` take precedence.
     pub fn merge(&mut self, other: VariantConfig) {
         // Extend variants (later values replace earlier ones)
         self.variants.extend(other.variants);
 
-        // Replace zip_keys if provided
+        // Replace special keys if provided
         if other.zip_keys.is_some() {
             self.zip_keys = other.zip_keys;
+        }
+        if other.force_use.is_some() {
+            self.force_use = other.force_use;
         }
     }
 
@@ -235,8 +242,10 @@ impl VariantConfig {
         &self,
         used_vars: &HashSet<NormalizedKey>,
     ) -> Result<Vec<BTreeMap<NormalizedKey, Variable>>, VariantExpandError> {
+        let mut used_vars = used_vars.clone();
+        used_vars.extend(self.force_use.iter().flatten().cloned());
         let zip_keys = self.zip_keys.as_deref().unwrap_or(&[]);
-        compute_combinations(&self.variants, zip_keys, used_vars)
+        compute_combinations(&self.variants, zip_keys, &used_vars)
     }
 
     /// Get all variant keys
@@ -297,6 +306,20 @@ zip_keys:
     }
 
     #[test]
+    fn test_parse_force_use() {
+        let config = VariantConfig::from_yaml_str(
+            "force_use: [target, emulator]\ntarget: [x86_64-linux-gnu]\nemulator: [qemu]",
+        )
+        .unwrap();
+        assert_eq!(
+            config.force_use,
+            Some(vec!["target".into(), "emulator".into()])
+        );
+        assert!(!config.variants.contains_key(&"force_use".into()));
+        assert_eq!(config.combinations(&HashSet::new()).unwrap()[0].len(), 2);
+    }
+
+    #[test]
     fn test_merge_configs() {
         let mut config1 = VariantConfig::new();
         config1.insert("python", vec!["3.9".into(), "3.10".into()]);
@@ -304,9 +327,11 @@ zip_keys:
         let mut config2 = VariantConfig::new();
         config2.insert("numpy", vec!["1.20".into(), "1.21".into()]);
         config2.insert("python", vec!["3.11".into()]); // Should override
+        config2.force_use = Some(vec!["numpy".into()]);
 
         config1.merge(config2);
 
+        assert_eq!(config1.force_use, Some(vec!["numpy".into()]));
         assert_eq!(config1.variants.len(), 2);
         assert_eq!(config1.get(&"python".into()).unwrap().len(), 1); // Overridden
         assert_eq!(

--- a/crates/rattler_build_variant_config/src/evaluate.rs
+++ b/crates/rattler_build_variant_config/src/evaluate.rs
@@ -26,6 +26,7 @@ pub fn evaluate_variant_config(
 
     Ok(VariantConfig {
         zip_keys: stage0.zip_keys.clone(),
+        force_use: stage0.force_use.clone(),
         variants,
     })
 }

--- a/crates/rattler_build_variant_config/src/evaluate.rs
+++ b/crates/rattler_build_variant_config/src/evaluate.rs
@@ -26,7 +26,7 @@ pub fn evaluate_variant_config(
 
     Ok(VariantConfig {
         zip_keys: stage0.zip_keys.clone(),
-        force_use: stage0.force_use.clone(),
+        force_use_keys: stage0.force_use_keys.clone(),
         variants,
     })
 }

--- a/crates/rattler_build_variant_config/src/yaml_parser.rs
+++ b/crates/rattler_build_variant_config/src/yaml_parser.rs
@@ -20,7 +20,7 @@ pub struct Stage0VariantConfig {
     pub zip_keys: Option<Vec<Vec<NormalizedKey>>>,
 
     /// Variant keys that should be included in every build
-    pub force_use: Option<Vec<NormalizedKey>>,
+    pub force_use_keys: Option<Vec<NormalizedKey>>,
 
     /// The variant values - a mapping of keys to lists with conditionals and templates
     pub variants: BTreeMap<NormalizedKey, ConditionalList>,
@@ -94,7 +94,7 @@ fn parse_node(node: &Node) -> ParseResult<Stage0VariantConfig> {
         .ok_or_else(|| ParseError::expected_type("mapping", "other", *node.span()))?;
 
     let mut zip_keys = None;
-    let mut force_use = None;
+    let mut force_use_keys = None;
     let mut variants = BTreeMap::new();
 
     for (key_node, value_node) in mapping.iter() {
@@ -105,9 +105,9 @@ fn parse_node(node: &Node) -> ParseResult<Stage0VariantConfig> {
             continue;
         }
 
-        if key_str == "force_use" {
-            let keys: Vec<String> = value_node.parse_sequence("force_use")?;
-            force_use = Some(keys.into_iter().map(NormalizedKey::from).collect());
+        if key_str == "force_use_keys" {
+            let keys: Vec<String> = value_node.parse_sequence("force_use_keys")?;
+            force_use_keys = Some(keys.into_iter().map(NormalizedKey::from).collect());
             continue;
         }
 
@@ -127,7 +127,7 @@ fn parse_node(node: &Node) -> ParseResult<Stage0VariantConfig> {
 
     Ok(Stage0VariantConfig {
         zip_keys,
-        force_use,
+        force_use_keys,
         variants,
         path: None,
     })

--- a/crates/rattler_build_variant_config/src/yaml_parser.rs
+++ b/crates/rattler_build_variant_config/src/yaml_parser.rs
@@ -19,6 +19,9 @@ pub struct Stage0VariantConfig {
     /// Keys that should be "zipped" together when creating the build matrix
     pub zip_keys: Option<Vec<Vec<NormalizedKey>>>,
 
+    /// Variant keys that should be included in every build
+    pub force_use: Option<Vec<NormalizedKey>>,
+
     /// The variant values - a mapping of keys to lists with conditionals and templates
     pub variants: BTreeMap<NormalizedKey, ConditionalList>,
 
@@ -91,6 +94,7 @@ fn parse_node(node: &Node) -> ParseResult<Stage0VariantConfig> {
         .ok_or_else(|| ParseError::expected_type("mapping", "other", *node.span()))?;
 
     let mut zip_keys = None;
+    let mut force_use = None;
     let mut variants = BTreeMap::new();
 
     for (key_node, value_node) in mapping.iter() {
@@ -98,6 +102,12 @@ fn parse_node(node: &Node) -> ParseResult<Stage0VariantConfig> {
 
         if key_str == "zip_keys" {
             zip_keys = Some(parse_zip_keys(value_node)?);
+            continue;
+        }
+
+        if key_str == "force_use" {
+            let keys: Vec<String> = value_node.parse_sequence("force_use")?;
+            force_use = Some(keys.into_iter().map(NormalizedKey::from).collect());
             continue;
         }
 
@@ -117,6 +127,7 @@ fn parse_node(node: &Node) -> ParseResult<Stage0VariantConfig> {
 
     Ok(Stage0VariantConfig {
         zip_keys,
+        force_use,
         variants,
         path: None,
     })

--- a/docs/variants.md
+++ b/docs/variants.md
@@ -163,12 +163,12 @@ The resulting variants with the zip applied are:
 
 ### Force use
 
-The `force_use` key lists variant keys that should be included in every build,
+The `force_use_keys` key lists variant keys that should be included in every build,
 even when they are not referenced by the recipe. Their values are added to the
 build matrix, hash input, and build-script environment.
 
 ```yaml
-force_use:
+force_use_keys:
   - TARGET
   - CROSSCOMPILING_EMULATOR
 

--- a/docs/variants.md
+++ b/docs/variants.md
@@ -5,7 +5,7 @@ For example, a Python package might need multiple variants per Python version
 (especially if it is a binary package such as `numpy`).
 
 For this use case, one can specify _variant_ configuration files. A variant
-configuration file has 2 special entries and a list of packages with variants.
+configuration file can have special entries and a list of packages with variants.
 For example:
 
 ```yaml title="variants.yaml"
@@ -159,6 +159,23 @@ The resulting variants with the zip applied are:
 ```
 - python 3.8, numpy 1.12
 - python 3.9, numpy 1.14
+```
+
+### Force use
+
+The `force_use` key lists variant keys that should be included in every build,
+even when they are not referenced by the recipe. Their values are added to the
+build matrix, hash input, and build-script environment.
+
+```yaml
+force_use:
+  - TARGET
+  - CROSSCOMPILING_EMULATOR
+
+TARGET:
+  - x86_64-conda-linux-gnu
+CROSSCOMPILING_EMULATOR:
+  - qemu-x86_64
 ```
 
 ### Pin run as build

--- a/py-rattler-build/rust/src/variant_config.rs
+++ b/py-rattler-build/rust/src/variant_config.rs
@@ -18,12 +18,13 @@ pub struct PyVariantConfig {
 
 #[pymethods]
 impl PyVariantConfig {
-    /// Create a new VariantConfig with optional variants and zip_keys
+    /// Create a new VariantConfig with optional variants, zip_keys, and force_use
     #[new]
-    #[pyo3(signature = (variants=None, zip_keys=None))]
+    #[pyo3(signature = (variants=None, zip_keys=None, force_use=None))]
     fn new(
         variants: Option<Bound<'_, PyDict>>,
         zip_keys: Option<Vec<Vec<String>>>,
+        force_use: Option<Vec<String>>,
     ) -> PyResult<Self> {
         let mut inner = VariantConfig {
             zip_keys: zip_keys.map(|zk| {
@@ -31,6 +32,7 @@ impl PyVariantConfig {
                     .map(|group| group.into_iter().map(NormalizedKey::from).collect())
                     .collect()
             }),
+            force_use: force_use.map(|keys| keys.into_iter().map(NormalizedKey::from).collect()),
             ..Default::default()
         };
 
@@ -174,6 +176,15 @@ impl PyVariantConfig {
                 .map(|group| group.iter().map(|k| k.normalize()).collect())
                 .collect()
         })
+    }
+
+    /// Get keys that are included in every build
+    #[getter]
+    fn force_use(&self) -> Option<Vec<String>> {
+        self.inner
+            .force_use
+            .as_ref()
+            .map(|keys| keys.iter().map(NormalizedKey::normalize).collect())
     }
 
     /// Get values for a specific variant key

--- a/py-rattler-build/rust/src/variant_config.rs
+++ b/py-rattler-build/rust/src/variant_config.rs
@@ -18,13 +18,13 @@ pub struct PyVariantConfig {
 
 #[pymethods]
 impl PyVariantConfig {
-    /// Create a new VariantConfig with optional variants, zip_keys, and force_use
+    /// Create a new VariantConfig with optional variants, zip_keys, and force_use_keys
     #[new]
-    #[pyo3(signature = (variants=None, zip_keys=None, force_use=None))]
+    #[pyo3(signature = (variants=None, zip_keys=None, force_use_keys=None))]
     fn new(
         variants: Option<Bound<'_, PyDict>>,
         zip_keys: Option<Vec<Vec<String>>>,
-        force_use: Option<Vec<String>>,
+        force_use_keys: Option<Vec<String>>,
     ) -> PyResult<Self> {
         let mut inner = VariantConfig {
             zip_keys: zip_keys.map(|zk| {
@@ -32,7 +32,8 @@ impl PyVariantConfig {
                     .map(|group| group.into_iter().map(NormalizedKey::from).collect())
                     .collect()
             }),
-            force_use: force_use.map(|keys| keys.into_iter().map(NormalizedKey::from).collect()),
+            force_use_keys: force_use_keys
+                .map(|keys| keys.into_iter().map(NormalizedKey::from).collect()),
             ..Default::default()
         };
 
@@ -180,9 +181,9 @@ impl PyVariantConfig {
 
     /// Get keys that are included in every build
     #[getter]
-    fn force_use(&self) -> Option<Vec<String>> {
+    fn force_use_keys(&self) -> Option<Vec<String>> {
         self.inner
-            .force_use
+            .force_use_keys
             .as_ref()
             .map(|keys| keys.iter().map(NormalizedKey::normalize).collect())
     }


### PR DESCRIPTION
## Summary

- add a `force_use_keys` special key to variant configuration files
- include forced keys in every package and staging build matrix, hash, and script environment
- keep recipe-level `ignore_keys` as the local override
- expose `force_use_keys` through the Python bindings and document it

Addresses #2587.

## Tests

- `cargo test -p rattler_build_variant_config`
- `cargo test -p rattler_build_recipe`
- `cargo check --manifest-path py-rattler-build/rust/Cargo.toml`